### PR TITLE
key off of Status instead of Type to decide whether to set Location.

### DIFF
--- a/daemon/response.go
+++ b/daemon/response.go
@@ -70,7 +70,7 @@ func (r *resp) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	hdr := w.Header()
-	if r.Type == ResponseTypeAsync {
+	if r.Status == http.StatusAccepted || r.Status == http.StatusCreated {
 		if m, ok := r.Result.(map[string]interface{}); ok {
 			if location, ok := m["resource"]; ok {
 				if location, ok := location.(string); ok && location != "" {

--- a/daemon/response_test.go
+++ b/daemon/response_test.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"gopkg.in/check.v1"
+)
+
+type responseSuite struct{}
+
+var _ = check.Suite(&responseSuite{})
+
+func (s *responseSuite) TestRespSetsLocationIfAccepted(c *check.C) {
+	rec := httptest.NewRecorder()
+
+	rsp := &resp{
+		Status: http.StatusAccepted,
+		Result: map[string]interface{}{
+			"resource": "foo/bar",
+		},
+	}
+
+	rsp.ServeHTTP(rec, nil)
+	hdr := rec.Header()
+	c.Check(hdr.Get("Location"), check.Equals, "foo/bar")
+}
+
+func (s *responseSuite) TestRespSetsLocationIfCreated(c *check.C) {
+	rec := httptest.NewRecorder()
+
+	rsp := &resp{
+		Status: http.StatusCreated,
+		Result: map[string]interface{}{
+			"resource": "foo/bar",
+		},
+	}
+
+	rsp.ServeHTTP(rec, nil)
+	hdr := rec.Header()
+	c.Check(hdr.Get("Location"), check.Equals, "foo/bar")
+}
+
+func (s *responseSuite) TestRespDoesNotSetLocationIfOther(c *check.C) {
+	rec := httptest.NewRecorder()
+
+	rsp := &resp{
+		Status: http.StatusTeapot,
+		Result: map[string]interface{}{
+			"resource": "foo/bar",
+		},
+	}
+
+	rsp.ServeHTTP(rec, nil)
+	hdr := rec.Header()
+	c.Check(hdr.Get("Location"), check.Equals, "")
+}


### PR DESCRIPTION
Support setting location on Created as well as (ResponseTypeAsync's) Accepted. Opens the path for sync POST that create an element in a collection to behave properly.