### PR TITLE
Allow to pass build constraints to the integration tests

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -204,7 +204,7 @@ reboot.
 ### Excluding flaky tests on low-performance systems
 
 We have found that some tests give random results on low-performance systems. You can
-exclude this tests by passing `excludeFlakyOnLowPerformance` to the `test-build-tags`
+exclude this tests by passing `lowperformance` to the `test-build-tags`
 flag:
 
-    go run integration-tests/main.go -test-build-tags=excludeFlakyOnLowPerformance
+    go run integration-tests/main.go -test-build-tags=lowperformance

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -204,7 +204,7 @@ reboot.
 ### Excluding flaky tests on low-performance systems
 
 We have found that some tests give random results on low-performance systems. You can
-exclude this tests by passing `lowperformance` to the `test-build-tags`
+exclude these tests by passing `lowperformance` to the `test-build-tags`
 flag:
 
     go run integration-tests/main.go -test-build-tags=lowperformance

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -201,9 +201,9 @@ reboot, write it like this:
 *Always* make sure that your test is removing the mark once it handled the
 reboot.
 
-### Excluding flaky tests
+### Excluding flaky tests on low-performance systems
 
 We have found that some tests give random results on low-performance systems. You can
 exclude this tests by passing ```excludeflaky``` to the ```test-build-tags``` flag:
 
-    go run integration-tests/main.go -test-build-tags=excludeflaky
+    go run integration-tests/main.go -test-build-tags=excludeFlakyOnLowPerformance

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -200,3 +200,10 @@ reboot, write it like this:
 
 *Always* make sure that your test is removing the mark once it handled the
 reboot.
+
+### Excluding flaky tests
+
+We have found that some tests give random results on low-performance systems. You can
+exclude this tests by passing ```excludeflaky``` to the ```test-build-tags``` flag:
+
+    go run integration-tests/main.go -test-build-tags=excludeflaky

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -204,6 +204,7 @@ reboot.
 ### Excluding flaky tests on low-performance systems
 
 We have found that some tests give random results on low-performance systems. You can
-exclude this tests by passing ```excludeflaky``` to the ```test-build-tags``` flag:
+exclude this tests by passing ```excludeFlakyOnLowPerformance``` to the ```test-build-tags```
+flag:
 
     go run integration-tests/main.go -test-build-tags=excludeFlakyOnLowPerformance

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -204,7 +204,7 @@ reboot.
 ### Excluding flaky tests on low-performance systems
 
 We have found that some tests give random results on low-performance systems. You can
-exclude this tests by passing ```excludeFlakyOnLowPerformance``` to the ```test-build-tags```
+exclude this tests by passing `excludeFlakyOnLowPerformance` to the `test-build-tags`
 flag:
 
     go run integration-tests/main.go -test-build-tags=excludeFlakyOnLowPerformance

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -70,13 +70,14 @@ func main() {
 			"If the update flag is used, the image will be updated to this channel before running the tests.")
 		rollback = flag.Bool("rollback", false,
 			"If this flag is used, the image will be updated and then rolled back before running the tests.")
-		outputDir   = flag.String("output-dir", defaultOutputDir, "Directory where test artifacts will be stored.")
-		shellOnFail = flag.Bool("shell-fail", false, "Run a shell in the testbed if the suite fails.")
+		outputDir     = flag.String("output-dir", defaultOutputDir, "Directory where test artifacts will be stored.")
+		shellOnFail   = flag.Bool("shell-fail", false, "Run a shell in the testbed if the suite fails.")
+		testBuildTags = flag.String("test-build-tags", "", "Build tags to be passed to the go test command")
 	)
 
 	flag.Parse()
 
