### PR TITLE
Add the testutil package with the Contains Checker

### DIFF
--- a/testutil/checkers.go
+++ b/testutil/checkers.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"fmt"
+	"gopkg.in/check.v1"
+	"reflect"
+	"strings"
+)
+
+type containsChecker struct {
+	*check.CheckerInfo
+}
+
+// Contains is a Checker that looks for a needle in a haystack.
+// The needle can be any object. The haystack can be an array, slice or string.
+var Contains check.Checker = &containsChecker{
+	&check.CheckerInfo{Name: "Contains", Params: []string{"haystack", "needle"}},
+}
+
+func (c *containsChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	defer func() {
+		if v := recover(); v != nil {
+			result = false
+			error = fmt.Sprint(v)
+		}
+	}()
+	var haystack interface{} = params[0]
+	var needle interface{} = params[1]
+	switch haystackV := reflect.ValueOf(haystack); haystackV.Kind() {
+	case reflect.Slice, reflect.Array:
+		// Ensure that type of elements in haystack is compatible with needle
+		if needleV := reflect.ValueOf(needle); haystackV.Type().Elem() != needleV.Type() {
+			panic(fmt.Sprintf("haystack contains items of type %s but needle is a %s",
+				haystackV.Type().Elem(), needleV.Type()))
+		}
+		for len, i := haystackV.Len(), 0; i < len; i++ {
+			itemV := haystackV.Index(i)
+			if itemV.Interface() == needle {
+				return true, ""
+			}
+		}
+		return false, ""
+	case reflect.Map:
+		// Ensure that type of elements in haystack is compatible with needle
+		if needleV := reflect.ValueOf(needle); haystackV.Type().Elem() != needleV.Type() {
+			panic(fmt.Sprintf("haystack contains items of type %s but needle is a %s",
+				haystackV.Type().Elem(), needleV.Type()))
+		}
+		for _, keyV := range haystackV.MapKeys() {
+			itemV := haystackV.MapIndex(keyV)
+			if itemV.Interface() == needle {
+				return true, ""
+			}
+		}
+		return false, ""
+	case reflect.String:
+		// When haystack is a string, we expect needle to be a string as well
+		needle := params[1].(string)
+		haystack := params[0].(string)
+		return strings.Contains(haystack, needle), ""
+	default:
+		panic(fmt.Sprintf("haystack is of unsupported type %T", params[0]))
+	}
+}

--- a/testutil/checkers_test.go
+++ b/testutil/checkers_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	. "gopkg.in/check.v1"
+	"testing"
+)
+
+func Test2(t *testing.T) {
+	TestingT(t)
+}
+
+type CheckersSuite struct{}
+
+var _ = Suite(&CheckersSuite{})
+
+func (s *CheckersSuite) TestUnsupportedTypes(c *C) {
+	c.ExpectFailure("haystack is of unsupported type int")
+	c.Assert(5, Contains, "foo")
+}
+
+func (s *CheckersSuite) TestContainsVerifiesTypes(c *C) {
+	c.ExpectFailure("haystack contains items of type int but needle is a string")
+	c.Assert([...]int{1, 2, 3}, Contains, "foo")
+	c.Assert([]int{1, 2, 3}, Contains, "foo")
+	// This looks tricky, Contains looks at _values_, not at keys
+	c.Assert(map[string]int{"foo": 1, "bar": 2}, Contains, "foo")
+}
+
+func (s *CheckersSuite) TestContainsString(c *C) {
+	c.Assert("foo", Contains, "f")
+	c.Assert("foo", Contains, "fo")
+	c.Assert("foo", Not(Contains), "foobar")
+}
+
+func (s *CheckersSuite) TestContainsArray(c *C) {
+	c.Assert([...]int{1, 2, 3}, Contains, 1)
+	c.Assert([...]int{1, 2, 3}, Contains, 2)
+	c.Assert([...]int{1, 2, 3}, Contains, 3)
+	c.Assert([...]int{1, 2, 3}, Not(Contains), 4)
+}
+
+func (s *CheckersSuite) TestContainsSlice(c *C) {
+	c.Assert([]int{1, 2, 3}, Contains, 1)
+	c.Assert([]int{1, 2, 3}, Contains, 2)
+	c.Assert([]int{1, 2, 3}, Contains, 3)
+	c.Assert([]int{1, 2, 3}, Not(Contains), 4)
+}
+
+func (s *CheckersSuite) TestContainsMap(c *C) {
+	c.Assert(map[string]int{"foo": 1, "bar": 2}, Contains, 1)
+	c.Assert(map[string]int{"foo": 1, "bar": 2}, Contains, 2)
+	c.Assert(map[string]int{"foo": 1, "bar": 2}, Not(Contains), 3)
+}


### PR DESCRIPTION
This checker is useful for writing tests that work with the three most
primitive collection types, arrays, slices and maps.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>