### PR TITLE
Implement markBootSuccessfulAllSnaps() and add test

### DIFF
--- a/docs/system-updates.rst
+++ b/docs/system-updates.rst
@@ -1,6 +1,6 @@
-===================================
-Snappy Transactional System Updates
-===================================
+==================================================
+Snappy Transactional System Updates on a/b systems
+==================================================
 
 .. contents::
 .. sectnum::
@@ -10,6 +10,11 @@ Introduction
 
 This document provides an overview of how system-level updates are
 applied to a snappy system, and how the system boot operates.
+
+Note that this document describes systems that use a snappy a/b
+partition layout. Newer snappy systems use a different mechanism
+called "all-snap" that is using a different strategy for the
+transnational updates.
 
 System-level updates
 --------------------

--- a/partition/partition.go
+++ b/partition/partition.go
@@ -352,9 +352,38 @@ func (p *Partition) markBootSuccessfulSnappyAB() error {
 	return bootloader.MarkCurrentBootSuccessful(currentRootfs)
 }
 
-// FIXME: stub
 func (p *Partition) markBootSuccessfulAllSnaps() error {
-	panic("markBootSuccessfulAllSnaps is not implemented yet")
+	bootloader, err := bootloader(p)
+	if err != nil {
+		return err
+	}
+
+	// FIXME: we should have something more atomic here, i.e. one write
+	//        to the bootloader environment only, need to figure
+	//        if that is possible with grub/uboot
+	for _, k := range []string{"snappy_os", "snappy_kernel"} {
+		value, err := bootloader.GetBootVar(k)
+		if err != nil {
+			return err
+		}
+
+		// FIXME: ugly string replace
+		newKey := strings.Replace(k, "snappy_", "snappy_good_", -1)
+		if err := bootloader.SetBootVar(newKey, value); err != nil {
+			return err
+		}
+
+		if err := bootloader.SetBootVar("snappy_mode", "regular"); err != nil {
+			return err
+		}
+
+		if err := bootloader.SetBootVar("snappy_trial_boot", "0"); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
 }
 
 // IsNextBootOther return true if the next boot will use the other rootfs

--- a/partition/partition.go
+++ b/partition/partition.go
@@ -358,9 +358,11 @@ func (p *Partition) markBootSuccessfulAllSnaps() error {
 		return err
 	}
 
-	// FIXME: we should have something more atomic here, i.e. one write
-	//        to the bootloader environment only, need to figure
-	//        if that is possible with grub/uboot
+	// FIXME: we should have something better here, i.e. one write
+	//        to the bootloader environment only (instead of three)
+	//        We need to figure out if that is possible with grub/uboot
+	// (if we could also do atomic writes to the boot env, that would
+	//  be even better)
 	for _, k := range []string{"snappy_os", "snappy_kernel"} {
 		value, err := bootloader.GetBootVar(k)
 		if err != nil {


### PR DESCRIPTION
Small branch that implements the boot-success logic for all-snaps.

It will simply store the current good os and kernel version in the bootloader variables snappy_os_good and snappy_kernel_good if it detects that its running on an all-snap system. The test simulates such a system by mocking the lsblk output.