### PR TITLE
Replace caps.FileType with caps.BoolFile with required "path"

### DIFF
--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -40,6 +40,6 @@ var testCapability = &Capability{
 }
 
 func (s *CapabilitySuite) TestString(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: FileType}
+	cap := &Capability{Name: "name", Label: "label", Type: testType}
 	c.Assert(cap.String(), Equals, "name")
 }

--- a/caps/misc_test.go
+++ b/caps/misc_test.go
@@ -42,8 +42,8 @@ func (s *MiscSuite) TestLoadBuiltInTypes(c *C) {
 	repo := NewRepository()
 	err := LoadBuiltInTypes(repo)
 	c.Assert(err, IsNil)
-	c.Assert(repo.types, testutil.Contains, FileType)
+	c.Assert(repo.types, testutil.Contains, BoolFileType)
 	c.Assert(repo.types, HasLen, 1) // Update this whenever new built-in type is added
 	err = LoadBuiltInTypes(repo)
-	c.Assert(err, ErrorMatches, `cannot add type "file": name already exists`)
+	c.Assert(err, ErrorMatches, `cannot add type "bool-file": name already exists`)
 }

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -71,7 +71,7 @@ func (s *RepositorySuite) TestAddInvalidName(c *C) {
 }
 
 func (s *RepositorySuite) TestAddType(c *C) {
-	t := &Type{"foo"}
+	t := &Type{Name: "foo"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, IsNil)
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"foo"})
@@ -79,8 +79,8 @@ func (s *RepositorySuite) TestAddType(c *C) {
 }
 
 func (s *RepositorySuite) TestAddTypeClash(c *C) {
-	t1 := &Type{"foo"}
-	t2 := &Type{"foo"}
+	t1 := &Type{Name: "foo"}
+	t2 := &Type{Name: "foo"}
 	err := s.emptyRepo.AddType(t1)
 	c.Assert(err, IsNil)
 	err = s.emptyRepo.AddType(t2)
@@ -91,7 +91,7 @@ func (s *RepositorySuite) TestAddTypeClash(c *C) {
 }
 
 func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
-	t := &Type{"bad-name-"}
+	t := &Type{Name: "bad-name-"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
@@ -126,9 +126,9 @@ func (s *RepositorySuite) TestNames(c *C) {
 
 func (s *RepositorySuite) TestTypeNames(c *C) {
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
-	s.emptyRepo.AddType(&Type{"a"})
-	s.emptyRepo.AddType(&Type{"b"})
-	s.emptyRepo.AddType(&Type{"c"})
+	s.emptyRepo.AddType(&Type{Name: "a"})
+	s.emptyRepo.AddType(&Type{Name: "b"})
+	s.emptyRepo.AddType(&Type{Name: "c"})
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"a", "b", "c"})
 }
 

--- a/caps/types.go
+++ b/caps/types.go
@@ -31,6 +31,9 @@ type Type struct {
 	// Name is a key that identifies the capability type. It must be unique
 	// within the whole OS. The name forms a part of the stable system API.
 	Name string
+	// SupportedAttrs contains names of attributes that are understood by
+	// capability of this type.
+	SupportedAttrs []string
 }
 
 var (

--- a/caps/types.go
+++ b/caps/types.go
@@ -58,7 +58,7 @@ func (t *Type) Validate(c *Capability) error {
 	if t != c.Type {
 		return fmt.Errorf("capability is not of type %q", t)
 	}
-	// Check that all supported attributes are present
+	// Check that all required attributes are present
 	for _, attr := range t.RequiredAttrs {
 		if _, ok := c.Attrs[attr]; !ok {
 			return fmt.Errorf("capability lacks required attribute %q", attr)

--- a/caps/types.go
+++ b/caps/types.go
@@ -37,15 +37,20 @@ type Type struct {
 }
 
 var (
-	// FileType is a basic capability vaguely expressing access to a specific
-	// file. This single capability  type is here just to help bootstrap
-	// the capability concept before we get to load capability interfaces
-	// from YAML.
-	FileType = &Type{Name: "file"}
+	// BoolFileType is a built-in capability type for files that follow a
+	// simple boolean protocol. The file can be read, which yields ASCII '0'
+	// (zero) or ASCII '1' (one). The same can be done for writing.
+	//
+	// This capability type can be used to describe many boolean flags exposed
+	// in sysfs, including certain hardware like exported GPIO pins.
+	BoolFileType = &Type{
+		Name:          "bool-file",
+		RequiredAttrs: []string{"path"},
+	}
 )
 
 var builtInTypes = [...]*Type{
-	FileType,
+	BoolFileType,
 }
 
 // String returns a string representation for the capability type.

--- a/caps/types.go
+++ b/caps/types.go
@@ -31,9 +31,9 @@ type Type struct {
 	// Name is a key that identifies the capability type. It must be unique
 	// within the whole OS. The name forms a part of the stable system API.
 	Name string
-	// SupportedAttrs contains names of attributes that are understood by
+	// RequiredAttrs contains names of attributes that are understood by
 	// capability of this type.
-	SupportedAttrs []string
+	RequiredAttrs []string
 }
 
 var (
@@ -59,17 +59,17 @@ func (t *Type) Validate(c *Capability) error {
 		return fmt.Errorf("capability is not of type %q", t)
 	}
 	// Check that all supported attributes are present
-	for _, attr := range t.SupportedAttrs {
+	for _, attr := range t.RequiredAttrs {
 		if _, ok := c.Attrs[attr]; !ok {
 			return fmt.Errorf("capability lacks required attribute %q", attr)
 		}
 	}
 	// Look for any unexpected attributes
-	if len(t.SupportedAttrs) != len(c.Attrs) {
+	if len(t.RequiredAttrs) != len(c.Attrs) {
 		for attr := range c.Attrs {
 			supported := false
-			for _, attrSupported := range t.SupportedAttrs {
-				if attr == attrSupported {
+			for _, attrRequired := range t.RequiredAttrs {
+				if attr == attrRequired {
 					supported = true
 					break
 				}

--- a/caps/types.go
+++ b/caps/types.go
@@ -66,7 +66,7 @@ func (t *Type) Validate(c *Capability) error {
 	}
 	// Look for any unexpected attributes
 	if len(t.SupportedAttrs) != len(c.Attrs) {
-		for attr, _ := range c.Attrs {
+		for attr := range c.Attrs {
 			supported := false
 			for _, attrSupported := range t.SupportedAttrs {
 				if attr == attrSupported {

--- a/caps/types.go
+++ b/caps/types.go
@@ -58,11 +58,26 @@ func (t *Type) Validate(c *Capability) error {
 	if t != c.Type {
 		return fmt.Errorf("capability is not of type %q", t)
 	}
-	// While we don't have any support for type-specific attribute schema,
-	// let's ensure that attributes are totally empty. This will make tests
-	// show that this code is actually being used.
-	if c.Attrs != nil && len(c.Attrs) != 0 {
-		return fmt.Errorf("attributes must be empty for now")
+	// Check that all supported attributes are present
+	for _, attr := range t.SupportedAttrs {
+		if _, ok := c.Attrs[attr]; !ok {
+			return fmt.Errorf("capability lacks required attribute %q", attr)
+		}
+	}
+	// Look for any unexpected attributes
+	if len(t.SupportedAttrs) != len(c.Attrs) {
+		for attr, _ := range c.Attrs {
+			supported := false
+			for _, attrSupported := range t.SupportedAttrs {
+				if attr == attrSupported {
+					supported = true
+					break
+				}
+			}
+			if !supported {
+				return fmt.Errorf("capability contains unexpected attribute %q", attr)
+			}
+		}
 	}
 	return nil
 }

--- a/caps/types.go
+++ b/caps/types.go
@@ -41,7 +41,7 @@ var (
 	// file. This single capability  type is here just to help bootstrap
 	// the capability concept before we get to load capability interfaces
 	// from YAML.
-	FileType = &Type{"file"}
+	FileType = &Type{Name: "file"}
 )
 
 var builtInTypes = [...]*Type{

--- a/caps/types.go
+++ b/caps/types.go
@@ -31,7 +31,7 @@ type Type struct {
 	// Name is a key that identifies the capability type. It must be unique
 	// within the whole OS. The name forms a part of the stable system API.
 	Name string
-	// RequiredAttrs contains names of attributes that are understood by
+	// RequiredAttrs contains names of attributes that are required by
 	// capability of this type.
 	RequiredAttrs []string
 }

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -32,8 +32,8 @@ var _ = Suite(&TypeSuite{})
 // testType is only meant for testing. It is not useful in any way except
 // that it offers an simple capability type that will happily validate.
 var testType = &Type{
-	Name:           "test",
-	SupportedAttrs: nil,
+	Name:          "test",
+	RequiredAttrs: nil,
 }
 
 func (s *TypeSuite) TestTypeString(c *C) {
@@ -55,8 +55,8 @@ func (s *TypeSuite) TestValidateOK(c *C) {
 
 func (s *TypeSuite) TestValidateAttributesUnexpectedAttrs(c *C) {
 	t := &Type{
-		Name:           "t",
-		SupportedAttrs: nil,
+		Name:          "t",
+		RequiredAttrs: nil,
 	}
 	cap := &Capability{
 		Name:  "name",
@@ -70,8 +70,8 @@ func (s *TypeSuite) TestValidateAttributesUnexpectedAttrs(c *C) {
 
 func (s *TypeSuite) TestValidateAttributesRequiredAttrs(c *C) {
 	t := &Type{
-		Name:           "t",
-		SupportedAttrs: []string{"k"},
+		Name:          "t",
+		RequiredAttrs: []string{"k"},
 	}
 	cap := &Capability{
 		Name:  "name",

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -31,14 +31,17 @@ var _ = Suite(&TypeSuite{})
 
 // testType is only meant for testing. It is not useful in any way except
 // that it offers an simple capability type that will happily validate.
-var testType = &Type{"test"}
+var testType = &Type{
+	Name:           "test",
+	SupportedAttrs: nil,
+}
 
 func (s *TypeSuite) TestTypeString(c *C) {
 	c.Assert(testType.String(), Equals, "test")
 }
 
 func (s *TypeSuite) TestValidateMismatchedType(c *C) {
-	testType2 := &Type{"test-two"} // Another test-like type that's not test itself
+	testType2 := &Type{Name: "test-two"} // Another test-like type that's not test itself
 	cap := &Capability{Name: "name", Label: "label", Type: testType2}
 	err := testType.Validate(cap)
 	c.Assert(err, ErrorMatches, `capability is not of type "test"`)
@@ -50,17 +53,34 @@ func (s *TypeSuite) TestValidateOK(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *TypeSuite) TestValidateAttributes(c *C) {
+func (s *TypeSuite) TestValidateAttributesUnexpectedAttrs(c *C) {
+	t := &Type{
+		Name:           "t",
+		SupportedAttrs: nil,
+	}
 	cap := &Capability{
 		Name:  "name",
 		Label: "label",
-		Type:  testType,
-		Attrs: map[string]string{
-			"Key": "Value",
-		},
+		Type:  t,
+		Attrs: map[string]string{"k": "v"},
 	}
-	err := testType.Validate(cap)
-	c.Assert(err, ErrorMatches, "attributes must be empty for now")
+	err := t.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability contains unexpected attribute "k"`)
+}
+
+func (s *TypeSuite) TestValidateAttributesRequiredAttrs(c *C) {
+	t := &Type{
+		Name:           "t",
+		SupportedAttrs: []string{"k"},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+		Attrs: map[string]string{},
+	}
+	err := t.Validate(cap)
+	c.Assert(err, ErrorMatches, `capability lacks required attribute "k"`)
 }
 
 func (s *TypeSuite) TestMarhshalJSON(c *C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/snappy"
 	"github.com/ubuntu-core/snappy/systemd"
-	"github.com/ubuntu-core/snappy/testutil"
 	"github.com/ubuntu-core/snappy/timeout"
 )
 
@@ -1198,23 +1197,32 @@ func (s *apiSuite) TestInstallLicensedIntegration(c *check.C) {
 
 func (s *apiSuite) TestGetCapabilities(c *check.C) {
 	d := newTestDaemon()
-	d.capRepo.Add(&caps.Capability{"serial-port", "A serial port", caps.FileType, nil})
+	d.capRepo.Add(&caps.Capability{
+		Name:  "caps-lock-led",
+		Label: "Caps Lock LED",
+		Type:  caps.BoolFileType,
+		Attrs: map[string]string{
+			"path": "/sys/class/leds/input::capslock/brightness",
+		},
+	})
 	req, err := http.NewRequest("GET", "/1.0/capabilities", nil)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	capabilitiesCmd.GET(capabilitiesCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 200)
-	c.Check(rec.Body.String(), testutil.Contains, "serial-port")
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
 			"capabilities": map[string]interface{}{
-				"serial-port": map[string]interface{}{
-					"label": "A serial port",
-					"name":  "serial-port",
-					"type":  "file",
+				"caps-lock-led": map[string]interface{}{
+					"name":  "caps-lock-led",
+					"label": "Caps Lock LED",
+					"type":  "bool-file",
+					"attrs": map[string]interface{}{
+						"path": "/sys/class/leds/input::capslock/brightness",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This branch depends on #205 

This patch kills the early development "file" type and replaces it with
the "bool-file" type that can be used to describe simple GPIO pins.