### PR TITLE
switch everything not in build to use helpers.AtomicWriteFile

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -296,7 +296,7 @@ func NewSideloadVersion() string {
 type AtomicWriteFlags uint
 
 const (
-	// AtomicWriteFollow makes AtomicWriteFile follows symlinks
+	// AtomicWriteFollow makes AtomicWriteFile follow symlinks
 	AtomicWriteFollow AtomicWriteFlags = 1 << iota
 )
 

--- a/pkg/clickdeb/deb.go
+++ b/pkg/clickdeb/deb.go
@@ -221,7 +221,7 @@ func (d *ClickDeb) ExtractHashes(dir string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(hashesFile, hashesData, 0644)
+	return helpers.AtomicWriteFile(hashesFile, hashesData, 0644, 0)
 }
 
 // Unpack unpacks the data.tar.{gz,bz2,xz} into the given target directory

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -512,7 +512,7 @@ func (m *packageYaml) addPackageServices(baseDir string, inhibitHooks bool, inte
 		}
 		serviceFilename := generateServiceFileName(m, service)
 		os.MkdirAll(filepath.Dir(serviceFilename), 0755)
-		if err := ioutil.WriteFile(serviceFilename, []byte(content), 0644); err != nil {
+		if err := helpers.AtomicWriteFile(serviceFilename, []byte(content), 0644, 0); err != nil {
 			return err
 		}
 		// Generate systemd socket file if needed
@@ -523,7 +523,7 @@ func (m *packageYaml) addPackageServices(baseDir string, inhibitHooks bool, inte
 			}
 			socketFilename := generateSocketFileName(m, service)
 			os.MkdirAll(filepath.Dir(socketFilename), 0755)
-			if err := ioutil.WriteFile(socketFilename, []byte(content), 0644); err != nil {
+			if err := helpers.AtomicWriteFile(socketFilename, []byte(content), 0644, 0); err != nil {
 				return err
 			}
 		}
@@ -536,7 +536,7 @@ func (m *packageYaml) addPackageServices(baseDir string, inhibitHooks bool, inte
 			}
 			policyFilename := generateBusPolicyFileName(m, service)
 			os.MkdirAll(filepath.Dir(policyFilename), 0755)
-			if err := ioutil.WriteFile(policyFilename, []byte(content), 0644); err != nil {
+			if err := helpers.AtomicWriteFile(policyFilename, []byte(content), 0644, 0); err != nil {
 				return err
 			}
 		}
@@ -644,7 +644,7 @@ func (m *packageYaml) addPackageBinaries(baseDir string) error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(generateBinaryName(m, binary), []byte(content), 0755); err != nil {
+		if err := helpers.AtomicWriteFile(generateBinaryName(m, binary), []byte(content), 0755, 0); err != nil {
 			return err
 		}
 	}
@@ -671,7 +671,7 @@ func (m *packageYaml) addOneSecurityPolicy(name string, sd SecurityDefinitions, 
 	}
 
 	fn := filepath.Join(dirs.SnapSeccompDir, profileName)
-	if err := ioutil.WriteFile(fn, content, 0644); err != nil {
+	if err := helpers.AtomicWriteFile(fn, content, 0644, 0); err != nil {
 		return err
 	}
 

--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -22,7 +22,6 @@ package snappy
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,7 +114,7 @@ func stampFirstBoot() error {
 		}
 	}
 
-	return ioutil.WriteFile(stampFile, []byte{}, 0644)
+	return helpers.AtomicWriteFile(stampFile, []byte{}, 0644, 0)
 }
 
 var globs = []string{"/sys/class/net/eth*", "/sys/class/net/en*"}

--- a/snappy/oem.go
+++ b/snappy/oem.go
@@ -25,13 +25,13 @@ package snappy
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/pkg"
 )
@@ -221,7 +221,7 @@ func writeOemHardwareUdevRules(m *packageYaml) error {
 			return err
 		}
 		outfile := filepath.Join(dirs.SnapUdevRulesDir, fmt.Sprintf("80-snappy_%s_%s.rules", m.Name, h.PartID))
-		if err := ioutil.WriteFile(outfile, []byte(rulesContent), 0644); err != nil {
+		if err := helpers.AtomicWriteFile(outfile, []byte(rulesContent), 0644, 0); err != nil {
 			return err
 		}
 	}
@@ -270,7 +270,7 @@ func writeApparmorAdditionalFile(m *packageYaml) error {
 
 	for _, h := range m.OEM.Hardware.Assign {
 		jsonAdditionalPath := filepath.Join(dirs.SnapAppArmorDir, fmt.Sprintf("%s.json.additional", h.PartID))
-		if err := ioutil.WriteFile(jsonAdditionalPath, []byte(apparmorAdditionalContent), 0644); err != nil {
+		if err := helpers.AtomicWriteFile(jsonAdditionalPath, []byte(apparmorAdditionalContent), 0644, 0); err != nil {
 			return err
 		}
 	}

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -31,6 +31,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/pkg"
 )
@@ -103,7 +104,7 @@ func handleApparmor(buildDir string, m *packageYaml, hookName string, s *Securit
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(buildDir, apparmorJSONFile), securityJSONContent, 0644); err != nil {
+	if err := helpers.AtomicWriteFile(filepath.Join(buildDir, apparmorJSONFile), securityJSONContent, 0644, 0); err != nil {
 		return err
 	}
 

--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -1624,7 +1624,7 @@ func (s *RemoteSnapPart) saveStoreManifest() error {
 	}
 
 	// don't worry about previous contents
-	return ioutil.WriteFile(RemoteManifestPath(s), content, 0644)
+	return helpers.AtomicWriteFile(RemoteManifestPath(s), content, 0644, 0)
 }
 
 // Install installs the snap


### PR DESCRIPTION
The rationale for not switching build is that the build is done in a tmpdir anyway. Clickdeb's file is not syncing things, but it's tricky and on the way out. I trust `mksquashfs` is doing the right thing.