### PR TITLE
launchpad.net/snappy -> github.com/ubuntu-core/snappy

### DIFF
--- a/.tarmac.sh
+++ b/.tarmac.sh
@@ -7,8 +7,8 @@ export GOPATH=$(mktemp -d)
 trap 'rm -rf "$GOPATH"' EXIT
 
 # this is a hack, but not sure tarmac is golang friendly
-mkdir -p $GOPATH/src/launchpad.net/snappy
-cp -a . $GOPATH/src/launchpad.net/snappy/
-cd $GOPATH/src/launchpad.net/snappy
+mkdir -p $GOPATH/src/github.com/ubuntu-core/snappy
+cp -a . $GOPATH/src/github.com/ubuntu-core/snappy/
+cd $GOPATH/src/github.com/ubuntu-core/snappy
 
 sh -v ./run-checks

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add `$GOPATH/bin` to your `PATH`, so you can run the go programs you install:
 
 The easiest way to get the source for `snappy` is to use the `go get` command.
 
-    go get -d -v launchpad.net/snappy/...
+    go get -d -v github.com/ubuntu-core/snappy/...
 
 This command will checkout the source of `snappy` and inspect it for any unmet
 Go package dependencies, downloading those as well. `go get` will also build
@@ -44,19 +44,19 @@ the `-d` flag. More details on the `go get` flags are available using
     go help get
 
 At this point you will have the git local repository of the `snappy` source at
-`$GOPATH/launchpad.net/snappy/snappy`. The source for any
+`$GOPATH/github.com/ubuntu-core/snappy/snappy`. The source for any
 dependent packages will also be available inside `$GOPATH`.
 
 ### Building
 
 To build, once the sources are available and `GOPATH` is set, you can just run
 
-    go build -o /tmp/snappy launchpad.net/snappy/cmd/snappy
+    go build -o /tmp/snappy github.com/ubuntu-core/snappy/cmd/snappy
 
 to get the `snappy` binary in /tmp (or without -o to get it in the current
 working directory). Alternatively:
 
-    go install launchpad.net/snappy/...
+    go install github.com/ubuntu-core/snappy/...
 
 to have it available in `$GOPATH/bin`
 

