### PR TITLE
Introduce iotaType capability type for testing

### DIFF
--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -32,8 +32,8 @@ func TestRepository(t *testing.T) {
 }
 
 type RepositorySuite struct {
-	// Typical repository with known types
-	repo *Repository
+	// Repository pre-populated with iotaType
+	iotaRepo *Repository
 	// Empty repository
 	emptyRepo *Repository
 }
@@ -41,39 +41,39 @@ type RepositorySuite struct {
 var _ = Suite(&RepositorySuite{})
 
 func (s *RepositorySuite) SetUpTest(c *C) {
-	s.repo = NewRepository()
-	s.emptyRepo = NewRepository()
-	err := LoadBuiltInTypes(s.repo)
+	s.iotaRepo = NewRepository()
+	err := s.iotaRepo.AddType(iotaType)
 	c.Assert(err, IsNil)
+	s.emptyRepo = NewRepository()
 }
 
 func (s *RepositorySuite) TestAdd(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: FileType}
-	c.Assert(s.repo.Names(), Not(testutil.Contains), cap.Name)
-	err := s.repo.Add(cap)
+	cap := &Capability{Name: "name", Label: "label", Type: iotaType}
+	c.Assert(s.iotaRepo.Names(), Not(testutil.Contains), cap.Name)
+	err := s.iotaRepo.Add(cap)
 	c.Assert(err, IsNil)
-	c.Assert(s.repo.Names(), DeepEquals, []string{"name"})
-	c.Assert(s.repo.Names(), testutil.Contains, cap.Name)
+	c.Assert(s.iotaRepo.Names(), DeepEquals, []string{"name"})
+	c.Assert(s.iotaRepo.Names(), testutil.Contains, cap.Name)
 }
 
 func (s *RepositorySuite) TestAddClash(c *C) {
-	cap1 := &Capability{Name: "name", Label: "label 1", Type: FileType}
-	err := s.repo.Add(cap1)
+	cap1 := &Capability{Name: "name", Label: "label 1", Type: iotaType}
+	err := s.iotaRepo.Add(cap1)
 	c.Assert(err, IsNil)
-	cap2 := &Capability{Name: "name", Label: "label 2", Type: FileType}
-	err = s.repo.Add(cap2)
+	cap2 := &Capability{Name: "name", Label: "label 2", Type: iotaType}
+	err = s.iotaRepo.Add(cap2)
 	c.Assert(err, ErrorMatches,
 		`cannot add capability "name": name already exists`)
-	c.Assert(s.repo.Names(), DeepEquals, []string{"name"})
-	c.Assert(s.repo.Names(), testutil.Contains, cap1.Name)
+	c.Assert(s.iotaRepo.Names(), DeepEquals, []string{"name"})
+	c.Assert(s.iotaRepo.Names(), testutil.Contains, cap1.Name)
 }
 
 func (s *RepositorySuite) TestAddInvalidName(c *C) {
-	cap := &Capability{Name: "bad-name-", Label: "label", Type: FileType}
-	err := s.repo.Add(cap)
+	cap := &Capability{Name: "bad-name-", Label: "label", Type: iotaType}
+	err := s.iotaRepo.Add(cap)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
-	c.Assert(s.repo.Names(), DeepEquals, []string{})
-	c.Assert(s.repo.Names(), Not(testutil.Contains), cap.Name)
+	c.Assert(s.iotaRepo.Names(), DeepEquals, []string{})
+	c.Assert(s.iotaRepo.Names(), Not(testutil.Contains), cap.Name)
 }
 
 func (s *RepositorySuite) TestAddType(c *C) {
@@ -105,13 +105,13 @@ func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
 }
 
 func (s *RepositorySuite) TestRemoveGood(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: FileType}
-	err := s.repo.Add(cap)
+	cap := &Capability{Name: "name", Label: "label", Type: iotaType}
+	err := s.iotaRepo.Add(cap)
 	c.Assert(err, IsNil)
-	err = s.repo.Remove(cap.Name)
+	err = s.iotaRepo.Remove(cap.Name)
 	c.Assert(err, IsNil)
