### PR TITLE
Caps type attrs

### DIFF
--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -40,6 +40,6 @@ var testCapability = &Capability{
 }
 
 func (s *CapabilitySuite) TestString(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: FileType}
+	cap := &Capability{Name: "name", Label: "label", Type: testType}
 	c.Assert(cap.String(), Equals, "name")
 }

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -71,7 +71,7 @@ func (s *RepositorySuite) TestAddInvalidName(c *C) {
 }
 
 func (s *RepositorySuite) TestAddType(c *C) {
-	t := &Type{"foo"}
+	t := &Type{Name: "foo"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, IsNil)
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"foo"})
@@ -79,8 +79,8 @@ func (s *RepositorySuite) TestAddType(c *C) {
 }
 
 func (s *RepositorySuite) TestAddTypeClash(c *C) {
-	t1 := &Type{"foo"}
-	t2 := &Type{"foo"}
+	t1 := &Type{Name: "foo"}
+	t2 := &Type{Name: "foo"}
 	err := s.emptyRepo.AddType(t1)
 	c.Assert(err, IsNil)
 	err = s.emptyRepo.AddType(t2)
@@ -91,7 +91,7 @@ func (s *RepositorySuite) TestAddTypeClash(c *C) {
 }
 
 func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
-	t := &Type{"bad-name-"}
+	t := &Type{Name: "bad-name-"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
@@ -126,9 +126,9 @@ func (s *RepositorySuite) TestNames(c *C) {
 
 func (s *RepositorySuite) TestTypeNames(c *C) {
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
-	s.emptyRepo.AddType(&Type{"a"})
-	s.emptyRepo.AddType(&Type{"b"})
-	s.emptyRepo.AddType(&Type{"c"})
+	s.emptyRepo.AddType(&Type{Name: "a"})
+	s.emptyRepo.AddType(&Type{Name: "b"})
+	s.emptyRepo.AddType(&Type{Name: "c"})
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"a", "b", "c"})
 }
 

--- a/caps/types.go
+++ b/caps/types.go
@@ -31,6 +31,9 @@ type Type struct {
 	// Name is a key that identifies the capability type. It must be unique
 	// within the whole OS. The name forms a part of the stable system API.
 	Name string
+	// SupportedAttrs contains names of attributes that are understood by
+	// capability of this type.
+	SupportedAttrs []string
 }
 
 var (

--- a/caps/types.go
+++ b/caps/types.go
@@ -58,7 +58,7 @@ func (t *Type) Validate(c *Capability) error {
 	if t != c.Type {
 		return fmt.Errorf("capability is not of type %q", t)
 	}
-	// Check that all supported attributes are present
+	// Check that all required attributes are present
 	for _, attr := range t.RequiredAttrs {
 		if _, ok := c.Attrs[attr]; !ok {
 			return fmt.Errorf("capability lacks required attribute %q", attr)

--- a/caps/types.go
+++ b/caps/types.go
@@ -31,9 +31,9 @@ type Type struct {
 	// Name is a key that identifies the capability type. It must be unique
 	// within the whole OS. The name forms a part of the stable system API.
 	Name string
-	// SupportedAttrs contains names of attributes that are understood by
+	// RequiredAttrs contains names of attributes that are understood by
 	// capability of this type.
-	SupportedAttrs []string
+	RequiredAttrs []string
 }
 
 var (
@@ -59,17 +59,17 @@ func (t *Type) Validate(c *Capability) error {
 		return fmt.Errorf("capability is not of type %q", t)
 	}
 	// Check that all supported attributes are present
-	for _, attr := range t.SupportedAttrs {
+	for _, attr := range t.RequiredAttrs {
 		if _, ok := c.Attrs[attr]; !ok {
 			return fmt.Errorf("capability lacks required attribute %q", attr)
 		}
 	}
 	// Look for any unexpected attributes
-	if len(t.SupportedAttrs) != len(c.Attrs) {
+	if len(t.RequiredAttrs) != len(c.Attrs) {
 		for attr := range c.Attrs {
 			supported := false
-			for _, attrSupported := range t.SupportedAttrs {
-				if attr == attrSupported {
+			for _, attrRequired := range t.RequiredAttrs {
+				if attr == attrRequired {
 					supported = true
 					break
 				}

--- a/caps/types.go
+++ b/caps/types.go
@@ -66,7 +66,7 @@ func (t *Type) Validate(c *Capability) error {
 	}
 	// Look for any unexpected attributes
 	if len(t.SupportedAttrs) != len(c.Attrs) {
-		for attr, _ := range c.Attrs {
+		for attr := range c.Attrs {
 			supported := false
 			for _, attrSupported := range t.SupportedAttrs {
 				if attr == attrSupported {

--- a/caps/types.go
+++ b/caps/types.go
@@ -64,21 +64,6 @@ func (t *Type) Validate(c *Capability) error {
 			return fmt.Errorf("capabilities of type %q must provide a %q attribute", t, attr)
 		}
 	}
-	// Look for any unexpected attributes
-	if len(t.RequiredAttrs) != len(c.Attrs) {
-		for attr := range c.Attrs {
-			supported := false
-			for _, attrRequired := range t.RequiredAttrs {
-				if attr == attrRequired {
-					supported = true
-					break
-				}
-			}
-			if !supported {
-				return fmt.Errorf("capability contains unexpected attribute %q", attr)
-			}
-		}
-	}
 	return nil
 }
 

--- a/caps/types.go
+++ b/caps/types.go
@@ -61,7 +61,7 @@ func (t *Type) Validate(c *Capability) error {
 	// Check that all required attributes are present
 	for _, attr := range t.RequiredAttrs {
 		if _, ok := c.Attrs[attr]; !ok {
-			return fmt.Errorf("capability lacks required attribute %q", attr)
+			return fmt.Errorf("capabilities of type %q must provide a %q attribute", t, attr)
 		}
 	}
 	// Look for any unexpected attributes

--- a/caps/types.go
+++ b/caps/types.go
@@ -58,11 +58,26 @@ func (t *Type) Validate(c *Capability) error {
 	if t != c.Type {
 		return fmt.Errorf("capability is not of type %q", t)
 	}
-	// While we don't have any support for type-specific attribute schema,
-	// let's ensure that attributes are totally empty. This will make tests
-	// show that this code is actually being used.
-	if c.Attrs != nil && len(c.Attrs) != 0 {
-		return fmt.Errorf("attributes must be empty for now")
+	// Check that all supported attributes are present
+	for _, attr := range t.SupportedAttrs {
+		if _, ok := c.Attrs[attr]; !ok {
+			return fmt.Errorf("capability lacks required attribute %q", attr)
+		}
+	}
+	// Look for any unexpected attributes
+	if len(t.SupportedAttrs) != len(c.Attrs) {
+		for attr, _ := range c.Attrs {
+			supported := false
+			for _, attrSupported := range t.SupportedAttrs {
+				if attr == attrSupported {
+					supported = true
+					break
+				}
+			}
+			if !supported {
+				return fmt.Errorf("capability contains unexpected attribute %q", attr)
+			}
+		}
 	}
 	return nil
 }

--- a/caps/types.go
+++ b/caps/types.go
@@ -41,7 +41,7 @@ var (
 	// file. This single capability  type is here just to help bootstrap
 	// the capability concept before we get to load capability interfaces
 	// from YAML.
-	FileType = &Type{"file"}
+	FileType = &Type{Name: "file"}
 )
 
 var builtInTypes = [...]*Type{

--- a/caps/types.go
+++ b/caps/types.go
@@ -31,7 +31,7 @@ type Type struct {
 	// Name is a key that identifies the capability type. It must be unique
 	// within the whole OS. The name forms a part of the stable system API.
 	Name string
-	// RequiredAttrs contains names of attributes that are understood by
+	// RequiredAttrs contains names of attributes that are required by
 	// capability of this type.
 	RequiredAttrs []string
 }

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -32,8 +32,8 @@ var _ = Suite(&TypeSuite{})
 // testType is only meant for testing. It is not useful in any way except
 // that it offers an simple capability type that will happily validate.
 var testType = &Type{
-	Name:           "test",
-	SupportedAttrs: nil,
+	Name:          "test",
+	RequiredAttrs: nil,
 }
 
 func (s *TypeSuite) TestTypeString(c *C) {
@@ -55,8 +55,8 @@ func (s *TypeSuite) TestValidateOK(c *C) {
 
 func (s *TypeSuite) TestValidateAttributesUnexpectedAttrs(c *C) {
 	t := &Type{
-		Name:           "t",
-		SupportedAttrs: nil,
+		Name:          "t",
+		RequiredAttrs: nil,
 	}
 	cap := &Capability{
 		Name:  "name",
@@ -70,8 +70,8 @@ func (s *TypeSuite) TestValidateAttributesUnexpectedAttrs(c *C) {
 
 func (s *TypeSuite) TestValidateAttributesRequiredAttrs(c *C) {
 	t := &Type{
-		Name:           "t",
-		SupportedAttrs: []string{"k"},
+		Name:          "t",
+		RequiredAttrs: []string{"k"},
 	}
 	cap := &Capability{
 		Name:  "name",

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -31,14 +31,17 @@ var _ = Suite(&TypeSuite{})
 
 // testType is only meant for testing. It is not useful in any way except
 // that it offers an simple capability type that will happily validate.
-var testType = &Type{"test"}
+var testType = &Type{
+	Name:           "test",
+	SupportedAttrs: nil,
+}
 
 func (s *TypeSuite) TestTypeString(c *C) {
 	c.Assert(testType.String(), Equals, "test")
 }
 
 func (s *TypeSuite) TestValidateMismatchedType(c *C) {
-	testType2 := &Type{"test-two"} // Another test-like type that's not test itself
+	testType2 := &Type{Name: "test-two"} // Another test-like type that's not test itself
 	cap := &Capability{Name: "name", Label: "label", Type: testType2}
 	err := testType.Validate(cap)
 	c.Assert(err, ErrorMatches, `capability is not of type "test"`)
@@ -50,17 +53,34 @@ func (s *TypeSuite) TestValidateOK(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *TypeSuite) TestValidateAttributes(c *C) {
+func (s *TypeSuite) TestValidateAttributesUnexpectedAttrs(c *C) {
+	t := &Type{
+		Name:           "t",
+		SupportedAttrs: nil,
+	}
 	cap := &Capability{
 		Name:  "name",
 		Label: "label",
-		Type:  testType,
-		Attrs: map[string]string{
-			"Key": "Value",
-		},
+		Type:  t,
+		Attrs: map[string]string{"k": "v"},
 	}
-	err := testType.Validate(cap)
-	c.Assert(err, ErrorMatches, "attributes must be empty for now")
+	err := t.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability contains unexpected attribute "k"`)
+}
+
+func (s *TypeSuite) TestValidateAttributesRequiredAttrs(c *C) {
+	t := &Type{
+		Name:           "t",
+		SupportedAttrs: []string{"k"},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+		Attrs: map[string]string{},
+	}
+	err := t.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability lacks required attribute "k"`)
 }
 
 func (s *TypeSuite) TestMarhshalJSON(c *C) {

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -68,7 +68,7 @@ func (s *TypeSuite) TestValidateAttributesUnexpectedAttrs(c *C) {
 	c.Assert(err, ErrorMatches, `capability contains unexpected attribute "k"`)
 }
 
-func (s *TypeSuite) TestValidateAttributesRequiredAttrs(c *C) {
+func (s *TypeSuite) TestValidateAttributesRequiredAttrsMissing(c *C) {
 	t := &Type{
 		Name:          "t",
 		RequiredAttrs: []string{"k"},
@@ -80,6 +80,21 @@ func (s *TypeSuite) TestValidateAttributesRequiredAttrs(c *C) {
 	}
 	err := t.Validate(cap)
 	c.Assert(err, ErrorMatches, `capabilities of type "t" must provide a "k" attribute`)
+}
+
+func (s *TypeSuite) TestValidateAttributesRequiredAttrsSatisfied(c *C) {
+	t := &Type{
+		Name:          "t",
+		RequiredAttrs: []string{"k"},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+		Attrs: map[string]string{"k": "v"},
+	}
+	err := t.Validate(cap)
+	c.Assert(err, IsNil)
 }
 
 func (s *TypeSuite) TestMarhshalJSON(c *C) {

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -80,7 +80,7 @@ func (s *TypeSuite) TestValidateAttributesRequiredAttrs(c *C) {
 		Attrs: map[string]string{},
 	}
 	err := t.Validate(cap)
-	c.Assert(err, ErrorMatches, `capability lacks required attribute "k"`)
+	c.Assert(err, ErrorMatches, `capabilities of type "t" must provide a "k" attribute`)
 }
 
 func (s *TypeSuite) TestMarhshalJSON(c *C) {

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -53,21 +53,6 @@ func (s *TypeSuite) TestValidateOK(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *TypeSuite) TestValidateAttributesUnexpectedAttrs(c *C) {
-	t := &Type{
-		Name:          "t",
-		RequiredAttrs: nil,
-	}
-	cap := &Capability{
-		Name:  "name",
-		Label: "label",
-		Type:  t,
-		Attrs: map[string]string{"k": "v"},
-	}
-	err := t.Validate(cap)
-	c.Assert(err, ErrorMatches, `capability contains unexpected attribute "k"`)
-}
-
 func (s *TypeSuite) TestValidateAttributesRequiredAttrsMissing(c *C) {
 	t := &Type{
 		Name:          "t",

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -77,7 +77,6 @@ func (s *TypeSuite) TestValidateAttributesRequiredAttrs(c *C) {
 		Name:  "name",
 		Label: "label",
 		Type:  t,
-		Attrs: map[string]string{},
 	}
 	err := t.Validate(cap)
 	c.Assert(err, ErrorMatches, `capabilities of type "t" must provide a "k" attribute`)


### PR DESCRIPTION
This branch adds simple attribute validation to capability types. Each type now contains the list of attributes that must (and only those) be present in a capability.