### PR TITLE
Reset locale for testing

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -1,5 +1,6 @@
 #!/bin/sh
-
+export LANG=C.UTF-8
+export LANGUAGE=en
 set -eu
 
 if which goctest >/dev/null; then


### PR DESCRIPTION
This patch resets LANG and LANGUAGE to predictable good value that
ensure tests don't choke on some localized output.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>