### PR TITLE
End-to-end API for listing capabilities 

### DIFF
--- a/caps/repo.go
+++ b/caps/repo.go
@@ -172,3 +172,15 @@ func (r *Repository) All() []Capability {
 	sort.Sort(byName(caps))
 	return caps
 }
+
+// Caps returns a shallow copy of the map of capabilities.
+func (r *Repository) Caps() map[string]*Capability {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	caps := make(map[string]*Capability, len(r.caps))
+	for k, v := range r.caps {
+		caps[k] = v
+	}
+	return caps
+}

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -161,3 +161,17 @@ func (s *RepositorySuite) TestHasType(c *C) {
 	// otherwise identical, the test fails.
 	c.Assert(s.testRepo.HasType(&Type{Name: testType.Name}), Equals, false)
 }
+
+func (s *RepositorySuite) TestCaps(c *C) {
+	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
+	c.Assert(err, IsNil)
+	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
+	c.Assert(err, IsNil)
+	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
+	c.Assert(err, IsNil)
+	c.Assert(s.testRepo.Caps(), DeepEquals, map[string]*Capability{
+		"a": &Capability{Name: "a", Label: "label-a", Type: testType},
+		"b": &Capability{Name: "b", Label: "label-b", Type: testType},
+		"c": &Capability{Name: "c", Label: "label-c", Type: testType},
+	})
+}

--- a/client/client.go
+++ b/client/client.go
@@ -147,8 +147,8 @@ type Capability struct {
 	Attrs map[string]string `json:"attrs,omitempty"`
 }
 
