### PR TITLE
On integration tests, check IsInRebootProcess.

### DIFF
--- a/integration-tests/tests/service_test.go
+++ b/integration-tests/tests/service_test.go
@@ -41,7 +41,7 @@ type serviceSuite struct {
 }
 
 func (s *serviceSuite) TearDownTest(c *check.C) {
-	if !common.NeedsReboot() && common.CheckRebootMark("") {
+	if !common.IsInRebootProcess() {
 		common.RemoveSnap(c, data.BasicServiceSnapName)
 	}
 	// run cleanup last

--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -124,7 +124,7 @@ func (s *SnappySuite) SetUpTest(c *check.C) {
 // the test.
 // It also runs the cleanup handlers
 func (s *SnappySuite) TearDownTest(c *check.C) {
-	if !NeedsReboot() && CheckRebootMark("") {
+	if !IsInRebootProcess() {
 		// Only restore the channel config files if the reboot has been handled.
 		m := make(map[string]string)
 		m[channelCfgBackupFile()] = "/"


### PR DESCRIPTION
Tiny branch that updates a couple of checks on the integration tests that need to execute only if no test has requested a reboot and any requested reboots have been handled.