### PR TITLE
Proposal fix for Bug #1496319

### DIFF
--- a/cmd/snappy/cmd_hwassign.go
+++ b/cmd/snappy/cmd_hwassign.go
@@ -29,14 +29,15 @@ import (
 
 type cmdHWAssign struct {
 	Positional struct {
-		PackageName string `positional-arg-name:"package name"`
-		DevicePath  string `positional-arg-name:"device path"`
-	} `required:"true" positional-args:"yes"`
+		PackageName string `positional-arg-name:"package_name" required:"true"`
+		DevicePath  string `positional-arg-name:"device_path" required:"true"`
+		SymlinkPath string `positional-arg-name:"symlink_path"`
+	} `positional-args:"yes"`
 }
 
 var shortHWAssignHelp = i18n.G("Assign a hardware device to a package")
 
-var longHWAssignHelp = i18n.G("This command adds access to a specific hardware device (e.g. /dev/ttyUSB0) for an installed package.")
+var longHWAssignHelp = i18n.G("This command adds access to a specific hardware device (e.g. /dev/ttyUSB0) for an installed package, possibly through symlink if provided.")
 
 func init() {
 	arg, err := parser.AddCommand("hw-assign",
@@ -46,8 +47,9 @@ func init() {
 	if err != nil {
 		logger.Panicf("Unable to hwassign: %v", err)
 	}
-	addOptionDescription(arg, "package name", i18n.G("Assign hardware to a specific installed package"))
-	addOptionDescription(arg, "device path", i18n.G("The hardware device path (e.g. /dev/ttyUSB0)"))
+	addOptionDescription(arg, "package_name", i18n.G("Assign hardware to a specific installed package"))
+	addOptionDescription(arg, "device_path", i18n.G("The hardware device path (e.g. /dev/ttyUSB0)"))
+	addOptionDescription(arg, "symlink_path", i18n.G("The optional symlink to device path (e.g. /dev/symlink)"))
 }
 
 func (x *cmdHWAssign) Execute(args []string) error {
@@ -57,15 +59,29 @@ func (x *cmdHWAssign) Execute(args []string) error {
 func (x *cmdHWAssign) doHWAssign() error {
 	if err := snappy.AddHWAccess(x.Positional.PackageName, x.Positional.DevicePath); err != nil {
 		if err == snappy.ErrHWAccessAlreadyAdded {
-			// TRANSLATORS: the first %s is a pkgname, the second %s is a path
-			fmt.Printf(i18n.G("'%s' previously allowed access to '%s'. Skipping\n"), x.Positional.PackageName, x.Positional.DevicePath)
-			return nil
+			if "" == x.Positional.SymlinkPath {
+				// TRANSLATORS: the first %s is a pkgname, the second %s is a path
+				fmt.Printf(i18n.G("'%s' previously allowed access to '%s'. Skipping\n"), x.Positional.PackageName, x.Positional.DevicePath)
+				return nil
+			}
+		} else {
+			return err
 		}
-
-		return err
 	}
 
-	// TRANSLATORS: the first %s is a pkgname, the second %s is a path
-	fmt.Printf(i18n.G("'%s' is now allowed to access '%s'\n"), x.Positional.PackageName, x.Positional.DevicePath)
+	if "" != x.Positional.SymlinkPath {
+		if err := snappy.AddSymlinkToHWDevice(
+			x.Positional.PackageName,
+			x.Positional.DevicePath,
+			x.Positional.SymlinkPath); err != nil {
+			return err
+		}
+		// TRANSLATORS: the first %s is a pkgname, the second %s is a path
+		fmt.Printf(i18n.G("'%s' is allowed to access '%s' through symlink '%s' \n"), x.Positional.PackageName, x.Positional.DevicePath, x.Positional.SymlinkPath)
+	} else {
+		// TRANSLATORS: the first %s is a pkgname, the second %s is a path
+		fmt.Printf(i18n.G("'%s' is allowed to access '%s'\n"), x.Positional.PackageName, x.Positional.DevicePath)
+	}
+
 	return nil
 }

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2015-10-28 16:28+0100\n"
+        "POT-Creation-Date: 2015-10-30 00:20+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,12 +28,17 @@ msgstr  ""
 
 #. TRANSLATORS: the first %s is a pkgname, the second %s is a path
 #, c-format
-msgid   "'%s' is no longer allowed to access '%s'\n"
+msgid   "'%s' is allowed to access '%s' through symlink '%s' \n"
 msgstr  ""
 
 #. TRANSLATORS: the first %s is a pkgname, the second %s is a path
 #, c-format
-msgid   "'%s' is now allowed to access '%s'\n"
+msgid   "'%s' is allowed to access '%s'\n"
+msgstr  ""
+
+#. TRANSLATORS: the first %s is a pkgname, the second %s is a path
+#, c-format
+msgid   "'%s' is no longer allowed to access '%s'\n"
 msgstr  ""
 
 #. TRANSLATORS: the first %s is a pkgname, the second %s is a path
@@ -295,6 +300,9 @@ msgstr  ""
 msgid   "The hardware device path (e.g. /dev/ttyUSB0)"
 msgstr  ""
 
+msgid   "The optional symlink to device path (e.g. /dev/symlink)"
+msgstr  ""
+
 msgid   "The package to rollback "
 msgstr  ""
 
@@ -307,7 +315,7 @@ msgstr  ""
 msgid   "The version to rollback to"
 msgstr  ""
 
-msgid   "This command adds access to a specific hardware device (e.g. /dev/ttyUSB0) for an installed package."
+msgid   "This command adds access to a specific hardware device (e.g. /dev/ttyUSB0) for an installed package, possibly through symlink if provided."
 msgstr  ""
 
 msgid   "This command is no longer available, please use the \"list\" command"

--- a/snappy/errors.go
+++ b/snappy/errors.go
@@ -51,6 +51,14 @@ var (
 	// is given in the hw-assign command
 	ErrInvalidHWDevice = errors.New("invalid hardware device")
 
+	// ErrInvalidSymlinkToHWDevice is returned when a invalid symlink to hardware device
+	// is given in the hw-assign command
+	ErrInvalidSymlinkToHWDevice = errors.New("invalid symlink to hardware device")
+
+	// ErrSymlinkToHWNameCollision is returned when a symlink with the same name of a
+	// device in the write path is requested
+	ErrSymlinkToHWNameCollision = errors.New("symlink's name collides with on of the snap's write paths")
+
 	// ErrHWAccessRemoveNotFound is returned if the user tries to
 	// remove a device that does not exist
 	ErrHWAccessRemoveNotFound = errors.New("can not find device in hw-access list")
@@ -58,6 +66,14 @@ var (
 	// ErrHWAccessAlreadyAdded is returned if you try to add a device
 	// that is already in the hwaccess list
 	ErrHWAccessAlreadyAdded = errors.New("device is already in hw-access list")
+
+	// ErrHwDeviceAlreadySymlinked is returned when the device has already a symlink
+	// with a different name
+	ErrHwDeviceAlreadySymlinked = errors.New("device has a symlink already")
+
+	// ErrSymlinkToHWAlreadyAdded is returned if you try to add a symlink
+	// that is already in the hwaccess list
+	ErrSymlinkToHWAlreadyAdded = errors.New("symlink is already in hw-access list")
 
 	// ErrReadmeInvalid is returned if the package contains a invalid
 	// meta/readme.md


### PR DESCRIPTION
This branch extends hw-assign in order to have also a symlink to a "hw-assigned" device node.

The new signature of the command is:

snappy hw-assign

the parameter is optional, this way the new hw-assign is backward compatible.