### PR TITLE
Add built-in capabilities to the daemon

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -99,14 +99,15 @@ func NewRepository() *Repository {
 	}
 }
 
-// AddBuiltInTypes adds all built-in types to the repository
-// If any of the additions fail the function panics.
-func (r *Repository) AddBuiltInTypes() {
+// LoadBuiltInTypes adds all built-in types to the repository
+// If any of the additions fail the function returns the error and stops.
+func LoadBuiltInTypes(r *Repository) error {
 	for _, t := range builtInTypes {
 		if err := r.AddType(t); err != nil {
-			panic(err.Error())
+			return err
 		}
 	}
+	return nil
 }
 
 // Add a capability to the repository.

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -75,6 +75,10 @@ const (
 	FileType Type = "file"
 )
 
+var builtInTypes = [...]Type{
+	FileType,
+}
+
 // Regular expression describing correct identifiers
 var validName = regexp.MustCompile("^[a-z]([a-z0-9-]+[a-z0-9])?$")
 
@@ -92,6 +96,16 @@ func NewRepository() *Repository {
 	return &Repository{
 		caps:  make(map[string]*Capability),
 		types: make([]Type, 0),
+	}
+}
+
+// AddBuiltInTypes adds all built-in types to the repository
+// If any of the additions fail the function panics.
+func (r *Repository) AddBuiltInTypes() {
+	for _, t := range builtInTypes {
+		if err := r.AddType(t); err != nil {
+			panic(err.Error())
+		}
 	}
 }
 

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -124,6 +124,14 @@ func (s *CapabilitySuite) TestRemoveNoSuchCapability(c *C) {
 	c.Assert(err, ErrorMatches, `can't remove capability "name", no such capability`)
 }
 
+func (s *CapabilitySuite) TestAddBuiltInTypes(c *C) {
+	repo := NewRepository()
+	repo.AddBuiltInTypes()
+	c.Assert(repo.types, testutil.Contains, FileType)
+	c.Assert(repo.types, HasLen, 1) // Update this whenever new built-in type is added
+	c.Assert(func() { repo.AddBuiltInTypes() }, Panics, `cannot add type "file": name already exists`)
+}
+
 func (s *CapabilitySuite) TestNames(c *C) {
 	repo := NewRepository()
 	// Note added in non-sorted order

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -124,12 +124,14 @@ func (s *CapabilitySuite) TestRemoveNoSuchCapability(c *C) {
 	c.Assert(err, ErrorMatches, `can't remove capability "name", no such capability`)
 }
 
-func (s *CapabilitySuite) TestAddBuiltInTypes(c *C) {
+func (s *CapabilitySuite) TestLoadBuiltInTypes(c *C) {
 	repo := NewRepository()
-	repo.AddBuiltInTypes()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	c.Assert(repo.types, testutil.Contains, FileType)
 	c.Assert(repo.types, HasLen, 1) // Update this whenever new built-in type is added
-	c.Assert(func() { repo.AddBuiltInTypes() }, Panics, `cannot add type "file": name already exists`)
+	err = LoadBuiltInTypes(repo)
+	c.Assert(err, ErrorMatches, `cannot add type "file": name already exists`)
 }
 
 func (s *CapabilitySuite) TestNames(c *C) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -204,7 +204,10 @@ func (d *Daemon) DeleteTask(uuid string) error {
 // New Daemon
 func New() *Daemon {
 	repo := caps.NewRepository()
-	repo.AddBuiltInTypes()
+	err := caps.LoadBuiltInTypes(repo)
+	if err != nil {
+		panic(err.Error())
+	}
 	return &Daemon{
 		tasks:   make(map[string]*Task),
 		capRepo: repo,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -203,8 +203,10 @@ func (d *Daemon) DeleteTask(uuid string) error {
 
 // New Daemon
 func New() *Daemon {
+	repo := caps.NewRepository()
+	repo.AddBuiltInTypes()
 	return &Daemon{
 		tasks:   make(map[string]*Task),
-		capRepo: caps.NewRepository(),
+		capRepo: repo,
 	}
 }


### PR DESCRIPTION
We want to start validating capability types as they are being added. To do that though, I want to have some temporary built-in capability types so that it's easier to experiment. Later on those built-in capability types will be loaded from storage so the concept is long-lived.