### PR TITLE
Fixed regexp for unhandled verbs' response

### DIFF
--- a/integration-tests/tests/snapd_test.go
+++ b/integration-tests/tests/snapd_test.go
@@ -223,7 +223,7 @@ func doMethodNotAllowed(c *check.C, resource, verb string) {
 		resource,
 		verb,
 		apiInteraction{
-			responsePattern: `{"result":{},"status":"Method Not Allowed","status_code":405,"type":"error"}`})
+			responsePattern: `{"result":{},"status":"Unauthorized","status_code":401,"type":"error"}`})
 }
 
 // this is the function which makes requests to the api


### PR DESCRIPTION
Fixes these errors in the REST API integration tests:

```
2015/11/30 11:33:13 ** Trying interaction { {"result":{},"status":"Not Found","status_code":404,"type":"error"} <nil>  <nil>}
2015/11/30 11:33:13 *** Exercising API for resource http://127.0.0.1:9999/ with verb GET
2015/11/30 11:33:13 ** Trying interaction { (?U){"result":\[".*"\],"status":"OK","status_code":200,"type":"sync"} <nil>  <nil>}
2015/11/30 11:33:13 ** Trying interaction { {"result":{},"status":"Method Not Allowed","status_code":405,"type":"error"} <nil>  <nil>}
/home/fgimenez/workspace/snappy/integration-tests/tests/snapd_root_test.go:32:
    ...open /home/fgimenez/workspace/snappy/integration-tests/tests/snapd_root_test.go: no such file or directory
/home/fgimenez/workspace/snappy/integration-tests/tests/snapd_test.go:205:
    ...open /home/fgimenez/workspace/snappy/integration-tests/tests/snapd_test.go: no such file or directory
... value string = "{\"result\":{},\"status\":\"Unauthorized\",\"status_code\":401,\"type\":\"error\"}"
... regex string = "{\"result\":{},\"status\":\"Method Not Allowed\",\"status_code\":405,\"type\":\"error\"}"

2015/11/30 11:33:13 ** Trying interaction { {"result":{},"status":"Method Not Allowed","status_code":405,"type":"error"} <nil>  <nil>}
/home/fgimenez/workspace/snappy/integration-tests/tests/snapd_root_test.go:32:
    ...open /home/fgimenez/workspace/snappy/integration-tests/tests/snapd_root_test.go: no such file or directory
/home/fgimenez/workspace/snappy/integration-tests/tests/snapd_test.go:205:
    ...open /home/fgimenez/workspace/snappy/integration-tests/tests/snapd_test.go: no such file or directory
... value string = "{\"result\":{},\"status\":\"Unauthorized\",\"status_code\":401,\"type\":\"error\"}"
... regex string = "{\"result\":{},\"status\":\"Method Not Allowed\",\"status_code\":405,\"type\":\"error\"}"

2015/11/30 11:33:13 ** Trying interaction { {"result":{},"status":"Method Not Allowed","status_code":405,"type":"error"} <nil>  <nil>}
/home/fgimenez/workspace/snappy/integration-tests/tests/snapd_root_test.go:32:
    ...open /home/fgimenez/workspace/snappy/integration-tests/tests/snapd_root_test.go: no such file or directory
/home/fgimenez/workspace/snappy/integration-tests/tests/snapd_test.go:205:
    ...open /home/fgimenez/workspace/snappy/integration-tests/tests/snapd_test.go: no such file or directory
... value string = "{\"result\":{},\"status\":\"Unauthorized\",\"status_code\":401,\"type\":\"error\"}"
... regex string = "{\"result\":{},\"status\":\"Method Not Allowed\",\"status_code\":405,\"type\":\"error\"}"
```