-// GetCapabilities gets the list of capabilities from the REST API
-func (client *Client) GetCapabilities() ([]Capability, error) {
+// Capabilities returns the capabilities currently available for snaps to consume.
+func (client *Client) Capabilities() ([]Capability, error) {
 	var rsp response
 	if err := client.do("GET", "/1.0/capabilities", nil, &rsp); err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -129,8 +129,28 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 }
 
 type Capability struct {
-	Name		string `json:"name"`
-	Label		string `json:"label"`
-	Type		string `json:"type"`
-	Attrs		map[string]string `json:"attrs,omitempty"`
+	Name  string            `json:"name"`
+	Label string            `json:"label"`
+	Type  string            `json:"type"`
+	Attrs map[string]string `json:"attrs,omitempty"`
+}
+
+// GetCapabilities gets the list of capabilities from the REST API
+func (client *Client) GetCapabilities() ([]Capability, error) {
+	var rsp response
+	if err := client.do("GET", "/1.0/capabilities", nil, &rsp); err != nil {
+		return nil, err
+	}
+	if rsp.Type == "error" {
+		// TODO: handle structured errors
+		return nil, fmt.Errorf("failed with %q", rsp.Status)
+	}
+	if rsp.Type != "sync" {
+		return nil, fmt.Errorf("unexpected result type %q", rsp.Type)
+	}
+	var caps []Capability
+	if err := json.Unmarshal(rsp.Result, &caps); err != nil {
+		return nil, err
+	}
+	return caps, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -128,10 +128,22 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 	return &sysInfo, nil
 }
 
+// Capability holds information about a capability that a snap may request
+// from a snappy system to do its job while running on it.
 type Capability struct {
-	Name  string            `json:"name"`
-	Label string            `json:"label"`
-	Type  string            `json:"type"`
+	// Name is a key that identifies the capability. It must be unique within
+	// its context, which may be either a snap or a snappy runtime.
+	Name string `json:"name"`
+	// Label provides an optional title for the capability to help a human tell
+	// which physical device this capability is referring to. It might say
+	// "Front USB", or "Green Serial Port", for example.
+	Label string `json:"label"`
+	// Type defines the type of this capability. The capability type defines
+	// the behavior allowed and expected from providers and consumers of that
+	// capability, and also which information should be exchanged by these
+	// parties.
+	Type string `json:"type"`
+	// Attrs are key-value pairs that provide type-specific capability details.
 	Attrs map[string]string `json:"attrs,omitempty"`
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -148,7 +148,7 @@ type Capability struct {
 }
 
 // Capabilities returns the capabilities currently available for snaps to consume.
-func (client *Client) Capabilities() ([]Capability, error) {
+func (client *Client) Capabilities() (map[string]Capability, error) {
 	var rsp response
 	if err := client.do("GET", "/1.0/capabilities", nil, &rsp); err != nil {
 		return nil, err
@@ -160,9 +160,9 @@ func (client *Client) Capabilities() ([]Capability, error) {
 	if rsp.Type != "sync" {
 		return nil, fmt.Errorf("cannot obtain capabilities: expected sync response, got %s", rsp.Type)
 	}
-	var caps []Capability
-	if err := json.Unmarshal(rsp.Result, &caps); err != nil {
+	var result map[string]map[string]Capability
+	if err := json.Unmarshal(rsp.Result, &result); err != nil {
 		return nil, fmt.Errorf("cannot obtain capabilities: failed to unmarshal response: %v", err)
 	}
-	return caps, nil
+	return result["capabilities"], nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -127,3 +127,10 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 
 	return &sysInfo, nil
 }
+
+type Capability struct {
+	Name		string `json:"name"`
+	Label		string `json:"label"`
+	Type		string `json:"type"`
+	Attrs		map[string]string `json:"attrs,omitempty"`
+}

--- a/client/client.go
+++ b/client/client.go
@@ -155,14 +155,14 @@ func (client *Client) Capabilities() ([]Capability, error) {
 	}
 	if rsp.Type == "error" {
 		// TODO: handle structured errors
-		return nil, fmt.Errorf("failed with %q", rsp.Status)
+		return nil, fmt.Errorf("cannot obtain capabilities: %s", rsp.Status)
 	}
 	if rsp.Type != "sync" {
-		return nil, fmt.Errorf("unexpected result type %q", rsp.Type)
+		return nil, fmt.Errorf("cannot obtain capabilities: expected sync response, got %s", rsp.Type)
 	}
 	var caps []Capability
 	if err := json.Unmarshal(rsp.Result, &caps); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot obtain capabilities: failed to unmarshal response: %v", err)
 	}
 	return caps, nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -118,3 +118,25 @@ func (cs *clientSuite) TestClientReportsInnerJSONError(c *check.C) {
 	_, err := cs.cli.SysInfo()
 	c.Check(err, check.ErrorMatches, `bad sysinfo result .*`)
 }
+
+func (cs *clientSuite) TestClientGetCapabilities(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": [
+		{
+			"name": "n",
+			"label": "l",
+			"type": "t",
+			"attrs": {"k": "v"}
+		}
+		]
+	}`
+	caps, err := cs.cli.GetCapabilities()
+	c.Check(err, check.IsNil)
+	c.Check(caps, check.DeepEquals, []client.Capability{{
+		Name:  "n",
+		Label: "l",
+		Type:  "t",
+		Attrs: map[string]string{"k": "v"},
+	}})
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -122,21 +122,25 @@ func (cs *clientSuite) TestClientReportsInnerJSONError(c *check.C) {
 func (cs *clientSuite) TestClientCapabilities(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
-		"result": [
-		{
-			"name": "n",
-			"label": "l",
-			"type": "t",
-			"attrs": {"k": "v"}
+		"result": {
+			"capabilities": {
+				"n": {
+					"name": "n",
+					"label": "l",
+					"type": "t",
+					"attrs": {"k": "v"}
+				}
+			}
 		}
-		]
 	}`
 	caps, err := cs.cli.Capabilities()
 	c.Check(err, check.IsNil)
-	c.Check(caps, check.DeepEquals, []client.Capability{{
-		Name:  "n",
-		Label: "l",
-		Type:  "t",
-		Attrs: map[string]string{"k": "v"},
-	}})
+	c.Check(caps, check.DeepEquals, map[string]client.Capability{
+		"n": client.Capability{
+			Name:  "n",
+			Label: "l",
+			Type:  "t",
+			Attrs: map[string]string{"k": "v"},
+		},
+	})
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -119,7 +119,7 @@ func (cs *clientSuite) TestClientReportsInnerJSONError(c *check.C) {
 	c.Check(err, check.ErrorMatches, `bad sysinfo result .*`)
 }
 
-func (cs *clientSuite) TestClientGetCapabilities(c *check.C) {
+func (cs *clientSuite) TestClientCapabilities(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
 		"result": [
@@ -131,7 +131,7 @@ func (cs *clientSuite) TestClientGetCapabilities(c *check.C) {
 		}
 		]
 	}`
-	caps, err := cs.cli.GetCapabilities()
+	caps, err := cs.cli.Capabilities()
 	c.Check(err, check.IsNil)
 	c.Check(caps, check.DeepEquals, []client.Capability{{
 		Name:  "n",

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -46,7 +46,7 @@ func init() {
 
 func (x *cmdListCaps) Execute(args []string) error {
 	cli := client.New()
-	caps, err := cli.GetCapabilities()
+	caps, err := cli.Capabilities()
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -48,7 +48,7 @@ func (x *cmdListCaps) Execute(args []string) error {
 	cli := client.New()
 	caps, err := cli.Capabilities()
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot get capabilities: %v", err)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 1, ' ', 0)
 	fmt.Fprintln(w, "Name\tLabel\tType")

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type cmdListCaps struct {
+}
+
+var (
+	shortListCapsHelp = i18n.G("List system capabilities")
+	longListCapsHelp  = i18n.G("This command shows all capabilities and their allocation")
+)
+
+func init() {
+	_, err := parser.AddCommand("list-caps", shortListCapsHelp, longListCapsHelp, &cmdListCaps{})
+	if err != nil {
+		logger.Panicf("Unable to list capabilities: %v", err)
+	}
+}
+
+func (x *cmdListCaps) Execute(args []string) error {
+	cli := client.New()
+	caps, err := cli.GetCapabilities()
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 1, ' ', 0)
+	fmt.Fprintln(w, "Name\tLabel\tType")
+	for _, cap := range caps {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", cap.Name, cap.Label, cap.Type)
+	}
+	w.Flush()
+	return nil
+}

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -40,7 +40,7 @@ var (
 func init() {
 	_, err := parser.AddCommand("list-caps", shortListCapsHelp, longListCapsHelp, &cmdListCaps{})
 	if err != nil {
-		logger.Panicf("Unable to list capabilities: %v", err)
+		logger.Panicf("unable to add list-caps command: %v", err)
 	}
 }
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -22,18 +22,33 @@ package main
 import (
 	"fmt"
 	"os"
-	"text/tabwriter"
 
-	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/logger"
+
+	"github.com/jessevdk/go-flags"
 )
 
+type options struct {
+	// No global options yet
+}
+
+var optionsData options
+
+var parser = flags.NewParser(&optionsData, flags.HelpFlag|flags.PassDoubleDash)
+
+func init() {
+	err := logger.SimpleSetup()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %s\n", err)
+	}
+}
+
 func main() {
-	cli := client.New()
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, ' ', 0)
-	fmt.Fprintln(w, "What\tError\tResult")
-	sysInfo, err := cli.SysInfo()
-	fmt.Fprintf(w, "get system info\t%v\t%#v\n", err, sysInfo)
-
-	w.Flush()
+	if _, err := parser.Parse(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		if _, ok := err.(*flags.Error); !ok {
+			logger.Debugf("%v failed: %v", os.Args, err)
+		}
+		os.Exit(1)
+	}
 }

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -48,6 +48,9 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	if _, ok := err.(*flags.Error); !ok {
+		logger.Debugf("cannot parse arguments: %v: %v", os.Args, err)
+	}
 	return nil
 }
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -43,6 +43,13 @@ func init() {
 	}
 }
 
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
 func run() error {
 	_, err := parser.Parse()
 	if err != nil {
@@ -52,11 +59,4 @@ func run() error {
 		logger.Debugf("cannot parse arguments: %v: %v", os.Args, err)
 	}
 	return nil
-}
-
-func main() {
-	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
 }

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -43,12 +43,17 @@ func init() {
 	}
 }
 
+func run() error {
+	_, err := parser.Parse()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func main() {
-	if _, err := parser.Parse(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		if _, ok := err.(*flags.Error); !ok {
-			logger.Debugf("%v failed: %v", os.Args, err)
-		}
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/ubuntu-core/snappy/caps"
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/lockfile"
 	"github.com/ubuntu-core/snappy/logger"
@@ -58,6 +59,7 @@ var api = []*Command{
 	packageSvcsCmd,
 	packageSvcLogsCmd,
 	operationCmd,
+	capabilitiesCmd,
 }
 
 var (
@@ -121,6 +123,11 @@ var (
 		Path:   "/1.0/operations/{uuid}",
 		GET:    getOpInfo,
 		DELETE: deleteOp,
+	}
+
+	capabilitiesCmd = &Command{
+		Path: "/1.0/capabilities",
+		GET:  getCapabilities,
 	}
 )
 
@@ -899,4 +906,8 @@ func appIconGet(c *Command, r *http.Request) Response {
 	}
 
 	return FileResponse(path)
+}
+
+func getCapabilities(c *Command, r *http.Request) Response {
+	return SyncResponse(c.d.capRepo.All())
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -133,9 +133,9 @@ var (
 	}
 
 	capabilitiesCmd = &Command{
-		Path: "/1.0/capabilities",
+		Path:   "/1.0/capabilities",
 		UserOK: true,
-		GET:  getCapabilities,
+		GET:    getCapabilities,
 	}
 )
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -908,5 +908,7 @@ func appIconGet(c *Command, r *http.Request) Response {
 }
 
 func getCapabilities(c *Command, r *http.Request) Response {
-	return SyncResponse(c.d.capRepo.All())
+	return SyncResponse(map[string]interface{}{
+		"capabilities": c.d.capRepo.Caps(),
+	})
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -134,6 +134,7 @@ var (
 
 	capabilitiesCmd = &Command{
 		Path: "/1.0/capabilities",
+		UserOK: true,
 		GET:  getCapabilities,
 	}
 )

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/ubuntu-core/snappy/caps"
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/lockfile"
 	"github.com/ubuntu-core/snappy/logger"

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1206,7 +1206,21 @@ func (s *apiSuite) TestGetCapabilities(c *check.C) {
 	capabilitiesCmd.GET(capabilitiesCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(rec.Body.String(), testutil.Contains, "serial-port")
-	c.Check(rec.Body.String(), check.Equals,
-		`{"result":[{"name":"serial-port","label":"A serial port",`+
-			`"type":"file"}],"status":"OK","status_code":200,"type":"sync"}`)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"result": map[string]interface{}{
+			"capabilities": map[string]interface{}{
+				"serial-port": map[string]interface{}{
+					"label": "A serial port",
+					"name":  "serial-port",
+					"type":  "file",
+				},
+			},
+		},
+		"status":      "OK",
+		"status_code": 200.0, // A float because $reasons
+		"type":        "sync",
+	})
 }

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -544,14 +544,18 @@ This fetches the icon from the package itself.
 ## /1.0/capabilities
 ### GET
 
-* Description: List of snappy capabilities
+* Description: Get all of the capabilities that exist in the system
 * Authorization: guest
 * Operation: sync
-* Return: information about all of the snappy capabilities 
+* Return: map of capabilities, see below.
 
-The result is a JSON object with a capabilities key; its value itself is a JSON
+The result is a JSON object with a *capabilities* key; its value itself is a JSON
 object whose keys are capability names (e.g., "power-button") and whose values
 describe that capability.
+
+The method returns *all* capabilities. Regardless of their assignment to snaps.
+Note that capabilities are dynamic, they can be added and removed to the system
+and individual capabilities can change state over time.
 
 Each capability has the following attributes:
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -563,7 +563,7 @@ This is *not* a standard return type.
 ### GET
 
 * Description: Get all of the capabilities that exist in the system
-* Authorization: guest
+* Authorization: authenticated
 * Operation: sync
 * Return: map of capabilities, see below.
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -540,3 +540,33 @@ Get an icon from a snap installed on the system. The response will be the raw
 contents of the icon file; the content-type will be set accordingly.
 
 This fetches the icon from the package itself.
+
+## /1.0/capabilities
+### GET
+
+* Description: List of snappy capabilities
+* Authorization: guest
+* Operation: sync
+* Return: information about all of the snappy capabilities 
+
+The result is a JSON object with a capabilities key; its value itself is a JSON
+object whose keys are capability names (e.g., "power-button") and whose values
+describe that capability.
+
+Sample result:
+
+```javascript
+{
+	"capabilities": {
+		"power-button": {
+			"resource": "/1.0/capabilities/power-button",
+			"name": "power-button",
+			"label": "Power Button",
+			"type": "evdev",
+			"attrs": {
+				"path": "/dev/input/event2"
+			},
+		}
+	}
+}
+```

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -553,6 +553,28 @@ The result is a JSON object with a capabilities key; its value itself is a JSON
 object whose keys are capability names (e.g., "power-button") and whose values
 describe that capability.
 
+Each capability has the following attributes:
+
+name:
+	Name is a key that identifies the capability. It must be unique within its
+	context, which may be either a snap or a snappy runtime.
+
+label:
+	Label provides an optional title for the capability to help a human tell
+	which physical device this capability is referring to. It might say "Front
+	USB", or "Green Serial Port", for example.
+
+type:
+	Type defines the type of this capability. The capability type defines the
+	behavior allowed and expected from providers and consumers of that
+	capability, and also which information should be exchanged by these
+	parties.
+
+attrs:
+	Attrs are key-value pairs that provide type-specific capability details.
+	The attribute 'attrs' itself may not be present if there are no attributes
+	to mention.
+
 Sample result:
 
 ```javascript

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2015-11-18 10:56+0100\n"
+        "POT-Creation-Date: 2015-11-26 13:02+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -140,6 +140,9 @@ msgid   "List assigned hardware device for a package"
 msgstr  ""
 
 msgid   "List assigned hardware for a specific installed package"
+msgstr  ""
+
+msgid   "List system capabilities"
 msgstr  ""
 
 msgid   "Log into the store"
@@ -327,6 +330,9 @@ msgid   "This command logs the given username into the store"
 msgstr  ""
 
 msgid   "This command removes access of a specific hardware device (e.g. /dev/ttyUSB0) for an installed package."
+msgstr  ""
+
+msgid   "This command shows all capabilities and their allocation"
 msgstr  ""
 
 msgid   "Unassign a hardware device to a package"


### PR DESCRIPTION
This branch adds (as neat separate patches), end-to-end (from internal go API, though documented REST API, to go client API to a command line tool) method for listing snappy capabilities.