### PR TITLE
hw assign bug 1498921

### DIFF
--- a/snappy/hwaccess.go
+++ b/snappy/hwaccess.go
@@ -53,6 +53,18 @@ func validDevice(device string) bool {
 	return false
 }
 
+func validDeviceForUdev(device string) bool {
+	inValidPrefixes := []string{"/sys/devices", "/sys/class/gpio"}
+
+	for _, s := range inValidPrefixes {
+		if strings.HasPrefix(device, s) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func readHWAccessYamlFile(snapname string) (SecurityOverrideDefinition, error) {
 	var appArmorAdditional SecurityOverrideDefinition
 
@@ -200,8 +212,10 @@ func AddHWAccess(snapname, device string) error {
 	}
 
 	// add udev rule for device cgroup
-	if err := writeUdevRuleForDeviceCgroup(snapname, device); err != nil {
-		return err
+	if validDeviceForUdev(device) {
+		if err := writeUdevRuleForDeviceCgroup(snapname, device); err != nil {
+			return err
+		}
 	}
 
 	// re-generate apparmor fules

--- a/snappy/hwaccess.go
+++ b/snappy/hwaccess.go
@@ -42,7 +42,7 @@ func getHWAccessYamlFile(snapname string) string {
 
 // Return true if the device string is a valid device
 func validDevice(device string) bool {
-	validPrefixes := []string{"/dev", "/sys/devices", "/sys/class/gpio"}
+	validPrefixes := []string{"/dev/", "/sys/devices/", "/sys/class/gpio/"}
 
 	for _, s := range validPrefixes {
 		if strings.HasPrefix(device, s) {
@@ -54,15 +54,15 @@ func validDevice(device string) bool {
 }
 
 func validDeviceForUdev(device string) bool {
-	inValidPrefixes := []string{"/sys/devices", "/sys/class/gpio"}
+	validPrefixes := []string{"/dev/"}
 
-	for _, s := range inValidPrefixes {
+	for _, s := range validPrefixes {
 		if strings.HasPrefix(device, s) {
-			return false
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func readHWAccessYamlFile(snapname string) (SecurityOverrideDefinition, error) {

--- a/snappy/hwaccess_test.go
+++ b/snappy/hwaccess_test.go
@@ -295,7 +295,7 @@ func (s *SnapTestSuite) TestAddSysDevice(c *C) {
 	err := AddHWAccess("hello-app", "/sys/devices/foo1")
 	c.Assert(err, IsNil)
 	err = AddHWAccess("hello-app", "/sys/class/gpio/foo2")
-	c.Assert(err, Equals, nil)
+	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-app.hwaccess.yaml"))
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Hello,

this is a fix proposal for bug #1498921 "
hw-assign should not add udev rules when specifying /sys/devices/... and /sys/class/..."