### PR TITLE
asserts: squashfs snaps hash digest and encode digest helper

### DIFF
--- a/asserts/digest.go
+++ b/asserts/digest.go
@@ -35,7 +35,7 @@ func EncodeDigest(hash crypto.Hash, hashDigest []byte) (string, error) {
 		return "", fmt.Errorf("unsupported hash")
 	}
 	if len(hashDigest) != hash.Size() {
-		return "", fmt.Errorf("hash digest for %s should be %d bytes", algo, hash.Size())
+		return "", fmt.Errorf("hash digest by %s should be %d bytes", algo, hash.Size())
 	}
 	return fmt.Sprintf("%s %s", algo, base64.RawURLEncoding.EncodeToString(hashDigest)), nil
 }

--- a/asserts/digest.go
+++ b/asserts/digest.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"crypto"
+	"encoding/base64"
+	"fmt"
+)
+
+// EncodeDigest encodes a hash algorithm and a digest to be put in an assertion header.
+func EncodeDigest(hash crypto.Hash, hashDigest []byte) (string, error) {
+	algo := ""
+	switch hash {
+	case crypto.SHA256:
+		algo = "sha256"
+	default:
+		return "", fmt.Errorf("unsupported hash")
+	}
+	if len(hashDigest) != hash.Size() {
+		return "", fmt.Errorf("hash digest for %s should be %d bytes", algo, hash.Size())
+	}
+	return fmt.Sprintf("%s %s", algo, base64.RawURLEncoding.EncodeToString(hashDigest)), nil
+}

--- a/asserts/digest_test.go
+++ b/asserts/digest_test.go
@@ -52,5 +52,5 @@ func (eds *encodeDigestSuite) TestEncodeDigestErrors(c *C) {
 	c.Check(err, ErrorMatches, "unsupported hash")
 
 	_, err = asserts.EncodeDigest(crypto.SHA256, []byte{1, 2})
-	c.Check(err, ErrorMatches, "hash digest for sha256 should be 32 bytes")
+	c.Check(err, ErrorMatches, "hash digest by sha256 should be 32 bytes")
 }

--- a/asserts/digest_test.go
+++ b/asserts/digest_test.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts_test
+
+import (
+	"crypto"
+	_ "crypto/sha256"
+	"encoding/base64"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/asserts"
+)
+
+type encodeDigestSuite struct{}
+
+var _ = Suite(&encodeDigestSuite{})
+
+func (eds *encodeDigestSuite) TestEncodeDigestOK(c *C) {
+	h := crypto.SHA256.New()
+	h.Write([]byte("some stuff to hash"))
+	digest := h.Sum(nil)
+	encoded, err := asserts.EncodeDigest(crypto.SHA256, digest)
+	c.Assert(err, IsNil)
+
+	c.Check(strings.HasPrefix(encoded, "sha256 "), Equals, true)
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded[len("sha256 "):])
+	c.Assert(err, IsNil)
+	c.Check(decoded, DeepEquals, digest)
+}
+
+func (eds *encodeDigestSuite) TestEncodeDigestErrors(c *C) {
+	_, err := asserts.EncodeDigest(crypto.SHA1, nil)
+	c.Check(err, ErrorMatches, "unsupported hash")
+
+	_, err = asserts.EncodeDigest(crypto.SHA256, []byte{1, 2})
+	c.Check(err, ErrorMatches, "hash digest for sha256 should be 32 bytes")
+}

--- a/pkg/squashfs/squashfs_test.go
+++ b/pkg/squashfs/squashfs_test.go
@@ -20,6 +20,8 @@
 package squashfs
 
 import (
+	"crypto"
+	_ "crypto/sha256"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -76,6 +78,14 @@ func (s *SquashfsTestSuite) SetUpTest(c *C) {
 func (s *SquashfsTestSuite) TestName(c *C) {
 	snap := New("/path/to/foo.snap")
 	c.Assert(snap.Name(), Equals, "foo.snap")
+}
+
+func (s *SquashfsTestSuite) TestHashFile(c *C) {
+	snap := makeSnap(c, "name: test", "")
+	size, digest, err := snap.HashDigest(crypto.SHA256)
+	c.Assert(err, IsNil)
+	c.Check(size, Equals, uint64(4096))
+	c.Check(digest, HasLen, crypto.SHA256.Size())
 }
 
 // FIXME: stub that needs to be fleshed out once assertions land


### PR DESCRIPTION
* implement helper to encode a hash digest to use in an assertion header
* implement computing a hash digest for squashfs snaps