### PR TITLE
asserts demo: check for assertions when installing a local file squashfs snap

### DIFF
--- a/snappy/demo_asserts_install.go
+++ b/snappy/demo_asserts_install.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snappy
+
+import (
+	"crypto"
+	"fmt"
+	"strings"
+
+	"github.com/ubuntu-core/snappy/asserts"
+	"github.com/ubuntu-core/snappy/pkg/squashfs"
+)
+
+func demoCheckSnapAssertions(snap *squashfs.Snap) (string, error) {
+	defer snap.Close()
+
+	sysAssertDb, err := asserts.OpenSysDatabase()
+	if err != nil {
+		return "", err
+	}
+
+	nameParts := strings.SplitN(snap.Name(), "_", 2)
+	snapID := nameParts[0] // XXX: cheat/guess
+	size, hashDigest, err := snap.HashDigest(crypto.SHA256)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash snap: %v", err)
+	}
+	formattedDigest, err := asserts.EncodeDigest(crypto.SHA256, hashDigest)
+	if err != nil {
+		return "", err
+	}
+	a, err := sysAssertDb.Find(asserts.SnapDeclarationType, map[string]string{
+		"snap-id":     snapID,
+		"snap-digest": formattedDigest,
+	})
+	if err == asserts.ErrNotFound {
+		return "", fmt.Errorf("no assertion found that validates the snap to be installed")
+	}
+	if err != nil {
+		return "", nil
+	}
+	snapDecl := a.(*asserts.SnapDeclaration)
+	if size != snapDecl.SnapSize() {
+		return "", fmt.Errorf("size mismatch between snap and assertion")
+	}
+	return snapDecl.AuthorityID(), nil // XXX: use this as origin
+}

--- a/snappy/demo_asserts_install.go
+++ b/snappy/demo_asserts_install.go
@@ -60,5 +60,6 @@ func demoCheckSnapAssertions(snap *squashfs.Snap) (string, error) {
 	if size != snapDecl.SnapSize() {
 		return "", fmt.Errorf("size mismatch between snap and assertion")
 	}
-	return snapDecl.AuthorityID(), nil // XXX: use this as origin
+	// XXX: here we cheat/assume we can use the developer-id as the origin
+	return snapDecl.AuthorityID(), nil
 }


### PR DESCRIPTION
NB: targeting a demo branch

There are issues about placement of the code, and issues/open questions about

snap-id vs origin and snap name
origin vs developer-id

Also thinking about final usage patterns: do we want to keep sideloading as it was? what should be the new rules for it? support having that with a snap-declaration we get the non sideloaded effect of a set origin? or do we need a store assertion for that even if the local snap installing needs sudo and is explicitly requested? or we distinguish devel-mode vs not