### PR TITLE
asserts: sign and check tests and fixes

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -278,10 +278,10 @@ func buildAssertion(headers map[string]string, body, content, signature []byte) 
 }
 
 func writeHeader(buf *bytes.Buffer, headers map[string]string, name string) {
+	buf.WriteByte('\n')
 	buf.WriteString(name)
 	buf.WriteString(": ")
 	buf.WriteString(headers[name])
-	buf.WriteByte('\n')
 }
 
 // TODO: expose this in some form on Database appropriately
@@ -310,8 +310,9 @@ func buildAndSign(assertType AssertionType, headers map[string]string, body []by
 		return nil, err
 	}
 
-	buf := new(bytes.Buffer)
-	writeHeader(buf, finalHeaders, "type")
+	buf := bytes.NewBufferString("type: ")
+	buf.WriteString(string(assertType))
+
 	writeHeader(buf, finalHeaders, "authority-id")
 	if revision > 0 {
 		writeHeader(buf, finalHeaders, "revision")

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -172,3 +172,34 @@ func (as *AssertsSuite) TestEncode(c *C) {
 	encodeRes := asserts.Encode(a)
 	c.Check(encodeRes, DeepEquals, encoded)
 }
+
+func (as *AssertsSuite) TestSignFormatSanityEmptyBody(c *C) {
+	key1, err := asserts.GeneratePrivateKeyInTest()
+	c.Assert(err, IsNil)
+
+	headers := map[string]string{
+		"authority-id": "canonical",
+	}
+	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, key1)
+	c.Assert(err, IsNil)
+
+	_, err = asserts.Decode(asserts.Encode(a))
+	c.Check(err, IsNil)
+}
+
+func (as *AssertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
+	key1, err := asserts.GeneratePrivateKeyInTest()
+	c.Assert(err, IsNil)
+
+	headers := map[string]string{
+		"authority-id": "canonical",
+	}
+	body := []byte("THE-BODY")
+	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, body, key1)
+	c.Assert(err, IsNil)
+	c.Check(a.Body(), DeepEquals, body)
+
+	decoded, err := asserts.Decode(asserts.Encode(a))
+	c.Assert(err, IsNil)
+	c.Check(decoded.Body(), DeepEquals, body)
+}

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -178,7 +178,7 @@ func (as *AssertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 	c.Assert(err, IsNil)
 
 	headers := map[string]string{
-		"authority-id": "canonical",
+		"authority-id": "auth-id1",
 	}
 	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, key1)
 	c.Assert(err, IsNil)
@@ -192,7 +192,7 @@ func (as *AssertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 	c.Assert(err, IsNil)
 
 	headers := map[string]string{
-		"authority-id": "canonical",
+		"authority-id": "auth-id1",
 	}
 	body := []byte("THE-BODY")
 	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, body, key1)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -174,5 +174,5 @@ func (db *Database) Check(assert Assertion) error {
 	if lastErr == nil {
 		return fmt.Errorf("no valid known public key verifies assertion")
 	}
-	return lastErr
+	return fmt.Errorf("failed signature verification: %v", lastErr)
 }


### PR DESCRIPTION
two things here:
* fix BuildAndSign so that the result can be Decode()d, headers are '\n' separated, not terminated
  we were getting an extra '\n' at the end of header that would confuse Decode()
* tests about the main unhappy paths in Check()