### PR TITLE
Feature/git buildpackage

### DIFF
--- a/.bzr-builddeb/default.conf
+++ b/.bzr-builddeb/default.conf
@@ -1,2 +1,0 @@
-[BUILDDEB]
-split = True

--- a/.bzrignore
+++ b/.bzrignore
@@ -1,5 +1,0 @@
-_integration-tests/bin/
-_integration-tests/data/output/
-./share
-./snappy/hello_1.0.1_all.snap
-./tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+_integration-tests/bin/
+_integration-tests/data/output/
+share
+tags
+.coverage

--- a/debian/control
+++ b/debian/control
@@ -28,8 +28,8 @@ Build-Depends: bash-completion,
                squashfs-tools
 Standards-Version: 3.9.6
 Homepage: https://github.com/ubuntu-core/snappy
-Vcs-Browser: http://bazaar.launchpad.net/~snappy-dev/snappy/trunk/files
-Vcs-Bzr: lp:snappy
+Vcs-Browser: https://github.com/ubuntu-core/snappy
+Vcs-Git: https://github.com/ubuntu-core/snappy.git
 
 Package: golang-snappy-dev
 Architecture: all

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+debian-branch = master
+export-dir = ../build-area


### PR DESCRIPTION
Tiny branch that allows us to use "git-buildpackage" (gbp buildpackage) to build a deb out of snappy. Along the way I removed .bzrignore and .bzr-buildpackage/.