### PR TITLE
Add initial capability package

### DIFF
--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package capabilities
+
+import (
+	"errors"
+	"regexp"
+)
+
+// Capability that expressess an instance Snappy Capability.
+type Capability struct {
+	// Name that is also used for programmatic access on command line and
+	// at application runtime. This is constrained to [a-z][a-z0-9-]+
+	Name string
+	// Label meant for humans. This is the English version of this label.
+	// TODO: Add an i18n mechanism later.
+	Label string
+	// CapabilityType describes a group of capabilities sharing some common
+	// traits. In particular, this is where security bits are coming from.
+	Type CapabilityType
+}
+
+// CapabilityType describes a group of cabability instances.
+// All capability types are maintained with snappy source code.
+// In other words, there are no 3rd party capabilitites as they have
+// deep access to system security API promisses.
+type CapabilityType struct {
+	// Name of a capability type. This name is a part of the stable public API
+	// as snaps will refer to capabilities types with a given name. Gadget
+	// snaps will also provide mechanisms to create capabilities with a given
+	// type name.
+	Name string
+}
+
+// CapTypeFile is a basic capability vaguely expressing access to a specific
+// file. This single capability  type is here just to help boostrap
+// the capability concept before we get to load capability interfaces from YAML.
+var CapTypeFile = CapabilityType{"file"}
+
+// Regular expression describing correct identifiers
+var validName = regexp.MustCompile("^[a-z][a-z0-9-]+$")
+
+// NewCapability creates a new Capability object after validating arguments
+func NewCapability(Name, Label string, Type CapabilityType) (*Capability, error) {
+	if !validName.MatchString(Name) {
+		return nil, errors.New("Name is not a valid identifier")
+	}
+	return &Capability{Name, Label, Type}, nil
+}

--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -64,3 +64,33 @@ func NewCapability(Name, Label string, Type CapabilityType) (*Capability, error)
 	}
 	return &Capability{Name, Label, Type}, nil
 }
+
+// A CapabilityRepository stores all known snappy capabilities and types
+type CapabilityRepository struct {
+	// Map of capabilities, indexed by Capability.Name
+	Caps map[string]*Capability
+}
+
+// NewCapabilityRepository creates an empty capability repository
+func NewCapabilityRepository() *CapabilityRepository {
+	return &CapabilityRepository{
+		make(map[string]*Capability),
+	}
+}
+
+// Add a capability to the repository.
+// Capability names must be unique within the repository.
+// An error is returned if this constraint is violated.
+func (r *CapabilityRepository) Add(cap *Capability) error {
+	if _, capPresent := r.Caps[cap.Name]; capPresent {
+		return errors.New("Capability with that name already exists")
+	}
+	r.Caps[cap.Name] = cap
+	return nil
+}
+
+// Remove a capability with a given name.
+// Removing a capability that doesn't exist silently does nothing
+func (r *CapabilityRepository) Remove(Name string) {
+	delete(r.Caps, Name)
+}