--- a/_integration-tests/main.go
+++ b/_integration-tests/main.go
@@ -26,11 +26,11 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"launchpad.net/snappy/_integration-tests/testutils"
-	"launchpad.net/snappy/_integration-tests/testutils/autopkgtest"
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/config"
-	"launchpad.net/snappy/_integration-tests/testutils/image"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/autopkgtest"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/config"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/image"
 )
 
 const (

--- a/_integration-tests/tests/activate_test.go
+++ b/_integration-tests/tests/activate_test.go
@@ -24,10 +24,10 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/data"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/data"
 )
 
 const (

--- a/_integration-tests/tests/apt_test.go
+++ b/_integration-tests/tests/apt_test.go
@@ -20,8 +20,8 @@
 package tests
 
 import (
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/base_test.go
+++ b/_integration-tests/tests/base_test.go
@@ -26,11 +26,11 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/partition"
-	"launchpad.net/snappy/_integration-tests/testutils/report"
-	"launchpad.net/snappy/_integration-tests/testutils/runner"
-	"launchpad.net/snappy/_integration-tests/testutils/wait"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/partition"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/report"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/runner"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/wait"
 )
 
 func init() {

--- a/_integration-tests/tests/build_test.go
+++ b/_integration-tests/tests/build_test.go
@@ -24,9 +24,9 @@ import (
 	"os"
 	"os/exec"
 
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/data"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/data"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/config_test.go
+++ b/_integration-tests/tests/config_test.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/console_test.go
+++ b/_integration-tests/tests/console_test.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"os/exec"
 
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/examples_test.go
+++ b/_integration-tests/tests/examples_test.go
@@ -25,9 +25,9 @@ import (
 	"net/http"
 	"os"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/wait"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/wait"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/failover_rclocal_crash_test.go
+++ b/_integration-tests/tests/failover_rclocal_crash_test.go
@@ -22,9 +22,9 @@ package tests
 import (
 	"fmt"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/partition"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/partition"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/failover_systemd_loop_test.go
+++ b/_integration-tests/tests/failover_systemd_loop_test.go
@@ -22,9 +22,9 @@ package tests
 import (
 	"fmt"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/partition"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/partition"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/failover_test.go
+++ b/_integration-tests/tests/failover_test.go
@@ -22,7 +22,7 @@ package tests
 import (
 	"gopkg.in/check.v1"
 
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 )
 
 var _ = check.Suite(&failoverSuite{})

--- a/_integration-tests/tests/failover_zero_size_file_test.go
+++ b/_integration-tests/tests/failover_zero_size_file_test.go
@@ -25,9 +25,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/partition"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/partition"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/hwAssign_test.go
+++ b/_integration-tests/tests/hwAssign_test.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"os/exec"
 
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/info_test.go
+++ b/_integration-tests/tests/info_test.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"os"
 
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/data"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/data"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/initramfs_test.go
+++ b/_integration-tests/tests/initramfs_test.go
@@ -26,9 +26,9 @@ import (
 	"strconv"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/partition"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/partition"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/installApp_test.go
+++ b/_integration-tests/tests/installApp_test.go
@@ -24,10 +24,10 @@ import (
 	"os"
 	"os/exec"
 
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/data"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/data"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/installFramework_test.go
+++ b/_integration-tests/tests/installFramework_test.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"os"
 
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/data"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/data"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/list_test.go
+++ b/_integration-tests/tests/list_test.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"os"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 
 	"github.com/mvo5/goconfigparser"
 	"gopkg.in/check.v1"

--- a/_integration-tests/tests/rollback_test.go
+++ b/_integration-tests/tests/rollback_test.go
@@ -22,8 +22,8 @@ package tests
 import (
 	"strconv"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/search_test.go
+++ b/_integration-tests/tests/search_test.go
@@ -20,8 +20,8 @@
 package tests
 
 import (
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/service_test.go
+++ b/_integration-tests/tests/service_test.go
@@ -24,11 +24,11 @@ import (
 	"os"
 	"regexp"
 
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/data"
-	"launchpad.net/snappy/_integration-tests/testutils/wait"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/data"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/wait"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/snapd_1_0_packages_test.go
+++ b/_integration-tests/tests/snapd_1_0_packages_test.go
@@ -22,9 +22,9 @@ package tests
 import (
 	"os"
 
-	"launchpad.net/snappy/_integration-tests/testutils/build"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/data"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/build"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/data"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/snapd_test.go
+++ b/_integration-tests/tests/snapd_test.go
@@ -30,8 +30,8 @@ import (
 	"strconv"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/wait"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/wait"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/ubuntuFan_test.go
+++ b/_integration-tests/tests/ubuntuFan_test.go
@@ -25,9 +25,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/wait"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/wait"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/update_test.go
+++ b/_integration-tests/tests/update_test.go
@@ -23,8 +23,8 @@ import (
 	"io/ioutil"
 	"path"
 
-	"launchpad.net/snappy/_integration-tests/testutils/common"
-	"launchpad.net/snappy/_integration-tests/testutils/partition"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/partition"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/tests/writablePaths_test.go
+++ b/_integration-tests/tests/writablePaths_test.go
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
 )

--- a/_integration-tests/testutils/autopkgtest/autopkgtest.go
+++ b/_integration-tests/testutils/autopkgtest/autopkgtest.go
@@ -24,8 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils"
-	"launchpad.net/snappy/_integration-tests/testutils/tpl"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/tpl"
 )
 
 const (

--- a/_integration-tests/testutils/build/build.go
+++ b/_integration-tests/testutils/build/build.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils"
 )
 
 const (

--- a/_integration-tests/testutils/build/snap.go
+++ b/_integration-tests/testutils/build/snap.go
@@ -24,8 +24,9 @@ import (
 	"path/filepath"
 
 	"gopkg.in/check.v1"
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/data"
+
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/data"
 )
 
 const snapFilenameSufix = "_1.0_all.snap"

--- a/_integration-tests/testutils/common/common.go
+++ b/_integration-tests/testutils/common/common.go
@@ -30,9 +30,9 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/config"
-	"launchpad.net/snappy/_integration-tests/testutils/partition"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/config"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/partition"
 )
 
 const (

--- a/_integration-tests/testutils/common/info.go
+++ b/_integration-tests/testutils/common/info.go
@@ -24,7 +24,8 @@ import (
 	"strings"
 
 	"gopkg.in/check.v1"
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
+
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
 )
 
 // dependency aliasing

--- a/_integration-tests/testutils/image/image.go
+++ b/_integration-tests/testutils/image/image.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/_integration-tests/testutils"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils"
 )
 
 // Image type encapsulates image actions

--- a/_integration-tests/testutils/partition/partition.go
+++ b/_integration-tests/testutils/partition/partition.go
@@ -27,8 +27,8 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
-	"launchpad.net/snappy/_integration-tests/testutils/wait"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/wait"
 )
 
 const (

--- a/_integration-tests/testutils/report/parser_test.go
+++ b/_integration-tests/testutils/report/parser_test.go
@@ -76,7 +76,7 @@ func (s *ParserReportSuite) TestParserReporterReturnsTheNumberOfBytesWritten(c *
 }
 
 func (s *ParserReportSuite) TestParserReporterOutputsSuccess(c *check.C) {
-	s.subject.Write([]byte(fmt.Sprintf("PASS: /tmp/snappy-tests-job/18811/src/launchpad.net/snappy/_integration-tests/tests/apt_test.go:34: %s      0.005s\n", s.testID)))
+	s.subject.Write([]byte(fmt.Sprintf("PASS: /tmp/snappy-tests-job/18811/src/github.com/ubuntu-core/snappy/_integration-tests/tests/apt_test.go:34: %s      0.005s\n", s.testID)))
 
 	expected := fmt.Sprintf("success: %s\n", s.testID)
 	actual := s.output.String()
@@ -87,7 +87,7 @@ func (s *ParserReportSuite) TestParserReporterOutputsSuccess(c *check.C) {
 }
 
 func (s *ParserReportSuite) TestParserReporterOutputsFailure(c *check.C) {
-	s.subject.Write([]byte(fmt.Sprintf("FAIL: /tmp/snappy-tests-job/710/src/launchpad.net/snappy/_integration-tests/tests/installFramework_test.go:85: %s\n", s.testID)))
+	s.subject.Write([]byte(fmt.Sprintf("FAIL: /tmp/snappy-tests-job/710/src/github.com/ubuntu-core/snappy/_integration-tests/tests/installFramework_test.go:85: %s\n", s.testID)))
 
 	expected := fmt.Sprintf("failure: %s\n", s.testID)
 	actual := s.output.String()
@@ -99,7 +99,7 @@ func (s *ParserReportSuite) TestParserReporterOutputsFailure(c *check.C) {
 
 func (s *ParserReportSuite) TestParserReporterOutputsSkip(c *check.C) {
 	skipReason := "skip reason"
-	s.subject.Write([]byte(fmt.Sprintf("SKIP: /tmp/snappy-tests-job/21647/src/launchpad.net/snappy/_integration-tests/tests/info_test.go:36: %s (%s)\n", s.testID, skipReason)))
+	s.subject.Write([]byte(fmt.Sprintf("SKIP: /tmp/snappy-tests-job/21647/src/github.com/ubuntu-core/snappy/_integration-tests/tests/info_test.go:36: %s (%s)\n", s.testID, skipReason)))
 
 	expected := fmt.Sprintf("skip: %s [\n%s\n]\n", s.testID, skipReason)
 	actual := s.output.String()

--- a/_integration-tests/testutils/wait/wait.go
+++ b/_integration-tests/testutils/wait/wait.go
@@ -26,7 +26,7 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"launchpad.net/snappy/_integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/_integration-tests/testutils/cli"
 )
 
 var (

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -25,8 +25,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"launchpad.net/snappy/daemon"
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/daemon"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 func init() {

--- a/cmd/snappy/cmd_activate.go
+++ b/cmd/snappy/cmd_activate.go
@@ -20,10 +20,10 @@
 package main
 
 import (
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdActivate struct {

--- a/cmd/snappy/cmd_booted.go
+++ b/cmd/snappy/cmd_booted.go
@@ -20,9 +20,9 @@
 package main
 
 import (
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdBooted struct {

--- a/cmd/snappy/cmd_build.go
+++ b/cmd/snappy/cmd_build.go
@@ -22,9 +22,9 @@ package main
 import (
 	"fmt"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 const clickReview = "click-review"

--- a/cmd/snappy/cmd_config.go
+++ b/cmd/snappy/cmd_config.go
@@ -25,9 +25,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdConfig struct {

--- a/cmd/snappy/cmd_console.go
+++ b/cmd/snappy/cmd_console.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/peterh/liner"
 
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 // for testing

--- a/cmd/snappy/cmd_first_boot.go
+++ b/cmd/snappy/cmd_first_boot.go
@@ -22,9 +22,9 @@ package main
 import (
 	"fmt"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdInternalFirstBootOemConfig struct{}

--- a/cmd/snappy/cmd_grub_migrate.go
+++ b/cmd/snappy/cmd_grub_migrate.go
@@ -20,8 +20,8 @@
 package main
 
 import (
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/partition"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/partition"
 )
 
 type cmdGrubMigrate struct {

--- a/cmd/snappy/cmd_hwassign.go
+++ b/cmd/snappy/cmd_hwassign.go
@@ -22,9 +22,9 @@ package main
 import (
 	"fmt"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdHWAssign struct {

--- a/cmd/snappy/cmd_hwinfo.go
+++ b/cmd/snappy/cmd_hwinfo.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"strings"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdHWInfo struct {

--- a/cmd/snappy/cmd_hwunassign.go
+++ b/cmd/snappy/cmd_hwunassign.go
@@ -22,9 +22,9 @@ package main
 import (
 	"fmt"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdHWUnassign struct {

--- a/cmd/snappy/cmd_info.go
+++ b/cmd/snappy/cmd_info.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"strings"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdInfo struct {

--- a/cmd/snappy/cmd_install.go
+++ b/cmd/snappy/cmd_install.go
@@ -24,10 +24,10 @@ import (
 	"fmt"
 	"os"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdInstall struct {

--- a/cmd/snappy/cmd_internal_run_hooks.go
+++ b/cmd/snappy/cmd_internal_run_hooks.go
@@ -20,8 +20,8 @@
 package main
 
 import (
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdInternalRunHooks struct {

--- a/cmd/snappy/cmd_internal_unpack.go
+++ b/cmd/snappy/cmd_internal_unpack.go
@@ -30,9 +30,9 @@ import (
 	"strings"
 	"syscall"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg/clickdeb"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg/clickdeb"
 )
 
 // #include <sys/prctl.h>

--- a/cmd/snappy/cmd_list.go
+++ b/cmd/snappy/cmd_list.go
@@ -26,10 +26,10 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdList struct {

--- a/cmd/snappy/cmd_login.go
+++ b/cmd/snappy/cmd_login.go
@@ -24,9 +24,9 @@ import (
 	"fmt"
 	"os"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdLogin struct {

--- a/cmd/snappy/cmd_man.go
+++ b/cmd/snappy/cmd_man.go
@@ -22,8 +22,8 @@ package main
 import (
 	"os"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 type man struct{}

--- a/cmd/snappy/cmd_purge.go
+++ b/cmd/snappy/cmd_purge.go
@@ -22,10 +22,10 @@ package main
 import (
 	"fmt"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdPurge struct {

--- a/cmd/snappy/cmd_remove.go
+++ b/cmd/snappy/cmd_remove.go
@@ -22,10 +22,10 @@ package main
 import (
 	"fmt"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdRemove struct {

--- a/cmd/snappy/cmd_rollback.go
+++ b/cmd/snappy/cmd_rollback.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"os"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdRollback struct {

--- a/cmd/snappy/cmd_search.go
+++ b/cmd/snappy/cmd_search.go
@@ -24,10 +24,10 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdSearch struct {

--- a/cmd/snappy/cmd_service.go
+++ b/cmd/snappy/cmd_service.go
@@ -24,11 +24,11 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdService struct {

--- a/cmd/snappy/cmd_set.go
+++ b/cmd/snappy/cmd_set.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"strings"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdSet struct {

--- a/cmd/snappy/cmd_update.go
+++ b/cmd/snappy/cmd_update.go
@@ -25,10 +25,10 @@ import (
 	"os/exec"
 	"strings"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdUpdate struct {

--- a/cmd/snappy/cmd_versions.go
+++ b/cmd/snappy/cmd_versions.go
@@ -22,8 +22,8 @@ package main
 import (
 	"fmt"
 
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 type cmdVersions struct {

--- a/cmd/snappy/common.go
+++ b/cmd/snappy/common.go
@@ -20,8 +20,8 @@
 package main
 
 import (
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/priv"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/priv"
 
 	"github.com/jessevdk/go-flags"
 )

--- a/cmd/snappy/common_test.go
+++ b/cmd/snappy/common_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jessevdk/go-flags"
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/cmd/snappy/main.go
+++ b/cmd/snappy/main.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"os"
 
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/priv"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/priv"
+	"github.com/ubuntu-core/snappy/snappy"
 
 	"github.com/jessevdk/go-flags"
 )

--- a/coreconfig/config.go
+++ b/coreconfig/config.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"syscall"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	"gopkg.in/yaml.v2"
 )

--- a/coreconfig/config_test.go
+++ b/coreconfig/config_test.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	. "gopkg.in/check.v1"
 )

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -33,12 +33,12 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg/lightweight"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/release"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg/lightweight"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/release"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 var api = []*Command{

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -39,13 +39,13 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/lightweight"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/release"
-	"launchpad.net/snappy/snappy"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/lightweight"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/release"
+	"github.com/ubuntu-core/snappy/snappy"
+	"github.com/ubuntu-core/snappy/systemd"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/tomb.v2"
 
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 // A Daemon listens for requests and routes them to the right command

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 // ResponseType is the response type

--- a/daemon/snappy_part_iface_test.go
+++ b/daemon/snappy_part_iface_test.go
@@ -22,9 +22,9 @@ package daemon
 import (
 	"time"
 
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // a for-testing Part

--- a/daemon/snappy_service_iface_test.go
+++ b/daemon/snappy_service_iface_test.go
@@ -20,8 +20,8 @@
 package daemon
 
 import (
-	"launchpad.net/snappy/snappy"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/snappy"
+	"github.com/ubuntu-core/snappy/systemd"
 )
 
 type tSA struct {

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Build-Depends: bash-completion,
                python3-markdown,
                squashfs-tools
 Standards-Version: 3.9.6
-Homepage: https://launchpad.net/snappy
+Homepage: https://github.com/ubuntu-core/snappy
 Vcs-Browser: http://bazaar.launchpad.net/~snappy-dev/snappy/trunk/files
 Vcs-Bzr: lp:snappy
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: snappy
-Source: https://launchpad.net/snappy
+Source: https://github.com/ubuntu-core/snappy
 
 Files: *
 Copyright: Copyright (C) 2014,2015 Canonical, Ltd.

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 
 #export DH_VERBOSE=1
 export DH_OPTIONS
-export DH_GOPKG := launchpad.net/snappy
+export DH_GOPKG := github.com/ubuntu-core/snappy
 #export DEB_BUILD_OPTIONS=nocheck
 
 RELEASE = $(shell lsb_release -c -s)

--- a/docs/cross-build.md
+++ b/docs/cross-build.md
@@ -9,10 +9,10 @@ And then set up your environment:
 
 With that, `go build` will produce binaries for armhf. E.g.,
 
-    go build -o snappy_armhf launchpad.net/snappy/cmd/snappy
+    go build -o snappy_armhf github.com/ubuntu-core/snappy/cmd/snappy
 
 
 As usual, for one-off commands you can simply prepend the environment
 to the command, e.g.
 
-    GOARCH=arm GOARM=7 CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc go build -o snappy_armhf launchpad.net/snappy/cmd/snappy
+    GOARCH=arm GOARM=7 CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc go build -o snappy_armhf github.com/ubuntu-core/snappy/cmd/snappy

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -38,7 +38,7 @@ import (
 	"text/template"
 	"time"
 
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 var goarch = runtime.GOARCH

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"time"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 // Token contains the sso token

--- a/partition/bootloader.go
+++ b/partition/bootloader.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 const (

--- a/partition/bootloader_grub.go
+++ b/partition/bootloader_grub.go
@@ -22,7 +22,7 @@ package partition
 import (
 	"fmt"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	"github.com/mvo5/goconfigparser"
 )

--- a/partition/bootloader_grub_test.go
+++ b/partition/bootloader_grub_test.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	. "gopkg.in/check.v1"
 )

--- a/partition/bootloader_uboot.go
+++ b/partition/bootloader_uboot.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"strings"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	"github.com/mvo5/goconfigparser"
 	"github.com/mvo5/uboot-go/uenv"

--- a/partition/bootloader_uboot_test.go
+++ b/partition/bootloader_uboot_test.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"time"
 
-	. "gopkg.in/check.v1"
-	"launchpad.net/snappy/helpers"
-
 	"github.com/mvo5/uboot-go/uenv"
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 // TODO move to uboot specific test suite.

--- a/partition/migrate_grub.go
+++ b/partition/migrate_grub.go
@@ -26,8 +26,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 const newGrubConfig string = `

--- a/partition/partition.go
+++ b/partition/partition.go
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"syscall"
 
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 const (

--- a/pkg/clickdeb/deb.go
+++ b/pkg/clickdeb/deb.go
@@ -33,7 +33,7 @@ import (
 	"strings"
 	"time"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	"github.com/blakesmith/ar"
 )

--- a/pkg/clickdeb/deb_test.go
+++ b/pkg/clickdeb/deb_test.go
@@ -31,7 +31,8 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
-	"launchpad.net/snappy/helpers"
+
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 // Hook up check.v1 into the "go test" runner.

--- a/pkg/clickdeb/verify.go
+++ b/pkg/clickdeb/verify.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"os/exec"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 const (

--- a/pkg/lightweight/example_test.go
+++ b/pkg/lightweight/example_test.go
@@ -25,8 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/pkg/lightweight"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/pkg/lightweight"
 )
 
 // we don't use example tests nearly as often as we should :-)

--- a/pkg/lightweight/lightweight.go
+++ b/pkg/lightweight/lightweight.go
@@ -31,11 +31,11 @@ import (
 	"strconv"
 	"strings"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/removed"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/removed"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // split a path into the name and extension of the directory, and the file.

--- a/pkg/lightweight/lightweight_test.go
+++ b/pkg/lightweight/lightweight_test.go
@@ -29,11 +29,11 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/remote"
-	"launchpad.net/snappy/pkg/removed"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/remote"
+	"github.com/ubuntu-core/snappy/pkg/removed"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type lightweightSuite struct {

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -20,7 +20,7 @@
 package remote
 
 import (
-	"launchpad.net/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg"
 )
 
 // A Snap encapsulates the data sent to us from the store.

--- a/pkg/removed/removed.go
+++ b/pkg/removed/removed.go
@@ -29,10 +29,10 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/remote"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/remote"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // ErrRemoved is returned when you ask to operate on a removed package.

--- a/pkg/removed/removed_test.go
+++ b/pkg/removed/removed_test.go
@@ -27,10 +27,10 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/snappy"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type removedSuite struct{}

--- a/pkg/snapfs/pkg.go
+++ b/pkg/snapfs/pkg.go
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 // Snap is the squashfs based snap

--- a/pkg/snapfs/pkg_test.go
+++ b/pkg/snapfs/pkg_test.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"testing"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	. "gopkg.in/check.v1"
 )

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 var (

--- a/priv/filelock_test.go
+++ b/priv/filelock_test.go
@@ -22,7 +22,7 @@ package priv
 import (
 	"path/filepath"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	. "gopkg.in/check.v1"
 )

--- a/priv/priv_test.go
+++ b/priv/priv_test.go
@@ -20,7 +20,7 @@
 package priv
 
 import (
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	"path/filepath"
 	"testing"

--- a/provisioning/provisioning.go
+++ b/provisioning/provisioning.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/logger"
 
 	"gopkg.in/yaml.v2"
 )

--- a/run-checks
+++ b/run-checks
@@ -55,7 +55,7 @@ if [ -z "$QUICK" ]; then
     godeps -u dependencies.tsv
 
     echo Building
-    go build -v launchpad.net/snappy/...
+    go build -v github.com/ubuntu-core/snappy/...
 
 
     # tests

--- a/snappy/arch.go
+++ b/snappy/arch.go
@@ -20,7 +20,7 @@
 package snappy
 
 import (
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 // ArchitectureType is the type for a supported snappy architecture

--- a/snappy/auth.go
+++ b/snappy/auth.go
@@ -27,8 +27,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/oauth"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/oauth"
 )
 
 var (

--- a/snappy/auth_test.go
+++ b/snappy/auth_test.go
@@ -27,8 +27,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/oauth"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/oauth"
 
 	. "gopkg.in/check.v1"
 )

--- a/snappy/build.go
+++ b/snappy/build.go
@@ -32,9 +32,9 @@ import (
 	"syscall"
 	"text/template"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/pkg/clickdeb"
-	"launchpad.net/snappy/pkg/snapfs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/pkg/clickdeb"
+	"github.com/ubuntu-core/snappy/pkg/snapfs"
 
 	"gopkg.in/yaml.v2"
 )

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"syscall"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 
 	. "gopkg.in/check.v1"
 )

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -41,14 +41,14 @@ import (
 	"text/template"
 	"time"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/clickdeb"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/clickdeb"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/systemd"
 
 	"github.com/mvo5/goconfigparser"
 )

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -31,13 +31,13 @@ import (
 	"github.com/mvo5/goconfigparser"
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/clickdeb"
-	"launchpad.net/snappy/policy"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/clickdeb"
+	"github.com/ubuntu-core/snappy/policy"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/systemd"
 )
 
 func (s *SnapTestSuite) TestReadManifest(c *C) {

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -29,10 +29,10 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/remote"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/remote"
 )
 
 const (

--- a/snappy/datadir.go
+++ b/snappy/datadir.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/dirs"
+	"github.com/ubuntu-core/snappy/dirs"
 )
 
 // A SnapDataDir represents a single data directory for a version of a package

--- a/snappy/datadir_test.go
+++ b/snappy/datadir_test.go
@@ -26,7 +26,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
+	"github.com/ubuntu-core/snappy/dirs"
 )
 
 type DataDirSuite struct{}

--- a/snappy/dbus.go
+++ b/snappy/dbus.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 	"text/template"
 
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 func verifyBusName(busName string) error {

--- a/snappy/errors.go
+++ b/snappy/errors.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 	"strings"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 var (

--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -26,8 +26,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/pkg"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/pkg"
 
 	"gopkg.in/yaml.v2"
 )

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -27,7 +27,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg"
 )
 
 type fakePart struct {

--- a/snappy/globals.go
+++ b/snappy/globals.go
@@ -22,8 +22,8 @@ package snappy
 import (
 	"os"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/release"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/release"
 )
 
 func init() {

--- a/snappy/hwaccess.go
+++ b/snappy/hwaccess.go
@@ -29,8 +29,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 const udevDataGlob = "/run/udev/data/*"

--- a/snappy/hwaccess_test.go
+++ b/snappy/hwaccess_test.go
@@ -25,8 +25,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 func mockRegenerateAppArmorRules() *bool {

--- a/snappy/install.go
+++ b/snappy/install.go
@@ -25,10 +25,10 @@ import (
 	"sort"
 	"strings"
 
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/partition"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/provisioning"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/partition"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/provisioning"
 )
 
 // InstallFlags can be used to pass additional flags to the install of a

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -31,9 +31,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/partition"
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/partition"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 func makeCloudInitMetaData(c *C, content string) string {

--- a/snappy/oem.go
+++ b/snappy/oem.go
@@ -31,9 +31,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg"
 )
 
 // OEM represents the structure inside the package.yaml for the oem component

--- a/snappy/oem_test.go
+++ b/snappy/oem_test.go
@@ -28,8 +28,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 type OemSuite struct {

--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -27,9 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 // SystemConfig is a config map holding configs for multiple packages

--- a/snappy/parts_test.go
+++ b/snappy/parts_test.go
@@ -26,9 +26,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 func (s *SnapTestSuite) TestActiveSnapByType(c *C) {

--- a/snappy/pkgformat.go
+++ b/snappy/pkgformat.go
@@ -25,8 +25,8 @@ import (
 	"os"
 	"strings"
 
-	"launchpad.net/snappy/pkg/clickdeb"
-	"launchpad.net/snappy/pkg/snapfs"
+	"github.com/ubuntu-core/snappy/pkg/clickdeb"
+	"github.com/ubuntu-core/snappy/pkg/snapfs"
 )
 
 // PackageFile is the interface to interact with the low-level snap files

--- a/snappy/purge.go
+++ b/snappy/purge.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 // PurgeFlags can be used to pass additional flags to the snap removal request

--- a/snappy/purge_test.go
+++ b/snappy/purge_test.go
@@ -27,9 +27,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/systemd"
 )
 
 type purgeSuite struct {

--- a/snappy/remove.go
+++ b/snappy/remove.go
@@ -22,7 +22,7 @@ package snappy
 import (
 	"strings"
 
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 // RemoveFlags can be used to pass additional flags to the snap removal request

--- a/snappy/remove_test.go
+++ b/snappy/remove_test.go
@@ -22,8 +22,8 @@ package snappy
 import (
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 func (s *SnapTestSuite) TestRemoveNonExistingRaisesError(c *C) {

--- a/snappy/rollback.go
+++ b/snappy/rollback.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"sort"
 
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 // Rollback will roll the given pkg back to the given ver. If the version

--- a/snappy/rollback_test.go
+++ b/snappy/rollback_test.go
@@ -22,7 +22,7 @@ package snappy
 import (
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg"
 )
 
 func (s *SnapTestSuite) TestRollbackWithVersion(c *C) {

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -30,9 +30,9 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/pkg"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/pkg"
 )
 
 type apparmorJSONTemplate struct {

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -27,8 +27,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/pkg"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/pkg"
 )
 
 type SecurityTestSuite struct {

--- a/snappy/service.go
+++ b/snappy/service.go
@@ -24,10 +24,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/i18n"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/systemd"
 )
 
 // A ServiceActor collects the services found by FindServices and lets

--- a/snappy/service_test.go
+++ b/snappy/service_test.go
@@ -26,9 +26,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/systemd"
 )
 
 type ServiceActorSuite struct {

--- a/snappy/set.go
+++ b/snappy/set.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"strings"
 
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 // map from

--- a/snappy/set_active.go
+++ b/snappy/set_active.go
@@ -22,7 +22,7 @@ package snappy
 import (
 	"sort"
 
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 // SetActive sets the active state of the given package

--- a/snappy/set_test.go
+++ b/snappy/set_test.go
@@ -25,9 +25,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 func (s *SnapTestSuite) TestParseSetPropertyCmdlineEmpty(c *C) {

--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -38,16 +38,16 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/oauth"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/remote"
-	"launchpad.net/snappy/policy"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/release"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/oauth"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/remote"
+	"github.com/ubuntu-core/snappy/policy"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/release"
+	"github.com/ubuntu-core/snappy/systemd"
 )
 
 const (

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -22,9 +22,9 @@ package snappy
 import (
 	"path/filepath"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/pkg/snapfs"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/pkg/snapfs"
 
 	. "gopkg.in/check.v1"
 )

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -30,14 +30,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/partition"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/pkg/clickdeb"
-	"launchpad.net/snappy/policy"
-	"launchpad.net/snappy/release"
-	"launchpad.net/snappy/systemd"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/partition"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/pkg/clickdeb"
+	"github.com/ubuntu-core/snappy/policy"
+	"github.com/ubuntu-core/snappy/release"
+	"github.com/ubuntu-core/snappy/systemd"
 
 	. "gopkg.in/check.v1"
 )

--- a/snappy/sort.go
+++ b/snappy/sort.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 const (

--- a/snappy/sort_test.go
+++ b/snappy/sort_test.go
@@ -24,8 +24,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/pkg/remote"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/pkg/remote"
 )
 
 type SortTestSuite struct {

--- a/snappy/systemimage.go
+++ b/snappy/systemimage.go
@@ -30,14 +30,14 @@ import (
 
 	"github.com/mvo5/goconfigparser"
 
-	"launchpad.net/snappy/coreconfig"
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/logger"
-	"launchpad.net/snappy/partition"
-	"launchpad.net/snappy/pkg"
-	"launchpad.net/snappy/progress"
-	"launchpad.net/snappy/provisioning"
+	"github.com/ubuntu-core/snappy/coreconfig"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/partition"
+	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/provisioning"
 )
 
 // SystemImagePart have constant name, origin, and vendor.

--- a/snappy/systemimage_native.go
+++ b/snappy/systemimage_native.go
@@ -34,8 +34,8 @@ import (
 
 	"github.com/mvo5/goconfigparser"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/progress"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 var systemImageServer string

--- a/snappy/systemimage_test.go
+++ b/snappy/systemimage_test.go
@@ -28,9 +28,9 @@ import (
 	"strings"
 	"testing"
 
-	"launchpad.net/snappy/dirs"
-	"launchpad.net/snappy/partition"
-	"launchpad.net/snappy/provisioning"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/partition"
+	"github.com/ubuntu-core/snappy/provisioning"
 
 	. "gopkg.in/check.v1"
 )

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -33,8 +33,8 @@ import (
 	"text/template"
 	"time"
 
-	"launchpad.net/snappy/helpers"
-	"launchpad.net/snappy/logger"
+	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/logger"
 )
 
 var (

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -28,7 +28,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"launchpad.net/snappy/helpers"
+	"github.com/ubuntu-core/snappy/helpers"
 )
 
 type testreporter struct {

--- a/update-pot
+++ b/update-pot
@@ -11,7 +11,7 @@ if [ -n "$1" ]; then
 fi
 
 # ensure we have our xgettext-go
-go install launchpad.net/snappy/i18n/xgettext-go
+go install github.com/ubuntu-core/snappy/i18n/xgettext-go
 
 $GOPATH/bin/xgettext-go \
     -o "$OUTPUT" \


### PR DESCRIPTION
Changed all references to launchpad.net/snappy to github.com/ubuntu-core/snappy other than those for URLs (notably, of bugs).