### PR TITLE
[15.04] Default to SocketMode=0660 if no socket mode option is given

### DIFF
--- a/snappy/click.go
+++ b/snappy/click.go
@@ -457,6 +457,12 @@ func generateSnapSocketFile(service ServiceYaml, baseDir string, aaProfile strin
 		return "", err
 	}
 
+	// lp: #1515709, systemd will default to 0666 if no socket mode
+	// is specified
+	if service.SocketMode == "" {
+		service.SocketMode = "0660"
+	}
+
 	serviceFileName := filepath.Base(generateServiceFileName(m, service))
 
 	return systemd.New(dirs.GlobalRootDir, nil).GenSocketFile(

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -1673,3 +1673,22 @@ func (s *SnapTestSuite) TestWriteCompatManifestJSONNoFollow(c *C) {
 	c.Check(helpers.FileExists(manifestJSON), Equals, true)
 	c.Check(helpers.FileExists(symlinkTarget), Equals, false)
 }
+
+func (s *SnapTestSuite) TestGenerateSnapSocketFile(c *C) {
+	srv := ServiceYaml{}
+	baseDir := "/base/dir"
+	aaProfile := "pkg_app_1.0"
+	m := &packageYaml{}
+
+	// no socket mode means 0660
+	content, err := generateSnapSocketFile(srv, baseDir, aaProfile, m)
+	c.Assert(err, IsNil)
+	c.Assert(content, Matches, "(?ms).*SocketMode=0660")
+
+	// SocketMode itself is honored
+	srv.SocketMode = "0600"
+	content, err = generateSnapSocketFile(srv, baseDir, aaProfile, m)
+	c.Assert(err, IsNil)
+	c.Assert(content, Matches, "(?ms).*SocketMode=0600")
+
+}


### PR DESCRIPTION
[cherry pick of the corresponding master branch change]

Systemd will use mode 0666 if no socket mode is specified. This
is too broad for us.

Closes: #1515709