### PR TITLE
Fixed the integration fake update tests for uboot. 

### DIFF
--- a/integration-tests/tests/failover_zero_size_file_test.go
+++ b/integration-tests/tests/failover_zero_size_file_test.go
@@ -59,7 +59,7 @@ func (zeroSizeInitrd) set(c *check.C) {
 	c.Assert(err, check.IsNil, check.Commentf("Error getting the boot system: %s", err))
 	dir := partition.BootDir(boot)
 
-	bootFileNamePattern := newKernelFilenamePattern(c, boot, true)
+	bootFileNamePattern := newKernelFilenamePattern(c, boot)
 	commonSet(c, dir, bootFileNamePattern, initrdFilename)
 }
 
@@ -68,7 +68,7 @@ func (zeroSizeInitrd) unset(c *check.C) {
 	c.Assert(err, check.IsNil, check.Commentf("Error getting the boot system: %s", err))
 	dir := partition.BootDir(boot)
 
-	bootFileNamePattern := newKernelFilenamePattern(c, boot, false)
+	bootFileNamePattern := newKernelFilenamePattern(c, boot)
 	commonUnset(c, dir, bootFileNamePattern, initrdFilename)
 }
 
@@ -146,19 +146,11 @@ func getSingleFilename(c *check.C, pattern string) string {
 // and this function would return "b/%s%s*"
 // If we are not in an update process (ie. we are unsetting the failover conditions)
 // we want to change the files in the other partition
-func newKernelFilenamePattern(c *check.C, bootSystem string, afterUpdate bool) string {
-	var part string
-	var err error
-	if afterUpdate {
-		part, err = partition.NextBootPartition()
-		c.Assert(err, check.IsNil,
-			check.Commentf("Error getting the next boot partition: %s", err))
-	} else {
-		part, err = partition.CurrentPartition()
-		c.Assert(err, check.IsNil,
-			check.Commentf("Error getting the current partition: %s", err))
-		part = partition.OtherPartition(part)
-	}
+func newKernelFilenamePattern(c *check.C, bootSystem string) string {
+	part, err := partition.CurrentPartition()
+	c.Assert(err, check.IsNil,
+		check.Commentf("Error getting the current partition: %s", err))
+	part = partition.OtherPartition(part)
 	return filepath.Join(part, "%s%s*")
 }
 

--- a/integration-tests/testutils/partition/bootloader.go
+++ b/integration-tests/testutils/partition/bootloader.go
@@ -74,32 +74,19 @@ func BootDir(bootSystem string) string {
 // if we are upgrading. In grub systems it is the partition pointed in the boot
 // config file. For uboot systems the boot config file does not change, so that
 // we take the other partition in that case
-func NextBootPartition() (partition string, err error) {
+func NextBootPartition() (string, error) {
 	m, err := Mode()
 	if err != nil {
-		return
+		return "", err
 	}
 	if m != "try" {
 		return "", errors.New("Snappy is not in try mode")
 	}
 	snappyab, err := confValue("snappy_ab")
-	if err != nil || snappyab == "" {
-		return
-	}
-	system, err := BootSystem()
 	if err != nil {
-		return
+		return "", err
 	}
-	if system == "grub" {
-		// in grub based systems, the boot config file is changed before
-		// the update has been applied
-		partition = snappyab
-	} else {
-		// in uboot based systems, the boot config file is not changed until
-		// the update has been applied
-		partition = OtherPartition(snappyab)
-	}
-	return
+	return snappyab, nil
 }
 
 // Mode returns the current bootloader mode, regular or try.
@@ -178,16 +165,7 @@ func CurrentPartition() (partition string, err error) {
 		return
 	}
 	if m == "try" {
-		var system string
-		system, err = BootSystem()
-		if err != nil {
-			return
-		}
-		if system == "grub" {
-			// in grub based systems, the boot config file is changed before
-			// the update has been applied
-			partition = OtherPartition(partition)
-		}
+		partition = OtherPartition(partition)
 	}
 	return
 }

--- a/integration-tests/testutils/partition/bootloader.go
+++ b/integration-tests/testutils/partition/bootloader.go
@@ -46,7 +46,7 @@ var (
 	BootSystem = bootSystem
 
 	confValue = getConfValue
-	
+
 	configFiles = map[string]string{"uboot": ubootConfigFile, "grub": grubConfigFile}
 )
 

--- a/integration-tests/testutils/partition/bootloader_test.go
+++ b/integration-tests/testutils/partition/bootloader_test.go
@@ -105,7 +105,7 @@ func (s *bootloaderTestSuite) TestBootSystemCallsFilepathGlob(c *check.C) {
 
 	p := bootBase + "/grub"
 	calls := s.filepathGlobCalls[p]
-	
+
 	c.Assert(calls, check.Equals, 1,
 		check.Commentf("Expected calls to filepath.Glob with path %s to be 1, %d found", p, calls))
 }
@@ -135,7 +135,7 @@ func (s *bootloaderTestSuite) TestNextBootPartitionReturnsBootSystemError(c *che
 		"snappy_mode": "try",
 		"snappy_ab":   "dummy",
 	}
-	
+
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
 	expectedErr := fmt.Errorf("Error from BootSystem!")
@@ -151,7 +151,7 @@ func (s *bootloaderTestSuite) TestNextBootPartitionReturnsBootSystemError(c *che
 
 func (s *bootloaderTestSuite) TestNextBootPartitionReturnsEmptyIfPatternsNotFound(c *check.C) {
 	s.fakeConf = map[string]string{"snappy_mode": "try"}
-	
+
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
 	BootSystem = func() (system string, err error) {
@@ -168,7 +168,7 @@ func (s *bootloaderTestSuite) TestNextBootPartitionReturnsEmptyIfPatternsNotFoun
 func (s *bootloaderTestSuite) TestNextBootPartitionReturnsSamePartitionForGrub(c *check.C) {
 	s.fakeConf = map[string]string{
 		"snappy_mode": "try",
-		"snappy_ab":    "a",
+		"snappy_ab":   "a",
 	}
 
 	backBootSystem := BootSystem
@@ -249,7 +249,7 @@ func (s *bootloaderTestSuite) TestCurrentPartitionOnTryModeReturnsOtherPartition
 		"snappy_mode": "try",
 		"snappy_ab":   "a",
 	}
-	
+
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
 	BootSystem = func() (system string, err error) {

--- a/integration-tests/testutils/partition/bootloader_test.go
+++ b/integration-tests/testutils/partition/bootloader_test.go
@@ -130,25 +130,6 @@ func (s *bootloaderTestSuite) TestBootSystemForUBoot(c *check.C) {
 		check.Commentf("Expected uboot boot system not found, %s", bootSystem))
 }
 
-func (s *bootloaderTestSuite) TestNextBootPartitionReturnsBootSystemError(c *check.C) {
-	s.fakeConf = map[string]string{
-		"snappy_mode": "try",
-		"snappy_ab":   "dummy",
-	}
-
-	backBootSystem := BootSystem
-	defer func() { BootSystem = backBootSystem }()
-	expectedErr := fmt.Errorf("Error from BootSystem!")
-	BootSystem = func() (system string, err error) {
-		return "", expectedErr
-	}
-
-	_, err := NextBootPartition()
-
-	c.Assert(err, check.Equals, expectedErr,
-		check.Commentf("Expected error %v not found, %v", expectedErr, err))
-}
-
 func (s *bootloaderTestSuite) TestNextBootPartitionReturnsEmptyIfPatternsNotFound(c *check.C) {
 	s.fakeConf = map[string]string{"snappy_mode": "try"}
 
@@ -165,16 +146,10 @@ func (s *bootloaderTestSuite) TestNextBootPartitionReturnsEmptyIfPatternsNotFoun
 		check.Commentf("NextBootPartition %s, expected empty", partition))
 }
 
-func (s *bootloaderTestSuite) TestNextBootPartitionReturnsSamePartitionForGrub(c *check.C) {
+func (s *bootloaderTestSuite) TestNextBootPartitionAfterUpdateReturnsSamePartition(c *check.C) {
 	s.fakeConf = map[string]string{
 		"snappy_mode": "try",
 		"snappy_ab":   "a",
-	}
-
-	backBootSystem := BootSystem
-	defer func() { BootSystem = backBootSystem }()
-	BootSystem = func() (system string, err error) {
-		return "grub", nil
 	}
 
 	partition, err := NextBootPartition()
@@ -182,25 +157,6 @@ func (s *bootloaderTestSuite) TestNextBootPartitionReturnsSamePartitionForGrub(c
 	c.Assert(err, check.IsNil, check.Commentf("Unexpected error %v", err))
 	c.Assert(partition, check.Equals, "a",
 		check.Commentf("NextBootPartition %s, expected a", partition))
-}
-
-func (s *bootloaderTestSuite) TestNextBootPartitionReturnsOtherPartitionForUBoot(c *check.C) {
-	s.fakeConf = map[string]string{
-		"snappy_mode": "try",
-		"snappy_ab":   "a",
-	}
-
-	backBootSystem := BootSystem
-	defer func() { BootSystem = backBootSystem }()
-	BootSystem = func() (system string, err error) {
-		return "uboot", nil
-	}
-
-	partition, err := NextBootPartition()
-
-	c.Assert(err, check.IsNil, check.Commentf("Unexpected error %v", err))
-	c.Assert(partition, check.Equals, "b",
-		check.Commentf("NextBootPartition %s, expected b", partition))
 }
 
 func (s *bootloaderTestSuite) TestModeReturnsSnappyModeFromConf(c *check.C) {
@@ -226,34 +182,10 @@ func (s *bootloaderTestSuite) TestCurrentPartitionNotOnTryMode(c *check.C) {
 	c.Assert(part, check.Equals, "test_partition", check.Commentf("Wrong partition"))
 }
 
-func (s *bootloaderTestSuite) TestCurrentPartitionOnTryModeReturnsSamePartitionForUboot(c *check.C) {
+func (s *bootloaderTestSuite) TestCurrentPartitionOnTryModeReturnsOtherPartition(c *check.C) {
 	s.fakeConf = map[string]string{
 		"snappy_mode": "try",
 		"snappy_ab":   "a",
-	}
-
-	backBootSystem := BootSystem
-	defer func() { BootSystem = backBootSystem }()
-	BootSystem = func() (system string, err error) {
-		return "uboot", nil
-	}
-
-	mode, err := CurrentPartition()
-
-	c.Assert(err, check.IsNil, check.Commentf("Unexpected error %v", err))
-	c.Assert(mode, check.Equals, "a", check.Commentf("Wrong partition"))
-}
-
-func (s *bootloaderTestSuite) TestCurrentPartitionOnTryModeReturnsOtherPartitionForGrub(c *check.C) {
-	s.fakeConf = map[string]string{
-		"snappy_mode": "try",
-		"snappy_ab":   "a",
-	}
-
-	backBootSystem := BootSystem
-	defer func() { BootSystem = backBootSystem }()
-	BootSystem = func() (system string, err error) {
-		return "grub", nil
 	}
 
 	mode, err := CurrentPartition()

--- a/integration-tests/testutils/partition/bootloader_test.go
+++ b/integration-tests/testutils/partition/bootloader_test.go
@@ -24,8 +24,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
+	"github.com/mvo5/uboot-go/uenv"
 	"gopkg.in/check.v1"
 )
 
@@ -37,31 +39,33 @@ type bootloaderTestSuite struct {
 	backFilepathGlob         func(string) ([]string, error)
 	filepathGlobFail         bool
 	filepathGlobReturnValues []string
+	backConfValue            func(string) (string, error)
+	fakeConf                 map[string]string
 }
 
 var _ = check.Suite(&bootloaderTestSuite{})
 
-func createConfigFile(c *check.C, contents string) (name string) {
-	file, _ := ioutil.TempFile("", "snappy-bootloader-test")
-	err := ioutil.WriteFile(file.Name(), []byte(contents), 0644)
-	c.Assert(err, check.IsNil, check.Commentf("Error writing test bootloader file"))
-
-	return file.Name()
-}
-
 func (s *bootloaderTestSuite) SetUpSuite(c *check.C) {
 	s.backFilepathGlob = filepathGlob
 	filepathGlob = s.fakeFilepathGlob
+	s.backConfValue = confValue
+	confValue = s.fakeConfValue
+	s.fakeConf = map[string]string{}
 }
 
 func (s *bootloaderTestSuite) TearDownSuite(c *check.C) {
 	filepathGlob = s.backFilepathGlob
+	confValue = s.backConfValue
 }
 
 func (s *bootloaderTestSuite) SetUpTest(c *check.C) {
 	s.filepathGlobCalls = make(map[string]int)
 	s.filepathGlobFail = false
 	s.filepathGlobReturnValues = nil
+}
+
+func (s *bootloaderTestSuite) fakeConfValue(key string) (string, error) {
+	return s.fakeConf[key], nil
 }
 
 func (s *bootloaderTestSuite) fakeFilepathGlob(path string) (matches []string, err error) {
@@ -99,11 +103,11 @@ func (s *bootloaderTestSuite) TestBootSystemReturnsGlobError(c *check.C) {
 func (s *bootloaderTestSuite) TestBootSystemCallsFilepathGlob(c *check.C) {
 	BootSystem()
 
-	path := bootBase + "/grub"
-	calls := s.filepathGlobCalls[path]
-
+	p := bootBase + "/grub"
+	calls := s.filepathGlobCalls[p]
+	
 	c.Assert(calls, check.Equals, 1,
-		check.Commentf("Expected calls to filepath.Glob with path %s to be 1, %d found", path, calls))
+		check.Commentf("Expected calls to filepath.Glob with path %s to be 1, %d found", p, calls))
 }
 
 func (s *bootloaderTestSuite) TestBootSystemForGrub(c *check.C) {
@@ -127,6 +131,11 @@ func (s *bootloaderTestSuite) TestBootSystemForUBoot(c *check.C) {
 }
 
 func (s *bootloaderTestSuite) TestNextBootPartitionReturnsBootSystemError(c *check.C) {
+	s.fakeConf = map[string]string{
+		"snappy_mode": "try",
+		"snappy_ab":   "dummy",
+	}
+	
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
 	expectedErr := fmt.Errorf("Error from BootSystem!")
@@ -140,31 +149,9 @@ func (s *bootloaderTestSuite) TestNextBootPartitionReturnsBootSystemError(c *che
 		check.Commentf("Expected error %v not found, %v", expectedErr, err))
 }
 
-func (s *bootloaderTestSuite) TestNextBootPartitionReturnsOsOpenError(c *check.C) {
-	backBootSystem := BootSystem
-	defer func() { BootSystem = backBootSystem }()
-	BootSystem = func() (system string, err error) {
-		return "not-expected-system", nil
-	}
-
-	backConfigFiles := configFiles
-	defer func() { configFiles = backConfigFiles }()
-	configFiles = map[string]string{"not-expected-system": "not-a-file"}
-
-	_, err := NextBootPartition()
-
-	c.Assert(err, check.FitsTypeOf, &os.PathError{},
-		check.Commentf("Expected error type *os.PathError not found, %T", err))
-}
-
 func (s *bootloaderTestSuite) TestNextBootPartitionReturnsEmptyIfPatternsNotFound(c *check.C) {
-	cfgFile := createConfigFile(c, "snappy_mode=try")
-	defer os.Remove(cfgFile)
-
-	backConfigFiles := configFiles
-	defer func() { configFiles = backConfigFiles }()
-	configFiles = map[string]string{"test-system": cfgFile}
-
+	s.fakeConf = map[string]string{"snappy_mode": "try"}
+	
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
 	BootSystem = func() (system string, err error) {
@@ -179,16 +166,10 @@ func (s *bootloaderTestSuite) TestNextBootPartitionReturnsEmptyIfPatternsNotFoun
 }
 
 func (s *bootloaderTestSuite) TestNextBootPartitionReturnsSamePartitionForGrub(c *check.C) {
-	cfgFileContents := `blabla
-snappy_mode=try
-snappy_ab=a
-blabla`
-	cfgFile := createConfigFile(c, cfgFileContents)
-	defer os.Remove(cfgFile)
-
-	backConfigFiles := configFiles
-	defer func() { configFiles = backConfigFiles }()
-	configFiles = map[string]string{"grub": cfgFile}
+	s.fakeConf = map[string]string{
+		"snappy_mode": "try",
+		"snappy_ab":    "a",
+	}
 
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
@@ -204,16 +185,10 @@ blabla`
 }
 
 func (s *bootloaderTestSuite) TestNextBootPartitionReturnsOtherPartitionForUBoot(c *check.C) {
-	cfgFileContents := `blabla
-snappy_mode=try
-snappy_ab=a
-blabla`
-	cfgFile := createConfigFile(c, cfgFileContents)
-	defer os.Remove(cfgFile)
-
-	backConfigFiles := configFiles
-	defer func() { configFiles = backConfigFiles }()
-	configFiles = map[string]string{"uboot": cfgFile}
+	s.fakeConf = map[string]string{
+		"snappy_mode": "try",
+		"snappy_ab":   "a",
+	}
 
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
@@ -229,20 +204,8 @@ blabla`
 }
 
 func (s *bootloaderTestSuite) TestModeReturnsSnappyModeFromConf(c *check.C) {
-	cfgFileContents := `blabla
-snappy_mode=test_mode
-blabla`
-	cfgFile := createConfigFile(c, cfgFileContents)
-	defer os.Remove(cfgFile)
-
-	backConfigFiles := configFiles
-	defer func() { configFiles = backConfigFiles }()
-	configFiles = map[string]string{"test-system": cfgFile}
-
-	backBootSystem := BootSystem
-	defer func() { BootSystem = backBootSystem }()
-	BootSystem = func() (system string, err error) {
-		return "test-system", nil
+	s.fakeConf = map[string]string{
+		"snappy_mode": "test_mode",
 	}
 
 	mode, err := Mode()
@@ -252,40 +215,22 @@ blabla`
 }
 
 func (s *bootloaderTestSuite) TestCurrentPartitionNotOnTryMode(c *check.C) {
-	cfgFileContents := `blabla
-snappy_mode=nottry
-snappy_ab=test_partition
-blabla`
-	cfgFile := createConfigFile(c, cfgFileContents)
-	defer os.Remove(cfgFile)
-
-	backConfigFiles := configFiles
-	defer func() { configFiles = backConfigFiles }()
-	configFiles = map[string]string{"test-system": cfgFile}
-
-	backBootSystem := BootSystem
-	defer func() { BootSystem = backBootSystem }()
-	BootSystem = func() (system string, err error) {
-		return "test-system", nil
+	s.fakeConf = map[string]string{
+		"snappy_mode": "not_try",
+		"snappy_ab":   "test_partition",
 	}
 
-	mode, err := CurrentPartition()
+	part, err := CurrentPartition()
 
 	c.Assert(err, check.IsNil, check.Commentf("Unexpected error %v", err))
-	c.Assert(mode, check.Equals, "test_partition", check.Commentf("Wrong partition"))
+	c.Assert(part, check.Equals, "test_partition", check.Commentf("Wrong partition"))
 }
 
 func (s *bootloaderTestSuite) TestCurrentPartitionOnTryModeReturnsSamePartitionForUboot(c *check.C) {
-	cfgFileContents := `blabla
-snappy_mode=try
-snappy_ab=a
-blabla`
-	cfgFile := createConfigFile(c, cfgFileContents)
-	defer os.Remove(cfgFile)
-
-	backConfigFiles := configFiles
-	defer func() { configFiles = backConfigFiles }()
-	configFiles = map[string]string{"uboot": cfgFile}
+	s.fakeConf = map[string]string{
+		"snappy_mode": "try",
+		"snappy_ab":   "a",
+	}
 
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
@@ -299,18 +244,12 @@ blabla`
 	c.Assert(mode, check.Equals, "a", check.Commentf("Wrong partition"))
 }
 
-func (s *bootloaderTestSuite) TestCurrentPartitionOnTryModeReturnsOtherPartitionForUboot(c *check.C) {
-	cfgFileContents := `blabla
-snappy_mode=try
-snappy_ab=a
-blabla`
-	cfgFile := createConfigFile(c, cfgFileContents)
-	defer os.Remove(cfgFile)
-
-	backConfigFiles := configFiles
-	defer func() { configFiles = backConfigFiles }()
-	configFiles = map[string]string{"grub": cfgFile}
-
+func (s *bootloaderTestSuite) TestCurrentPartitionOnTryModeReturnsOtherPartitionForGrub(c *check.C) {
+	s.fakeConf = map[string]string{
+		"snappy_mode": "try",
+		"snappy_ab":   "a",
+	}
+	
 	backBootSystem := BootSystem
 	defer func() { BootSystem = backBootSystem }()
 	BootSystem = func() (system string, err error) {
@@ -321,4 +260,80 @@ blabla`
 
 	c.Assert(err, check.IsNil, check.Commentf("Unexpected error %v", err))
 	c.Assert(mode, check.Equals, "b", check.Commentf("Wrong partition"))
+}
+
+type confTestSuite struct {
+	backBootSystem  func() (string, error)
+	system          string
+	backConfigFiles map[string]string
+}
+
+var _ = check.Suite(&confTestSuite{})
+
+func (s *confTestSuite) SetUpSuite(c *check.C) {
+	s.backBootSystem = BootSystem
+	BootSystem = s.fakeBootSystem
+	s.backConfigFiles = configFiles
+}
+
+func (s *confTestSuite) fakeBootSystem() (system string, err error) {
+	return s.system, nil
+}
+
+func (s *confTestSuite) TearDownSuite(c *check.C) {
+	BootSystem = s.backBootSystem
+	configFiles = s.backConfigFiles
+}
+
+func createConfigFile(c *check.C, system string, contents map[string]string) (name string) {
+	if system == "grub" {
+		name = createGrubConfigFile(c, contents)
+	} else if system == "uboot" {
+		name = createUbootConfigFile(c, contents)
+	}
+	return
+}
+
+func createGrubConfigFile(c *check.C, contents map[string]string) (name string) {
+	var contentsStr string
+	for key, value := range contents {
+		contentsStr += fmt.Sprintf("%s=%s\n", key, value)
+	}
+	file, err := ioutil.TempFile("", "snappy-grub-test")
+	c.Assert(err, check.IsNil, check.Commentf("Error creating temp file: %s", err))
+	err = ioutil.WriteFile(file.Name(), []byte(contentsStr), 0644)
+	c.Assert(err, check.IsNil, check.Commentf("Error writing test bootloader file: %s", err))
+
+	return file.Name()
+}
+
+func createUbootConfigFile(c *check.C, contents map[string]string) (name string) {
+	tmpDir, err := ioutil.TempDir("", "snappy-uboot-test")
+	c.Assert(err, check.IsNil, check.Commentf("Error creating temp dir: %s", err))
+	fileName := path.Join(tmpDir, "uboot.env")
+	env, err := uenv.Create(fileName, 4096)
+	c.Assert(err, check.IsNil, check.Commentf("Error creating the uboot env file: %s", err))
+	for key, value := range contents {
+		env.Set(key, value)
+	}
+	err = env.Save()
+	c.Assert(err, check.IsNil, check.Commentf("Error saving the uboot env file: %s", err))
+	return fileName
+}
+
+func (s *confTestSuite) TestGetConfValue(c *check.C) {
+	for _, s.system = range []string{"grub", "uboot"} {
+		cfgFileContents := map[string]string{
+			"blabla1": "bla",
+			"testkey": "testvalue",
+			"blabla2": "bla",
+		}
+		cfgFile := createConfigFile(c, s.system, cfgFileContents)
+		defer os.Remove(cfgFile)
+		configFiles = map[string]string{s.system: cfgFile}
+
+		value, err := confValue("testkey")
+		c.Check(err, check.IsNil, check.Commentf("Error getting configuration value: %s", err))
+		c.Check(value, check.Equals, "testvalue", check.Commentf("Wrong configuration value"))
+	}
 }

--- a/integration-tests/testutils/partition/partition_test.go
+++ b/integration-tests/testutils/partition/partition_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	testPath        = "mypath"
+	testPath    = "mypath"
 	writableCmd = "sudo mount -o remount,rw " + testPath
 	readonlyCmd = "sudo mount -o remount,ro " + testPath
 	waitCmd     = lsofNotBeingWritten

--- a/integration-tests/testutils/partition/partition_test.go
+++ b/integration-tests/testutils/partition/partition_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	path        = "mypath"
-	writableCmd = "sudo mount -o remount,rw " + path
-	readonlyCmd = "sudo mount -o remount,ro " + path
+	testPath        = "mypath"
+	writableCmd = "sudo mount -o remount,rw " + testPath
+	readonlyCmd = "sudo mount -o remount,ro " + testPath
 	waitCmd     = lsofNotBeingWritten
 )
 
@@ -87,14 +87,14 @@ func (s *partitionTestSuite) fakeWaitForFunction(c *check.C, pattern string, f f
 }
 
 func (s *partitionTestSuite) TestMakeWritableCallsExecCommand(c *check.C) {
-	err := MakeWritable(c, path)
+	err := MakeWritable(c, testPath)
 
 	c.Assert(err, check.IsNil)
 	c.Assert(s.execCalls[writableCmd], check.Equals, 1)
 }
 
 func (s *partitionTestSuite) TestMakeWritableWaitsForIdlePartition(c *check.C) {
-	err := MakeWritable(c, path)
+	err := MakeWritable(c, testPath)
 
 	c.Assert(err, check.IsNil)
 	c.Assert(s.waitCalls[waitCmd], check.Equals, 1)
@@ -102,7 +102,7 @@ func (s *partitionTestSuite) TestMakeWritableWaitsForIdlePartition(c *check.C) {
 
 func (s *partitionTestSuite) TestMakeWritableReturnsWaitError(c *check.C) {
 	s.waitError = true
-	err := MakeWritable(c, path)
+	err := MakeWritable(c, testPath)
 
 	c.Assert(err, check.NotNil)
 	c.Assert(s.waitCalls[waitCmd], check.Equals, 1)
@@ -110,14 +110,14 @@ func (s *partitionTestSuite) TestMakeWritableReturnsWaitError(c *check.C) {
 }
 
 func (s *partitionTestSuite) TestMakeReadOnlyCallsExecCommand(c *check.C) {
-	err := MakeReadonly(c, path)
+	err := MakeReadonly(c, testPath)
 
 	c.Assert(err, check.IsNil)
 	c.Assert(s.execCalls[readonlyCmd], check.Equals, 1)
 }
 
 func (s *partitionTestSuite) TestMakeReadonlyWaitsForIdlePartition(c *check.C) {
-	err := MakeReadonly(c, path)
+	err := MakeReadonly(c, testPath)
 
 	c.Assert(err, check.IsNil)
 	c.Assert(s.waitCalls[waitCmd], check.Equals, 1)
@@ -125,7 +125,7 @@ func (s *partitionTestSuite) TestMakeReadonlyWaitsForIdlePartition(c *check.C) {
 
 func (s *partitionTestSuite) TestMakeReadonlyReturnsWaitError(c *check.C) {
 	s.waitError = true
-	err := MakeReadonly(c, path)
+	err := MakeReadonly(c, testPath)
 
 	c.Assert(err, check.NotNil)
 	c.Assert(s.waitCalls[waitCmd], check.Equals, 1)
@@ -148,7 +148,7 @@ prg  4827 user   1w   REG    8,2    197132 12452026 /home/user/prg`, "15w"},
 
 	for _, testCase := range testCases {
 		s.execOutput = testCase.execCommandOutput
-		f := checkPathBusyFunc(path)
+		f := checkPathBusyFunc(testPath)
 
 		actual, err := f()
 		c.Check(err, check.IsNil)
@@ -162,7 +162,7 @@ func (s *partitionTestSuite) TestCheckPartitionBusyFuncReturnsErrorOnLsofError(c
 	s.execOutput = "not a lsof common output on not used partitions"
 	s.execError = true
 
-	f := checkPathBusyFunc(path)
+	f := checkPathBusyFunc(testPath)
 
 	actual, err := f()
 


### PR DESCRIPTION
They were using the deprecated uboot config file.

This was an old branch that was left on launchpad: https://code.launchpad.net/~elopio/snappy/integration-fix-rollback/+merge/274651