### PR TITLE
no need for DEBIAN/ in the squashfs snap

### DIFF
--- a/snappy/build.go
+++ b/snappy/build.go
@@ -507,6 +507,12 @@ func BuildSquashfsSnap(sourceDir, targetDir string) (string, error) {
 		return "", err
 	}
 
+	// we really don't need this in the brave new all-snap world
+	// FIXME: remove once we kill legacy snap building
+	if err := os.RemoveAll(filepath.Join(buildDir, "DEBIAN")); err != nil {
+		return "", err
+	}
+
 	d := squashfs.New(snapName)
 	if err = d.Build(buildDir); err != nil {
 		return "", err

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 
 	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/testutil"
 
 	. "gopkg.in/check.v1"
 )
@@ -527,4 +528,8 @@ integration:
 		expr := fmt.Sprintf(`(?ms).*%s.*`, regexp.QuoteMeta(needle))
 		c.Assert(string(output), Matches, expr)
 	}
+
+	// ensure we don't have cruft in our squashfs
+	c.Assert(string(output), Not(testutil.Contains), "DEBIAN")
+	c.Assert(string(output), Not(testutil.Contains), ".click")
 }


### PR DESCRIPTION
We have the somewhat ugly DEBIAN/ dir that we generate for 15.04 compatibility. We really don't need this in the new squashfs snaps (and once we stop supporting old-style snaps we don't need it at all). 

P.S. \o/ for testutil.Contains() :)