### PR TITLE
fix test failure with "umask 0022"

### DIFF
--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -45,7 +45,7 @@ var _ = Suite(&openSuite{})
 
 func (opens *openSuite) TestOpenDatabaseOK(c *C) {
 	// ensure umask has clean when creating the DB dir
-	oldUmask := syscall.Umask(0002)
+	oldUmask := syscall.Umask(0)
 	defer func() { syscall.Umask(oldUmask) }()
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -44,6 +44,10 @@ type openSuite struct{}
 var _ = Suite(&openSuite{})
 
 func (opens *openSuite) TestOpenDatabaseOK(c *C) {
+	// ensure umask has clean when creating the DB dir
+	oldUmask := syscall.Umask(0002)
+	defer func() { syscall.Umask(oldUmask) }()
+
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{Path: rootDir}
 	db, err := asserts.OpenDatabase(cfg)


### PR DESCRIPTION
The testsuite fails currently if the umask is set to 0022. The reason is the database_test.go:55 which assumes that os.MakedirAll(rooDir, 0775) will actually result in a 0775 dir. Because of the umask this is not necessarily the case. This branch fixes it by chaning the test. My first impulse was to set the umask in database creation but there is a check that prevents it from being writable so that seems to be over the top.