--- a/capabilities/capabilities_test.go
+++ b/capabilities/capabilities_test.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package capabilities
+
+import (
+	. "gopkg.in/check.v1"
+	"testing"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type CapabilitySuite struct{}
+
+var _ = Suite(&CapabilitySuite{})
+
+func (s *CapabilitySuite) TestNewCapabilityAllOK(c *C) {
+	cap, err := NewCapability("name", "label", CapTypeFile)
+	c.Assert(err, IsNil)
+	c.Assert(cap.Name, Equals, "name")
+	c.Assert(cap.Label, Equals, "label")
+	c.Assert(cap.Type, Equals, CapTypeFile)
+}
+
+func (s *CapabilitySuite) TestNewCapabilityInvalidName(c *C) {
+	cap, err := NewCapability("name with space", "label", CapTypeFile)
+	c.Assert(cap, IsNil)
+	c.Assert(err, ErrorMatches, "Name is not a valid identifier")
+}

--- a/capabilities/capabilities_test.go
+++ b/capabilities/capabilities_test.go
@@ -20,6 +20,7 @@
 package capabilities
 
 import (
+	"github.com/ubuntu-core/snappy/testutil"
 	. "gopkg.in/check.v1"
 	"testing"
 )
@@ -44,4 +45,48 @@ func (s *CapabilitySuite) TestNewCapabilityInvalidName(c *C) {
 	cap, err := NewCapability("name with space", "label", CapTypeFile)
 	c.Assert(cap, IsNil)
 	c.Assert(err, ErrorMatches, "Name is not a valid identifier")
+}
+
+func (s *CapabilitySuite) TestAddCapabilityAllOk(c *C) {
+	cap, capErr := NewCapability("name", "label", CapTypeFile)
+	c.Assert(capErr, IsNil)
+	repo := NewCapabilityRepository()
+	err := repo.Add(cap)
+	c.Assert(err, IsNil)
+}
+
+func (s *CapabilitySuite) TestNewRepository(c *C) {
+	repo := NewCapabilityRepository()
+	c.Assert(len(repo.Caps), Equals, 0)
+}
+
+func (s *CapabilitySuite) TestAdd(c *C) {
+	repo := NewCapabilityRepository()
+	cap, _ := NewCapability("name", "label", CapTypeFile)
+	c.Assert(repo.Caps, Not(testutil.Contains), cap)
+	repo.Add(cap)
+	c.Assert(repo.Caps, testutil.Contains, cap)
+}
+
+func (s *CapabilitySuite) TestAddClash(c *C) {
+	repo := NewCapabilityRepository()
+	cap1, cap1Err := NewCapability("name", "label 1", CapTypeFile)
+	cap2, cap2Err := NewCapability("name", "label 2", CapTypeFile)
+	c.Assert(cap1Err, IsNil)
+	c.Assert(cap2Err, IsNil)
+	err1 := repo.Add(cap1)
+	err2 := repo.Add(cap2)
+	c.Assert(err1, IsNil)
+	c.Assert(err2, ErrorMatches, "Capability with that name already exists")
+	c.Assert(repo.Caps, testutil.Contains, cap1)
+	c.Assert(repo.Caps, Not(testutil.Contains), cap2)
+}
+
+func (s *CapabilitySuite) TestRemove(c *C) {
+	cap, _ := NewCapability("name", "label", CapTypeFile)
+	repo := NewCapabilityRepository()
+	repo.Remove(cap.Name) // This does nothing, silently
+	repo.Add(cap)         // This is tested elsewhere
+	repo.Remove(cap.Name)
+	c.Assert(repo.Caps, Not(testutil.Contains), cap)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/tomb.v2"
 
+	"github.com/ubuntu-core/snappy/capabilities"
 	"github.com/ubuntu-core/snappy/logger"
 )
 
@@ -41,6 +42,7 @@ type Daemon struct {
 	listener     net.Listener
 	tomb         tomb.Tomb
 	router       *mux.Router
+	capRepo      *capabilities.CapabilityRepository
 }
 
 // A ResponseFunc handles one of the individual verbs for a method
@@ -202,6 +204,7 @@ func (d *Daemon) DeleteTask(uuid string) error {
 // New Daemon
 func New() *Daemon {
 	return &Daemon{
-		tasks: make(map[string]*Task),
+		tasks:   make(map[string]*Task),
+		capRepo: capabilities.NewCapabilityRepository(),
 	}
 }

--- a/testutil/checkers.go
+++ b/testutil/checkers.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"fmt"
+	"gopkg.in/check.v1"
+	"reflect"
+	"strings"
+)
+
+type containsChecker struct {
+	*check.CheckerInfo
+}
+
+// Contains is a Checker that looks for a needle in a haystack.
+// The needle can be any object. The haystack can be an array, slice or string.
+var Contains check.Checker = &containsChecker{
+	&check.CheckerInfo{Name: "Contains", Params: []string{"haystack", "needle"}},
+}
+
+func (c *containsChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	defer func() {
+		if v := recover(); v != nil {
+			result = false
+			error = fmt.Sprint(v)
+		}
+	}()
+	var haystack interface{} = params[0]
+	var needle interface{} = params[1]
+	switch haystackV := reflect.ValueOf(haystack); haystackV.Kind() {
+	case reflect.Slice, reflect.Array:
+		// Ensure that type of elements in haystack is compatible with needle
+		if needleV := reflect.ValueOf(needle); haystackV.Type().Elem() != needleV.Type() {
+			panic(fmt.Sprintf("haystack contains items of type %s but needle is a %s",
+				haystackV.Type().Elem(), needleV.Type()))
+		}
+		for len, i := haystackV.Len(), 0; i < len; i++ {
+			itemV := haystackV.Index(i)
+			if itemV.Interface() == needle {
+				return true, ""
+			}
+		}
+		return false, ""
+	case reflect.Map:
+		// Ensure that type of elements in haystack is compatible with needle
+		if needleV := reflect.ValueOf(needle); haystackV.Type().Elem() != needleV.Type() {
+			panic(fmt.Sprintf("haystack contains items of type %s but needle is a %s",
+				haystackV.Type().Elem(), needleV.Type()))
+		}
+		for _, keyV := range haystackV.MapKeys() {
+			itemV := haystackV.MapIndex(keyV)
+			if itemV.Interface() == needle {
+				return true, ""
+			}
+		}
+		return false, ""
+	case reflect.String:
+		// When haystack is a string, we expect needle to be a string as well
+		needle := params[1].(string)
+		haystack := params[0].(string)
+		return strings.Contains(haystack, needle), ""
+	default:
+		panic(fmt.Sprintf("haystack is of unsupported type %T", params[0]))
+	}
+}

--- a/testutil/checkers_test.go
+++ b/testutil/checkers_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	. "gopkg.in/check.v1"
+	"testing"
+)
+
+func Test2(t *testing.T) {
+	TestingT(t)
+}
+
+type CheckersSuite struct{}
+
+var _ = Suite(&CheckersSuite{})
+
+func (s *CheckersSuite) TestUnsupportedTypes(c *C) {
+	c.ExpectFailure("haystack is of unsupported type int")
+	c.Assert(5, Contains, "foo")
+}
+
+func (s *CheckersSuite) TestContainsVerifiesTypes(c *C) {
+	c.ExpectFailure("haystack contains items of type int but needle is a string")
+	c.Assert([...]int{1, 2, 3}, Contains, "foo")
+	c.Assert([]int{1, 2, 3}, Contains, "foo")
+	// This looks tricky, Contains looks at _values_, not at keys
+	c.Assert(map[string]int{"foo": 1, "bar": 2}, Contains, "foo")
+}
+
+func (s *CheckersSuite) TestContainsString(c *C) {
+	c.Assert("foo", Contains, "f")
+	c.Assert("foo", Contains, "fo")
+	c.Assert("foo", Not(Contains), "foobar")
+}
+
+func (s *CheckersSuite) TestContainsArray(c *C) {
+	c.Assert([...]int{1, 2, 3}, Contains, 1)
+	c.Assert([...]int{1, 2, 3}, Contains, 2)
+	c.Assert([...]int{1, 2, 3}, Contains, 3)
+	c.Assert([...]int{1, 2, 3}, Not(Contains), 4)
+}
+
+func (s *CheckersSuite) TestContainsSlice(c *C) {
+	c.Assert([]int{1, 2, 3}, Contains, 1)
+	c.Assert([]int{1, 2, 3}, Contains, 2)
+	c.Assert([]int{1, 2, 3}, Contains, 3)
+	c.Assert([]int{1, 2, 3}, Not(Contains), 4)
+}
+
+func (s *CheckersSuite) TestContainsMap(c *C) {
+	c.Assert(map[string]int{"foo": 1, "bar": 2}, Contains, 1)
+	c.Assert(map[string]int{"foo": 1, "bar": 2}, Contains, 2)
+	c.Assert(map[string]int{"foo": 1, "bar": 2}, Not(Contains), 3)
+}


### PR DESCRIPTION
This patch adds a trivial package for snappy capabilities. So far
there's just a set of basic types Capability, CapabilityType, one
function NewCapability and some tests.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>