### PR TITLE
make run-hooks run before firstboot

### DIFF
--- a/debian/ubuntu-snappy.run-hooks.service
+++ b/debian/ubuntu-snappy.run-hooks.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Run snappy compatibility hooks
-After=ubuntu-snappy.firstboot.service
+After=local-fs.target
+Before=ubuntu-snappy.firstboot.service
+DefaultDependencies=false
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
If the oem package has configuration for preinstalled packages, firstboot will attempt to apply that configuration. Run-hooks creates the apparmor profiles under which those configuration hooks need to run, so it needs to run before them.

This fixes lp:1511435.