### PR TITLE
Also ignore the test events for tests in the reboot process.

### DIFF
--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -40,8 +40,8 @@ const (
 	// BaseAltPartitionPath is the path to the B system partition.
 	BaseAltPartitionPath = "/writable/cache/system"
 	// NeedsRebootFile is the file that a test writes in order to request a reboot.
-	NeedsRebootFile      = "/tmp/needs-reboot"
-	channelCfgFile       = "/etc/system-image/channel.ini"
+	NeedsRebootFile = "/tmp/needs-reboot"
+	channelCfgFile  = "/etc/system-image/channel.ini"
 	// FormatSkipDuringReboot is the reason used to skip the pending tests when a test requested
 	// a reboot.
 	FormatSkipDuringReboot = "****** Skipped %s during reboot caused by %s"

--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -39,7 +39,8 @@ import (
 const (
 	// BaseAltPartitionPath is the path to the B system partition.
 	BaseAltPartitionPath = "/writable/cache/system"
-	needsRebootFile      = "/tmp/needs-reboot"
+	// NeedsRebootFile is the file that a test writes in order to request a reboot.
+	NeedsRebootFile      = "/tmp/needs-reboot"
 	channelCfgFile       = "/etc/system-image/channel.ini"
 	// FormatSkipDuringReboot is the reason used to skip the pending tests when a test requested
 	// a reboot.
@@ -101,7 +102,7 @@ func (s *SnappySuite) SetUpSuite(c *check.C) {
 // test bed was rebooted, it will resume the test that requested the reboot.
 func (s *SnappySuite) SetUpTest(c *check.C) {
 	if NeedsReboot() {
-		contents, err := ioutil.ReadFile(needsRebootFile)
+		contents, err := ioutil.ReadFile(NeedsRebootFile)
 		c.Assert(err, check.IsNil, check.Commentf("Error reading needs-reboot file %v", err))
 		c.Skip(fmt.Sprintf(FormatSkipDuringReboot, c.TestName(), contents))
 	} else {
@@ -249,13 +250,13 @@ func Reboot(c *check.C) {
 // RebootWithMark requests a reboot using a specified mark.
 func RebootWithMark(c *check.C, mark string) {
 	c.Log("Preparing reboot with mark " + mark)
-	err := ioutil.WriteFile(needsRebootFile, []byte(mark), 0777)
+	err := ioutil.WriteFile(NeedsRebootFile, []byte(mark), 0777)
 	c.Assert(err, check.IsNil, check.Commentf("Error writing needs-reboot file: %v", err))
 }
 
 // NeedsReboot returns True if a reboot has been requested by a test.
 func NeedsReboot() bool {
-	_, err := os.Stat(needsRebootFile)
+	_, err := os.Stat(NeedsRebootFile)
 	return err == nil
 }
 

--- a/integration-tests/testutils/report/parser.go
+++ b/integration-tests/testutils/report/parser.go
@@ -95,12 +95,12 @@ func (fr *SubunitV2ParserReporter) Write(data []byte) (int, error) {
 
 	if matches := announceRegexp.FindStringSubmatch(sdata); len(matches) == 2 {
 		testID := matches[1]
-		if isTest(testID) {
+		if isTest(testID) && !common.IsInRebootProcess() {
 			err = fr.statuser.Status(subunit.Event{TestID: matches[1], Status: "exists"})
 		}
 	} else if matches := successRegexp.FindStringSubmatch(sdata); len(matches) == 2 {
 		testID := matches[1]
-		if isTest(testID) {
+		if isTest(testID) && !common.IsInRebootProcess() {
 			err = fr.statuser.Status(subunit.Event{TestID: matches[1], Status: "success"})
 		}
 	} else if matches := failureRegexp.FindStringSubmatch(sdata); len(matches) == 2 {

--- a/integration-tests/testutils/report/parser_test.go
+++ b/integration-tests/testutils/report/parser_test.go
@@ -135,9 +135,9 @@ func (s *ParserReportSuite) TestParserSendsNothingForTestsAfterReboot(c *check.C
 	defer os.Setenv("ADT_REBOOT_MARK", "")
 	ignoreTests := []string{
 		"****** Running testSuite.TestSomething\n",
-		"PASS: /dummy/path:34: testSuite.TestSomething      0.005s\n",		
+		"PASS: /dummy/path:34: testSuite.TestSomething      0.005s\n",
 	}
-	for _, gocheckOutput := range ignoreTests{
+	for _, gocheckOutput := range ignoreTests {
 		s.spy.calls = []subunit.Event{}
 		s.subject.Write([]byte(gocheckOutput))
 
@@ -150,12 +150,12 @@ func (s *ParserReportSuite) TestParserSendsNothingForTestsDuringReboot(c *check.
 	err := ioutil.WriteFile(common.NeedsRebootFile, []byte("rebooting"), 0777)
 	c.Assert(err, check.IsNil, check.Commentf("Error writing the reboot file: %v", err))
 	defer os.Remove(common.NeedsRebootFile)
-	
+
 	ignoreTests := []string{
 		"****** Running testSuite.TestSomething\n",
-		"PASS: /dummy/path:34: testSuite.TestSomething      0.005s\n",		
+		"PASS: /dummy/path:34: testSuite.TestSomething      0.005s\n",
 	}
-	for _, gocheckOutput := range ignoreTests{
+	for _, gocheckOutput := range ignoreTests {
 		s.spy.calls = []subunit.Event{}
 		s.subject.Write([]byte(gocheckOutput))
 

--- a/integration-tests/testutils/report/parser_test.go
+++ b/integration-tests/testutils/report/parser_test.go
@@ -23,6 +23,8 @@ package report
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"regexp/syntax"
 
 	"github.com/testing-cabal/subunit-go"
@@ -120,6 +122,40 @@ func (s *ParserReportSuite) TestParserSendsNothingForSetUpAndTearDown(c *check.C
 			"SKIP: /dummy/path:36: %s (%s)\n", "testSuite.TestSkip", common.FormatSkipAfterReboot),
 	}
 	for _, gocheckOutput := range ignoreTests {
+		s.spy.calls = []subunit.Event{}
+		s.subject.Write([]byte(gocheckOutput))
+
+		c.Check(len(s.spy.calls), check.Equals, 0,
+			check.Commentf("Unexpected event sent to subunit: %v", s.spy.calls))
+	}
+}
+
+func (s *ParserReportSuite) TestParserSendsNothingForTestsAfterReboot(c *check.C) {
+	os.Setenv("ADT_REBOOT_MARK", "rebooting")
+	defer os.Setenv("ADT_REBOOT_MARK", "")
+	ignoreTests := []string{
+		"****** Running testSuite.TestSomething\n",
+		"PASS: /dummy/path:34: testSuite.TestSomething      0.005s\n",		
+	}
+	for _, gocheckOutput := range ignoreTests{
+		s.spy.calls = []subunit.Event{}
+		s.subject.Write([]byte(gocheckOutput))
+
+		c.Check(len(s.spy.calls), check.Equals, 0,
+			check.Commentf("Unexpected event sent to subunit: %v", s.spy.calls))
+	}
+}
+
+func (s *ParserReportSuite) TestParserSendsNothingForTestsDuringReboot(c *check.C) {
+	err := ioutil.WriteFile(common.NeedsRebootFile, []byte("rebooting"), 0777)
+	c.Assert(err, check.IsNil, check.Commentf("Error writing the reboot file: %v", err))
+	defer os.Remove(common.NeedsRebootFile)
+	
+	ignoreTests := []string{
+		"****** Running testSuite.TestSomething\n",
+		"PASS: /dummy/path:34: testSuite.TestSomething      0.005s\n",		
+	}
+	for _, gocheckOutput := range ignoreTests{
 		s.spy.calls = []subunit.Event{}
 		s.subject.Write([]byte(gocheckOutput))
 


### PR DESCRIPTION
When a tests requests a reboot, it will finish successfully, reboot the machine and restart.
So we have to ignore that first success message on the subunit report, and wait for the real status when no reboot is in progress.