### PR TITLE
Remove pointless indirection in cmd_booted

### DIFF
--- a/cmd/snappy/cmd_booted.go
+++ b/cmd/snappy/cmd_booted.go
@@ -21,8 +21,7 @@ package main
 
 import (
 	"github.com/ubuntu-core/snappy/logger"
-	"github.com/ubuntu-core/snappy/pkg"
-	"github.com/ubuntu-core/snappy/snappy"
+	"github.com/ubuntu-core/snappy/partition"
 )
 
 type cmdBooted struct {
@@ -43,10 +42,6 @@ func (x *cmdBooted) Execute(args []string) error {
 }
 
 func (x *cmdBooted) doBooted() error {
-	parts, err := snappy.ActiveSnapsByType(pkg.TypeCore)
-	if err != nil {
-		return err
-	}
-
-	return parts[0].(*snappy.SystemImagePart).MarkBootSuccessful()
+	p := partition.New()
+	return p.MarkBootSuccessful()
 }

--- a/partition/partition.go
+++ b/partition/partition.go
@@ -334,7 +334,15 @@ func (p *Partition) ToggleNextBoot() (err error) {
 }
 
 // MarkBootSuccessful marks the boot as successful
-func (p *Partition) MarkBootSuccessful() (err error) {
+func (p *Partition) MarkBootSuccessful() error {
+	if p.rootPartition() != nil {
+		return p.markBootSuccessfulSnappyAB()
+	}
+
+	return p.markBootSuccessfulAllSnaps()
+}
+
+func (p *Partition) markBootSuccessfulSnappyAB() error {
 	bootloader, err := bootloader(p)
 	if err != nil {
 		return err
@@ -342,6 +350,11 @@ func (p *Partition) MarkBootSuccessful() (err error) {
 
 	currentRootfs := p.rootPartition().shortName
 	return bootloader.MarkCurrentBootSuccessful(currentRootfs)
+}
+
+// FIXME: stub
+func (p *Partition) markBootSuccessfulAllSnaps() error {
+	panic("markBootSuccessfulAllSnaps is not implemented yet")
 }
 
 // IsNextBootOther return true if the next boot will use the other rootfs

--- a/snappy/systemimage.go
+++ b/snappy/systemimage.go
@@ -301,14 +301,6 @@ func (s *SystemImagePart) NeedsReboot() bool {
 	return false
 }
 
-// MarkBootSuccessful marks the *currently* booted rootfs as "good"
-// (it booted :)
-// Note: Not part of the Part interface.
-func (s *SystemImagePart) MarkBootSuccessful() (err error) {
-
-	return s.partition.MarkBootSuccessful()
-}
-
 // Channel returns the system-image-server channel used
 func (s *SystemImagePart) Channel() string {
 	return s.channelName


### PR DESCRIPTION
This cleans up the partition.MarkBootSuccessful handling in
preparation for the all-snap work. It also adds a stub for
the coming markBootSuccessfulAllSnaps().