### PR TITLE
Feature/extract into more pkgs1

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/snappy"
 	"github.com/ubuntu-core/snappy/systemd"
+	"github.com/ubuntu-core/snappy/timeout"
 )
 
 type apiSuite struct {
@@ -850,7 +851,7 @@ func (s *apiSuite) TestPackageServiceGet(c *check.C) {
 	m := rsp.Result.(map[string]*svcDesc)
 	c.Assert(m["svc"], check.FitsTypeOf, new(svcDesc))
 	c.Check(m["svc"].Op, check.Equals, "status")
-	c.Check(m["svc"].Spec, check.DeepEquals, &snappy.ServiceYaml{Name: "svc", StopTimeout: snappy.DefaultTimeout})
+	c.Check(m["svc"].Spec, check.DeepEquals, &snappy.ServiceYaml{Name: "svc", StopTimeout: timeout.DefaultTimeout})
 	c.Check(m["svc"].Status, check.DeepEquals, &snappy.PackageServiceStatus{ServiceName: "svc"})
 }
 

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ubuntu-core/snappy/policy"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/systemd"
+	"github.com/ubuntu-core/snappy/timeout"
 )
 
 func (s *SnapTestSuite) TestReadManifest(c *C) {
@@ -1251,7 +1252,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceTypeForking(c *C) {
 		Start:       "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
-		StopTimeout: DefaultTimeout,
+		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
 		Forking:     true,
 	}
@@ -1271,7 +1272,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapper(c *C) {
 		Start:       "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
-		StopTimeout: DefaultTimeout,
+		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
 	}
 	pkgPath := "/apps/xkcd-webserver.canonical/0.3.4/"
@@ -1290,7 +1291,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapperWithExternalPort(
 		Start:       "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
-		StopTimeout: DefaultTimeout,
+		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
 		Ports:       &Ports{External: map[string]Port{"foo": Port{}}},
 	}
@@ -1310,7 +1311,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceFmkWrapper(c *C) {
 		Start:       "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
-		StopTimeout: DefaultTimeout,
+		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
 		BusName:     "foo.bar.baz",
 	}
@@ -1332,7 +1333,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWrapperWhitelist(c *C) {
 		Start:       "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
-		StopTimeout: DefaultTimeout,
+		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver\nExec=foo",
 	}
 	pkgPath := "/apps/xkcd-webserver.canonical/0.3.4/"
@@ -1570,7 +1571,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWithSockte(c *C) {
 		Start:       "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
-		StopTimeout: DefaultTimeout,
+		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
 		Socket:      true,
 	}

--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/systemd"
+	"github.com/ubuntu-core/snappy/timeout"
 )
 
 const (
@@ -122,12 +123,12 @@ type ServiceYaml struct {
 	Name        string `yaml:"name" json:"name,omitempty"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 
-	Start       string  `yaml:"start,omitempty" json:"start,omitempty"`
-	Stop        string  `yaml:"stop,omitempty" json:"stop,omitempty"`
-	PostStop    string  `yaml:"poststop,omitempty" json:"poststop,omitempty"`
-	StopTimeout Timeout `yaml:"stop-timeout,omitempty" json:"stop-timeout,omitempty"`
-	BusName     string  `yaml:"bus-name,omitempty" json:"bus-name,omitempty"`
-	Forking     bool    `yaml:"forking,omitempty" json:"forking,omitempty"`
+	Start       string          `yaml:"start,omitempty" json:"start,omitempty"`
+	Stop        string          `yaml:"stop,omitempty" json:"stop,omitempty"`
+	PostStop    string          `yaml:"poststop,omitempty" json:"poststop,omitempty"`
+	StopTimeout timeout.Timeout `yaml:"stop-timeout,omitempty" json:"stop-timeout,omitempty"`
+	BusName     string          `yaml:"bus-name,omitempty" json:"bus-name,omitempty"`
+	Forking     bool            `yaml:"forking,omitempty" json:"forking,omitempty"`
 
 	// set to yes if we need to create a systemd socket for this service
 	Socket       bool   `yaml:"socket,omitempty" json:"socket,omitempty"`
@@ -316,7 +317,7 @@ func parsePackageYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error)
 
 	for i := range m.ServiceYamls {
 		if m.ServiceYamls[i].StopTimeout == 0 {
-			m.ServiceYamls[i].StopTimeout = DefaultTimeout
+			m.ServiceYamls[i].StopTimeout = timeout.DefaultTimeout
 		}
 	}
 

--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -17,7 +17,7 @@
  *
  */
 
-package snappy
+package timeout
 
 import (
 	"encoding/json"

--- a/timeout/timeout_test.go
+++ b/timeout/timeout_test.go
@@ -17,16 +17,25 @@
  *
  */
 
-package snappy
+package timeout
 
 import (
 	"encoding/json"
+	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
 )
 
-func (s *SnapTestSuite) TestTimeoutMarshal(c *C) {
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type TimeoutTestSuite struct {
+}
+
+var _ = Suite(&TimeoutTestSuite{})
+
+func (s *TimeoutTestSuite) TestTimeoutMarshal(c *C) {
 	bs, err := Timeout(DefaultTimeout).MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(bs), Equals, `"30s"`)
@@ -36,13 +45,13 @@ type testT struct {
 	T Timeout
 }
 
-func (s *SnapTestSuite) TestTimeoutMarshalIndirect(c *C) {
+func (s *TimeoutTestSuite) TestTimeoutMarshalIndirect(c *C) {
 	bs, err := json.Marshal(testT{DefaultTimeout})
 	c.Assert(err, IsNil)
 	c.Check(string(bs), Equals, `{"T":"30s"}`)
 }
 
-func (s *SnapTestSuite) TestTimeoutUnmarshal(c *C) {
+func (s *TimeoutTestSuite) TestTimeoutUnmarshal(c *C) {
 	var t testT
 	c.Assert(json.Unmarshal([]byte(`{"T": "17ms"}`), &t), IsNil)
 	c.Check(t, DeepEquals, testT{T: Timeout(17 * time.Millisecond)})


### PR DESCRIPTION
Build on top of the native-security branch, once thats in this branch diff is a lot smaller.

This branch moves the timeout into its own (tiny) package. The idea is to get it out of the way to move the security.go into its own package eventually. Doing that is a bit tricky because of the inter-dependencies between packageYaml and SecurityDefinition (used in ServicesYaml and Binaries) in the code right now.