### PR TITLE
partition/bootloader_grub.go: pass the correct grub path to newBootLoader()

### DIFF
--- a/partition/bootloader_grub.go
+++ b/partition/bootloader_grub.go
@@ -64,7 +64,7 @@ func newGrub(partition *Partition) bootLoader {
 		return nil
 	}
 
-	b := newBootLoader(partition, bootloaderGrubConfigFile())
+	b := newBootLoader(partition, bootloaderGrubDir())
 	if b == nil {
 		return nil
 	}


### PR DESCRIPTION
Silly me, trivial fix from the mvo5/feature/bootloader-global-rootdir merge. Sorry for this, the whole partition code will get cleanup once we have kernel/os snaps, I swear!