### PR TITLE
Do not export dirs.snappyDir

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -44,8 +44,11 @@ var (
 
 	ClickSystemHooksDir string
 	CloudMetaDataFile   string
+)
 
-	SnappyDir = filepath.Join("var", "lib", "snappy")
+var (
+	// not exported because it does not honor the global rootdir
+	snappyDir = filepath.Join("var", "lib", "snappy")
 )
 
 // SetRootDir allows settings a new global root directory, this is useful
@@ -57,11 +60,11 @@ func SetRootDir(rootdir string) {
 	SnapOemDir = filepath.Join(rootdir, "/oem")
 	SnapDataDir = filepath.Join(rootdir, "/var/lib/apps")
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/apps/")
-	SnapAppArmorDir = filepath.Join(rootdir, SnappyDir, "apparmor", "profiles")
-	SnapAppArmorAdditionalDir = filepath.Join(rootdir, SnappyDir, "apparmor", "additional")
-	SnapSeccompDir = filepath.Join(rootdir, SnappyDir, "seccomp", "profiles")
-	SnapIconsDir = filepath.Join(rootdir, SnappyDir, "icons")
-	SnapMetaDir = filepath.Join(rootdir, SnappyDir, "meta")
+	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
+	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")
+	SnapSeccompDir = filepath.Join(rootdir, snappyDir, "seccomp", "profiles")
+	SnapIconsDir = filepath.Join(rootdir, snappyDir, "icons")
+	SnapMetaDir = filepath.Join(rootdir, snappyDir, "meta")
 	SnapLockFile = filepath.Join(rootdir, "/run/snappy.lock")
 
 	SnapBinariesDir = filepath.Join(SnapAppsDir, "bin")


### PR DESCRIPTION
The dirs.snappyDir is used to build other paths and should not
be accessible from the outside as it does not honor the global
root directory.

Alternatively we could export it but then it needs to take the rootdir into account.