### PR TITLE
Split capabilities package into separate file

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -118,12 +118,22 @@ func (r *Repository) Add(cap *Capability) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
+	// Reject capabilities with invalid names
 	if err := ValidateName(cap.Name); err != nil {
 		return err
 	}
+	// Reject capabilities with duplicate names
 	if _, ok := r.caps[cap.Name]; ok {
 		return fmt.Errorf("cannot add capability %q: name already exists", cap.Name)
 	}
+	// Reject capabilities with unknown types
+	for _, t := range r.types {
+		if cap.Type == t {
+			goto typeFound
+		}
+	}
+	return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
+typeFound:
 	r.caps[cap.Name] = cap
 	return nil
 }

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -19,11 +19,6 @@
 
 package caps
 
-import (
-	"fmt"
-	"regexp"
-)
-
 // Capability holds information about a capability that a snap may request
 // from a snappy system to do its job while running on it.
 type Capability struct {
@@ -43,44 +38,7 @@ type Capability struct {
 	Attrs map[string]string
 }
 
-// NotFoundError means that a capability was not found
-type NotFoundError struct {
-	what, name string
-}
-
-// Regular expression describing correct identifiers
-var validName = regexp.MustCompile("^[a-z]([a-z0-9-]+[a-z0-9])?$")
-
-// ValidateName checks if a string as a capability name
-func ValidateName(name string) error {
-	valid := validName.MatchString(name)
-	if !valid {
-		return fmt.Errorf("%q is not a valid snap name", name)
-	}
-	return nil
-}
-
-// LoadBuiltInTypes adds all built-in types to the repository
-// If any of the additions fail the function returns the error and stops.
-func LoadBuiltInTypes(r *Repository) error {
-	for _, t := range builtInTypes {
-		if err := r.AddType(t); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // String representation of a capability.
 func (c Capability) String() string {
 	return c.Name
-}
-
-func (e *NotFoundError) Error() string {
-	switch e.what {
-	case "remove":
-		return fmt.Sprintf("can't remove capability %q, no such capability", e.name)
-	default:
-		panic(fmt.Sprintf("unexpected what: %q", e.what))
-	}
 }

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -134,6 +134,10 @@ func (r *Repository) Add(cap *Capability) error {
 	}
 	return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
 typeFound:
+	// Reject capabilities that don't pass type-specific validation
+	if err := cap.Type.Validate(cap); err != nil {
+		return err
+	}
 	r.caps[cap.Name] = cap
 	return nil
 }

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -26,14 +26,6 @@ import (
 	"sync"
 )
 
-// Type is the name of a capability type.
-type Type string
-
-// String returns a string representation for the capability type.
-func (t Type) String() string {
-	return string(t)
-}
-
 // Capability holds information about a capability that a snap may request
 // from a snappy system to do its job while running on it.
 type Capability struct {
@@ -65,18 +57,6 @@ type Repository struct {
 // NotFoundError means that a capability was not found
 type NotFoundError struct {
 	what, name string
-}
-
-const (
-	// FileType is a basic capability vaguely expressing access to a specific
-	// file. This single capability  type is here just to help bootstrap
-	// the capability concept before we get to load capability interfaces
-	// from YAML.
-	FileType Type = "file"
-)
-
-var builtInTypes = [...]Type{
-	FileType,
 }
 
 // Regular expression describing correct identifiers
@@ -241,18 +221,4 @@ func (e *NotFoundError) Error() string {
 	default:
 		panic(fmt.Sprintf("unexpected what: %q", e.what))
 	}
-}
-
-// Validate if a capability is correct according to the given type
-func (t Type) Validate(c *Capability) error {
-	if t != c.Type {
-		return fmt.Errorf("capability is not of type %q", t)
-	}
-	// While we don't have any support for type-specific attribute schema,
-	// let's ensure that attributes are totally empty. This will make tests
-	// show that this code is actually being used
-	if c.Attrs != nil && len(c.Attrs) != 0 {
-		return fmt.Errorf("attributes must be empty for now")
-	}
-	return nil
 }

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -222,3 +222,11 @@ func (e *NotFoundError) Error() string {
 		panic(fmt.Sprintf("unexpected what: %q", e.what))
 	}
 }
+
+// Validate if a capability is correct according to the given type
+func (t Type) Validate(c *Capability) error {
+	if t != c.Type {
+		return fmt.Errorf("capability is not of type %q", t)
+	}
+	return nil
+}

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -127,19 +127,25 @@ func (r *Repository) Add(cap *Capability) error {
 		return fmt.Errorf("cannot add capability %q: name already exists", cap.Name)
 	}
 	// Reject capabilities with unknown types
-	for _, t := range r.types {
-		if cap.Type == t {
-			goto typeFound
-		}
+	if !r.HasType(cap.Type) {
+		return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
 	}
-	return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
-typeFound:
 	// Reject capabilities that don't pass type-specific validation
 	if err := cap.Type.Validate(cap); err != nil {
 		return err
 	}
 	r.caps[cap.Name] = cap
 	return nil
+}
+
+// HasType checks if the repository contains the given type
+func (r *Repository) HasType(t Type) bool {
+	for _, tt := range r.types {
+		if tt == t {
+			return true
+		}
+	}
+	return false
 }
 
 // AddType adds a capability type to the repository.

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -242,5 +242,11 @@ func (t Type) Validate(c *Capability) error {
 	if t != c.Type {
 		return fmt.Errorf("capability is not of type %q", t)
 	}
+	// While we don't have any support for type-specific attribute schema,
+	// let's ensure that attributes are totally empty. This will make tests
+	// show that this code is actually being used
+	if c.Attrs != nil && len(c.Attrs) != 0 {
+		return fmt.Errorf("attributes must be empty for now")
+	}
 	return nil
 }

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -22,8 +22,6 @@ package caps
 import (
 	"fmt"
 	"regexp"
-	"sort"
-	"sync"
 )
 
 // Capability holds information about a capability that a snap may request
@@ -45,15 +43,6 @@ type Capability struct {
 	Attrs map[string]string
 }
 
-// Repository stores all known snappy capabilities and types
-type Repository struct {
-	m sync.Mutex // protects the internals from concurrent access. If contention gets high, switch to a RWMutex
-	// Map of capabilities, indexed by Capability.Name
-	caps map[string]*Capability
-	// A slice of types that are recognized and accepted
-	types []Type
-}
-
 // NotFoundError means that a capability was not found
 type NotFoundError struct {
 	what, name string
@@ -71,14 +60,6 @@ func ValidateName(name string) error {
 	return nil
 }
 
-// NewRepository creates an empty capability repository
-func NewRepository() *Repository {
-	return &Repository{
-		caps:  make(map[string]*Capability),
-		types: make([]Type, 0),
-	}
-}
-
 // LoadBuiltInTypes adds all built-in types to the repository
 // If any of the additions fail the function returns the error and stops.
 func LoadBuiltInTypes(r *Repository) error {
@@ -90,128 +71,9 @@ func LoadBuiltInTypes(r *Repository) error {
 	return nil
 }
 
-// Add a capability to the repository.
-// Capability names must be valid snap names, as defined by ValidateName, and
-// must be unique within the repository.  An error is returned if this
-// constraint is violated.
-func (r *Repository) Add(cap *Capability) error {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	// Reject capabilities with invalid names
-	if err := ValidateName(cap.Name); err != nil {
-		return err
-	}
-	// Reject capabilities with duplicate names
-	if _, ok := r.caps[cap.Name]; ok {
-		return fmt.Errorf("cannot add capability %q: name already exists", cap.Name)
-	}
-	// Reject capabilities with unknown types
-	if !r.HasType(cap.Type) {
-		return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
-	}
-	// Reject capabilities that don't pass type-specific validation
-	if err := cap.Type.Validate(cap); err != nil {
-		return err
-	}
-	r.caps[cap.Name] = cap
-	return nil
-}
-
-// HasType checks if the repository contains the given type
-func (r *Repository) HasType(t Type) bool {
-	for _, tt := range r.types {
-		if tt == t {
-			return true
-		}
-	}
-	return false
-}
-
-// AddType adds a capability type to the repository.
-// It's an error to add the same capability type more than once.
-func (r *Repository) AddType(t Type) error {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	if err := ValidateName(t.String()); err != nil {
-		return err
-	}
-	for _, otherT := range r.types {
-		if t == otherT {
-			return fmt.Errorf("cannot add type %q: name already exists", t)
-		}
-	}
-	r.types = append(r.types, t)
-	return nil
-}
-
-// Remove removes the capability with the provided name.
-// Removing a capability that doesn't exist silently does nothing
-func (r *Repository) Remove(name string) error {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	_, ok := r.caps[name]
-	if ok {
-		delete(r.caps, name)
-		return nil
-	}
-	return &NotFoundError{"remove", name}
-}
-
-// Names returns all capability names in the repository in lexicographical order.
-func (r *Repository) Names() []string {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	keys := make([]string, len(r.caps))
-	i := 0
-	for key := range r.caps {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
-}
-
 // String representation of a capability.
 func (c Capability) String() string {
 	return c.Name
-}
-
-// TypeNames returns all type names in the repository in lexicographical order.
-func (r *Repository) TypeNames() []string {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	types := make([]string, len(r.types))
-	for i, t := range r.types {
-		types[i] = t.String()
-	}
-	sort.Strings(types)
-	return types
-}
-
-type byName []Capability
-
-func (c byName) Len() int           { return len(c) }
-func (c byName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
-func (c byName) Less(i, j int) bool { return c[i].Name < c[j].Name }
-
-// All returns all capabilities ordered by name.
-func (r *Repository) All() []Capability {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	caps := make([]Capability, len(r.caps))
-	i := 0
-	for _, capability := range r.caps {
-		caps[i] = *capability
-		i++
-	}
-	sort.Sort(byName(caps))
-	return caps
 }
 
 func (e *NotFoundError) Error() string {

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -44,94 +44,6 @@ func (s *CapabilitySuite) TestValidateName(c *C) {
 	c.Assert(ValidateName("name"), IsNil)
 }
 
-func (s *CapabilitySuite) TestAdd(c *C) {
-	repo := NewRepository()
-	err := LoadBuiltInTypes(repo)
-	c.Assert(err, IsNil)
-	cap := &Capability{Name: "name", Label: "label", Type: FileType}
-	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
-	err = repo.Add(cap)
-	c.Assert(err, IsNil)
-	c.Assert(repo.Names(), DeepEquals, []string{"name"})
-	c.Assert(repo.Names(), testutil.Contains, cap.Name)
-}
-
-func (s *CapabilitySuite) TestAddClash(c *C) {
-	repo := NewRepository()
-	err := LoadBuiltInTypes(repo)
-	c.Assert(err, IsNil)
-	cap1 := &Capability{Name: "name", Label: "label 1", Type: FileType}
-	err = repo.Add(cap1)
-	c.Assert(err, IsNil)
-	cap2 := &Capability{Name: "name", Label: "label 2", Type: FileType}
-	err = repo.Add(cap2)
-	c.Assert(err, ErrorMatches,
-		`cannot add capability "name": name already exists`)
-	c.Assert(repo.Names(), DeepEquals, []string{"name"})
-	c.Assert(repo.Names(), testutil.Contains, cap1.Name)
-}
-
-func (s *CapabilitySuite) TestAddInvalidName(c *C) {
-	repo := NewRepository()
-	err := LoadBuiltInTypes(repo)
-	c.Assert(err, IsNil)
-	cap := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
-	err = repo.Add(cap)
-	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
-	c.Assert(repo.Names(), DeepEquals, []string{})
-	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
-}
-
-func (s *CapabilitySuite) TestAddType(c *C) {
-	repo := NewRepository()
-	t := Type("foo")
-	err := repo.AddType(t)
-	c.Assert(err, IsNil)
-	c.Assert(repo.TypeNames(), DeepEquals, []string{"foo"})
-	c.Assert(repo.TypeNames(), testutil.Contains, "foo")
-}
-
-func (s *CapabilitySuite) TestAddTypeClash(c *C) {
-	repo := NewRepository()
-	t1 := Type("foo")
-	t2 := Type("foo")
-	err := repo.AddType(t1)
-	c.Assert(err, IsNil)
-	err = repo.AddType(t2)
-	c.Assert(err, ErrorMatches,
-		`cannot add type "foo": name already exists`)
-	c.Assert(repo.TypeNames(), DeepEquals, []string{"foo"})
-	c.Assert(repo.TypeNames(), testutil.Contains, "foo")
-}
-
-func (s *CapabilitySuite) TestAddTypeInvalidName(c *C) {
-	repo := NewRepository()
-	t := Type("bad-name-")
-	err := repo.AddType(t)
-	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
-	c.Assert(repo.TypeNames(), DeepEquals, []string{})
-	c.Assert(repo.TypeNames(), Not(testutil.Contains), string(t))
-}
-
-func (s *CapabilitySuite) TestRemoveGood(c *C) {
-	repo := NewRepository()
-	err := LoadBuiltInTypes(repo)
-	c.Assert(err, IsNil)
-	cap := &Capability{Name: "name", Label: "label", Type: FileType}
-	err = repo.Add(cap)
-	c.Assert(err, IsNil)
-	err = repo.Remove(cap.Name)
-	c.Assert(err, IsNil)
-	c.Assert(repo.Names(), HasLen, 0)
-	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
-}
-
-func (s *CapabilitySuite) TestRemoveNoSuchCapability(c *C) {
-	repo := NewRepository()
-	err := repo.Remove("name")
-	c.Assert(err, ErrorMatches, `can't remove capability "name", no such capability`)
-}
-
 func (s *CapabilitySuite) TestLoadBuiltInTypes(c *C) {
 	repo := NewRepository()
 	err := LoadBuiltInTypes(repo)
@@ -142,48 +54,7 @@ func (s *CapabilitySuite) TestLoadBuiltInTypes(c *C) {
 	c.Assert(err, ErrorMatches, `cannot add type "file": name already exists`)
 }
 
-func (s *CapabilitySuite) TestNames(c *C) {
-	repo := NewRepository()
-	err := LoadBuiltInTypes(repo)
-	c.Assert(err, IsNil)
-	// Note added in non-sorted order
-	err = repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
-	c.Assert(err, IsNil)
-	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
-	c.Assert(err, IsNil)
-	err = repo.Add(&Capability{Name: "b", Label: "label-b", Type: FileType})
-	c.Assert(err, IsNil)
-	c.Assert(repo.Names(), DeepEquals, []string{"a", "b", "c"})
-}
-
-func (s *CapabilitySuite) TestTypeNames(c *C) {
-	repo := NewRepository()
-	c.Assert(repo.TypeNames(), DeepEquals, []string{})
-	repo.AddType(Type("a"))
-	repo.AddType(Type("b"))
-	repo.AddType(Type("c"))
-	c.Assert(repo.TypeNames(), DeepEquals, []string{"a", "b", "c"})
-}
-
 func (s *CapabilitySuite) TestString(c *C) {
 	cap := &Capability{Name: "name", Label: "label", Type: FileType}
 	c.Assert(cap.String(), Equals, "name")
-}
-
-func (s *CapabilitySuite) TestAll(c *C) {
-	repo := NewRepository()
-	err := LoadBuiltInTypes(repo)
-	c.Assert(err, IsNil)
-	// Note added in non-sorted order
-	err = repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
-	c.Assert(err, IsNil)
-	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
-	c.Assert(err, IsNil)
-	err = repo.Add(&Capability{Name: "b", Label: "label-b", Type: FileType})
-	c.Assert(err, IsNil)
-	c.Assert(repo.All(), DeepEquals, []Capability{
-		Capability{Name: "a", Label: "label-a", Type: FileType},
-		Capability{Name: "b", Label: "label-b", Type: FileType},
-		Capability{Name: "c", Label: "label-c", Type: FileType},
-	})
 }

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -180,3 +180,15 @@ func (s *CapabilitySuite) TestAll(c *C) {
 		Capability{Name: "c", Label: "label-c", Type: FileType},
 	})
 }
+
+func (s *CapabilitySuite) TestValidateMismatchedType(c *C) {
+	cap := &Capability{Name: "name", Label: "label", Type: Type("device")}
+	err := FileType.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability is not of type "file"`)
+}
+
+func (s *CapabilitySuite) TestValidateOK(c *C) {
+	cap := &Capability{Name: "name", Label: "label", Type: FileType}
+	err := FileType.Validate(cap)
+	c.Assert(err, IsNil)
+}

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -46,9 +46,11 @@ func (s *CapabilitySuite) TestValidateName(c *C) {
 
 func (s *CapabilitySuite) TestAdd(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	cap := &Capability{Name: "name", Label: "label", Type: FileType}
 	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
-	err := repo.Add(cap)
+	err = repo.Add(cap)
 	c.Assert(err, IsNil)
 	c.Assert(repo.Names(), DeepEquals, []string{"name"})
 	c.Assert(repo.Names(), testutil.Contains, cap.Name)
@@ -56,8 +58,10 @@ func (s *CapabilitySuite) TestAdd(c *C) {
 
 func (s *CapabilitySuite) TestAddClash(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	cap1 := &Capability{Name: "name", Label: "label 1", Type: FileType}
-	err := repo.Add(cap1)
+	err = repo.Add(cap1)
 	c.Assert(err, IsNil)
 	cap2 := &Capability{Name: "name", Label: "label 2", Type: FileType}
 	err = repo.Add(cap2)
@@ -69,8 +73,10 @@ func (s *CapabilitySuite) TestAddClash(c *C) {
 
 func (s *CapabilitySuite) TestAddInvalidName(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	cap := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
-	err := repo.Add(cap)
+	err = repo.Add(cap)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(repo.Names(), DeepEquals, []string{})
 	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
@@ -109,8 +115,10 @@ func (s *CapabilitySuite) TestAddTypeInvalidName(c *C) {
 
 func (s *CapabilitySuite) TestRemoveGood(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	cap := &Capability{Name: "name", Label: "label", Type: FileType}
-	err := repo.Add(cap)
+	err = repo.Add(cap)
 	c.Assert(err, IsNil)
 	err = repo.Remove(cap.Name)
 	c.Assert(err, IsNil)
@@ -136,8 +144,10 @@ func (s *CapabilitySuite) TestLoadBuiltInTypes(c *C) {
 
 func (s *CapabilitySuite) TestNames(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	// Note added in non-sorted order
-	err := repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
+	err = repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
 	c.Assert(err, IsNil)
 	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
 	c.Assert(err, IsNil)
@@ -167,8 +177,10 @@ func (s *CapabilitySuite) TestTypeString(c *C) {
 
 func (s *CapabilitySuite) TestAll(c *C) {
 	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
 	// Note added in non-sorted order
-	err := repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
+	err = repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
 	c.Assert(err, IsNil)
 	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
 	c.Assert(err, IsNil)

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
-
-	"github.com/ubuntu-core/snappy/testutil"
 )
 
 func Test(t *testing.T) {
@@ -34,25 +32,6 @@ func Test(t *testing.T) {
 type CapabilitySuite struct{}
 
 var _ = Suite(&CapabilitySuite{})
-
-func (s *CapabilitySuite) TestValidateName(c *C) {
-	c.Assert(ValidateName("name with space"), ErrorMatches,
-		`"name with space" is not a valid snap name`)
-	c.Assert(ValidateName("name-with-trailing-dash-"), ErrorMatches,
-		`"name-with-trailing-dash-" is not a valid snap name`)
-	c.Assert(ValidateName("name-with-3-dashes"), IsNil)
-	c.Assert(ValidateName("name"), IsNil)
-}
-
-func (s *CapabilitySuite) TestLoadBuiltInTypes(c *C) {
-	repo := NewRepository()
-	err := LoadBuiltInTypes(repo)
-	c.Assert(err, IsNil)
-	c.Assert(repo.types, testutil.Contains, FileType)
-	c.Assert(repo.types, HasLen, 1) // Update this whenever new built-in type is added
-	err = LoadBuiltInTypes(repo)
-	c.Assert(err, ErrorMatches, `cannot add type "file": name already exists`)
-}
 
 func (s *CapabilitySuite) TestString(c *C) {
 	cap := &Capability{Name: "name", Label: "label", Type: FileType}

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -170,11 +170,6 @@ func (s *CapabilitySuite) TestString(c *C) {
 	c.Assert(cap.String(), Equals, "name")
 }
 
-func (s *CapabilitySuite) TestTypeString(c *C) {
-	c.Assert(FileType.String(), Equals, "file")
-	c.Assert(Type("device").String(), Equals, "device")
-}
-
 func (s *CapabilitySuite) TestAll(c *C) {
 	repo := NewRepository()
 	err := LoadBuiltInTypes(repo)
@@ -191,29 +186,4 @@ func (s *CapabilitySuite) TestAll(c *C) {
 		Capability{Name: "b", Label: "label-b", Type: FileType},
 		Capability{Name: "c", Label: "label-c", Type: FileType},
 	})
-}
-
-func (s *CapabilitySuite) TestValidateMismatchedType(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: Type("device")}
-	err := FileType.Validate(cap)
-	c.Assert(err, ErrorMatches, `capability is not of type "file"`)
-}
-
-func (s *CapabilitySuite) TestValidateOK(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: FileType}
-	err := FileType.Validate(cap)
-	c.Assert(err, IsNil)
-}
-
-func (s *CapabilitySuite) TestValidateAttributes(c *C) {
-	cap := &Capability{
-		Name:  "name",
-		Label: "label",
-		Type:  FileType,
-		Attrs: map[string]string{
-			"Key": "Value",
-		},
-	}
-	err := FileType.Validate(cap)
-	c.Assert(err, ErrorMatches, "attributes must be empty for now")
 }

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -204,3 +204,16 @@ func (s *CapabilitySuite) TestValidateOK(c *C) {
 	err := FileType.Validate(cap)
 	c.Assert(err, IsNil)
 }
+
+func (s *CapabilitySuite) TestValidateAttributes(c *C) {
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  FileType,
+		Attrs: map[string]string{
+			"Key": "Value",
+		},
+	}
+	err := FileType.Validate(cap)
+	c.Assert(err, ErrorMatches, "attributes must be empty for now")
+}

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -69,11 +69,11 @@ func (s *CapabilitySuite) TestAddClash(c *C) {
 
 func (s *CapabilitySuite) TestAddInvalidName(c *C) {
 	repo := NewRepository()
-	cap1 := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
-	err := repo.Add(cap1)
+	cap := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
+	err := repo.Add(cap)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(repo.Names(), DeepEquals, []string{})
-	c.Assert(repo.Names(), Not(testutil.Contains), cap1.Name)
+	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
 }
 
 func (s *CapabilitySuite) TestAddType(c *C) {

--- a/caps/misc.go
+++ b/caps/misc.go
@@ -1,0 +1,62 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// NotFoundError means that a capability was not found
+type NotFoundError struct {
+	what, name string
+}
+
+// Regular expression describing correct identifiers
+var validName = regexp.MustCompile("^[a-z]([a-z0-9-]+[a-z0-9])?$")
+
+// ValidateName checks if a string as a capability name
+func ValidateName(name string) error {
+	valid := validName.MatchString(name)
+	if !valid {
+		return fmt.Errorf("%q is not a valid snap name", name)
+	}
+	return nil
+}
+
+func (e *NotFoundError) Error() string {
+	switch e.what {
+	case "remove":
+		return fmt.Sprintf("can't remove capability %q, no such capability", e.name)
+	default:
+		panic(fmt.Sprintf("unexpected what: %q", e.what))
+	}
+}
+
+// LoadBuiltInTypes adds all built-in types to the repository
+// If any of the additions fail the function returns the error and stops.
+func LoadBuiltInTypes(r *Repository) error {
+	for _, t := range builtInTypes {
+		if err := r.AddType(t); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/caps/misc_test.go
+++ b/caps/misc_test.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/testutil"
+)
+
+func TestMisc(t *testing.T) {
+	TestingT(t)
+}
+
+type MiscSuite struct{}
+
+var _ = Suite(&MiscSuite{})
+
+func (s *MiscSuite) TestValidateName(c *C) {
+	c.Assert(ValidateName("name with space"), ErrorMatches,
+		`"name with space" is not a valid snap name`)
+	c.Assert(ValidateName("name-with-trailing-dash-"), ErrorMatches,
+		`"name-with-trailing-dash-" is not a valid snap name`)
+	c.Assert(ValidateName("name-with-3-dashes"), IsNil)
+	c.Assert(ValidateName("name"), IsNil)
+}
+
+func (s *MiscSuite) TestLoadBuiltInTypes(c *C) {
+	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
+	c.Assert(repo.types, testutil.Contains, FileType)
+	c.Assert(repo.types, HasLen, 1) // Update this whenever new built-in type is added
+	err = LoadBuiltInTypes(repo)
+	c.Assert(err, ErrorMatches, `cannot add type "file": name already exists`)
+}

--- a/caps/repo.go
+++ b/caps/repo.go
@@ -1,0 +1,162 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Repository stores all known snappy capabilities and types
+type Repository struct {
+	m sync.Mutex // protects the internals from concurrent access. If contention gets high, switch to a RWMutex
+	// Map of capabilities, indexed by Capability.Name
+	caps map[string]*Capability
+	// A slice of types that are recognized and accepted
+	types []Type
+}
+
+// NewRepository creates an empty capability repository
+func NewRepository() *Repository {
+	return &Repository{
+		caps:  make(map[string]*Capability),
+		types: make([]Type, 0),
+	}
+}
+
+// Add a capability to the repository.
+// Capability names must be valid snap names, as defined by ValidateName, and
+// must be unique within the repository.  An error is returned if this
+// constraint is violated.
+func (r *Repository) Add(cap *Capability) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	// Reject capabilities with invalid names
+	if err := ValidateName(cap.Name); err != nil {
+		return err
+	}
+	// Reject capabilities with duplicate names
+	if _, ok := r.caps[cap.Name]; ok {
+		return fmt.Errorf("cannot add capability %q: name already exists", cap.Name)
+	}
+	// Reject capabilities with unknown types
+	if !r.HasType(cap.Type) {
+		return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
+	}
+	// Reject capabilities that don't pass type-specific validation
+	if err := cap.Type.Validate(cap); err != nil {
+		return err
+	}
+	r.caps[cap.Name] = cap
+	return nil
+}
+
+// HasType checks if the repository contains the given type
+func (r *Repository) HasType(t Type) bool {
+	for _, tt := range r.types {
+		if tt == t {
+			return true
+		}
+	}
+	return false
+}
+
+// AddType adds a capability type to the repository.
+// It's an error to add the same capability type more than once.
+func (r *Repository) AddType(t Type) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if err := ValidateName(t.String()); err != nil {
+		return err
+	}
+	for _, otherT := range r.types {
+		if t == otherT {
+			return fmt.Errorf("cannot add type %q: name already exists", t)
+		}
+	}
+	r.types = append(r.types, t)
+	return nil
+}
+
+// Remove removes the capability with the provided name.
+// Removing a capability that doesn't exist silently does nothing
+func (r *Repository) Remove(name string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	_, ok := r.caps[name]
+	if ok {
+		delete(r.caps, name)
+		return nil
+	}
+	return &NotFoundError{"remove", name}
+}
+
+// Names returns all capability names in the repository in lexicographical order.
+func (r *Repository) Names() []string {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	keys := make([]string, len(r.caps))
+	i := 0
+	for key := range r.caps {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TypeNames returns all type names in the repository in lexicographical order.
+func (r *Repository) TypeNames() []string {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	types := make([]string, len(r.types))
+	for i, t := range r.types {
+		types[i] = t.String()
+	}
+	sort.Strings(types)
+	return types
+}
+
+type byName []Capability
+
+func (c byName) Len() int           { return len(c) }
+func (c byName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c byName) Less(i, j int) bool { return c[i].Name < c[j].Name }
+
+// All returns all capabilities ordered by name.
+func (r *Repository) All() []Capability {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	caps := make([]Capability, len(r.caps))
+	i := 0
+	for _, capability := range r.caps {
+		caps[i] = *capability
+		i++
+	}
+	sort.Sort(byName(caps))
+	return caps
+}

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -1,0 +1,165 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/testutil"
+)
+
+func TestRepository(t *testing.T) {
+	TestingT(t)
+}
+
+type RepositorySuite struct{}
+
+var _ = Suite(&RepositorySuite{})
+
+func (s *RepositorySuite) TestAdd(c *C) {
+	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
+	cap := &Capability{Name: "name", Label: "label", Type: FileType}
+	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
+	err = repo.Add(cap)
+	c.Assert(err, IsNil)
+	c.Assert(repo.Names(), DeepEquals, []string{"name"})
+	c.Assert(repo.Names(), testutil.Contains, cap.Name)
+}
+
+func (s *RepositorySuite) TestAddClash(c *C) {
+	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
+	cap1 := &Capability{Name: "name", Label: "label 1", Type: FileType}
+	err = repo.Add(cap1)
+	c.Assert(err, IsNil)
+	cap2 := &Capability{Name: "name", Label: "label 2", Type: FileType}
+	err = repo.Add(cap2)
+	c.Assert(err, ErrorMatches,
+		`cannot add capability "name": name already exists`)
+	c.Assert(repo.Names(), DeepEquals, []string{"name"})
+	c.Assert(repo.Names(), testutil.Contains, cap1.Name)
+}
+
+func (s *RepositorySuite) TestAddInvalidName(c *C) {
+	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
+	cap := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
+	err = repo.Add(cap)
+	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
+	c.Assert(repo.Names(), DeepEquals, []string{})
+	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
+}
+
+func (s *RepositorySuite) TestAddType(c *C) {
+	repo := NewRepository()
+	t := Type("foo")
+	err := repo.AddType(t)
+	c.Assert(err, IsNil)
+	c.Assert(repo.TypeNames(), DeepEquals, []string{"foo"})
+	c.Assert(repo.TypeNames(), testutil.Contains, "foo")
+}
+
+func (s *RepositorySuite) TestAddTypeClash(c *C) {
+	repo := NewRepository()
+	t1 := Type("foo")
+	t2 := Type("foo")
+	err := repo.AddType(t1)
+	c.Assert(err, IsNil)
+	err = repo.AddType(t2)
+	c.Assert(err, ErrorMatches,
+		`cannot add type "foo": name already exists`)
+	c.Assert(repo.TypeNames(), DeepEquals, []string{"foo"})
+	c.Assert(repo.TypeNames(), testutil.Contains, "foo")
+}
+
+func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
+	repo := NewRepository()
+	t := Type("bad-name-")
+	err := repo.AddType(t)
+	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
+	c.Assert(repo.TypeNames(), DeepEquals, []string{})
+	c.Assert(repo.TypeNames(), Not(testutil.Contains), string(t))
+}
+
+func (s *RepositorySuite) TestRemoveGood(c *C) {
+	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
+	cap := &Capability{Name: "name", Label: "label", Type: FileType}
+	err = repo.Add(cap)
+	c.Assert(err, IsNil)
+	err = repo.Remove(cap.Name)
+	c.Assert(err, IsNil)
+	c.Assert(repo.Names(), HasLen, 0)
+	c.Assert(repo.Names(), Not(testutil.Contains), cap.Name)
+}
+
+func (s *RepositorySuite) TestRemoveNoSuchCapability(c *C) {
+	repo := NewRepository()
+	err := repo.Remove("name")
+	c.Assert(err, ErrorMatches, `can't remove capability "name", no such capability`)
+}
+
+func (s *RepositorySuite) TestNames(c *C) {
+	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
+	// Note added in non-sorted order
+	err = repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
+	c.Assert(err, IsNil)
+	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
+	c.Assert(err, IsNil)
+	err = repo.Add(&Capability{Name: "b", Label: "label-b", Type: FileType})
+	c.Assert(err, IsNil)
+	c.Assert(repo.Names(), DeepEquals, []string{"a", "b", "c"})
+}
+
+func (s *RepositorySuite) TestTypeNames(c *C) {
+	repo := NewRepository()
+	c.Assert(repo.TypeNames(), DeepEquals, []string{})
+	repo.AddType(Type("a"))
+	repo.AddType(Type("b"))
+	repo.AddType(Type("c"))
+	c.Assert(repo.TypeNames(), DeepEquals, []string{"a", "b", "c"})
+}
+
+func (s *RepositorySuite) TestAll(c *C) {
+	repo := NewRepository()
+	err := LoadBuiltInTypes(repo)
+	c.Assert(err, IsNil)
+	// Note added in non-sorted order
+	err = repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
+	c.Assert(err, IsNil)
+	err = repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
+	c.Assert(err, IsNil)
+	err = repo.Add(&Capability{Name: "b", Label: "label-b", Type: FileType})
+	c.Assert(err, IsNil)
+	c.Assert(repo.All(), DeepEquals, []Capability{
+		Capability{Name: "a", Label: "label-a", Type: FileType},
+		Capability{Name: "b", Label: "label-b", Type: FileType},
+		Capability{Name: "c", Label: "label-c", Type: FileType},
+	})
+}

--- a/caps/types.go
+++ b/caps/types.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"fmt"
+)
+
+// Type is the name of a capability type.
+type Type string
+
+const (
+	// FileType is a basic capability vaguely expressing access to a specific
+	// file. This single capability  type is here just to help bootstrap
+	// the capability concept before we get to load capability interfaces
+	// from YAML.
+	FileType Type = "file"
+)
+
+var builtInTypes = [...]Type{
+	FileType,
+}
+
+// String returns a string representation for the capability type.
+func (t Type) String() string {
+	return string(t)
+}
+
+// Validate if a capability is correct according to the given type
+func (t Type) Validate(c *Capability) error {
+	if t != c.Type {
+		return fmt.Errorf("capability is not of type %q", t)
+	}
+	// While we don't have any support for type-specific attribute schema,
+	// let's ensure that attributes are totally empty. This will make tests
+	// show that this code is actually being used
+	if c.Attrs != nil && len(c.Attrs) != 0 {
+		return fmt.Errorf("attributes must be empty for now")
+	}
+	return nil
+}

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestType(t *testing.T) {
+	TestingT(t)
+}
+
+type TypeSuite struct{}
+
+var _ = Suite(&TypeSuite{})
+
+func (s *TypeSuite) TestTypeString(c *C) {
+	c.Assert(FileType.String(), Equals, "file")
+	c.Assert(Type("device").String(), Equals, "device")
+}
+
+func (s *TypeSuite) TestValidateMismatchedType(c *C) {
+	cap := &Capability{Name: "name", Label: "label", Type: Type("device")}
+	err := FileType.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability is not of type "file"`)
+}
+
+func (s *TypeSuite) TestValidateOK(c *C) {
+	cap := &Capability{Name: "name", Label: "label", Type: FileType}
+	err := FileType.Validate(cap)
+	c.Assert(err, IsNil)
+}
+
+func (s *TypeSuite) TestValidateAttributes(c *C) {
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  FileType,
+		Attrs: map[string]string{
+			"Key": "Value",
+		},
+	}
+	err := FileType.Validate(cap)
+	c.Assert(err, ErrorMatches, "attributes must be empty for now")
+}


### PR DESCRIPTION
NOTE: this is based on #128 so please land that first.

This doing a split that everyone has asked for, capabilities.go becomes {capabilities,repo,misc}.go. Same thing is applied to tests.