### PR TITLE
asserts: opaque assertion structs

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -28,9 +28,9 @@ import (
 // belonging to the account.
 type AccountKey struct {
 	assertionBase
-	since time.Time
-	until time.Time
-	PublicKey
+	since  time.Time
+	until  time.Time
+	pubKey PublicKey
 }
 
 // AccountID returns the account-id of this account-key.
@@ -48,9 +48,19 @@ func (ak *AccountKey) Until() time.Time {
 	return ak.until
 }
 
+// Fingerprint returns the fingerprint of the account key.
+func (ak *AccountKey) Fingerprint() string {
+	return ak.pubKey.Fingerprint()
+}
+
 // IsValidAt returns whether the account key is valid at 'when' time.
 func (ak *AccountKey) IsValidAt(when time.Time) bool {
 	return (when.After(ak.since) || when.Equal(ak.since)) && when.Before(ak.until)
+}
+
+// Verify verifies signature is valid for content using the account key.
+func (ak *AccountKey) Verify(content []byte, sig Signature) error {
+	return ak.pubKey.Verify(content, sig)
 }
 
 func checkPublicKey(ab *assertionBase, fingerprintName string) (PublicKey, error) {
@@ -93,7 +103,7 @@ func buildAccountKey(assert assertionBase) (Assertion, error) {
 		assertionBase: assert,
 		since:         since,
 		until:         until,
-		PublicKey:     pubk,
+		pubKey:        pubk,
 	}, nil
 }
 

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -27,7 +27,7 @@ import (
 // AccountKey holds an account-key assertion, asserting a public key
 // belonging to the account.
 type AccountKey struct {
-	AssertionBase
+	assertionBase
 	since time.Time
 	until time.Time
 	PublicKey
@@ -53,7 +53,7 @@ func (ak *AccountKey) IsValidAt(when time.Time) bool {
 	return (when.After(ak.since) || when.Equal(ak.since)) && when.Before(ak.until)
 }
 
-func checkPublicKey(ab *AssertionBase, fingerprintName string) (PublicKey, error) {
+func checkPublicKey(ab *assertionBase, fingerprintName string) (PublicKey, error) {
 	pubKey, err := parsePublicKey(ab.Body())
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func checkPublicKey(ab *AssertionBase, fingerprintName string) (PublicKey, error
 	return pubKey, nil
 }
 
-func buildAccountKey(assert AssertionBase) (Assertion, error) {
+func buildAccountKey(assert assertionBase) (Assertion, error) {
 	_, err := checkMandatory(assert.headers, "account-id")
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func buildAccountKey(assert AssertionBase) (Assertion, error) {
 	}
 	// ignore extra headers for future compatibility
 	return &AccountKey{
-		AssertionBase: assert,
+		assertionBase: assert,
 		since:         since,
 		until:         until,
 		PublicKey:     pubk,

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -71,6 +71,7 @@ func (aks *accountKeySuite) TestDecodeOK(c *C) {
 	c.Check(a.Type(), Equals, asserts.AccountKeyType)
 	accKey := a.(*asserts.AccountKey)
 	c.Check(accKey.AccountID(), Equals, "acc-id1")
+	c.Check(accKey.Fingerprint(), Equals, aks.fp)
 	c.Check(accKey.Since(), Equals, aks.since)
 	c.Check(accKey.Until(), Equals, aks.until)
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -61,8 +61,8 @@ type Assertion interface {
 	Signature() (content, signature []byte)
 }
 
-// AssertionBase is the concrete base to hold representation data for actual assertions.
-type AssertionBase struct {
+// assertionBase is the concrete base to hold representation data for actual assertions.
+type assertionBase struct {
 	headers map[string]string
 	body    []byte
 	// parsed revision
@@ -74,37 +74,37 @@ type AssertionBase struct {
 }
 
 // Type returns the assertion type.
-func (ab *AssertionBase) Type() AssertionType {
+func (ab *assertionBase) Type() AssertionType {
 	return AssertionType(ab.headers["type"])
 }
 
 // Revision returns the assertion revision.
-func (ab *AssertionBase) Revision() int {
+func (ab *assertionBase) Revision() int {
 	return ab.revision
 }
 
 // AuthorityID returns the authority-id a.k.a the signer id of the assertion.
-func (ab *AssertionBase) AuthorityID() string {
+func (ab *assertionBase) AuthorityID() string {
 	return ab.headers["authority-id"]
 }
 
 // Header returns the value of an header by name.
-func (ab *AssertionBase) Header(name string) string {
+func (ab *assertionBase) Header(name string) string {
 	return ab.headers[name]
 }
 
 // Body returns the body of the assertion.
-func (ab *AssertionBase) Body() []byte {
+func (ab *assertionBase) Body() []byte {
 	return ab.body
 }
 
 // Signature returns the signed content and its unprocessed signature.
-func (ab *AssertionBase) Signature() (content, signature []byte) {
+func (ab *assertionBase) Signature() (content, signature []byte) {
 	return ab.content, ab.signature
 }
 
 // sanity check
-var _ Assertion = (*AssertionBase)(nil)
+var _ Assertion = (*assertionBase)(nil)
 
 var (
 	nlnl = []byte("\n\n")
@@ -233,7 +233,7 @@ func buildAssertion(headers map[string]string, body, content, signature []byte) 
 		return nil, fmt.Errorf("assertion: %v", err)
 	}
 
-	assert, err := reg.builder(AssertionBase{
+	assert, err := reg.builder(assertionBase{
 		headers:   headers,
 		body:      body,
 		revision:  revision,
@@ -334,7 +334,7 @@ func buildAndSign(assertType AssertionType, headers map[string]string, body []by
 		return nil, fmt.Errorf("failed to sign assertion: %v", err)
 	}
 
-	assert, err := reg.builder(AssertionBase{
+	assert, err := reg.builder(assertionBase{
 		headers:   finalHeaders,
 		body:      finalBody,
 		revision:  revision,
@@ -350,7 +350,7 @@ func buildAndSign(assertType AssertionType, headers map[string]string, body []by
 // registry for assertion types describing how to build them etc...
 
 type assertionTypeRegistration struct {
-	builder    func(assert AssertionBase) (Assertion, error)
+	builder    func(assert assertionBase) (Assertion, error)
 	primaryKey []string
 }
 

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -31,10 +31,10 @@ var BuildAndSignInTest = buildAndSign
 // define dummy assertion types to use in the tests
 
 type TestOnly struct {
-	AssertionBase
+	assertionBase
 }
 
-func buildTestOnly(assert AssertionBase) (Assertion, error) {
+func buildTestOnly(assert assertionBase) (Assertion, error) {
 	return &TestOnly{assert}, nil
 }
 

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -27,7 +27,7 @@ import (
 // SnapDeclaration holds a snap-declaration assertion, asserting the
 // properties of a built snap by the builder.
 type SnapDeclaration struct {
-	AssertionBase
+	assertionBase
 	size      uint64
 	timestamp time.Time
 }
@@ -65,7 +65,7 @@ func (snapdcl *SnapDeclaration) checkConsistency(db *Database, pubk PublicKey) e
 	return nil
 }
 
-func buildSnapDeclaration(assert AssertionBase) (Assertion, error) {
+func buildSnapDeclaration(assert assertionBase) (Assertion, error) {
 	_, err := checkMandatory(assert.headers, "snap-id")
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func buildSnapDeclaration(assert AssertionBase) (Assertion, error) {
 	}
 	// ignore extra headers and non-empty body for future compatibility
 	return &SnapDeclaration{
-		AssertionBase: assert,
+		assertionBase: assert,
 		size:          size,
 		timestamp:     timestamp,
 	}, nil


### PR DESCRIPTION
make sure the assertion structs we use don't have any exported fields and are opaque; it's useful to type check for specific types but they can't be usefully built.