### PR TITLE
Tight up wait for server regexp

### DIFF
--- a/integration-tests/testutils/wait/wait.go
+++ b/integration-tests/testutils/wait/wait.go
@@ -48,7 +48,7 @@ func ForActiveService(c *check.C, serviceName string) (err error) {
 
 // ForServerOnPort uses ForCommand to check for process listening on the given port
 func ForServerOnPort(c *check.C, protocol string, port int) (err error) {
-	return ForCommand(c, fmt.Sprintf(`(?msU)^.*%s .*:%d .* LISTEN.*`, protocol, port),
+	return ForCommand(c, fmt.Sprintf(`(?sU)^.*%s .*:%d\s*(0\.0\.0\.0|::):\*\s*LISTEN.*`, protocol, port),
 		"netstat", "-tapn")
 }
 

--- a/integration-tests/testutils/wait/wait_test.go
+++ b/integration-tests/testutils/wait/wait_test.go
@@ -180,7 +180,7 @@ func (s *waitTestSuite) TestForServerOnPortCallsForCommand(c *check.C) {
 
 	ForServerOnPort(c, "tcp", 1234)
 
-	expectedCalled := `ForCommand called with pattern '(?msU)^.*tcp .*:1234 .* LISTEN.*' and cmds 'netstat -tapn'`
+	expectedCalled := `ForCommand called with pattern '(?sU)^.*tcp .*:1234\s*(0\.0\.0\.0|::):\*\s*LISTEN.*' and cmds 'netstat -tapn'`
 	c.Assert(called, check.Equals, expectedCalled, check.Commentf("Expected call to ForCommand didn't happen"))
 }
 


### PR DESCRIPTION
It prevents false positives while looking for a listening service on port 80 with netstat outputs like:

```
tcp        0      0 10.42.56.129:42596      91.189.88.35:80         TIME_WAIT   -
tcp6       0      0 :::22                   :::*                    LISTEN      -
```