### PR TITLE
Honor global rootdir in partition/ package

### DIFF
--- a/partition/bootloader.go
+++ b/partition/bootloader.go
@@ -307,10 +307,10 @@ func (b *bootloaderType) HandleAssets() (err error) {
 // BootloaderDir returns the full path to the (mounted and writable)
 // bootloader-specific boot directory.
 func BootloaderDir() string {
-	if helpers.FileExists(bootloaderUbootDir) {
-		return bootloaderUbootDir
-	} else if helpers.FileExists(bootloaderGrubDir) {
-		return bootloaderGrubDir
+	if helpers.FileExists(bootloaderUbootDir()) {
+		return bootloaderUbootDir()
+	} else if helpers.FileExists(bootloaderGrubDir()) {
+		return bootloaderGrubDir()
 	}
 
 	return ""

--- a/partition/bootloader_grub.go
+++ b/partition/bootloader_grub.go
@@ -21,7 +21,9 @@ package partition
 
 import (
 	"fmt"
+	"path/filepath"
 
+	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
 
 	"github.com/mvo5/goconfigparser"
@@ -29,18 +31,14 @@ import (
 
 const (
 	bootloaderGrubDirReal        = "/boot/grub"
-	bootloaderGrubConfigFileReal = "/boot/grub/grub.cfg"
-	bootloaderGrubEnvFileReal    = "/boot/grub/grubenv"
+	bootloaderGrubConfigFileReal = "grub.cfg"
+	bootloaderGrubEnvFileReal    = "grubenv"
 
 	bootloaderGrubEnvCmdReal = "/usr/bin/grub-editenv"
 )
 
 // var to make it testable
 var (
-	bootloaderGrubDir        = bootloaderGrubDirReal
-	bootloaderGrubConfigFile = bootloaderGrubConfigFileReal
-	bootloaderGrubEnvFile    = bootloaderGrubEnvFileReal
-
 	bootloaderGrubEnvCmd = bootloaderGrubEnvCmdReal
 )
 
@@ -50,13 +48,23 @@ type grub struct {
 
 const bootloaderNameGrub bootloaderName = "grub"
 
+func bootloaderGrubDir() string {
+	return filepath.Join(dirs.GlobalRootDir, bootloaderGrubDirReal)
+}
+func bootloaderGrubConfigFile() string {
+	return filepath.Join(bootloaderGrubDir(), bootloaderGrubConfigFileReal)
+}
+func bootloaderGrubEnvFile() string {
+	return filepath.Join(bootloaderGrubDir(), bootloaderGrubEnvFileReal)
+}
+
 // newGrub create a new Grub bootloader object
 func newGrub(partition *Partition) bootLoader {
-	if !helpers.FileExists(bootloaderGrubConfigFile) {
+	if !helpers.FileExists(bootloaderGrubConfigFile()) {
 		return nil
 	}
 
-	b := newBootLoader(partition, bootloaderGrubDir)
+	b := newBootLoader(partition, bootloaderGrubConfigFile())
 	if b == nil {
 		return nil
 	}
@@ -89,7 +97,7 @@ func (g *grub) ToggleRootFS(otherRootfs string) (err error) {
 func (g *grub) GetBootVar(name string) (value string, err error) {
 	// Grub doesn't provide a get verb, so retrieve all values and
 	// search for the required variable ourselves.
-	output, err := runCommandWithStdout(bootloaderGrubEnvCmd, bootloaderGrubEnvFile, "list")
+	output, err := runCommandWithStdout(bootloaderGrubEnvCmd, bootloaderGrubEnvFile(), "list")
 	if err != nil {
 		return "", err
 	}
@@ -108,7 +116,7 @@ func (g *grub) setBootVar(name, value string) (err error) {
 	// RunCommand() does not use a shell and thus adding quotes
 	// stores them in the environment file (which is not desirable)
 	arg := fmt.Sprintf("%s=%s", name, value)
-	return runCommand(bootloaderGrubEnvCmd, bootloaderGrubEnvFile, "set", arg)
+	return runCommand(bootloaderGrubEnvCmd, bootloaderGrubEnvFile(), "set", arg)
 }
 
 func (g *grub) GetNextBootRootFSName() (label string, err error) {
@@ -129,5 +137,5 @@ func (g *grub) MarkCurrentBootSuccessful(currentRootfs string) (err error) {
 }
 
 func (g *grub) BootDir() string {
-	return bootloaderGrubDir
+	return bootloaderGrubDir()
 }

--- a/partition/bootloader_uboot_test.go
+++ b/partition/bootloader_uboot_test.go
@@ -67,15 +67,15 @@ snappy_boot=if test "${snappy_mode}" = "try"; then if test -e mmc ${bootpart} ${
 `
 
 func (s *PartitionTestSuite) makeFakeUbootEnv(c *C) {
-	err := os.MkdirAll(bootloaderUbootDir, 0755)
+	err := os.MkdirAll(bootloaderUbootDir(), 0755)
 	c.Assert(err, IsNil)
 
 	// this file just needs to exist
-	err = ioutil.WriteFile(bootloaderUbootConfigFile, []byte(""), 0644)
+	err = ioutil.WriteFile(bootloaderUbootConfigFile(), []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	// this file needs specific data
-	err = ioutil.WriteFile(bootloaderUbootEnvFile, []byte(fakeUbootEnvData), 0644)
+	err = ioutil.WriteFile(bootloaderUbootEnvFile(), []byte(fakeUbootEnvData), 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -253,9 +253,9 @@ func (s *PartitionTestSuite) TestUbootMarkCurrentBootSuccessful(c *C) {
 	// "snappy booted" if the system boots successfully. If this
 	// file exists when uboot starts, it will know that the previous
 	// boot failed, and will therefore toggle to the other rootfs.
-	err := ioutil.WriteFile(bootloaderUbootStampFile, []byte(""), 0640)
+	err := ioutil.WriteFile(bootloaderUbootStampFile(), []byte(""), 0640)
 	c.Assert(err, IsNil)
-	c.Assert(helpers.FileExists(bootloaderUbootStampFile), Equals, true)
+	c.Assert(helpers.FileExists(bootloaderUbootStampFile()), Equals, true)
 
 	partition := New()
 	u := newUboot(partition)
@@ -267,8 +267,8 @@ func (s *PartitionTestSuite) TestUbootMarkCurrentBootSuccessful(c *C) {
 	err = u.ToggleRootFS("b")
 	c.Assert(err, IsNil)
 
-	c.Assert(helpers.FileExists(bootloaderUbootEnvFile), Equals, true)
-	bytes, err := ioutil.ReadFile(bootloaderUbootEnvFile)
+	c.Assert(helpers.FileExists(bootloaderUbootEnvFile()), Equals, true)
+	bytes, err := ioutil.ReadFile(bootloaderUbootEnvFile())
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(bytes), "snappy_mode=try"), Equals, true)
 	c.Assert(strings.Contains(string(bytes), "snappy_mode=regular"), Equals, false)
@@ -277,10 +277,10 @@ func (s *PartitionTestSuite) TestUbootMarkCurrentBootSuccessful(c *C) {
 	err = u.MarkCurrentBootSuccessful("b")
 	c.Assert(err, IsNil)
 
-	c.Assert(helpers.FileExists(bootloaderUbootStampFile), Equals, false)
-	c.Assert(helpers.FileExists(bootloaderUbootEnvFile), Equals, true)
+	c.Assert(helpers.FileExists(bootloaderUbootStampFile()), Equals, false)
+	c.Assert(helpers.FileExists(bootloaderUbootEnvFile()), Equals, true)
 
-	bytes, err = ioutil.ReadFile(bootloaderUbootEnvFile)
+	bytes, err = ioutil.ReadFile(bootloaderUbootEnvFile())
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(bytes), "snappy_mode=try"), Equals, false)
 	c.Assert(strings.Contains(string(bytes), "snappy_mode=regular"), Equals, true)
@@ -308,7 +308,7 @@ func (s *PartitionTestSuite) TestWriteDueToMissingValues(c *C) {
 	s.makeFakeUbootEnv(c)
 
 	// this file needs specific data
-	c.Assert(ioutil.WriteFile(bootloaderUbootEnvFile, []byte(""), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(bootloaderUbootEnvFile(), []byte(""), 0644), IsNil)
 
 	atomiCall := false
 	atomicWriteFile = func(a string, b []byte, c os.FileMode, f helpers.AtomicWriteFlags) error {
@@ -323,7 +323,7 @@ func (s *PartitionTestSuite) TestWriteDueToMissingValues(c *C) {
 	c.Check(u.MarkCurrentBootSuccessful("a"), IsNil)
 	c.Assert(atomiCall, Equals, true)
 
-	bytes, err := ioutil.ReadFile(bootloaderUbootEnvFile)
+	bytes, err := ioutil.ReadFile(bootloaderUbootEnvFile())
 	c.Assert(err, IsNil)
 	c.Check(strings.Contains(string(bytes), "snappy_mode=try"), Equals, false)
 	c.Check(strings.Contains(string(bytes), "snappy_mode=regular"), Equals, true)
@@ -333,7 +333,7 @@ func (s *PartitionTestSuite) TestWriteDueToMissingValues(c *C) {
 func (s *PartitionTestSuite) TestUbootMarkCurrentBootSuccessfulFwEnv(c *C) {
 	s.makeFakeUbootEnv(c)
 
-	env, err := uenv.Create(bootloaderUbootFwEnvFile, 4096)
+	env, err := uenv.Create(bootloaderUbootFwEnvFile(), 4096)
 	c.Assert(err, IsNil)
 	env.Set("snappy_ab", "b")
 	env.Set("snappy_mode", "try")
@@ -348,7 +348,7 @@ func (s *PartitionTestSuite) TestUbootMarkCurrentBootSuccessfulFwEnv(c *C) {
 	err = u.MarkCurrentBootSuccessful("b")
 	c.Assert(err, IsNil)
 
-	env, err = uenv.Open(bootloaderUbootFwEnvFile)
+	env, err = uenv.Open(bootloaderUbootFwEnvFile())
 	c.Assert(err, IsNil)
 	c.Assert(env.String(), Equals, "snappy_ab=b\nsnappy_mode=regular\nsnappy_trial_boot=0\n")
 }
@@ -356,14 +356,14 @@ func (s *PartitionTestSuite) TestUbootMarkCurrentBootSuccessfulFwEnv(c *C) {
 func (s *PartitionTestSuite) TestUbootSetEnvNoUselessWrites(c *C) {
 	s.makeFakeUbootEnv(c)
 
-	env, err := uenv.Create(bootloaderUbootFwEnvFile, 4096)
+	env, err := uenv.Create(bootloaderUbootFwEnvFile(), 4096)
 	c.Assert(err, IsNil)
 	env.Set("snappy_ab", "b")
 	env.Set("snappy_mode", "regular")
 	err = env.Save()
 	c.Assert(err, IsNil)
 
-	st, err := os.Stat(bootloaderUbootFwEnvFile)
+	st, err := os.Stat(bootloaderUbootFwEnvFile())
 	c.Assert(err, IsNil)
 	time.Sleep(100 * time.Millisecond)
 
@@ -374,11 +374,11 @@ func (s *PartitionTestSuite) TestUbootSetEnvNoUselessWrites(c *C) {
 	err = setBootVar(bootloaderRootfsVar, "b")
 	c.Assert(err, IsNil)
 
-	env, err = uenv.Open(bootloaderUbootFwEnvFile)
+	env, err = uenv.Open(bootloaderUbootFwEnvFile())
 	c.Assert(err, IsNil)
 	c.Assert(env.String(), Equals, "snappy_ab=b\nsnappy_mode=regular\n")
 
-	st2, err := os.Stat(bootloaderUbootFwEnvFile)
+	st2, err := os.Stat(bootloaderUbootFwEnvFile())
 	c.Assert(err, IsNil)
 	c.Assert(st.ModTime(), Equals, st2.ModTime())
 }

--- a/partition/migrate_grub.go
+++ b/partition/migrate_grub.go
@@ -106,7 +106,7 @@ func copyKernelAssets(prefixDir, grubTargetDir string) error {
 			return fmt.Errorf("Incorrect matches for %v: %v", p, matches)
 		}
 		name := normalizeKernelInitrdName(filepath.Base(matches[0]))
-		targetPath := filepath.Join(bootloaderGrubDir, grubTargetDir, name)
+		targetPath := filepath.Join(bootloaderGrubDir(), grubTargetDir, name)
 		os.MkdirAll(filepath.Dir(targetPath), 0755)
 		// FIXME: valid?
 		if helpers.FileExists(targetPath) {
@@ -125,7 +125,7 @@ func copyKernelAssets(prefixDir, grubTargetDir string) error {
 // dynamic grub setup. Needed for when you rollback over the switch to
 // static grub.
 func MigrateToDynamicGrub() error {
-	grubConfigRaw, err := ioutil.ReadFile(bootloaderGrubConfigFile)
+	grubConfigRaw, err := ioutil.ReadFile(bootloaderGrubConfigFile())
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -149,5 +149,5 @@ func MigrateToDynamicGrub() error {
 		}
 	}
 
-	return helpers.AtomicWriteFile(bootloaderGrubConfigFile, []byte(newGrubConfig), 0644, 0)
+	return helpers.AtomicWriteFile(bootloaderGrubConfigFile(), []byte(newGrubConfig), 0644, 0)
 }

--- a/partition/migrate_grub_test.go
+++ b/partition/migrate_grub_test.go
@@ -22,7 +22,6 @@ package partition
 import (
 	"bytes"
 	"io/ioutil"
-	"path/filepath"
 
 	. "gopkg.in/check.v1"
 )
@@ -43,8 +42,7 @@ if [ "${next_entry}" ] ; then
 `
 
 func (s *PartitionTestSuite) TestMigrateDetectsOldConfig(c *C) {
-	bootloaderGrubConfigFile = filepath.Join(c.MkDir(), "grub.cfg")
-	err := ioutil.WriteFile(bootloaderGrubConfigFile, []byte(oldConfigHeader), 0644)
+	err := ioutil.WriteFile(bootloaderGrubConfigFile(), []byte(oldConfigHeader), 0644)
 	c.Assert(err, IsNil)
 
 	r := bytes.NewBufferString(oldConfigHeader)
@@ -52,8 +50,7 @@ func (s *PartitionTestSuite) TestMigrateDetectsOldConfig(c *C) {
 }
 
 func (s *PartitionTestSuite) TestMigrateNotMisdetects(c *C) {
-	bootloaderGrubConfigFile = filepath.Join(c.MkDir(), "grub.cfg")
-	err := ioutil.WriteFile(bootloaderGrubConfigFile, []byte(newGrubConfig), 0644)
+	err := ioutil.WriteFile(bootloaderGrubConfigFile(), []byte(newGrubConfig), 0644)
 	c.Assert(err, IsNil)
 
 	r := bytes.NewBufferString(oldConfigHeader)

--- a/partition/partition_test.go
+++ b/partition/partition_test.go
@@ -23,11 +23,12 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/dirs"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -51,17 +52,12 @@ func (s *PartitionTestSuite) SetUpTest(c *C) {
 	// custom mount target
 	mountTarget = c.MkDir()
 
-	// setup fake paths for grub
-	bootloaderGrubDir = filepath.Join(s.tempdir, "boot", "grub")
-	bootloaderGrubConfigFile = filepath.Join(bootloaderGrubDir, "grub.cfg")
-	bootloaderGrubEnvFile = filepath.Join(bootloaderGrubDir, "grubenv")
-
-	// and uboot
-	bootloaderUbootDir = filepath.Join(s.tempdir, "boot", "uboot")
-	bootloaderUbootConfigFile = filepath.Join(bootloaderUbootDir, "uEnv.txt")
-	bootloaderUbootEnvFile = filepath.Join(bootloaderUbootDir, "uEnv.txt")
-	bootloaderUbootFwEnvFile = filepath.Join(bootloaderUbootDir, "uboot.env")
-	bootloaderUbootStampFile = filepath.Join(bootloaderUbootDir, "snappy-stamp.txt")
+	// global roto
+	dirs.SetRootDir(s.tempdir)
+	err := os.MkdirAll(bootloaderGrubDir(), 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(bootloaderUbootDir(), 0755)
+	c.Assert(err, IsNil)
 
 	c.Assert(mounts, DeepEquals, mountEntryArray(nil))
 }
@@ -75,16 +71,6 @@ func (s *PartitionTestSuite) TearDownTest(c *C) {
 	cacheDir = cacheDirReal
 	hardwareSpecFile = hardwareSpecFileReal
 	mountTarget = mountTargetReal
-
-	// grub vars
-	bootloaderGrubConfigFile = bootloaderGrubConfigFileReal
-	bootloaderGrubEnvFile = bootloaderGrubEnvFileReal
-
-	// uboot vars
-	bootloaderUbootDir = bootloaderUbootDirReal
-	bootloaderUbootConfigFile = bootloaderUbootConfigFileReal
-	bootloaderUbootEnvFile = bootloaderUbootEnvFileReal
-	bootloaderUbootStampFile = bootloaderUbootStampFileReal
 
 	c.Assert(mounts, DeepEquals, mountEntryArray(nil))
 }


### PR DESCRIPTION
The current partition code is not honoring the global rootdir.
But the global rootdir is import for tools like ubuntu-device-flash
to detect what bootloader to use on the generated image.

This branch fixes this.