### PR TITLE
Bugfix/all snap fixes

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -255,12 +255,14 @@ func getPackagesInfo(c *Command, r *http.Request) Response {
 		sources = append(sources, "store")
 	}
 
-	upd, _ := newSystemRepo().Updates()
-	if len(upd) > 0 {
-		sources = append(sources, "system-image")
+	// systemRepo might be nil on all-snap systems
+	if systemRepo := newSystemRepo(); systemRepo != nil {
+		upd, _ := systemRepo.Updates()
+		if len(upd) > 0 {
+			sources = append(sources, "system-image")
+		}
+		found = append(found, upd...)
 	}
-
-	found = append(found, upd...)
 
 	sort.Sort(byQN(found))
 

--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -1868,7 +1868,7 @@ func (s *SnapUbuntuStoreRepository) Updates() (parts []Part, err error) {
 	// sense in sending it our ubuntu-core snap
 	//
 	// NOTE this *will* send .sideload apps to the store.
-	installed, err := ActiveSnapIterByType(fullNameWithChannel, pkg.TypeApp, pkg.TypeFramework, pkg.TypeOem)
+	installed, err := ActiveSnapIterByType(fullNameWithChannel, pkg.TypeApp, pkg.TypeFramework, pkg.TypeOem, pkg.TypeOS, pkg.TypeKernel)
 	if err != nil || len(installed) == 0 {
 		return nil, err
 	}

--- a/snappy/systemimage.go
+++ b/snappy/systemimage.go
@@ -324,6 +324,13 @@ type SystemImageRepository struct {
 
 // NewSystemImageRepository returns a new SystemImageRepository
 func NewSystemImageRepository() *SystemImageRepository {
+	// check if we are runnign on an all-snappy system and if
+	// so do not create a SystemImageRepository
+	configFile := filepath.Join(dirs.GlobalRootDir, systemImageChannelConfig)
+	if !helpers.FileExists(configFile) {
+		return nil
+	}
+
 	return &SystemImageRepository{partition: newPartition()}
 }
 

--- a/snappy/systemimage_test.go
+++ b/snappy/systemimage_test.go
@@ -49,13 +49,15 @@ func (s *SITestSuite) SetUpTest(c *C) {
 	newPartition = func() (p partition.Interface) {
 		return new(MockPartition)
 	}
+	dirs.SetRootDir(c.MkDir())
 
-	s.systemImage = NewSystemImageRepository()
-	c.Assert(s, NotNil)
-
+	// setup fake si-roots for / and /other
 	makeFakeSystemImageChannelConfig(c, filepath.Join(dirs.GlobalRootDir, systemImageChannelConfig), "1")
-	// setup fake /other partition
 	makeFakeSystemImageChannelConfig(c, filepath.Join(dirs.GlobalRootDir, "other", systemImageChannelConfig), "0")
+
+	// create repository after the fake channel config is in place
+	s.systemImage = NewSystemImageRepository()
+	c.Assert(s.systemImage, NotNil)
 
 	// run test webserver instead of talking to the real one
 	//
@@ -91,7 +93,7 @@ printf '{"type": "spinner", "msg": "Applying"}\n'
 
 func makeFakeSystemImageChannelConfig(c *C, cfgPath, buildNumber string) {
 	os.MkdirAll(filepath.Dir(cfgPath), 0775)
-	f, err := os.OpenFile(cfgPath, os.O_CREATE|os.O_RDWR, 0664)
+	f, err := os.Create(cfgPath)
 	c.Assert(err, IsNil)
 	defer f.Close()
 	f.Write([]byte(fmt.Sprintf(`


### PR DESCRIPTION
This fixes crashes if no system-image repository is available on the system. In the all-snap world it is ok if system-image is not used. In this case NewSystemImageRepository may return nil and the rest of the system should deal with that (which this branch ensures). In the next step (once we are confident in the image building from the store) we will remove the system-image support entirely.