### PR TITLE
use the network-client cap instead of the old, deprecated networking cap

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -162,7 +162,7 @@ framework in the above framework yaml example, it might use:
         description: "desc for qux service"
         start: bin/qux
         caps:
-          - networking
+          - network-client
           - foo_bar-client
 
 See `security.md` for more information on specifying `caps` and a

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -52,7 +52,7 @@ type securitySeccompOverride struct {
 
 const defaultTemplate = "default"
 
-var defaultPolicyGroups = []string{"networking"}
+var defaultPolicyGroups = []string{"network-client"}
 
 // TODO: autodetect, this won't work for personal
 const defaultPolicyVendor = "ubuntu-core"

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -90,7 +90,7 @@ func (a *SecurityTestSuite) TestSnappyHandleApparmorSecurityDefault(c *C) {
 	a.verifyApparmorFile(c, `{
   "template": "default",
   "policy_groups": [
-    "networking"
+    "network-client"
   ],
   "policy_vendor": "ubuntu-core",
   "policy_version": 15.04
@@ -221,7 +221,7 @@ func (a *SecurityTestSuite) TestSnappySeccompSecurityTemplate(c *C) {
 		"--policy-vendor=ubuntu-core",
 		"--policy-version=15.04",
 		"--template=something",
-		"--policy-groups=networking",
+		"--policy-groups=network-client",
 	})
 }
 

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -1018,7 +1018,7 @@ services:
    stop: bin/testme-service.stop
    description: "testme service"
    caps:
-     - "networking"
+     - "network-client"
      - "foo_group"
    security-template: "foo_template"
 `)
@@ -1031,7 +1031,7 @@ func (s *SnapTestSuite) TestPackageYamlSecurityServiceParsing(c *C) {
 	c.Assert(m.ServiceYamls[0].Start, Equals, "bin/testme-service.start")
 	c.Assert(m.ServiceYamls[0].Stop, Equals, "bin/testme-service.stop")
 	c.Assert(m.ServiceYamls[0].SecurityCaps, HasLen, 2)
-	c.Assert(m.ServiceYamls[0].SecurityCaps[0], Equals, "networking")
+	c.Assert(m.ServiceYamls[0].SecurityCaps[0], Equals, "network-client")
 	c.Assert(m.ServiceYamls[0].SecurityCaps[1], Equals, "foo_group")
 	c.Assert(m.ServiceYamls[0].SecurityTemplate, Equals, "foo_template")
 }


### PR DESCRIPTION
network-client was available on 15.04 so this is safe to backport to the
stable branch as well.

[on behalf of Jamie]