### PR TITLE
Add SetBootVar() to the bootloader interface

### DIFF
--- a/partition/bootloader.go
+++ b/partition/bootloader.go
@@ -70,6 +70,9 @@ type bootLoader interface {
 	// Return the value of the specified bootloader variable
 	GetBootVar(name string) (string, error)
 
+	// Set the value of the specified bootloader variable
+	SetBootVar(name, value string) error
+
 	// Return the 1-character name corresponding to the
 	// rootfs that will be used on _next_ boot.
 	//

--- a/partition/bootloader_grub.go
+++ b/partition/bootloader_grub.go
@@ -76,14 +76,14 @@ func (g *grub) Name() bootloaderName {
 // Update the grub configuration.
 func (g *grub) ToggleRootFS(otherRootfs string) (err error) {
 
-	if err := g.setBootVar(bootloaderBootmodeVar, bootloaderBootmodeTry); err != nil {
+	if err := g.SetBootVar(bootloaderBootmodeVar, bootloaderBootmodeTry); err != nil {
 		return err
 	}
 
 	// Record the partition that will be used for next boot. This
 	// isn't necessary for correct operation under grub, but allows
 	// us to query the next boot device easily.
-	return g.setBootVar(bootloaderRootfsVar, otherRootfs)
+	return g.SetBootVar(bootloaderRootfsVar, otherRootfs)
 }
 
 func (g *grub) GetBootVar(name string) (value string, err error) {
@@ -103,7 +103,7 @@ func (g *grub) GetBootVar(name string) (value string, err error) {
 	return cfg.Get("", name)
 }
 
-func (g *grub) setBootVar(name, value string) (err error) {
+func (g *grub) SetBootVar(name, value string) (err error) {
 	// note that strings are not quoted since because
 	// RunCommand() does not use a shell and thus adding quotes
 	// stores them in the environment file (which is not desirable)
@@ -117,15 +117,15 @@ func (g *grub) GetNextBootRootFSName() (label string, err error) {
 
 func (g *grub) MarkCurrentBootSuccessful(currentRootfs string) (err error) {
 	// Clear the variable set on boot to denote a good boot.
-	if err := g.setBootVar(bootloaderTrialBootVar, "0"); err != nil {
+	if err := g.SetBootVar(bootloaderTrialBootVar, "0"); err != nil {
 		return err
 	}
 
-	if err := g.setBootVar(bootloaderRootfsVar, currentRootfs); err != nil {
+	if err := g.SetBootVar(bootloaderRootfsVar, currentRootfs); err != nil {
 		return err
 	}
 
-	return g.setBootVar(bootloaderBootmodeVar, bootloaderBootmodeSuccess)
+	return g.SetBootVar(bootloaderBootmodeVar, bootloaderBootmodeSuccess)
 }
 
 func (g *grub) BootDir() string {

--- a/partition/bootloader_uboot.go
+++ b/partition/bootloader_uboot.go
@@ -165,6 +165,10 @@ func (u *uboot) GetBootVar(name string) (value string, err error) {
 	return getBootVar(name)
 }
 
+func (u *uboot) SetBootVar(name, value string) error {
+	return setBootVar(name, value)
+}
+
 func (u *uboot) GetNextBootRootFSName() (label string, err error) {
 	value, err := u.GetBootVar(bootloaderRootfsVar)
 	if err != nil {

--- a/partition/partition_test.go
+++ b/partition/partition_test.go
@@ -369,12 +369,12 @@ type mockBootloader struct {
 	HandleAssetsCalled              bool
 	MarkCurrentBootSuccessfulCalled bool
 	SyncBootFilesCalled             bool
-	Bootvars                        map[string]string
+	BootVars                        map[string]string
 }
 
 func newMockBootloader() *mockBootloader {
 	return &mockBootloader{
-		Bootvars: make(map[string]string),
+		BootVars: make(map[string]string),
 	}
 }
 
@@ -394,10 +394,10 @@ func (b *mockBootloader) HandleAssets() error {
 	return nil
 }
 func (b *mockBootloader) GetBootVar(name string) (string, error) {
-	return b.Bootvars[name], nil
+	return b.BootVars[name], nil
 }
 func (b *mockBootloader) SetBootVar(name, value string) error {
-	b.Bootvars[name] = value
+	b.BootVars[name] = value
 	return nil
 }
 func (b *mockBootloader) GetNextBootRootFSName() (string, error) {

--- a/partition/partition_test.go
+++ b/partition/partition_test.go
@@ -369,6 +369,13 @@ type mockBootloader struct {
 	HandleAssetsCalled              bool
 	MarkCurrentBootSuccessfulCalled bool
 	SyncBootFilesCalled             bool
+	Bootvars                        map[string]string
+}
+
+func newMockBootloader() *mockBootloader {
+	return &mockBootloader{
+		Bootvars: make(map[string]string),
+	}
 }
 
 func (b *mockBootloader) Name() bootloaderName {
@@ -387,7 +394,11 @@ func (b *mockBootloader) HandleAssets() error {
 	return nil
 }
 func (b *mockBootloader) GetBootVar(name string) (string, error) {
-	return "", nil
+	return b.Bootvars[name], nil
+}
+func (b *mockBootloader) SetBootVar(name, value string) error {
+	b.Bootvars[name] = value
+	return nil
 }
 func (b *mockBootloader) GetNextBootRootFSName() (string, error) {
 	return "", nil
@@ -402,7 +413,7 @@ func (b *mockBootloader) BootDir() string {
 
 func (s *PartitionTestSuite) TestToggleBootloaderRootfs(c *C) {
 	runCommand = mockRunCommand
-	b := &mockBootloader{}
+	b := newMockBootloader()
 	bootloader = func(p *Partition) (bootLoader, error) {
 		return b, nil
 	}
@@ -421,7 +432,7 @@ func (s *PartitionTestSuite) TestToggleBootloaderRootfs(c *C) {
 
 func (s *PartitionTestSuite) TestMarkBootSuccessful(c *C) {
 	runCommand = mockRunCommand
-	b := &mockBootloader{}
+	b := newMockBootloader()
 	bootloader = func(p *Partition) (bootLoader, error) {
 		return b, nil
 	}
@@ -436,7 +447,7 @@ func (s *PartitionTestSuite) TestMarkBootSuccessful(c *C) {
 
 func (s *PartitionTestSuite) TestSyncBootFiles(c *C) {
 	runCommand = mockRunCommand
-	b := &mockBootloader{}
+	b := newMockBootloader()
 	bootloader = func(p *Partition) (bootLoader, error) {
 		return b, nil
 	}


### PR DESCRIPTION
The SetBootVar() is required to implement that all-snap boot-success
handling. It will work by setting the current snappy_os bootloader
variable to snappy_good_os (or snappy_os_good). This branch just
adds the needed interfaces for this.