### PR TITLE
Ignore reboot skips, SetUpTest and TearDownTest on the subunit report of integration tests.

### DIFF
--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -41,6 +41,12 @@ const (
 	BaseAltPartitionPath = "/writable/cache/system"
 	needsRebootFile      = "/tmp/needs-reboot"
 	channelCfgFile       = "/etc/system-image/channel.ini"
+	// FormatSkipDuringReboot is the reason used to skip the pending tests when a test requested
+	// a reboot.
+	FormatSkipDuringReboot = "****** Skipped %s during reboot caused by %s"
+	// FormatSkipAfterReboot is the reason used to skip already ran tests after a reboot requested
+	// by a test.
+	FormatSkipAfterReboot = "****** Skipped %s after reboot caused by %s"
 )
 
 // Cfg is a struct that contains the configuration values passed from the
@@ -97,8 +103,7 @@ func (s *SnappySuite) SetUpTest(c *check.C) {
 	if NeedsReboot() {
 		contents, err := ioutil.ReadFile(needsRebootFile)
 		c.Assert(err, check.IsNil, check.Commentf("Error reading needs-reboot file %v", err))
-		c.Skip(fmt.Sprintf("****** Skipped %s during reboot caused by %s",
-			c.TestName(), contents))
+		c.Skip(fmt.Sprintf(FormatSkipDuringReboot, c.TestName(), contents))
 	} else {
 		if CheckRebootMark("") {
 			c.Logf("****** Running %s", c.TestName())
@@ -107,8 +112,7 @@ func (s *SnappySuite) SetUpTest(c *check.C) {
 			if AfterReboot(c) {
 				c.Logf("****** Resuming %s after reboot", c.TestName())
 			} else {
-				c.Skip(fmt.Sprintf("****** Skipped %s after reboot caused by %s",
-					c.TestName(), os.Getenv("ADT_REBOOT_MARK")))
+				c.Skip(fmt.Sprintf(FormatSkipAfterReboot, c.TestName(), os.Getenv("ADT_REBOOT_MARK")))
 			}
 		}
 	}

--- a/integration-tests/testutils/report/parser.go
+++ b/integration-tests/testutils/report/parser.go
@@ -101,7 +101,7 @@ func (fr *SubunitV2ParserReporter) Write(data []byte) (int, error) {
 		reason := matches[2]
 		// Do not report anything about the set ups skipped because of another test's reboot.
 		ignore, _ := regexp.MatchString(
-			"^\\*\\*\\*\\*\\*\\* Skipped .* during reboot caused by .*$", reason)		
+			"^\\*\\*\\*\\*\\*\\* Skipped .* reboot caused by .*$", reason)
 		if ignore {
 			return 0, nil
 		}

--- a/integration-tests/testutils/report/parser.go
+++ b/integration-tests/testutils/report/parser.go
@@ -89,14 +89,15 @@ func NewSubunitV2ParserReporter(writer io.Writer) *SubunitV2ParserReporter {
 
 func (fr *SubunitV2ParserReporter) Write(data []byte) (int, error) {
 	var err error
+	sdata := string(data)
 
-	if matches := announceRegexp.FindStringSubmatch(string(data)); len(matches) == 2 {
+	if matches := announceRegexp.FindStringSubmatch(sdata); len(matches) == 2 {
 		err = fr.statuser.Status(subunit.Event{TestID: matches[1], Status: "exists"})
-	} else if matches := successRegexp.FindStringSubmatch(string(data)); len(matches) == 2 {
+	} else if matches := successRegexp.FindStringSubmatch(sdata); len(matches) == 2 {
 		err = fr.statuser.Status(subunit.Event{TestID: matches[1], Status: "success"})
-	} else if matches := failureRegexp.FindStringSubmatch(string(data)); len(matches) == 2 {
+	} else if matches := failureRegexp.FindStringSubmatch(sdata); len(matches) == 2 {
 		err = fr.statuser.Status(subunit.Event{TestID: matches[1], Status: "fail"})
-	} else if matches := skipRegexp.FindStringSubmatch(string(data)); len(matches) == 3 {
+	} else if matches := skipRegexp.FindStringSubmatch(sdata); len(matches) == 3 {
 		err = fr.statuser.Status(subunit.Event{
 			TestID:    matches[1],
 			Status:    "skip",

--- a/integration-tests/testutils/report/parser.go
+++ b/integration-tests/testutils/report/parser.go
@@ -108,10 +108,10 @@ func (fr *SubunitV2ParserReporter) Write(data []byte) (int, error) {
 	} else if matches := skipRegexp.FindStringSubmatch(sdata); len(matches) == 3 {
 		reason := matches[2]
 		// Do not report anything about the set ups skipped because of another test's reboot.
-		duringReboot, _ := regexp.MatchString(
+		duringReboot := matchString(
 			fmt.Sprintf(regexp.QuoteMeta(common.FormatSkipDuringReboot), ".*", ".*"),
 			reason)
-		afterReboot, _ := regexp.MatchString(
+		afterReboot := matchString(
 			fmt.Sprintf(regexp.QuoteMeta(common.FormatSkipAfterReboot), ".*", ".*"),
 			reason)
 		if duringReboot || afterReboot {
@@ -133,7 +133,15 @@ func (fr *SubunitV2ParserReporter) Write(data []byte) (int, error) {
 }
 
 func isTest(testID string) bool {
-	matchesSetUp, _ := regexp.MatchString(".*\\.SetUpTest", testID)
-	matchesTearDown, _ := regexp.MatchString(".*\\.TearDownTest", testID)
+	matchesSetUp := matchString(".*\\.SetUpTest", testID)
+	matchesTearDown := matchString(".*\\.TearDownTest", testID)
 	return !matchesSetUp && !matchesTearDown
+}
+
+func matchString(pattern string, s string) bool {
+	matched, err := regexp.MatchString(pattern, s)
+	if err != nil {
+		panic(err)
+	}
+	return matched
 }

--- a/integration-tests/testutils/report/parser_test.go
+++ b/integration-tests/testutils/report/parser_test.go
@@ -113,5 +113,5 @@ func (s *ParserReportSuite) TestParserSendsNothingForRebootSkips(c *check.C) {
 			"****** Skipped testSuite.TestSkip during reboot caused by otherTestSuite.TestWithReboot")))
 	
 	c.Assert(len(s.spy.calls), check.Equals, 0,
-		check.Commentf("Unexpected event sent to subunit: %v", s.spy.calls))	
+		check.Commentf("Unexpected event sent to subunit: %v", s.spy.calls))
 }

--- a/integration-tests/testutils/report/parser_test.go
+++ b/integration-tests/testutils/report/parser_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/testing-cabal/subunit-go"
 	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/common"
 )
 
 var _ = check.Suite(&ParserReportSuite{})
@@ -106,12 +108,14 @@ func (s *ParserReportSuite) TestParserReporterSendsSkipEvent(c *check.C) {
 }
 
 func (s *ParserReportSuite) TestParserSendsNothingForRebootSkips(c *check.C) {
-	s.subject.Write([]byte(
-		fmt.Sprintf("SKIP: /tmp/snappy-tests-job/21647/src/github.com/ubuntu-core/snappy/"+
-			"integration-tests/tests/info_test.go:36: %s (%s)\n",
-			"testSuite.TestSkip",
-			"****** Skipped testSuite.TestSkip during reboot caused by otherTestSuite.TestWithReboot")))
-	
-	c.Assert(len(s.spy.calls), check.Equals, 0,
-		check.Commentf("Unexpected event sent to subunit: %v", s.spy.calls))
+	reasons := []string{common.FormatSkipDuringReboot, common.FormatSkipAfterReboot}
+	for _, reasonFormat := range reasons {
+		reason := fmt.Sprintf(reasonFormat, "testSuite.TestSkip", "otherTestSuite.TestWithReboot")
+		s.subject.Write([]byte(
+			fmt.Sprintf("SKIP: /tmp/snappy-tests-job/21647/src/github.com/ubuntu-core/snappy/"+
+				"integration-tests/tests/info_test.go:36: %s (%s)\n", "testSuite.TestSkip", reason)))
+
+		c.Check(len(s.spy.calls), check.Equals, 0,
+			check.Commentf("Unexpected event sent to subunit: %v", s.spy.calls))
+	}
 }

--- a/integration-tests/testutils/report/parser_test.go
+++ b/integration-tests/testutils/report/parser_test.go
@@ -23,6 +23,7 @@ package report
 import (
 	"bytes"
 	"fmt"
+	"regexp/syntax"
 
 	"github.com/testing-cabal/subunit-go"
 	"gopkg.in/check.v1"
@@ -125,4 +126,15 @@ func (s *ParserReportSuite) TestParserSendsNothingForSetUpAndTearDown(c *check.C
 		c.Check(len(s.spy.calls), check.Equals, 0,
 			check.Commentf("Unexpected event sent to subunit: %v", s.spy.calls))
 	}
+}
+
+var _ = check.Suite(&ParserHelpersSuite{})
+
+type ParserHelpersSuite struct{}
+
+func (s *ParserHelpersSuite) TestMatchStringPanicsWithBadPatter(c *check.C) {
+	c.Assert(func() { matchString("*", "dummy") }, check.Panics,
+		&syntax.Error{
+			Code: syntax.ErrMissingRepeatArgument,
+			Expr: "*"})
 }

--- a/integration-tests/testutils/report/parser_test.go
+++ b/integration-tests/testutils/report/parser_test.go
@@ -104,3 +104,14 @@ func (s *ParserReportSuite) TestParserReporterSendsSkipEvent(c *check.C) {
 	c.Check(event.FileName, check.Equals, "reason")
 	c.Check(string(event.FileBytes), check.Equals, skipReason)
 }
+
+func (s *ParserReportSuite) TestParserSendsNothingForRebootSkips(c *check.C) {
+	s.subject.Write([]byte(
+		fmt.Sprintf("SKIP: /tmp/snappy-tests-job/21647/src/github.com/ubuntu-core/snappy/"+
+			"integration-tests/tests/info_test.go:36: %s (%s)\n",
+			"testSuite.TestSkip",
+			"****** Skipped testSuite.TestSkip during reboot caused by otherTestSuite.TestWithReboot")))
+	
+	c.Assert(len(s.spy.calls), check.Equals, 0,
+		check.Commentf("Unexpected event sent to subunit: %v", s.spy.calls))	
+}


### PR DESCRIPTION
When a test requests a reboot, all the remaining tests to run check on their set up if a reboot was requested and skip themselves. Also after the reboot, all the tests that already ran do the same check and skip themselves.
This skips must be ignored on the subunit report of the executed tests.