### PR TITLE
asserts: generate just a couple private keys and reuse them across tests

### DIFF
--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -43,14 +43,13 @@ type accountKeySuite struct {
 var _ = Suite(&accountKeySuite{})
 
 func (aks *accountKeySuite) SetUpSuite(c *C) {
-	pk, err := asserts.GeneratePrivateKeyInTest()
-	c.Assert(err, IsNil)
-	aks.fp = hex.EncodeToString(pk.PublicKey.Fingerprint[:])
+	var err error
+	aks.fp = hex.EncodeToString(testPrivKey1.PublicKey.Fingerprint[:])
 	aks.since, err = time.Parse(time.RFC822, "16 Nov 15 15:04 UTC")
 	c.Assert(err, IsNil)
 	aks.until = aks.since.AddDate(1, 0, 0)
 	buf := new(bytes.Buffer)
-	err = pk.PublicKey.Serialize(buf)
+	err = testPrivKey1.PublicKey.Serialize(buf)
 	c.Assert(err, IsNil)
 	aks.pubKeyBody = "openpgp " + base64.StdEncoding.EncodeToString(buf.Bytes())
 	aks.sinceLine = "since: " + aks.since.Format(time.RFC3339) + "\n"
@@ -150,8 +149,7 @@ func (aks *accountKeySuite) TestDecodeFingerprintMismatch(c *C) {
 }
 
 func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
-	trustedKey, err := asserts.GeneratePrivateKeyInTest()
-	c.Assert(err, IsNil)
+	trustedKey := testPrivKey0
 
 	headers := map[string]string{
 		"authority-id": "canonical",
@@ -178,8 +176,7 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 }
 
 func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
-	trustedKey, err := asserts.GeneratePrivateKeyInTest()
-	c.Assert(err, IsNil)
+	trustedKey := testPrivKey0
 
 	headers := map[string]string{
 		"authority-id": "canonical",

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -174,14 +174,11 @@ func (as *AssertsSuite) TestEncode(c *C) {
 }
 
 func (as *AssertsSuite) TestSignFormatSanityEmptyBody(c *C) {
-	key1, err := asserts.GeneratePrivateKeyInTest()
-	c.Assert(err, IsNil)
-
 	headers := map[string]string{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
-	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, key1)
+	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, testPrivKey1)
 	c.Assert(err, IsNil)
 
 	_, err = asserts.Decode(asserts.Encode(a))
@@ -189,15 +186,12 @@ func (as *AssertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 }
 
 func (as *AssertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
-	key1, err := asserts.GeneratePrivateKeyInTest()
-	c.Assert(err, IsNil)
-
 	headers := map[string]string{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
 	body := []byte("THE-BODY")
-	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, body, key1)
+	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, body, testPrivKey1)
 	c.Assert(err, IsNil)
 	c.Check(a.Body(), DeepEquals, body)
 

--- a/asserts/privkeys_for_test.go
+++ b/asserts/privkeys_for_test.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts_test
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/openpgp/packet"
+
+	"github.com/ubuntu-core/snappy/asserts"
+)
+
+// private keys to use in tests
+var (
+	testPrivKey0 = genTestPrivKey()
+	testPrivKey1 = genTestPrivKey()
+)
+
+func genTestPrivKey() *packet.PrivateKey {
+	privKey, err := asserts.GeneratePrivateKeyInTest()
+	if err != nil {
+		panic(fmt.Errorf("failed to create priv key for tests: %v", err))
+	}
+	return privKey
+}


### PR DESCRIPTION
avoids a bit to slow them down because (lack of) entropy