### PR TITLE
Ensure squashfs snaps keep all uid/gid and permissions on build

### DIFF
--- a/helpers/cp.go
+++ b/helpers/cp.go
@@ -59,8 +59,10 @@ func doOpenFile(name string, flag int, perm os.FileMode) (fileish, error) {
 
 // CopyFile copies src to dst
 func CopyFile(src, dst string, flags CopyFlag) (err error) {
-	// we do not preserve all yet here natively so just use "cp"
 	if flags&CopyFlagPreserveAll != 0 {
+		// Our native copy code does not preserve all attributes
+		// (yet). If the user needs this functionatlity we just
+		// fallback to use the system's "cp" binary to do the copy.
 		return runCpPreserveAll(src, dst)
 	}
 

--- a/helpers/cp_test.go
+++ b/helpers/cp_test.go
@@ -220,10 +220,14 @@ func (s *cpSuite) TestCopyPreserveAll(c *C) {
 	err := ioutil.WriteFile(src, []byte(nil), 0644)
 	c.Assert(err, IsNil)
 
-	// wait a wee bit to get different mtimes in the copy
-	// (note this will not work on reiserfs and ext2 because
-	//  those do  not have sub-second precision)
-	time.Sleep(100 * time.Millisecond)
+	// give it some different atime/mtime
+	tv := []syscall.Timeval{
+		syscall.Timeval{Sec: 0, Usec: 0},
+		syscall.Timeval{Sec: 0, Usec: 0},
+	}
+	err = syscall.Utimes(src, tv)
+	c.Assert(err, IsNil)
+
 	err = CopyFile(src, dst, CopyFlagPreserveAll)
 	c.Assert(err, IsNil)
 

--- a/helpers/cp_test.go
+++ b/helpers/cp_test.go
@@ -212,3 +212,25 @@ func (s *cpSuite) TestCopySpecialFileErrors(c *C) {
 	err := CopySpecialFile("no-such-file", "no-such-target")
 	c.Assert(err, ErrorMatches, "failed to copy device node:.*cp:.*stat.*no-such-file.*")
 }
+
+func (s *cpSuite) TestCopyPreserveAll(c *C) {
+	src := filepath.Join(c.MkDir(), "meep")
+	dst := filepath.Join(c.MkDir(), "copied-meep")
+
+	err := ioutil.WriteFile(src, []byte(nil), 0644)
+	c.Assert(err, IsNil)
+
+	// wait a wee bit to get different mtimes in the copy
+	// (note this will not work on reiserfs and ext2 because
+	//  those do  not have sub-second precision)
+	time.Sleep(100 * time.Millisecond)
+	err = CopyFile(src, dst, CopyFlagPreserveAll)
+	c.Assert(err, IsNil)
+
+	// ensure that the mtime got preserved
+	st1, err := os.Stat(src)
+	c.Assert(err, IsNil)
+	st2, err := os.Stat(dst)
+	c.Assert(err, IsNil)
+	c.Assert(st1.ModTime(), Equals, st2.ModTime())
+}

--- a/pkg/squashfs/squashfs.go
+++ b/pkg/squashfs/squashfs.go
@@ -135,7 +135,6 @@ func (s *Snap) Build(buildDir string) error {
 		return runCommand(
 			"mksquashfs",
 			".", fullSnapPath,
-			"-all-root",
 			"-noappend",
 			"-comp", "xz")
 	})

--- a/snappy/build.go
+++ b/snappy/build.go
@@ -395,7 +395,9 @@ func copyToBuildDir(sourceDir, buildDir string) error {
 				return err
 			}
 			// ensure that premissions are preserved
-			return os.Chown(dest, int(info.Sys().(*syscall.Stat_t).Uid), int(info.Sys().(*syscall.Stat_t).Gid))
+			uid := int(info.Sys().(*syscall.Stat_t).Uid)
+			gid := int(info.Sys().(*syscall.Stat_t).Gid)
+			return os.Chown(dest, uid, gid)
 		}
 
 		// handle char/block devices

--- a/snappy/build.go
+++ b/snappy/build.go
@@ -391,7 +391,11 @@ func copyToBuildDir(sourceDir, buildDir string) error {
 
 		// handle dirs
 		if info.IsDir() {
-			return os.Mkdir(dest, info.Mode())
+			if err := os.Mkdir(dest, info.Mode()); err != nil {
+				return err
+			}
+			// ensure that premissions are preserved
+			return os.Chown(dest, int(info.Sys().(*syscall.Stat_t).Uid), int(info.Sys().(*syscall.Stat_t).Gid))
 		}
 
 		// handle char/block devices


### PR DESCRIPTION
When building a squashfs snap for the OS we need to preserve the
owner information of the dirs/files to support special files like
/etc/shadow that has a shadow gid. This branch ensures that this
is the case.