### PR TITLE
make the check* signatures more uniform, all take headers now

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -48,20 +48,6 @@ func (ak *AccountKey) Until() time.Time {
 	return ak.until
 }
 
-// TODO: move check* helpers to separate file if they get reused
-
-func checkRFC3339Date(ab *AssertionBase, name string) (time.Time, error) {
-	dateStr := ab.Header(name)
-	if dateStr == "" {
-		return time.Time{}, fmt.Errorf("%v header is mandatory", name)
-	}
-	date, err := time.Parse(time.RFC3339, dateStr)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("%v header is not a RFC3339 date: %v", name, err)
-	}
-	return date, nil
-}
-
 func checkPublicKey(ab *AssertionBase, fingerprintName string) (PublicKey, error) {
 	pubKey, err := parsePublicKey(ab.Body())
 	if err != nil {
@@ -78,14 +64,15 @@ func checkPublicKey(ab *AssertionBase, fingerprintName string) (PublicKey, error
 }
 
 func buildAccountKey(assert AssertionBase) (Assertion, error) {
-	if assert.Header("account-id") == "" {
-		return nil, fmt.Errorf("account-id header is mandatory")
-	}
-	since, err := checkRFC3339Date(&assert, "since")
+	_, err := checkMandatory(assert.headers, "account-id")
 	if err != nil {
 		return nil, err
 	}
-	until, err := checkRFC3339Date(&assert, "until")
+	since, err := checkRFC3339Date(assert.headers, "since")
+	if err != nil {
+		return nil, err
+	}
+	until, err := checkRFC3339Date(assert.headers, "until")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -53,9 +53,9 @@ func checkPublicKey(ab *AssertionBase, fingerprintName string) (PublicKey, error
 	if err != nil {
 		return nil, err
 	}
-	fp := ab.Header(fingerprintName)
-	if len(fp) == 0 {
-		return nil, fmt.Errorf("missing %v header", fingerprintName)
+	fp, err := checkMandatory(ab.headers, fingerprintName)
+	if err != nil {
+		return nil, err
 	}
 	if fp != pubKey.Fingerprint() {
 		return nil, fmt.Errorf("public key does not match provided fingerprint")

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -91,10 +91,10 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 		"openpgp c2ln"
 
 	invalidHeaderTests := []struct{ original, invalid, expectedErr string }{
-		{"account-id: acc-id1\n", "", "account-id header is mandatory"},
-		{aks.sinceLine, "", "since header is mandatory"},
-		{aks.untilLine, "", "until header is mandatory"},
-		{aks.sinceLine, "since: 12:30\n", "since header is not a RFC3339 date: .*"},
+		{"account-id: acc-id1\n", "", `"account-id" header is mandatory`},
+		{aks.sinceLine, "", `"since" header is mandatory`},
+		{aks.untilLine, "", `"until" header is mandatory`},
+		{aks.sinceLine, "since: 12:30\n", `"since" header is not a RFC3339 date: .*`},
 		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
 		{"fingerprint: " + aks.fp + "\n", "", "missing fingerprint header"},
 	}

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -96,7 +96,7 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 		{aks.untilLine, "", `"until" header is mandatory`},
 		{aks.sinceLine, "since: 12:30\n", `"since" header is not a RFC3339 date: .*`},
 		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
-		{"fingerprint: " + aks.fp + "\n", "", "missing fingerprint header"},
+		{"fingerprint: " + aks.fp + "\n", "", `"fingerprint" header is mandatory`},
 	}
 
 	for _, test := range invalidHeaderTests {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -235,12 +235,12 @@ func buildAssertion(headers map[string]string, body, content, signature []byte) 
 	}
 
 	if _, err := checkMandatory(headers, "authority-id"); err != nil {
-		return nil, fmt.Errorf("assertion %v", err)
+		return nil, fmt.Errorf("assertion: %v", err)
 	}
 
 	typ, err := checkMandatory(headers, "type")
 	if err != nil {
-		return nil, fmt.Errorf("assertion %v", err)
+		return nil, fmt.Errorf("assertion: %v", err)
 	}
 	assertType := AssertionType(typ)
 	reg, err := checkAssertType(assertType)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -193,34 +193,21 @@ func Decode(serializedAssertion []byte) (Assertion, error) {
 	return buildAssertion(headers, body, content, signature)
 }
 
-func checkInteger(headers map[string]string, name string) (int, error) {
-	valueStr, ok := headers[name]
-	if !ok {
-		// default to 0 if missing
-		return 0, nil
-	}
-	value, err := strconv.Atoi(valueStr)
-	if err != nil {
-		return -1, fmt.Errorf("assertion %v is not an integer: %v", name, valueStr)
-	}
-	return value, nil
-}
-
 func checkRevision(headers map[string]string) (int, error) {
-	revision, err := checkInteger(headers, "revision")
+	revision, err := checkInteger(headers, "revision", 0)
 	if err != nil {
 		return -1, err
 	}
 	if revision < 0 {
-		return -1, fmt.Errorf("assertion revision should be positive: %v", revision)
+		return -1, fmt.Errorf("revision should be positive: %v", revision)
 	}
 	return revision, nil
 }
 
 func buildAssertion(headers map[string]string, body, content, signature []byte) (Assertion, error) {
-	length, err := checkInteger(headers, "body-length")
+	length, err := checkInteger(headers, "body-length", 0)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("assertion: %v", err)
 	}
 	if length != len(body) {
 		return nil, fmt.Errorf("assertion body length and declared body-length don't match: %v != %v", len(body), length)
@@ -242,7 +229,7 @@ func buildAssertion(headers map[string]string, body, content, signature []byte) 
 
 	revision, err := checkRevision(headers)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("assertion: %v", err)
 	}
 
 	assert, err := reg.builder(AssertionBase{

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -193,17 +193,6 @@ func Decode(serializedAssertion []byte) (Assertion, error) {
 	return buildAssertion(headers, body, content, signature)
 }
 
-func checkMandatory(headers map[string]string, name string) (string, error) {
-	value, ok := headers[name]
-	if !ok {
-		return "", fmt.Errorf("assertion %v header is mandatory", name)
-	}
-	if len(value) == 0 {
-		return "", fmt.Errorf("assertion %v should not be empty", name)
-	}
-	return value, nil
-}
-
 func checkInteger(headers map[string]string, name string) (int, error) {
 	valueStr, ok := headers[name]
 	if !ok {
@@ -246,12 +235,12 @@ func buildAssertion(headers map[string]string, body, content, signature []byte) 
 	}
 
 	if _, err := checkMandatory(headers, "authority-id"); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("assertion %v", err)
 	}
 
 	typ, err := checkMandatory(headers, "type")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("assertion %v", err)
 	}
 	assertType := AssertionType(typ)
 	reg, err := checkAssertType(assertType)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -206,14 +206,6 @@ func checkInteger(headers map[string]string, name string) (int, error) {
 	return value, nil
 }
 
-func checkAssertType(assertType AssertionType) (*assertionTypeRegistration, error) {
-	reg := typeRegistry[assertType]
-	if reg == nil {
-		return nil, fmt.Errorf("unknown assertion type: %v", assertType)
-	}
-	return reg, nil
-}
-
 func checkRevision(headers map[string]string) (int, error) {
 	revision, err := checkInteger(headers, "revision")
 	if err != nil {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -137,15 +137,15 @@ func (as *AssertsSuite) TestDecodeInvalid(c *C) {
 		"openpgp c2ln"
 
 	invalidAssertTests := []struct{ original, invalid, expectedErr string }{
-		{"body-length: 5", "body-length: z", "assertion body-length is not an integer: z"},
+		{"body-length: 5", "body-length: z", `assertion: "body-length" header is not an integer: z`},
 		{"body-length: 5", "body-length: 3", "assertion body length and declared body-length don't match: 5 != 3"},
 		{"authority-id: auth-id\n", "", `assertion: "authority-id" header is mandatory`},
-		{"authority-id: auth-id\n", "authority-id: \n", `assertion: "authority-id" should not be empty`},
+		{"authority-id: auth-id\n", "authority-id: \n", `assertion: "authority-id" header should not be empty`},
 		{"openpgp c2ln", "", "empty assertion signature"},
 		{"type: test-only\n", "", `assertion: "type" header is mandatory`},
 		{"type: test-only\n", "type: unknown\n", "unknown assertion type: unknown"},
-		{"revision: 0\n", "revision: Z\n", "assertion revision is not an integer: Z"},
-		{"revision: 0\n", "revision: -10\n", "assertion revision should be positive: -10"},
+		{"revision: 0\n", "revision: Z\n", `assertion: "revision" header is not an integer: Z`},
+		{"revision: 0\n", "revision: -10\n", "assertion: revision should be positive: -10"},
 	}
 
 	for _, test := range invalidAssertTests {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -139,10 +139,10 @@ func (as *AssertsSuite) TestDecodeInvalid(c *C) {
 	invalidAssertTests := []struct{ original, invalid, expectedErr string }{
 		{"body-length: 5", "body-length: z", "assertion body-length is not an integer: z"},
 		{"body-length: 5", "body-length: 3", "assertion body length and declared body-length don't match: 5 != 3"},
-		{"authority-id: auth-id\n", "", "assertion authority-id header is mandatory"},
-		{"authority-id: auth-id\n", "authority-id: \n", "assertion authority-id should not be empty"},
+		{"authority-id: auth-id\n", "", `assertion: "authority-id" header is mandatory`},
+		{"authority-id: auth-id\n", "authority-id: \n", `assertion: "authority-id" should not be empty`},
 		{"openpgp c2ln", "", "empty assertion signature"},
-		{"type: test-only\n", "", "assertion type header is mandatory"},
+		{"type: test-only\n", "", `assertion: "type" header is mandatory`},
 		{"type: test-only\n", "type: unknown\n", "unknown assertion type: unknown"},
 		{"revision: 0\n", "revision: Z\n", "assertion revision is not an integer: Z"},
 		{"revision: 0\n", "revision: -10\n", "assertion revision should be positive: -10"},

--- a/asserts/checkers.go
+++ b/asserts/checkers.go
@@ -37,6 +37,14 @@ func checkMandatory(headers map[string]string, name string) (string, error) {
 	return value, nil
 }
 
+func checkAssertType(assertType AssertionType) (*assertionTypeRegistration, error) {
+	reg := typeRegistry[assertType]
+	if reg == nil {
+		return nil, fmt.Errorf("unknown assertion type: %v", assertType)
+	}
+	return reg, nil
+}
+
 func checkRFC3339Date(headers map[string]string, name string) (time.Time, error) {
 	dateStr, err := checkMandatory(headers, name)
 	if err != nil {

--- a/asserts/checkers.go
+++ b/asserts/checkers.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"fmt"
+	"time"
+)
+
+// common checkers used when decoding/building assertions
+
+func checkMandatory(headers map[string]string, name string) (string, error) {
+	value, ok := headers[name]
+	if !ok {
+		return "", fmt.Errorf("%v header is mandatory", name)
+	}
+	if len(value) == 0 {
+		return "", fmt.Errorf("%v should not be empty", name)
+	}
+	return value, nil
+}
+
+func checkRFC3339Date(headers map[string]string, name string) (time.Time, error) {
+	dateStr, err := checkMandatory(headers, name)
+	if err != nil {
+		return time.Time{}, err
+	}
+	date, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%v header is not a RFC3339 date: %v", name, err)
+	}
+	return date, nil
+}

--- a/asserts/checkers.go
+++ b/asserts/checkers.go
@@ -29,10 +29,10 @@ import (
 func checkMandatory(headers map[string]string, name string) (string, error) {
 	value, ok := headers[name]
 	if !ok {
-		return "", fmt.Errorf("%v header is mandatory", name)
+		return "", fmt.Errorf("%q header is mandatory", name)
 	}
 	if len(value) == 0 {
-		return "", fmt.Errorf("%v should not be empty", name)
+		return "", fmt.Errorf("%q should not be empty", name)
 	}
 	return value, nil
 }
@@ -44,7 +44,7 @@ func checkRFC3339Date(headers map[string]string, name string) (time.Time, error)
 	}
 	date, err := time.Parse(time.RFC3339, dateStr)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("%v header is not a RFC3339 date: %v", name, err)
+		return time.Time{}, fmt.Errorf("%q header is not a RFC3339 date: %v", name, err)
 	}
 	return date, nil
 }

--- a/asserts/checkers.go
+++ b/asserts/checkers.go
@@ -21,6 +21,7 @@ package asserts
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -32,7 +33,7 @@ func checkMandatory(headers map[string]string, name string) (string, error) {
 		return "", fmt.Errorf("%q header is mandatory", name)
 	}
 	if len(value) == 0 {
-		return "", fmt.Errorf("%q should not be empty", name)
+		return "", fmt.Errorf("%q header should not be empty", name)
 	}
 	return value, nil
 }
@@ -43,6 +44,19 @@ func checkAssertType(assertType AssertionType) (*assertionTypeRegistration, erro
 		return nil, fmt.Errorf("unknown assertion type: %v", assertType)
 	}
 	return reg, nil
+}
+
+// use 'defl' default if missing
+func checkInteger(headers map[string]string, name string, defl int) (int, error) {
+	valueStr, ok := headers[name]
+	if !ok {
+		return defl, nil
+	}
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		return -1, fmt.Errorf("%q header is not an integer: %v", name, valueStr)
+	}
+	return value, nil
 }
 
 func checkRFC3339Date(headers map[string]string, name string) (time.Time, error) {


### PR DESCRIPTION
but mmh checkPublicKey is still an outlier because it needs access both to headers and body