### PR TITLE
Fix systemd.Enable() symlink creation

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -167,8 +167,8 @@ func (s *systemd) Enable(serviceName string) error {
 		return nil
 	}
 
-	// important, do nt use the s.rootDir here as this is the
-	// real name (oldname)
+	// Do not use s.rootDir here. The link must point to the
+	// real (internal) path.
 	serviceFilename := filepath.Join(snapServicesDir, serviceName)
 	return os.Symlink(serviceFilename, enableSymlink)
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -162,13 +162,15 @@ func (*systemd) DaemonReload() error {
 func (s *systemd) Enable(serviceName string) error {
 	enableSymlink := filepath.Join(s.rootDir, snapServicesDir, servicesSystemdTarget+".wants", serviceName)
 
-	serviceFilename := filepath.Join(s.rootDir, snapServicesDir, serviceName)
 	// already enabled
 	if _, err := os.Lstat(enableSymlink); err == nil {
 		return nil
 	}
 
-	return os.Symlink(serviceFilename[len(s.rootDir):], enableSymlink)
+	// important, do nt use the s.rootDir here as this is the
+	// real name (oldname)
+	serviceFilename := filepath.Join(snapServicesDir, serviceName)
+	return os.Symlink(serviceFilename, enableSymlink)
 }
 
 // Disable the given service


### PR DESCRIPTION
The systemd.Enable() symlink did try to consider the global
rootdir. However in cases where that was just "/" it cut of
the first char of the path leading to symlinks pointing to
 etc/...
instead of
 /etc/...
This branch fixes it. The issues was uncovered by the
integration testsuite.