### PR TITLE
asserts: introduce Add() and Find()

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -220,7 +220,7 @@ func checkInteger(headers map[string]string, name string) (int, error) {
 func checkAssertType(assertType AssertionType) (*assertionTypeRegistration, error) {
 	reg := typeRegistry[assertType]
 	if reg == nil {
-		return nil, fmt.Errorf("cannot build assertion of unknown type: %v", assertType)
+		return nil, fmt.Errorf("cannot build assertion of unknown type: %v", assertType) // xxx make this more vague :/
 	}
 	return reg, nil
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -220,7 +220,7 @@ func checkInteger(headers map[string]string, name string) (int, error) {
 func checkAssertType(assertType AssertionType) (*assertionTypeRegistration, error) {
 	reg := typeRegistry[assertType]
 	if reg == nil {
-		return nil, fmt.Errorf("cannot build assertion of unknown type: %v", assertType) // xxx make this more vague :/
+		return nil, fmt.Errorf("unknown assertion type: %v", assertType)
 	}
 	return reg, nil
 }

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -143,7 +143,7 @@ func (as *AssertsSuite) TestDecodeInvalid(c *C) {
 		{"authority-id: auth-id\n", "authority-id: \n", "assertion authority-id should not be empty"},
 		{"openpgp c2ln", "", "empty assertion signature"},
 		{"type: test-only\n", "", "assertion type header is mandatory"},
-		{"type: test-only\n", "type: unknown\n", "cannot build assertion of unknown type: unknown"},
+		{"type: test-only\n", "type: unknown\n", "unknown assertion type: unknown"},
 		{"revision: 0\n", "revision: Z\n", "assertion revision is not an integer: Z"},
 		{"revision: 0\n", "revision: -10\n", "assertion revision should be positive: -10"},
 	}

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -179,6 +179,7 @@ func (as *AssertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 
 	headers := map[string]string{
 		"authority-id": "auth-id1",
+		"primary-key":  "0",
 	}
 	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, key1)
 	c.Assert(err, IsNil)
@@ -193,6 +194,7 @@ func (as *AssertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 
 	headers := map[string]string{
 		"authority-id": "auth-id1",
+		"primary-key":  "0",
 	}
 	body := []byte("THE-BODY")
 	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, body, key1)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -59,8 +59,8 @@ type DatabaseConfig struct {
 
 // Well-known errors
 var (
-	ErrAssertionNotFound       = errors.New("assertion not found")
-	ErrAssertionNotSuperseding = errors.New("assertion does not supersede current one")
+	ErrNotFound       = errors.New("assertion not found")
+	ErrNotSuperseding = errors.New("assertion does not supersede current one")
 )
 
 // Database holds assertions and can be used to sign or check
@@ -225,7 +225,7 @@ func (db *Database) Check(assert Assertion) error {
 }
 
 // Add persists the assertions after ensuring it is properly signed and consistent with all the stored knowledge.
-// Returns ErrAssertionNotSuperseding if trying to add a previous revision of the assertion.
+// Returns ErrNotSuperseding if trying to add a previous revision of the assertion.
 func (db *Database) Add(assert Assertion) error {
 	reg, err := checkAssertType(assert.Type())
 	if err != nil {
@@ -258,7 +258,7 @@ func (db *Database) Add(assert Assertion) error {
 			return fmt.Errorf("broken assertion storage, extracting revision from 'latest' revision symlink: %v", err)
 		}
 		if curRev >= assert.Revision() {
-			return ErrAssertionNotSuperseding
+			return ErrNotSuperseding
 		}
 		err = db.removeEntry(assertionsRoot, indexPath, "latest")
 		if err != nil {
@@ -283,7 +283,7 @@ func (db *Database) Add(assert Assertion) error {
 
 // Find an assertion based on arbitrary headers.
 // Provided headers must contain the primary key for the assertion type.
-// Returns ErrAssertionNotFound if the assertion cannot be found.
+// Returns ErrNotFound if the assertion cannot be found.
 func (db *Database) Find(assertionType AssertionType, headers map[string]string) (Assertion, error) {
 	reg, err := checkAssertType(assertionType)
 	if err != nil {
@@ -301,7 +301,7 @@ func (db *Database) Find(assertionType AssertionType, headers map[string]string)
 	_, err = db.statEntry(assertionsRoot, indexPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, ErrAssertionNotFound
+			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("broken assertion storage, failed to stat assertion directory: %v", err)
 	}
@@ -316,7 +316,7 @@ func (db *Database) Find(assertionType AssertionType, headers map[string]string)
 	// check non-primary-key headers as well
 	for expectedKey, expectedValue := range headers {
 		if assert.Header(expectedKey) != expectedValue {
-			return nil, ErrAssertionNotFound
+			return nil, ErrNotFound
 		}
 	}
 	return assert, nil

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -251,32 +251,32 @@ func (db *Database) Add(assert Assertion) error {
 		// directory for assertion is present
 		curRevStr, err := db.readlinkEntry(assertionsRoot, indexPath, "latest")
 		if err != nil {
-			return fmt.Errorf("broken assertion store, reading 'latest' revision symlink: %v", err)
+			return fmt.Errorf("broken assertion storage, reading 'latest' revision symlink: %v", err)
 		}
 		curRev, err := strconv.Atoi(curRevStr)
 		if err != nil {
-			return fmt.Errorf("broken assertion store, extracting revision from 'latest' revision symlink: %v", err)
+			return fmt.Errorf("broken assertion storage, extracting revision from 'latest' revision symlink: %v", err)
 		}
 		if curRev >= assert.Revision() {
 			return ErrAssertionNotSuperseding
 		}
 		err = db.removeEntry(assertionsRoot, indexPath, "latest")
 		if err != nil {
-			return fmt.Errorf("broken assertion store, could not remove 'latest' revision symlink: %v", err)
+			return fmt.Errorf("broken assertion storage, could not remove 'latest' revision symlink: %v", err)
 		}
 	case os.IsNotExist(err):
 		// nothing there yet
 	default:
-		return fmt.Errorf("broken assertion store, failed to stat assertion directory: %v", err)
+		return fmt.Errorf("broken assertion storage, failed to stat assertion directory: %v", err)
 	}
 	revStr := strconv.Itoa(assert.Revision())
 	err = db.atomicWriteEntry(Encode(assert), false, assertionsRoot, indexPath, revStr)
 	if err != nil {
-		return fmt.Errorf("broken assertion store, failed to write assertion: %v", err)
+		return fmt.Errorf("broken assertion storage, failed to write assertion: %v", err)
 	}
 	err = db.symlinkEntry(revStr, assertionsRoot, indexPath, "latest")
 	if err != nil {
-		return fmt.Errorf("broken assertion store, failed to create 'latest' revision symlink: %v", err)
+		return fmt.Errorf("broken assertion storage, failed to create 'latest' revision symlink: %v", err)
 	}
 	return nil
 }
@@ -303,11 +303,11 @@ func (db *Database) Find(assertionType AssertionType, headers map[string]string)
 		if os.IsNotExist(err) {
 			return nil, ErrAssertionNotFound
 		}
-		return nil, fmt.Errorf("broken assertion store, failed to stat assertion directory: %v", err)
+		return nil, fmt.Errorf("broken assertion storage, failed to stat assertion directory: %v", err)
 	}
 	encoded, err := db.readEntry(assertionsRoot, indexPath, "latest")
 	if err != nil {
-		return nil, fmt.Errorf("broken assertion store, failed to read assertion: %v", err)
+		return nil, fmt.Errorf("broken assertion storage, failed to read assertion: %v", err)
 	}
 	assert, err := Decode(encoded)
 	if err != nil {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -114,7 +114,7 @@ func (db *Database) removeEntry(subpath ...string) error {
 
 func (db *Database) symlinkEntry(entry string, subpath ...string) error {
 	fpath := filepath.Join(db.root, filepath.Join(subpath...))
-	// TODO: move the rest of this close to AtomicWriteFile?
+	// TODO: move the rest of this as a helper together with AtomicWriteFile?
 	dir, err := os.Open(filepath.Dir(fpath))
 	if err != nil {
 		return err

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -249,20 +249,20 @@ func (db *Database) Add(assert Assertion) error {
 	switch {
 	case err == nil:
 		// directory for assertion is present
-		curRevStr, err := db.readlinkEntry(assertionsRoot, indexPath, "newest")
+		curRevStr, err := db.readlinkEntry(assertionsRoot, indexPath, "latest")
 		if err != nil {
-			return fmt.Errorf("broken assertion store, reading 'newest' revision symlink: %v", err)
+			return fmt.Errorf("broken assertion store, reading 'latest' revision symlink: %v", err)
 		}
 		curRev, err := strconv.Atoi(curRevStr)
 		if err != nil {
-			return fmt.Errorf("broken assertion store, extracting revision from 'newest' revision symlink: %v", err)
+			return fmt.Errorf("broken assertion store, extracting revision from 'latest' revision symlink: %v", err)
 		}
 		if curRev >= assert.Revision() {
 			return ErrAssertionNotSuperseding
 		}
-		err = db.removeEntry(assertionsRoot, indexPath, "newest")
+		err = db.removeEntry(assertionsRoot, indexPath, "latest")
 		if err != nil {
-			return fmt.Errorf("broken assertion store, could not remove 'newest' revision symlink: %v", err)
+			return fmt.Errorf("broken assertion store, could not remove 'latest' revision symlink: %v", err)
 		}
 	case os.IsNotExist(err):
 		// nothing there yet
@@ -274,9 +274,9 @@ func (db *Database) Add(assert Assertion) error {
 	if err != nil {
 		return fmt.Errorf("broken assertion store, failed to write assertion: %v", err)
 	}
-	err = db.symlinkEntry(revStr, assertionsRoot, indexPath, "newest")
+	err = db.symlinkEntry(revStr, assertionsRoot, indexPath, "latest")
 	if err != nil {
-		return fmt.Errorf("broken assertion store, failed to create 'newest' revision symlink: %v", err)
+		return fmt.Errorf("broken assertion store, failed to create 'latest' revision symlink: %v", err)
 	}
 	return nil
 }
@@ -305,7 +305,7 @@ func (db *Database) Find(assertionType AssertionType, headers map[string]string)
 		}
 		return nil, fmt.Errorf("broken assertion store, failed to stat assertion directory: %v", err)
 	}
-	encoded, err := db.readEntry(assertionsRoot, indexPath, "newest")
+	encoded, err := db.readEntry(assertionsRoot, indexPath, "latest")
 	if err != nil {
 		return nil, fmt.Errorf("broken assertion store, failed to read assertion: %v", err)
 	}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -114,7 +114,7 @@ func (db *Database) removeEntry(subpath ...string) error {
 
 func (db *Database) symlinkEntry(entry string, subpath ...string) error {
 	fpath := filepath.Join(db.root, filepath.Join(subpath...))
-	// TODO: move to helpers/helpers.go
+	// TODO: move the rest of this close to AtomicWriteFile?
 	dir, err := os.Open(filepath.Dir(fpath))
 	if err != nil {
 		return err

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -207,7 +207,7 @@ func (db *Database) readAssertion(assertType AssertionType, primaryPath string) 
 	return assert, nil
 }
 
-// Add persists the assertions after ensuring it is properly signed and consistent with all the stored knowledge.
+// Add persists the assertion after ensuring it is properly signed and consistent with all the stored knowledge.
 // It will return an error when trying to add an older revision of the assertion than the one currently stored.
 func (db *Database) Add(assert Assertion) error {
 	reg, err := checkAssertType(assert.Type())

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -299,10 +299,10 @@ func (db *Database) Find(assertionType AssertionType, headers map[string]string)
 	}
 	indexPath := filepath.Join(string(assertionType), filepath.Join(primaryKey...))
 	_, err = db.statEntry(assertionsRoot, indexPath)
+	if os.IsNotExist(err) {
+		return nil, ErrNotFound
+	}
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, ErrNotFound
-		}
 		return nil, fmt.Errorf("broken assertion storage, failed to stat assertion directory: %v", err)
 	}
 	encoded, err := db.readEntry(assertionsRoot, indexPath, "latest")

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -252,7 +252,7 @@ func (afs *addFindSuite) TestAddSuperseding(c *C) {
 	c.Check(retrieved2.Revision(), Equals, 1)
 
 	err = afs.db.Add(a1)
-	c.Check(err, Equals, asserts.ErrAssertionNotSuperseding)
+	c.Check(err, Equals, asserts.ErrNotSuperseding)
 }
 
 func (afs *addFindSuite) TestFindNotFound(c *C) {
@@ -269,7 +269,7 @@ func (afs *addFindSuite) TestFindNotFound(c *C) {
 	retrieved1, err := afs.db.Find(asserts.AssertionType("test-only"), map[string]string{
 		"primary-key": "b",
 	})
-	c.Assert(err, Equals, asserts.ErrAssertionNotFound)
+	c.Assert(err, Equals, asserts.ErrNotFound)
 	c.Check(retrieved1, IsNil)
 
 	// checking also extra headers
@@ -277,7 +277,7 @@ func (afs *addFindSuite) TestFindNotFound(c *C) {
 		"primary-key":  "a",
 		"authority-id": "other-auth-id",
 	})
-	c.Assert(err, Equals, asserts.ErrAssertionNotFound)
+	c.Assert(err, Equals, asserts.ErrNotFound)
 	c.Check(retrieved1, IsNil)
 }
 

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -252,7 +252,7 @@ func (afs *addFindSuite) TestAddSuperseding(c *C) {
 	c.Check(retrieved2.Revision(), Equals, 1)
 
 	err = afs.db.Add(a1)
-	c.Check(err, Equals, asserts.ErrNotSuperseding)
+	c.Check(err, ErrorMatches, "assertion added must have more recent revision than current one.*")
 }
 
 func (afs *addFindSuite) TestFindNotFound(c *C) {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -140,6 +140,7 @@ func (chks *checkSuite) SetUpTest(c *C) {
 
 	headers := map[string]string{
 		"authority-id": "canonical",
+		"primary-key":  "0",
 	}
 	chks.a, err = asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, chks.key1)
 	c.Assert(err, IsNil)
@@ -191,4 +192,97 @@ func (chks *checkSuite) TestCheckForgery(c *C) {
 
 	err = db.Check(forgedAssert)
 	c.Assert(err, ErrorMatches, "failed signature verification: .*")
+}
+
+type addFindSuite struct {
+	key1 *packet.PrivateKey
+	db   *asserts.Database
+}
+
+var _ = Suite(&addFindSuite{})
+
+func (afs *addFindSuite) SetUpTest(c *C) {
+	var err error
+	afs.key1, err = asserts.GeneratePrivateKeyInTest()
+	c.Assert(err, IsNil)
+
+	rootDir := filepath.Join(c.MkDir(), "asserts-db")
+	dbTrustedKey := asserts.WrapPublicKey(&afs.key1.PublicKey)
+	cfg := &asserts.DatabaseConfig{
+		Path: rootDir,
+		TrustedKeys: map[string][]asserts.PublicKey{
+			"canonical": {dbTrustedKey},
+		},
+	}
+	db, err := asserts.OpenDatabase(cfg)
+	c.Assert(err, IsNil)
+	afs.db = db
+}
+
+func (afs *addFindSuite) TestAddSuperseding(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "a",
+	}
+	a1, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, afs.key1)
+	c.Assert(err, IsNil)
+
+	err = afs.db.Add(a1)
+	c.Assert(err, IsNil)
+
+	retrieved1, err := afs.db.Find(asserts.AssertionType("test-only"), map[string]string{
+		"primary-key": "a",
+	})
+	c.Assert(err, IsNil)
+	c.Check(retrieved1, NotNil)
+	c.Check(retrieved1.Revision(), Equals, 0)
+
+	headers["revision"] = "1"
+	a2, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, afs.key1)
+	c.Assert(err, IsNil)
+
+	err = afs.db.Add(a2)
+	c.Assert(err, IsNil)
+
+	retrieved2, err := afs.db.Find(asserts.AssertionType("test-only"), map[string]string{
+		"primary-key": "a",
+	})
+	c.Assert(err, IsNil)
+	c.Check(retrieved2, NotNil)
+	c.Check(retrieved2.Revision(), Equals, 1)
+
+	err = afs.db.Add(a1)
+	c.Check(err, Equals, asserts.ErrAssertionNotSuperseding)
+}
+
+func (afs *addFindSuite) TestFindNotFound(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "a",
+	}
+	a1, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, afs.key1)
+	c.Assert(err, IsNil)
+
+	err = afs.db.Add(a1)
+	c.Assert(err, IsNil)
+
+	retrieved1, err := afs.db.Find(asserts.AssertionType("test-only"), map[string]string{
+		"primary-key": "b",
+	})
+	c.Assert(err, Equals, asserts.ErrAssertionNotFound)
+	c.Check(retrieved1, IsNil)
+
+	// checking also extra headers
+	retrieved1, err = afs.db.Find(asserts.AssertionType("test-only"), map[string]string{
+		"primary-key":  "a",
+		"authority-id": "other-auth-id",
+	})
+	c.Assert(err, Equals, asserts.ErrAssertionNotFound)
+	c.Check(retrieved1, IsNil)
+}
+
+func (afs *addFindSuite) TestFindPrimaryLeftOut(c *C) {
+	retrieved1, err := afs.db.Find(asserts.AssertionType("test-only"), map[string]string{})
+	c.Assert(err, ErrorMatches, "must provide primary key: primary-key")
+	c.Check(retrieved1, IsNil)
 }

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -40,6 +40,7 @@ func buildTestOnly(assert AssertionBase) (Assertion, error) {
 
 func init() {
 	typeRegistry[AssertionType("test-only")] = &assertionTypeRegistration{
-		builder: buildTestOnly,
+		builder:    buildTestOnly,
+		primaryKey: []string{"primary-key"},
 	}
 }


### PR DESCRIPTION
Add() in the final version keeps only the latest revision of an assertion.

Find() takes a full primary key so it returns either one or no assertion. Later will likely need something that probably only takes a prefix of the primary key and can do some further filtering, we need to look at flows/use cases.