### PR TITLE
use EvalSymlinks to resolve 'current' to the correct version

### DIFF
--- a/snappy/security.go
+++ b/snappy/security.go
@@ -882,7 +882,13 @@ func parsePackageYamlFileWithVersion(fn string) (*packageYaml, error) {
 
 	// FIXME: duplicated code from snapp.go:NewSnapPartFromYaml,
 	//        version is overriden by sideloaded versions
-	m.Version = filepath.Base(filepath.Dir(filepath.Dir(fn)))
+
+	// use EvalSymlinks to resolve 'current' to the correct version
+	dir, err := filepath.EvalSymlinks(filepath.Dir(filepath.Dir(fn)))
+	if err != nil {
+		return nil, err
+	}
+	m.Version = filepath.Base(dir)
 
 	return m, err
 }

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -1020,9 +1020,9 @@ func (a *SecurityTestSuite) TestSecurityGeneratePolicyForServiceBinaryErrors(c *
 	c.Assert(err, ErrorMatches, "invalid package on system")
 }
 
-func (s *SecurityTestSuite) TestParsePackageYamlWithVersion(c *C) {
+func (a *SecurityTestSuite) TestParsePackageYamlWithVersion(c *C) {
 	testVersion := "1.0"
-	dir := filepath.Join(s.tempDir, "foo", testVersion, "meta")
+	dir := filepath.Join(a.tempDir, "foo", testVersion, "meta")
 	os.MkdirAll(dir, 0755)
 	y := filepath.Join(dir, "package.yaml")
 	ioutil.WriteFile(y, []byte(`
@@ -1034,10 +1034,10 @@ version: 123456789
 	c.Assert(m.Version, Equals, testVersion)
 }
 
-func (s *SecurityTestSuite) TestParsePackageYamlWithVersionSymlink(c *C) {
+func (a *SecurityTestSuite) TestParsePackageYamlWithVersionSymlink(c *C) {
 	testVersion := "1.0"
-	verDir := filepath.Join(s.tempDir, "foo", testVersion)
-	symDir := filepath.Join(s.tempDir, "foo", "current")
+	verDir := filepath.Join(a.tempDir, "foo", testVersion)
+	symDir := filepath.Join(a.tempDir, "foo", "current")
 	os.MkdirAll(filepath.Join(verDir, "meta"), 0755)
 	os.Symlink(verDir, symDir)
 	y := filepath.Join(symDir, "meta", "package.yaml")


### PR DESCRIPTION
'snappy policygen' takes a path to a yaml file as an argument. If the user
specifies /apps/foo/current/meta/package.yaml then the version is incorrectly
calculated to be 'current'. This issue was introduced in 8b04bd2d when fixing
CompareGeneratePolicyFromFile for sideloaded pkgs.

The fix adjusts parsePackageYamlFileWithVersion() to simply call EvalSymlinks()
to resolve the current symlink. Tested with store and sideloaded apps.