### PR TITLE
Revert "remove DEBIAN/*" dir for squashfs builds to unblock the store

### DIFF
--- a/snappy/build.go
+++ b/snappy/build.go
@@ -507,12 +507,6 @@ func BuildSquashfsSnap(sourceDir, targetDir string) (string, error) {
 		return "", err
 	}
 
-	// we really don't need this in the brave new all-snap world
-	// FIXME: remove once we kill legacy snap building
-	if err := os.RemoveAll(filepath.Join(buildDir, "DEBIAN")); err != nil {
-		return "", err
-	}
-
 	d := squashfs.New(snapName)
 	if err = d.Build(buildDir); err != nil {
 		return "", err

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
+	"github.com/ubuntu-core/snappy/testutil"
 
 	. "gopkg.in/check.v1"
 )

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
-	"github.com/ubuntu-core/snappy/testutil"
 
 	. "gopkg.in/check.v1"
 )
@@ -550,8 +549,4 @@ integration:
 		expr := fmt.Sprintf(`(?ms).*%s.*`, regexp.QuoteMeta(needle))
 		c.Assert(string(output), Matches, expr)
 	}
-
-	// ensure we don't have cruft in our squashfs
-	c.Assert(string(output), Not(testutil.Contains), "DEBIAN")
-	c.Assert(string(output), Not(testutil.Contains), ".click")
 }


### PR DESCRIPTION
A squashfs snap should not contain a DEBIAN/manifest.json or any
other debian dir. However right now the store will totally reject
snap packages that do not have this directory. So we must add
it back until the store is fixed.