### PR TITLE
Trivial fix for the output of "snappy list"

### DIFF
--- a/cmd/snappy/cmd_list.go
+++ b/cmd/snappy/cmd_list.go
@@ -133,7 +133,7 @@ func showRebootMessage(installed []snappy.Part, o io.Writer) {
 		}
 
 		// TRANSLATORS: the first %s is a pkgname the second a version
-		fmt.Fprintln(o, fmt.Sprintf(i18n.G("Reboot to use %s version %s."), part.Version(), part.Name()))
+		fmt.Fprintln(o, fmt.Sprintf(i18n.G("Reboot to use %s version %s."), part.Name(), part.Version()))
 	}
 }
 


### PR DESCRIPTION
Instead of:
 Reboot to use 2015.11.24-1 version ubuntu-core.
it will print
 Reboot to use ubuntu-core version 2015.11.24-1.