### PR TITLE
Drop sending the global channel to the store

### DIFF
--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -1721,7 +1721,6 @@ func setUbuntuStoreHeaders(req *http.Request) {
 	req.Header.Set("X-Ubuntu-Architecture", string(arch.UbuntuArchitecture()))
 	req.Header.Set("X-Ubuntu-Release", release.String())
 	req.Header.Set("X-Ubuntu-Wire-Protocol", UbuntuCoreWireProtocol)
-	req.Header.Set("X-Ubuntu-Device-Channel", release.Get().Channel)
 
 	if storeID := os.Getenv("UBUNTU_STORE_ID"); storeID != "" {
 		req.Header.Set("X-Ubuntu-Store", storeID)


### PR DESCRIPTION
As discussed on the mailing list drop the concept of a global channel preference for now.