### PR TITLE
Need "lsb-release" for the postinst of "ubuntu-snappy-cli".

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -55,7 +55,7 @@ Description: System components for Ubuntu Core Snappy.
 
 Package: ubuntu-snappy-cli
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, lsb-release
 Replaces: ubuntu-core-snappy (<< 0.2~ppa90)
 Breaks: ubuntu-core-snappy (<< 0.2~ppa90)
 Conflicts: snappy


### PR DESCRIPTION
While `lsb-release` is probably installed on most systems, it should be mentioned in `Depends` as it is used in the `postinst` script of `ubuntu-snappy-cli`.