### PR TITLE
Use common error handling for client.Capabilities()

### DIFF
--- a/client/caps.go
+++ b/client/caps.go
@@ -48,7 +48,7 @@ func (client *Client) Capabilities() (map[string]Capability, error) {
 	const errPrefix = "cannot obtain capabilities"
 	var rsp response
 	if err := client.do("GET", "/1.0/capabilities", nil, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: failed to communicate with server: %s", errPrefix, err)
 	}
 	if err := rsp.err(); err != nil {
 		return nil, err

--- a/client/caps.go
+++ b/client/caps.go
@@ -45,7 +45,7 @@ type Capability struct {
 
 // Capabilities returns the capabilities currently available for snaps to consume.
 func (client *Client) Capabilities() (map[string]Capability, error) {
-	errPrefix := "cannot obtain capabilities"
+	const errPrefix = "cannot obtain capabilities"
 	var rsp response
 	if err := client.do("GET", "/1.0/capabilities", nil, &rsp); err != nil {
 		return nil, err

--- a/client/caps.go
+++ b/client/caps.go
@@ -45,20 +45,21 @@ type Capability struct {
 
 // Capabilities returns the capabilities currently available for snaps to consume.
 func (client *Client) Capabilities() (map[string]Capability, error) {
+	errPrefix := "cannot obtain capabilities"
 	var rsp response
 	if err := client.do("GET", "/1.0/capabilities", nil, &rsp); err != nil {
 		return nil, err
 	}
-	if rsp.Type == "error" {
-		// TODO: handle structured errors
-		return nil, fmt.Errorf("cannot obtain capabilities: %s", rsp.Status)
+	switch rsp.Type {
+	case "error":
+		return nil, rsp.processErrorResponse()
+	case "sync":
+		var resultOk map[string]map[string]Capability
+		if err := json.Unmarshal(rsp.Result, &resultOk); err != nil {
+			return nil, fmt.Errorf("%s: failed to unmarshal response: %v", errPrefix, err)
+		}
+		return resultOk["capabilities"], nil
+	default:
+		return nil, fmt.Errorf("%s: expected sync response, got %s", errPrefix, rsp.Type)
 	}
-	if rsp.Type != "sync" {
-		return nil, fmt.Errorf("cannot obtain capabilities: expected sync response, got %s", rsp.Type)
-	}
-	var result map[string]map[string]Capability
-	if err := json.Unmarshal(rsp.Result, &result); err != nil {
-		return nil, fmt.Errorf("cannot obtain capabilities: failed to unmarshal response: %v", err)
-	}
-	return result["capabilities"], nil
 }

--- a/client/caps.go
+++ b/client/caps.go
@@ -60,6 +60,6 @@ func (client *Client) Capabilities() (map[string]Capability, error) {
 		}
 		return resultOk["capabilities"], nil
 	default:
-		return nil, fmt.Errorf("%s: expected sync response, got %s", errPrefix, rsp.Type)
+		return nil, fmt.Errorf("%s: expected sync response, got %q", errPrefix, rsp.Type)
 	}
 }

--- a/client/caps.go
+++ b/client/caps.go
@@ -53,14 +53,12 @@ func (client *Client) Capabilities() (map[string]Capability, error) {
 	if err := rsp.err(); err != nil {
 		return nil, err
 	}
-	switch rsp.Type {
-	case "sync":
-		var resultOk map[string]map[string]Capability
-		if err := json.Unmarshal(rsp.Result, &resultOk); err != nil {
-			return nil, fmt.Errorf("%s: failed to unmarshal response: %v", errPrefix, err)
-		}
-		return resultOk["capabilities"], nil
-	default:
+	if rsp.Type != "sync" {
 		return nil, fmt.Errorf("%s: expected sync response, got %q", errPrefix, rsp.Type)
 	}
+	var resultOk map[string]map[string]Capability
+	if err := json.Unmarshal(rsp.Result, &resultOk); err != nil {
+		return nil, fmt.Errorf("%s: failed to unmarshal response: %v", errPrefix, err)
+	}
+	return resultOk["capabilities"], nil
 }

--- a/client/caps.go
+++ b/client/caps.go
@@ -50,9 +50,10 @@ func (client *Client) Capabilities() (map[string]Capability, error) {
 	if err := client.do("GET", "/1.0/capabilities", nil, &rsp); err != nil {
 		return nil, err
 	}
+	if err := rsp.err(); err != nil {
+		return nil, err
+	}
 	switch rsp.Type {
-	case "error":
-		return nil, rsp.err()
 	case "sync":
 		var resultOk map[string]map[string]Capability
 		if err := json.Unmarshal(rsp.Result, &resultOk); err != nil {

--- a/client/caps.go
+++ b/client/caps.go
@@ -52,7 +52,7 @@ func (client *Client) Capabilities() (map[string]Capability, error) {
 	}
 	switch rsp.Type {
 	case "error":
-		return nil, rsp.processErrorResponse()
+		return nil, rsp.err()
 	case "sync":
 		var resultOk map[string]map[string]Capability
 		if err := json.Unmarshal(rsp.Result, &resultOk); err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -119,6 +119,9 @@ type SysInfo struct {
 // processErrorResponse handles the common error path for API requests.
 // This function should be called when response.Type == "error"
 func (rsp *response) err() error {
+	if rsp.Type != "error" {
+		return nil
+	}
 	var resultErr errorResult
 	err := json.Unmarshal(rsp.Result, &resultErr)
 	if err != nil || resultErr.Str == "" {

--- a/client/client.go
+++ b/client/client.go
@@ -136,8 +136,8 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 	if err := client.do("GET", "/1.0", nil, &rsp); err != nil {
 		return nil, err
 	}
-	if rsp.Type == "error" {
-		return nil, rsp.err()
+	if err := rsp.err(); err != nil {
+		return nil, err
 	}
 	if rsp.Type != "sync" {
 		return nil, fmt.Errorf("unexpected result type %q", rsp.Type)

--- a/client/client.go
+++ b/client/client.go
@@ -125,7 +125,7 @@ func (rsp *response) err() error {
 	var resultErr errorResult
 	err := json.Unmarshal(rsp.Result, &resultErr)
 	if err != nil || resultErr.Str == "" {
-		return fmt.Errorf("failed with %q", rsp.Status)
+		return fmt.Errorf("server error: %q", rsp.Status)
 	}
 	return &resultErr
 }

--- a/client/client.go
+++ b/client/client.go
@@ -118,7 +118,7 @@ type SysInfo struct {
 
 // processErrorResponse handles the common error path for API requests.
 // This function should be called when response.Type == "error"
-func (rsp *response) processErrorResponse() error {
+func (rsp *response) err() error {
 	var resultErr errorResult
 	err := json.Unmarshal(rsp.Result, &resultErr)
 	if err != nil || resultErr.Str == "" {
@@ -134,7 +134,7 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 		return nil, err
 	}
 	if rsp.Type == "error" {
-		return nil, rsp.processErrorResponse()
+		return nil, rsp.err()
 	}
 	if rsp.Type != "sync" {
 		return nil, fmt.Errorf("unexpected result type %q", rsp.Type)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -98,7 +98,7 @@ func (cs *clientSuite) TestClientSysInfo(c *check.C) {
 func (cs *clientSuite) TestClientReportsOpError(c *check.C) {
 	cs.rsp = `{"type": "error", "status": "potatoes"}`
 	_, err := cs.cli.SysInfo()
-	c.Check(err, check.ErrorMatches, `failed with "potatoes"`)
+	c.Check(err, check.ErrorMatches, `server error: "potatoes"`)
 }
 
 func (cs *clientSuite) TestClientReportsOpErrorStr(c *check.C) {
@@ -109,7 +109,7 @@ func (cs *clientSuite) TestClientReportsOpErrorStr(c *check.C) {
 		"type": "error"
 	}`
 	_, err := cs.cli.SysInfo()
-	c.Check(err, check.ErrorMatches, `failed with "Bad Request"`)
+	c.Check(err, check.ErrorMatches, `server error: "Bad Request"`)
 }
 
 func (cs *clientSuite) TestClientReportsBadType(c *check.C) {

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -48,7 +48,7 @@ func (x *cmdListCaps) Execute(args []string) error {
 	cli := client.New()
 	caps, err := cli.Capabilities()
 	if err != nil {
-		return fmt.Errorf("cannot get capabilities: %v", err)
+		return err
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 1, ' ', 0)
 	fmt.Fprintln(w, "Name\tLabel\tType")


### PR DESCRIPTION
This is just a follow-up from yesterday. The same method of handling errors is now used by client.Capabilities() and client.SysInfo()