### PR TITLE
Add the concept of capability attributes.

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -44,6 +44,10 @@ type Capability struct {
 	// capability, and also which information should be exchanged by these
 	// parties.
 	Type Type
+	// Attributes define additional key-value pairs that provide additional
+	// domain-specific information. They are closely related to the type of the
+	// capability.
+	Attributes map[string]string
 }
 
 // Repository stores all known snappy capabilities and types

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -44,10 +44,8 @@ type Capability struct {
 	// capability, and also which information should be exchanged by these
 	// parties.
 	Type Type
-	// Attributes define additional key-value pairs that provide additional
-	// domain-specific information. They are closely related to the type of the
-	// capability.
-	Attributes map[string]string
+	// Attrs are key-value pairs that provide type-specific capability details.
+	Attrs map[string]string
 }
 
 // Repository stores all known snappy capabilities and types

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -46,7 +46,7 @@ func (s *CapabilitySuite) TestValidateName(c *C) {
 
 func (s *CapabilitySuite) TestAdd(c *C) {
 	repo := NewRepository()
-	cap := &Capability{"name", "label", FileType}
+	cap := &Capability{Name: "name", Label: "label", Type: FileType}
 	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
 	err := repo.Add(cap)
 	c.Assert(err, IsNil)
@@ -56,10 +56,10 @@ func (s *CapabilitySuite) TestAdd(c *C) {
 
 func (s *CapabilitySuite) TestAddClash(c *C) {
 	repo := NewRepository()
-	cap1 := &Capability{"name", "label 1", FileType}
+	cap1 := &Capability{Name: "name", Label: "label 1", Type: FileType}
 	err := repo.Add(cap1)
 	c.Assert(err, IsNil)
-	cap2 := &Capability{"name", "label 2", FileType}
+	cap2 := &Capability{Name: "name", Label: "label 2", Type: FileType}
 	err = repo.Add(cap2)
 	c.Assert(err, ErrorMatches,
 		`cannot add capability "name": name already exists`)
@@ -69,7 +69,7 @@ func (s *CapabilitySuite) TestAddClash(c *C) {
 
 func (s *CapabilitySuite) TestAddInvalidName(c *C) {
 	repo := NewRepository()
-	cap1 := &Capability{"bad-name-", "label", FileType}
+	cap1 := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
 	err := repo.Add(cap1)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(repo.Names(), DeepEquals, []string{})
@@ -78,7 +78,7 @@ func (s *CapabilitySuite) TestAddInvalidName(c *C) {
 
 func (s *CapabilitySuite) TestRemoveGood(c *C) {
 	repo := NewRepository()
-	cap := &Capability{"name", "label", FileType}
+	cap := &Capability{Name: "name", Label: "label", Type: FileType}
 	err := repo.Add(cap)
 	c.Assert(err, IsNil)
 	err = repo.Remove(cap.Name)
@@ -96,32 +96,32 @@ func (s *CapabilitySuite) TestRemoveNoSuchCapability(c *C) {
 func (s *CapabilitySuite) TestNames(c *C) {
 	repo := NewRepository()
 	// Note added in non-sorted order
-	err := repo.Add(&Capability{"a", "label-a", FileType})
+	err := repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
 	c.Assert(err, IsNil)
-	err = repo.Add(&Capability{"c", "label-c", FileType})
+	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
 	c.Assert(err, IsNil)
-	err = repo.Add(&Capability{"b", "label-b", FileType})
+	err = repo.Add(&Capability{Name: "b", Label: "label-b", Type: FileType})
 	c.Assert(err, IsNil)
 	c.Assert(repo.Names(), DeepEquals, []string{"a", "b", "c"})
 }
 
 func (s *CapabilitySuite) TestString(c *C) {
-	cap := &Capability{"name", "label", FileType}
+	cap := &Capability{Name: "name", Label: "label", Type: FileType}
 	c.Assert(cap.String(), Equals, "name")
 }
 
 func (s *CapabilitySuite) TestAll(c *C) {
 	repo := NewRepository()
 	// Note added in non-sorted order
-	err := repo.Add(&Capability{"a", "label-a", FileType})
+	err := repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
 	c.Assert(err, IsNil)
-	err = repo.Add(&Capability{"c", "label-c", FileType})
+	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
 	c.Assert(err, IsNil)
-	err = repo.Add(&Capability{"b", "label-b", FileType})
+	err = repo.Add(&Capability{Name: "b", Label: "label-b", Type: FileType})
 	c.Assert(err, IsNil)
 	c.Assert(repo.All(), DeepEquals, []Capability{
-		Capability{"a", "label-a", FileType},
-		Capability{"b", "label-b", FileType},
-		Capability{"c", "label-c", FileType},
+		Capability{Name: "a", Label: "label-a", Type: FileType},
+		Capability{Name: "b", Label: "label-b", Type: FileType},
+		Capability{Name: "c", Label: "label-c", Type: FileType},
 	})
 }


### PR DESCRIPTION
Attributes are the primordial form of "properties" and "specifications"
that were discussed informally earlier. Since we're doing baby steps and
trying things out little by little, I want to introduce the concept of
capability attributes.

Attributes are intrinsically bound to types. So far types don't have a
representation but this if fine at this stage. Attributes will help us
make the first effective use of capabilities. My intent is to use them
as bits of data that can be used by applications to convey the location
of the resource (e.g. the path of the device to open: /dev/ttyUSB0).
Later on, they will also play the central role with enabling the
security parts that go along with this to work.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>