### PR TITLE
make "snappy config ubuntu-core" work again by applying coreconfig to the OS snap

### DIFF
--- a/snappy/config.go
+++ b/snappy/config.go
@@ -25,10 +25,24 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/ubuntu-core/snappy/coreconfig"
 )
 
 // can be overriden by tests
 var aaExec = "aa-exec"
+
+// for the unit tests
+var coreConfig = coreConfigImpl
+
+// coreConfig configure the OS snap
+func coreConfigImpl(configuration []byte) (newConfig string, err error) {
+	if cfg := string(configuration); cfg != "" {
+		return coreconfig.Set(cfg)
+	}
+
+	return coreconfig.Get()
+}
 
 // snapConfig configures a installed snap in the given directory
 //

--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -1126,6 +1126,10 @@ func (s *SnapPart) remove(inter interacter) (err error) {
 
 // Config is used to to configure the snap
 func (s *SnapPart) Config(configuration []byte) (new string, err error) {
+	if s.m.Type == pkg.TypeOS {
+		return coreConfig(configuration)
+	}
+
 	return snapConfig(s.basedir, s.origin, string(configuration))
 }
 

--- a/snappy/systemimage.go
+++ b/snappy/systemimage.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/mvo5/goconfigparser"
 
-	"github.com/ubuntu-core/snappy/coreconfig"
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/logger"
@@ -284,11 +283,7 @@ func (s *SystemImagePart) Uninstall(progress.Meter) error {
 
 // Config is used to to configure the snap
 func (s *SystemImagePart) Config(configuration []byte) (newConfig string, err error) {
-	if cfg := string(configuration); cfg != "" {
-		return coreconfig.Set(cfg)
-	}
-
-	return coreconfig.Get()
+	return coreConfig(configuration)
 }
 
 // NeedsReboot returns true if the snap becomes active on the next reboot


### PR DESCRIPTION
In order to configure ubuntu-core we have a "coreconfig" package in our code. This is applied only in the SystemImagePart code right now which makes the firstboot systemd unit in the all-snap image fail.

This branch moves it into the SnapPart for all os-snaps which will fix the failure.

While working on this I was wondering is if we should make the coreconfig a proper binary and put it into the OS snap as a real config handler. This actually seems like the cleanest solution. If there is agreement on this I will do a followup branch that creates a coreconfig binary and modify the mk-os.sh building script to pull in this new coreconfig binary into meta/hooks/config. The downside of this approach is that the OS snap will be bigger because the coreconfig binary is big (especially when considering how little its doing relatively speaking). Not sure if that should be a concern though.