### PR TITLE
Add release.{Lsb,ReadLsb()}

### DIFF
--- a/release/export_test.go
+++ b/release/export_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package release
+
+func SetLsbReleasePath(fn string) {
+	lsbReleasePath = fn
+}
+
+func LsbReleasePath() string {
+	return lsbReleasePath
+}

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -19,10 +19,10 @@
 
 package release
 
-func SetLsbReleasePath(fn string) {
+func HackLsbReleasePath(fn string) (reset func()) {
+	origLsbReleasePath := lsbReleasePath
 	lsbReleasePath = fn
-}
-
-func LsbReleasePath() string {
-	return lsbReleasePath
+	return func() {
+		lsbReleasePath = origLsbReleasePath
+	}
 }

--- a/release/release.go
+++ b/release/release.go
@@ -89,7 +89,7 @@ func ReadLsb() (*Lsb, error) {
 
 	content, err := ioutil.ReadFile(lsbReleasePath)
 	if err != nil {
-		return nil, fmt.Errorf("can not read lsb-release: %s", err)
+		return nil, fmt.Errorf("cannot read lsb-release: %s", err)
 	}
 
 	for _, line := range strings.Split(string(content), "\n") {

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -70,10 +70,8 @@ DISTRIB_DESCRIPTION=I'm not real!
 }
 
 func (a *ReleaseTestSuite) TestReadLsb(c *C) {
-	realLsbRelease := release.LsbReleasePath()
-	defer func() { release.SetLsbReleasePath(realLsbRelease) }()
-
-	release.SetLsbReleasePath(makeMockLsbRelease(c))
+	reset := release.HackLsbReleasePath(makeMockLsbRelease(c))
+	defer reset()
 
 	lsb, err := release.ReadLsb()
 	c.Assert(err, IsNil)
@@ -83,11 +81,9 @@ func (a *ReleaseTestSuite) TestReadLsb(c *C) {
 }
 
 func (a *ReleaseTestSuite) TestReadLsbNotFound(c *C) {
-	realLsbRelease := release.LsbReleasePath()
-	defer func() { release.SetLsbReleasePath(realLsbRelease) }()
-
-	release.SetLsbReleasePath("not-there")
+	reset := release.HackLsbReleasePath("not-there")
+	defer reset()
 
 	_, err := release.ReadLsb()
-	c.Assert(err, ErrorMatches, "can not read lsb-release:.*")
+	c.Assert(err, ErrorMatches, "cannot read lsb-release:.*")
 }

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -20,6 +20,8 @@
 package release_test
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -49,4 +51,43 @@ func (s *ReleaseTestSuite) TestOverride(c *C) {
 	release.Override(rel)
 	c.Check(release.String(), Equals, "10.06-personal")
 	c.Check(release.Get(), DeepEquals, rel)
+}
+
+func makeMockLsbRelease(c *C) string {
+	// FIXME: use AddCleanup here once available so that we
+	//        can do release.SetLsbReleasePath() here directly
+	mockLsbRelease := filepath.Join(c.MkDir(), "mock-lsb-release")
+	s := `
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=18.09
+DISTRIB_CODENAME=awsome
+DISTRIB_DESCRIPTION=I'm not real!
+`
+	err := ioutil.WriteFile(mockLsbRelease, []byte(s), 0644)
+	c.Assert(err, IsNil)
+
+	return mockLsbRelease
+}
+
+func (a *ReleaseTestSuite) TestReadLsb(c *C) {
+	realLsbRelease := release.LsbReleasePath()
+	defer func() { release.SetLsbReleasePath(realLsbRelease) }()
+
+	release.SetLsbReleasePath(makeMockLsbRelease(c))
+
+	lsb, err := release.ReadLsb()
+	c.Assert(err, IsNil)
+	c.Assert(lsb.ID, Equals, "Ubuntu")
+	c.Assert(lsb.Release, Equals, "18.09")
+	c.Assert(lsb.Codename, Equals, "awsome")
+}
+
+func (a *ReleaseTestSuite) TestReadLsbNotFound(c *C) {
+	realLsbRelease := release.LsbReleasePath()
+	defer func() { release.SetLsbReleasePath(realLsbRelease) }()
+
+	release.SetLsbReleasePath("not-there")
+
+	_, err := release.ReadLsb()
+	c.Assert(err, ErrorMatches, "can not read lsb-release:.*")
 }

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -776,33 +776,6 @@ write
 
 }
 
-func (a *SecurityTestSuite) TestSnappyFindUbuntuVersion(c *C) {
-	realLsbRelease := lsbRelease
-	defer func() { lsbRelease = realLsbRelease }()
-
-	lsbRelease = filepath.Join(c.MkDir(), "mock-lsb-release")
-	s := `DISTRIB_RELEASE=18.09`
-	err := ioutil.WriteFile(lsbRelease, []byte(s), 0644)
-	c.Assert(err, IsNil)
-
-	ver, err := findUbuntuVersion()
-	c.Assert(err, IsNil)
-	c.Assert(ver, Equals, "18.09")
-}
-
-func (a *SecurityTestSuite) TestSnappyFindUbuntuVersionNotFound(c *C) {
-	realLsbRelease := lsbRelease
-	defer func() { lsbRelease = realLsbRelease }()
-
-	lsbRelease = filepath.Join(c.MkDir(), "mock-lsb-release")
-	s := `silly stuff`
-	err := ioutil.WriteFile(lsbRelease, []byte(s), 0644)
-	c.Assert(err, IsNil)
-
-	_, err = findUbuntuVersion()
-	c.Assert(err, Equals, errSystemVersionNotFound)
-}
-
 func makeCustomAppArmorPolicy(c *C) string {
 	content := []byte(`# custom apparmor policy
 ###VAR###


### PR DESCRIPTION
While working on the new classic-mode I noticed that I have to download a lxd image based on the lsb information we have. This branch adds support for reading lsb-release data .

When mvo5:refactor/less-cleanup-in-buildtest lands the tests can be somewhat simplified by using the AddCleanup helper.