### PR TITLE
asserts: more openpgp packet encapsulation

### DIFF
--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -98,7 +98,6 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 		{aks.sinceLine, "since: 12:30\n", "since header is not a RFC3339 date: .*"},
 		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
 		{"fingerprint: " + aks.fp + "\n", "", "missing fingerprint header"},
-		{"fingerprint: " + aks.fp + "\n", "fingerprint: ywz\n", "could not parse fingerprint header: .*"},
 	}
 
 	for _, test := range invalidHeaderTests {
@@ -117,7 +116,7 @@ func (aks *accountKeySuite) TestDecodeInvalidPublicKey(c *C) {
 		aks.untilLine
 
 	invalidPublicKeyTests := []struct{ body, expectedErr string }{
-		{"", "expected public key, not empty body"},
+		{"", "empty public key"},
 		{"stuff", "public key: expected format and base64 data separated by space"},
 		{"openpgp _", "public key: could not decode base64 data: .*"},
 		{strings.Replace(aks.pubKeyBody, "openpgp", "mystery", 1), `unsupported public key format: "mystery"`},


### PR DESCRIPTION
don't use openpgp/packet directly in account_key.go anymore, introduce parsePublicKey in crypto.go instead and share a helper with parseSignature