### PR TITLE
Added method SetUbuntuArchitecture to override detected arch.

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -203,6 +203,12 @@ func UbuntuArchitecture() string {
 	}
 }
 
+// SetUbuntuArchitecture can be used to override the automatically detected
+// currently running architecture.
+func SetUbuntuArchitecture(newArch string) {
+	goarch = newArch
+}
+
 // IsSupportedArchitecture returns true if the system architecture is in the
 // list of architectures.
 func IsSupportedArchitecture(architectures []string) bool {

--- a/snappy/arch.go
+++ b/snappy/arch.go
@@ -45,4 +45,5 @@ func Architecture() ArchitectureType {
 // SetArchitecture allows overriding the auto detected Architecture
 func SetArchitecture(newArch ArchitectureType) {
 	arch = newArch
+	helpers.SetUbuntuArchitecture(string(newArch))
 }


### PR DESCRIPTION
This can be used by ubuntu-device-flash when cross-building OEM snaps to
change the architecture to the one from the hardware in the OEM snap.