-	c.Assert(s.repo.Names(), HasLen, 0)
-	c.Assert(s.repo.Names(), Not(testutil.Contains), cap.Name)
+	c.Assert(s.iotaRepo.Names(), HasLen, 0)
+	c.Assert(s.iotaRepo.Names(), Not(testutil.Contains), cap.Name)
 }
 
 func (s *RepositorySuite) TestRemoveNoSuchCapability(c *C) {
@@ -121,13 +121,13 @@ func (s *RepositorySuite) TestRemoveNoSuchCapability(c *C) {
 
 func (s *RepositorySuite) TestNames(c *C) {
 	// Note added in non-sorted order
-	err := s.repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
+	err := s.iotaRepo.Add(&Capability{Name: "a", Label: "label-a", Type: iotaType})
 	c.Assert(err, IsNil)
-	err = s.repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
+	err = s.iotaRepo.Add(&Capability{Name: "c", Label: "label-c", Type: iotaType})
 	c.Assert(err, IsNil)
-	err = s.repo.Add(&Capability{Name: "b", Label: "label-b", Type: FileType})
+	err = s.iotaRepo.Add(&Capability{Name: "b", Label: "label-b", Type: iotaType})
 	c.Assert(err, IsNil)
-	c.Assert(s.repo.Names(), DeepEquals, []string{"a", "b", "c"})
+	c.Assert(s.iotaRepo.Names(), DeepEquals, []string{"a", "b", "c"})
 }
 
 func (s *RepositorySuite) TestTypeNames(c *C) {
@@ -140,15 +140,15 @@ func (s *RepositorySuite) TestTypeNames(c *C) {
 
 func (s *RepositorySuite) TestAll(c *C) {
 	// Note added in non-sorted order
-	err := s.repo.Add(&Capability{Name: "a", Label: "label-a", Type: FileType})
+	err := s.iotaRepo.Add(&Capability{Name: "a", Label: "label-a", Type: iotaType})
 	c.Assert(err, IsNil)
-	err = s.repo.Add(&Capability{Name: "c", Label: "label-c", Type: FileType})
+	err = s.iotaRepo.Add(&Capability{Name: "c", Label: "label-c", Type: iotaType})
 	c.Assert(err, IsNil)
-	err = s.repo.Add(&Capability{Name: "b", Label: "label-b", Type: FileType})
+	err = s.iotaRepo.Add(&Capability{Name: "b", Label: "label-b", Type: iotaType})
 	c.Assert(err, IsNil)
-	c.Assert(s.repo.All(), DeepEquals, []Capability{
-		Capability{Name: "a", Label: "label-a", Type: FileType},
-		Capability{Name: "b", Label: "label-b", Type: FileType},
-		Capability{Name: "c", Label: "label-c", Type: FileType},
+	c.Assert(s.iotaRepo.All(), DeepEquals, []Capability{
+		Capability{Name: "a", Label: "label-a", Type: iotaType},
+		Capability{Name: "b", Label: "label-b", Type: iotaType},
+		Capability{Name: "c", Label: "label-c", Type: iotaType},
 	})
 }

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -32,8 +32,8 @@ func TestRepository(t *testing.T) {
 }
 
 type RepositorySuite struct {
-	// Repository pre-populated with iotaType
-	iotaRepo *Repository
+	// Repository pre-populated with testType
+	testRepo *Repository
 	// Empty repository
 	emptyRepo *Repository
 }
@@ -41,39 +41,39 @@ type RepositorySuite struct {
 var _ = Suite(&RepositorySuite{})
 
 func (s *RepositorySuite) SetUpTest(c *C) {
-	s.iotaRepo = NewRepository()
-	err := s.iotaRepo.AddType(iotaType)
+	s.testRepo = NewRepository()
+	err := s.testRepo.AddType(testType)
 	c.Assert(err, IsNil)
 	s.emptyRepo = NewRepository()
 }
 
 func (s *RepositorySuite) TestAdd(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: iotaType}
-	c.Assert(s.iotaRepo.Names(), Not(testutil.Contains), cap.Name)
-	err := s.iotaRepo.Add(cap)
+	cap := &Capability{Name: "name", Label: "label", Type: testType}
+	c.Assert(s.testRepo.Names(), Not(testutil.Contains), cap.Name)
+	err := s.testRepo.Add(cap)
 	c.Assert(err, IsNil)
-	c.Assert(s.iotaRepo.Names(), DeepEquals, []string{"name"})
-	c.Assert(s.iotaRepo.Names(), testutil.Contains, cap.Name)
+	c.Assert(s.testRepo.Names(), DeepEquals, []string{"name"})
+	c.Assert(s.testRepo.Names(), testutil.Contains, cap.Name)
 }
 
 func (s *RepositorySuite) TestAddClash(c *C) {
-	cap1 := &Capability{Name: "name", Label: "label 1", Type: iotaType}
-	err := s.iotaRepo.Add(cap1)
+	cap1 := &Capability{Name: "name", Label: "label 1", Type: testType}
+	err := s.testRepo.Add(cap1)
 	c.Assert(err, IsNil)
-	cap2 := &Capability{Name: "name", Label: "label 2", Type: iotaType}
-	err = s.iotaRepo.Add(cap2)
+	cap2 := &Capability{Name: "name", Label: "label 2", Type: testType}
+	err = s.testRepo.Add(cap2)
 	c.Assert(err, ErrorMatches,
 		`cannot add capability "name": name already exists`)
-	c.Assert(s.iotaRepo.Names(), DeepEquals, []string{"name"})
-	c.Assert(s.iotaRepo.Names(), testutil.Contains, cap1.Name)
+	c.Assert(s.testRepo.Names(), DeepEquals, []string{"name"})
+	c.Assert(s.testRepo.Names(), testutil.Contains, cap1.Name)
 }
 
 func (s *RepositorySuite) TestAddInvalidName(c *C) {
-	cap := &Capability{Name: "bad-name-", Label: "label", Type: iotaType}
-	err := s.iotaRepo.Add(cap)
+	cap := &Capability{Name: "bad-name-", Label: "label", Type: testType}
+	err := s.testRepo.Add(cap)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
-	c.Assert(s.iotaRepo.Names(), DeepEquals, []string{})
-	c.Assert(s.iotaRepo.Names(), Not(testutil.Contains), cap.Name)
+	c.Assert(s.testRepo.Names(), DeepEquals, []string{})
+	c.Assert(s.testRepo.Names(), Not(testutil.Contains), cap.Name)
 }
 
 func (s *RepositorySuite) TestAddType(c *C) {
@@ -105,13 +105,13 @@ func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
 }
 
 func (s *RepositorySuite) TestRemoveGood(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: iotaType}
-	err := s.iotaRepo.Add(cap)
+	cap := &Capability{Name: "name", Label: "label", Type: testType}
+	err := s.testRepo.Add(cap)
 	c.Assert(err, IsNil)
-	err = s.iotaRepo.Remove(cap.Name)
+	err = s.testRepo.Remove(cap.Name)
 	c.Assert(err, IsNil)
-	c.Assert(s.iotaRepo.Names(), HasLen, 0)
-	c.Assert(s.iotaRepo.Names(), Not(testutil.Contains), cap.Name)
+	c.Assert(s.testRepo.Names(), HasLen, 0)
+	c.Assert(s.testRepo.Names(), Not(testutil.Contains), cap.Name)
 }
 
 func (s *RepositorySuite) TestRemoveNoSuchCapability(c *C) {
@@ -121,13 +121,13 @@ func (s *RepositorySuite) TestRemoveNoSuchCapability(c *C) {
 
 func (s *RepositorySuite) TestNames(c *C) {
 	// Note added in non-sorted order
-	err := s.iotaRepo.Add(&Capability{Name: "a", Label: "label-a", Type: iotaType})
+	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
 	c.Assert(err, IsNil)
-	err = s.iotaRepo.Add(&Capability{Name: "c", Label: "label-c", Type: iotaType})
+	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
 	c.Assert(err, IsNil)
-	err = s.iotaRepo.Add(&Capability{Name: "b", Label: "label-b", Type: iotaType})
+	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
 	c.Assert(err, IsNil)
-	c.Assert(s.iotaRepo.Names(), DeepEquals, []string{"a", "b", "c"})
+	c.Assert(s.testRepo.Names(), DeepEquals, []string{"a", "b", "c"})
 }
 
 func (s *RepositorySuite) TestTypeNames(c *C) {
@@ -140,15 +140,15 @@ func (s *RepositorySuite) TestTypeNames(c *C) {
 
 func (s *RepositorySuite) TestAll(c *C) {
 	// Note added in non-sorted order
-	err := s.iotaRepo.Add(&Capability{Name: "a", Label: "label-a", Type: iotaType})
+	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
 	c.Assert(err, IsNil)
-	err = s.iotaRepo.Add(&Capability{Name: "c", Label: "label-c", Type: iotaType})
+	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
 	c.Assert(err, IsNil)
-	err = s.iotaRepo.Add(&Capability{Name: "b", Label: "label-b", Type: iotaType})
+	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
 	c.Assert(err, IsNil)
-	c.Assert(s.iotaRepo.All(), DeepEquals, []Capability{
-		Capability{Name: "a", Label: "label-a", Type: iotaType},
-		Capability{Name: "b", Label: "label-b", Type: iotaType},
-		Capability{Name: "c", Label: "label-c", Type: iotaType},
+	c.Assert(s.testRepo.All(), DeepEquals, []Capability{
+		Capability{Name: "a", Label: "label-a", Type: testType},
+		Capability{Name: "b", Label: "label-b", Type: testType},
+		Capability{Name: "c", Label: "label-c", Type: testType},
 	})
 }

--- a/caps/types.go
+++ b/caps/types.go
@@ -32,9 +32,9 @@ const (
 	// the capability concept before we get to load capability interfaces
 	// from YAML.
 	FileType Type = "file"
-	// Iota type is only meant for testing. It is not useful in any way except
+	// testType is only meant for testing. It is not useful in any way except
 	// that it offers an simple capability type that will happily validate.
-	iotaType Type = "iota"
+	testType Type = "test"
 )
 
 var builtInTypes = [...]Type{

--- a/caps/types.go
+++ b/caps/types.go
@@ -32,6 +32,9 @@ const (
 	// the capability concept before we get to load capability interfaces
 	// from YAML.
 	FileType Type = "file"
+	// Iota type is only meant for testing. It is not useful in any way except
+	// that it offers an simple capability type that will happily validate.
+	iotaType Type = "iota"
 )
 
 var builtInTypes = [...]Type{

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -34,19 +34,19 @@ type TypeSuite struct{}
 var _ = Suite(&TypeSuite{})
 
 func (s *TypeSuite) TestTypeString(c *C) {
-	c.Assert(FileType.String(), Equals, "file")
-	c.Assert(Type("device").String(), Equals, "device")
+	c.Assert(iotaType.String(), Equals, "iota")
 }
 
 func (s *TypeSuite) TestValidateMismatchedType(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: Type("device")}
-	err := FileType.Validate(cap)
-	c.Assert(err, ErrorMatches, `capability is not of type "file"`)
+	iotaType2 := Type("iota-two") // Another iota-like type that's not iota itself
+	cap := &Capability{Name: "name", Label: "label", Type: iotaType2}
+	err := iotaType.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability is not of type "iota"`)
 }
 
 func (s *TypeSuite) TestValidateOK(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: FileType}
-	err := FileType.Validate(cap)
+	cap := &Capability{Name: "name", Label: "label", Type: iotaType}
+	err := iotaType.Validate(cap)
 	c.Assert(err, IsNil)
 }
 
@@ -54,11 +54,11 @@ func (s *TypeSuite) TestValidateAttributes(c *C) {
 	cap := &Capability{
 		Name:  "name",
 		Label: "label",
-		Type:  FileType,
+		Type:  iotaType,
 		Attrs: map[string]string{
 			"Key": "Value",
 		},
 	}
-	err := FileType.Validate(cap)
+	err := iotaType.Validate(cap)
 	c.Assert(err, ErrorMatches, "attributes must be empty for now")
 }

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -34,19 +34,19 @@ type TypeSuite struct{}
 var _ = Suite(&TypeSuite{})
 
 func (s *TypeSuite) TestTypeString(c *C) {
-	c.Assert(iotaType.String(), Equals, "iota")
+	c.Assert(testType.String(), Equals, "test")
 }
 
 func (s *TypeSuite) TestValidateMismatchedType(c *C) {
-	iotaType2 := Type("iota-two") // Another iota-like type that's not iota itself
-	cap := &Capability{Name: "name", Label: "label", Type: iotaType2}
-	err := iotaType.Validate(cap)
-	c.Assert(err, ErrorMatches, `capability is not of type "iota"`)
+	testType2 := Type("test-two") // Another test-like type that's not test itself
+	cap := &Capability{Name: "name", Label: "label", Type: testType2}
+	err := testType.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability is not of type "test"`)
 }
 
 func (s *TypeSuite) TestValidateOK(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: iotaType}
-	err := iotaType.Validate(cap)
+	cap := &Capability{Name: "name", Label: "label", Type: testType}
+	err := testType.Validate(cap)
 	c.Assert(err, IsNil)
 }
 
@@ -54,11 +54,11 @@ func (s *TypeSuite) TestValidateAttributes(c *C) {
 	cap := &Capability{
 		Name:  "name",
 		Label: "label",
-		Type:  iotaType,
+		Type:  testType,
 		Attrs: map[string]string{
 			"Key": "Value",
 		},
 	}
-	err := iotaType.Validate(cap)
+	err := testType.Validate(cap)
 	c.Assert(err, ErrorMatches, "attributes must be empty for now")
 }


### PR DESCRIPTION
Testing the capability repository requires operating with valid types
and capabilities. Originally the FileType was used for that but it was
never really designed as a proper type. To differentiate production
types (that we'll have later) and the testing type, I've introduced
iotaType and added it to the testing iotaRepo.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>