### PR TITLE
Bugfix/squashfs dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,7 +41,6 @@ Description: snappy development go packages.
 Package: ubuntu-snappy
 Architecture: all
 Depends: debsig-verify,
-         squashfs-tools,
          system-image-cli (>= 3.0),
          ubuntu-snappy-cli (= ${binary:Version}),
          ubuntu-core-upgrader,
@@ -55,7 +54,7 @@ Description: System components for Ubuntu Core Snappy.
 
 Package: ubuntu-snappy-cli
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, lsb-release
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, lsb-release, squashfs-tools
 Replaces: ubuntu-core-snappy (<< 0.2~ppa90)
 Breaks: ubuntu-core-snappy (<< 0.2~ppa90)
 Conflicts: snappy

--- a/debian/control
+++ b/debian/control
@@ -44,17 +44,16 @@ Depends: debsig-verify,
          system-image-cli (>= 3.0),
          ubuntu-snappy-cli (= ${binary:Version}),
          ubuntu-core-upgrader,
-         ubuntu-core-launcher (>= 0.2.3),
-         ubuntu-core-security-seccomp,
-         ubuntu-core-security-apparmor,
-         ubuntu-core-security-utils,
          ${misc:Depends}
 Description: System components for Ubuntu Core Snappy.
  Components and services that take care of an Ubuntu system with snappy.
 
 Package: ubuntu-snappy-cli
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, lsb-release, squashfs-tools
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, lsb-release,
+ squashfs-tools, ubuntu-core-launcher (>= 0.2.3),
+ ubuntu-core-security-seccomp, ubuntu-core-security-apparmor,
+ ubuntu-core-security-utils,
 Replaces: ubuntu-core-snappy (<< 0.2~ppa90)
 Breaks: ubuntu-core-snappy (<< 0.2~ppa90)
 Conflicts: snappy


### PR DESCRIPTION
Shuffle some dependencies around. In order to use snappy in a classic environment tools like ubuntu-core-security-{seccomp,apparmor,utils}, ubuntu-core-launcher and squashfs-tools are required.