-	build.Assets(*useSnappyFromBranch, *arch)
+	build.Assets(*useSnappyFromBranch, *arch, *testBuildTags)
 
 	// TODO: generate the files out of the source tree. --elopio - 2015-07-15
 	testutils.PrepareTargetDir(dataOutputDir)

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -77,7 +77,10 @@ func main() {
 
 	flag.Parse()
 
-	build.Assets(*useSnappyFromBranch, *arch, *testBuildTags)
+	build.Assets(&build.Config{
+		UseSnappyFromBranch: *useSnappyFromBranch,
+		Arch:                *arch,
+		TestBuildTags:       *testBuildTags})
 
 	// TODO: generate the files out of the source tree. --elopio - 2015-07-15
 	testutils.PrepareTargetDir(dataOutputDir)

--- a/integration-tests/tests/ubuntuFan_test.go
+++ b/integration-tests/tests/ubuntuFan_test.go
@@ -1,5 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-// +build !excludeintegration,!excludeFlakyOnLowPerformance
+// +build !excludeintegration,!lowperformance
 
 /*
  * Copyright (C) 2015 Canonical Ltd

--- a/integration-tests/tests/ubuntuFan_test.go
+++ b/integration-tests/tests/ubuntuFan_test.go
@@ -1,5 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-// +build !excludeintegration,!excludeflaky
+// +build !excludeintegration,!excludeFlakyOnLowPerformance
 
 /*
  * Copyright (C) 2015 Canonical Ltd

--- a/integration-tests/tests/ubuntuFan_test.go
+++ b/integration-tests/tests/ubuntuFan_test.go
@@ -1,5 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-// +build !excludeintegration
+// +build !excludeintegration,!excludeflaky
 
 /*
  * Copyright (C) 2015 Canonical Ltd

--- a/integration-tests/testutils/build/build.go
+++ b/integration-tests/testutils/build/build.go
@@ -57,18 +57,24 @@ var (
 		filepath.Join(testsBinDir, "snapd") + " ." + string(os.PathSeparator) + filepath.Join("cmd", "snapd")
 )
 
+// Config comprises the parameters for the Assets function
+type Config struct {
+	UseSnappyFromBranch bool
+	Arch, TestBuildTags string
+}
+
 // Assets builds the snappy and integration tests binaries for the target
 // architecture.
-func Assets(useSnappyFromBranch bool, arch, testBuildTags string) {
+func Assets(cfg *Config) {
 	prepareTargetDir(testsBinDir)
 
-	if useSnappyFromBranch {
+	if cfg.UseSnappyFromBranch {
 		// FIXME We need to build an image that has the snappy from the branch
 		// installed. --elopio - 2015-06-25.
-		buildSnappyCLI(arch)
-		buildSnapd(arch)
+		buildSnappyCLI(cfg.Arch)
+		buildSnapd(cfg.Arch)
 	}
-	buildTests(arch, testBuildTags)
+	buildTests(cfg.Arch, cfg.TestBuildTags)
 }
 
 func buildSnappyCLI(arch string) {

--- a/integration-tests/testutils/build/build.go
+++ b/integration-tests/testutils/build/build.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	buildTestCmd = "go test%s -c ./integration-tests/tests"
+	buildTestCmdFmt = "go test%s -c ./integration-tests/tests"
 
 	// IntegrationTestName is the name of the test binary.
 	IntegrationTestName = "integration.test"
@@ -94,7 +94,7 @@ func buildTests(arch, testBuildTags string) {
 	if testBuildTags != "" {
 		tagText = " -tags=" + testBuildTags
 	}
-	cmd := fmt.Sprintf(buildTestCmd, tagText)
+	cmd := fmt.Sprintf(buildTestCmdFmt, tagText)
 
 	goCall(arch, cmd)
 	// XXX Go test 1.3 does not have the output flag, so we move the

--- a/integration-tests/testutils/build/build.go
+++ b/integration-tests/testutils/build/build.go
@@ -66,6 +66,9 @@ type Config struct {
 // Assets builds the snappy and integration tests binaries for the target
 // architecture.
 func Assets(cfg *Config) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
 	prepareTargetDir(testsBinDir)
 
 	if cfg.UseSnappyFromBranch {

--- a/integration-tests/testutils/build/build.go
+++ b/integration-tests/testutils/build/build.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	buildTestCmd = "go test -c ./integration-tests/tests"
+	buildTestCmd = "go test%s -c ./integration-tests/tests"
 
 	// IntegrationTestName is the name of the test binary.
 	IntegrationTestName = "integration.test"
@@ -59,7 +59,7 @@ var (
 
 // Assets builds the snappy and integration tests binaries for the target
 // architecture.
-func Assets(useSnappyFromBranch bool, arch string) {
+func Assets(useSnappyFromBranch bool, arch, testBuildTags string) {
 	prepareTargetDir(testsBinDir)
 
 	if useSnappyFromBranch {
@@ -68,7 +68,7 @@ func Assets(useSnappyFromBranch bool, arch string) {
 		buildSnappyCLI(arch)
 		buildSnapd(arch)
 	}
-	buildTests(arch)
+	buildTests(arch, testBuildTags)
 }
 
 func buildSnappyCLI(arch string) {
@@ -81,10 +81,16 @@ func buildSnapd(arch string) {
 	goCall(arch, buildSnapdCmd)
 }
 
-func buildTests(arch string) {
+func buildTests(arch, testBuildTags string) {
 	fmt.Println("Building tests...")
 
-	goCall(arch, buildTestCmd)
+	var tagText string
+	if testBuildTags != "" {
+		tagText = " -tags=" + testBuildTags
+	}
+	cmd := fmt.Sprintf(buildTestCmd, tagText)
+
+	goCall(arch, cmd)
 	// XXX Go test 1.3 does not have the output flag, so we move the
 	// binaries after they are generated.
 	osRename("tests.test", testsBinDir+IntegrationTestName)

--- a/integration-tests/testutils/build/build_test.go
+++ b/integration-tests/testutils/build/build_test.go
@@ -111,7 +111,7 @@ func (s *BuildSuite) fakeOsGetenv(key string) (value string) {
 }
 
 func (s *BuildSuite) TestAssetsCallsPrepareDir(c *check.C) {
-	Assets(&Config{})
+	Assets(nil)
 
 	mkDirCall := s.mkDirCalls[testsBinDir]
 
@@ -121,7 +121,7 @@ func (s *BuildSuite) TestAssetsCallsPrepareDir(c *check.C) {
 }
 
 func (s *BuildSuite) TestAssetsBuildsTests(c *check.C) {
-	Assets(&Config{})
+	Assets(nil)
 
 	// not passing test build tags by default
 	testBuildTags := ""
@@ -134,7 +134,7 @@ func (s *BuildSuite) TestAssetsBuildsTests(c *check.C) {
 }
 
 func (s *BuildSuite) TestAssetsRenamesBuiltBinary(c *check.C) {
-	Assets(&Config{})
+	Assets(nil)
 
 	cmd := "tests.test " + testsBinDir + IntegrationTestName
 	renameCall := s.osRenameCalls[cmd]
@@ -193,7 +193,7 @@ func (s *BuildSuite) TestAssetsSetsEnvironmentForArm(c *check.C) {
 }
 
 func (s *BuildSuite) TestAssetsDoesNotSetEnvironmentForEmptyArch(c *check.C) {
-	Assets(&Config{})
+	Assets(nil)
 
 	setenvGOARCHFirstCall := s.osSetenvCalls["GOARCH "]
 	setenvGOARCHFinalCall := s.osSetenvCalls["GOARCH "+os.Getenv("GOARCH")]
@@ -232,7 +232,7 @@ func (s *BuildSuite) TestAssetsBuildsSnappyCliFromBranch(c *check.C) {
 }
 
 func (s *BuildSuite) TestAssetsDoesNotBuildSnappyCliFromBranchIfNotInstructedTo(c *check.C) {
-	Assets(&Config{})
+	Assets(nil)
 
 	buildCall := s.execCalls[buildSnappyCliCmd]
 
@@ -252,7 +252,7 @@ func (s *BuildSuite) TestAssetsBuildsSnapdFromBranch(c *check.C) {
 }
 
 func (s *BuildSuite) TestAssetsDoesNotBuildSnapdFromBranchIfNotInstructedTo(c *check.C) {
-	Assets(&Config{})
+	Assets(nil)
 
 	buildCall := s.execCalls[buildSnapdCmd]
 

--- a/integration-tests/testutils/build/build_test.go
+++ b/integration-tests/testutils/build/build_test.go
@@ -125,7 +125,7 @@ func (s *BuildSuite) TestAssetsBuildsTests(c *check.C) {
 
 	// not passing test build tags by default
 	testBuildTags := ""
-	cmd := fmt.Sprintf(buildTestCmd, testBuildTags)
+	cmd := fmt.Sprintf(buildTestCmdFmt, testBuildTags)
 	buildCall := s.execCalls[cmd]
 
 	c.Assert(buildCall, check.Equals, 1,
@@ -265,7 +265,7 @@ func (s *BuildSuite) TestAssetsHonoursBuildTags(c *check.C) {
 	testBuildTags := "mybuildtag"
 	Assets(&Config{TestBuildTags: testBuildTags})
 
-	tagBuildTestCmd := fmt.Sprintf(buildTestCmd, " -tags=mybuildtag")
+	tagBuildTestCmd := fmt.Sprintf(buildTestCmdFmt, " -tags=mybuildtag")
 	buildCall := s.execCalls[tagBuildTestCmd]
 
 	c.Assert(buildCall, check.Equals, 1,


### PR DESCRIPTION
This will allow us to mark tests as slow, internet connection dependent, flaky, needing a specific relative version and channel (for instance, in the upcoming update-rollback stress tests), etc. Letting the compiler pick the tests to be executed makes unnecessary to add logic to select/skip them.

Also fanTestSuite marked as flaky, it gives random failures in low-performance systems (eyes canonistack instances). It has been tagged in a way that by default it is executed with the rest of the tests, you have to explicitly exclude the suite:

```go run integration-tests/main.go -test-build-tags=excludeflaky```
