### PR TITLE
auth error should be a 403 (forbidden), not a 401 (unauthorized)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -92,7 +92,7 @@ func (c *Command) canAccess(r *http.Request) bool {
 
 func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !c.canAccess(r) {
-		Unauthorized.ServeHTTP(w, r)
+		Forbidden.ServeHTTP(w, r)
 		return
 	}
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -78,7 +78,7 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
 
 		rec := httptest.NewRecorder()
 		cmd.ServeHTTP(rec, req)
-		c.Check(rec.Code, check.Equals, http.StatusUnauthorized)
+		c.Check(rec.Code, check.Equals, http.StatusForbidden, check.Commentf(method))
 
 		rec = httptest.NewRecorder()
 		req.RemoteAddr = "uid=0;" + req.RemoteAddr

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -183,5 +183,5 @@ var (
 	BadMethod      = ErrorResponse(http.StatusMethodNotAllowed)
 	InternalError  = ErrorResponse(http.StatusInternalServerError)
 	NotImplemented = ErrorResponse(http.StatusNotImplemented)
-	Unauthorized   = ErrorResponse(http.StatusUnauthorized)
+	Forbidden      = ErrorResponse(http.StatusForbidden)
 )

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -97,7 +97,7 @@ wrong, in those cases, the following return value is used:
 }
 ```
 
-HTTP code must be one of of 400, 401, 403, 404, 409, 412 or 500.
+HTTP code must be one of of 400, 401, 403, 404, 405, 409, 412 or 500.
 
 ### Timestamps
 


### PR DESCRIPTION
Given that with `SO_PEERCRED` we always get credentials, the error reported should be `403 Forbidden`, not `401 Unauthorized`.

If you want to be super picky, it should be a `Forbidden` if we were able to get a uid, and `Unauthorized` otherwise. We'll probably get around to this at some point, but it's a so far unreachable corner case I think this way around is better.