### PR TITLE
Add basic capability type verification

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -118,12 +118,22 @@ func (r *Repository) Add(cap *Capability) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
+	// Reject capabilities with invalid names
 	if err := ValidateName(cap.Name); err != nil {
 		return err
 	}
+	// Reject capabilities with duplicate names
 	if _, ok := r.caps[cap.Name]; ok {
 		return fmt.Errorf("cannot add capability %q: name already exists", cap.Name)
 	}
+	// Reject capabilities with unknown types
+	for _, t := range r.types {
+		if cap.Type == t {
+			goto typeFound
+		}
+	}
+	return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
+typeFound:
 	r.caps[cap.Name] = cap
 	return nil
 }

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -134,6 +134,10 @@ func (r *Repository) Add(cap *Capability) error {
 	}
 	return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
 typeFound:
+	// Reject capabilities that don't pass type-specific validation
+	if err := cap.Type.Validate(cap); err != nil {
+		return err
+	}
 	r.caps[cap.Name] = cap
 	return nil
 }

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -222,3 +222,11 @@ func (e *NotFoundError) Error() string {
 		panic(fmt.Sprintf("unexpected what: %q", e.what))
 	}
 }
+
+// Validate if a capability is correct according to the given type
+func (t Type) Validate(c *Capability) error {
+	if t != c.Type {
+		return fmt.Errorf("capability is not of type %q", t)
+	}
+	return nil
+}

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -127,19 +127,25 @@ func (r *Repository) Add(cap *Capability) error {
 		return fmt.Errorf("cannot add capability %q: name already exists", cap.Name)
 	}
 	// Reject capabilities with unknown types
-	for _, t := range r.types {
-		if cap.Type == t {
-			goto typeFound
-		}
+	if !r.HasType(cap.Type) {
+		return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
 	}
-	return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
-typeFound:
 	// Reject capabilities that don't pass type-specific validation
 	if err := cap.Type.Validate(cap); err != nil {
 		return err
 	}
 	r.caps[cap.Name] = cap
 	return nil
+}
+
+// HasType checks if the repository contains the given type
+func (r *Repository) HasType(t Type) bool {
+	for _, tt := range r.types {
+		if tt == t {
+			return true
+		}
+	}
+	return false
 }
 
 // AddType adds a capability type to the repository.

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -242,5 +242,11 @@ func (t Type) Validate(c *Capability) error {
 	if t != c.Type {
 		return fmt.Errorf("capability is not of type %q", t)
 	}
+	// While we don't have any support for type-specific attribute schema,
+	// let's ensure that attributes are totally empty. This will make tests
+	// show that this code is actually being used
+	if c.Attrs != nil && len(c.Attrs) != 0 {
+		return fmt.Errorf("attributes must be empty for now")
+	}
 	return nil
 }

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -180,3 +180,15 @@ func (s *CapabilitySuite) TestAll(c *C) {
 		Capability{Name: "c", Label: "label-c", Type: FileType},
 	})
 }
+
+func (s *CapabilitySuite) TestValidateMismatchedType(c *C) {
+	cap := &Capability{Name: "name", Label: "label", Type: Type("device")}
+	err := FileType.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability is not of type "file"`)
+}
+
+func (s *CapabilitySuite) TestValidateOK(c *C) {
+	cap := &Capability{Name: "name", Label: "label", Type: FileType}
+	err := FileType.Validate(cap)
+	c.Assert(err, IsNil)
+}

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -46,9 +46,11 @@ func (s *CapabilitySuite) TestValidateName(c *C) {
 
 func (s *CapabilitySuite) TestAdd(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	cap := &Capability{Name: "name", Label: "label", Type: FileType}
 	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
-	err := repo.Add(cap)
+	err = repo.Add(cap)
 	c.Assert(err, IsNil)
 	c.Assert(repo.Names(), DeepEquals, []string{"name"})
 	c.Assert(repo.Names(), testutil.Contains, cap.Name)
@@ -56,8 +58,10 @@ func (s *CapabilitySuite) TestAdd(c *C) {
 
 func (s *CapabilitySuite) TestAddClash(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	cap1 := &Capability{Name: "name", Label: "label 1", Type: FileType}
-	err := repo.Add(cap1)
+	err = repo.Add(cap1)
 	c.Assert(err, IsNil)
 	cap2 := &Capability{Name: "name", Label: "label 2", Type: FileType}
 	err = repo.Add(cap2)
@@ -69,8 +73,10 @@ func (s *CapabilitySuite) TestAddClash(c *C) {
 
 func (s *CapabilitySuite) TestAddInvalidName(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	cap := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
-	err := repo.Add(cap)
+	err = repo.Add(cap)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(repo.Names(), DeepEquals, []string{})
 	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
@@ -109,8 +115,10 @@ func (s *CapabilitySuite) TestAddTypeInvalidName(c *C) {
 
 func (s *CapabilitySuite) TestRemoveGood(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	cap := &Capability{Name: "name", Label: "label", Type: FileType}
-	err := repo.Add(cap)
+	err = repo.Add(cap)
 	c.Assert(err, IsNil)
 	err = repo.Remove(cap.Name)
 	c.Assert(err, IsNil)
@@ -136,8 +144,10 @@ func (s *CapabilitySuite) TestLoadBuiltInTypes(c *C) {
 
 func (s *CapabilitySuite) TestNames(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	// Note added in non-sorted order
-	err := repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
+	err = repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
 	c.Assert(err, IsNil)
 	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
 	c.Assert(err, IsNil)
@@ -167,8 +177,10 @@ func (s *CapabilitySuite) TestTypeString(c *C) {
 
 func (s *CapabilitySuite) TestAll(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	// Note added in non-sorted order
-	err := repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
+	err = repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
 	c.Assert(err, IsNil)
 	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
 	c.Assert(err, IsNil)

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -204,3 +204,16 @@ func (s *CapabilitySuite) TestValidateOK(c *C) {
 	err := FileType.Validate(cap)
 	c.Assert(err, IsNil)
 }
+
+func (s *CapabilitySuite) TestValidateAttributes(c *C) {
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  FileType,
+		Attrs: map[string]string{
+			"Key": "Value",
+		},
+	}
+	err := FileType.Validate(cap)
+	c.Assert(err, ErrorMatches, "attributes must be empty for now")
+}

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -69,11 +69,11 @@ func (s *CapabilitySuite) TestAddClash(c *C) {
 
 func (s *CapabilitySuite) TestAddInvalidName(c *C) {
 	repo := NewRepository()
-	cap1 := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
-	err := repo.Add(cap1)
+	cap := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
+	err := repo.Add(cap)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(repo.Names(), DeepEquals, []string{})
-	c.Assert(repo.Names(), Not(testutil.Contains), cap1.Name)
+	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
 }
 
 func (s *CapabilitySuite) TestAddType(c *C) {


### PR DESCRIPTION
This branch makes it possible to do some simple type-specific checks on each capability that is being added to a repository. Later on each caps.Type will carry more information (and will stop being a plain string) so we can finally do attribute checks against a schema. This sets the stage for that to happen.