### PR TITLE
asserts demo: implement snappy add-assertion

### DIFF
--- a/cmd/snappy/cmd_add_assertion.go
+++ b/cmd/snappy/cmd_add_assertion.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"io/ioutil"
+
+	"github.com/ubuntu-core/snappy/asserts"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type cmdAddAssertion struct {
+	Positional struct {
+		AssertionFile string `positional-arg-name:"assertion file"`
+	} `positional-args:"yes"`
+}
+
+func init() {
+	arg, err := parser.AddCommand("add-assertion",
+		i18n.G("Add an assertion to the assertion database"),
+		i18n.G("Add an assertion to the assertion database"),
+		&cmdAddAssertion{})
+	if err != nil {
+		logger.Panicf("Unable to install: %v", err)
+	}
+	addOptionDescription(arg, "assertion file", i18n.G("The file containing the assertion to add"))
+}
+
+func (x *cmdAddAssertion) Execute(args []string) error {
+	// XXX: no locking atm
+	return x.doAddAssertion()
+}
+
+func (x *cmdAddAssertion) doAddAssertion() error {
+	assertFile := x.Positional.AssertionFile
+
+	if assertFile == "" {
+		return errors.New(i18n.G("assertion file is required"))
+	}
+
+	sysAssertDb, err := asserts.OpenSysDatabase()
+	if err != nil {
+		return err
+	}
+
+	assertData, err := ioutil.ReadFile(assertFile)
+	if err != nil {
+		return err
+	}
+
+	assert, err := asserts.Decode(assertData)
+	if err != nil {
+		return err
+	}
+
+	return sysAssertDb.Add(assert)
+}

--- a/cmd/snappy/cmd_add_assertion.go
+++ b/cmd/snappy/cmd_add_assertion.go
@@ -40,14 +40,13 @@ func init() {
 		i18n.G("Add an assertion to the assertion database"),
 		&cmdAddAssertion{})
 	if err != nil {
-		logger.Panicf("Unable to install: %v", err)
+		logger.Panicf("Unable to add-assertion: %v", err)
 	}
 	addOptionDescription(arg, "assertion file", i18n.G("The file containing the assertion to add"))
 }
 
 func (x *cmdAddAssertion) Execute(args []string) error {
-	// XXX: no locking atm
-	return x.doAddAssertion()
+	return withMutexAndRetry(x.doAddAssertion)
 }
 
 func (x *cmdAddAssertion) doAddAssertion() error {

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2015-11-27 16:07+0100\n"
+        "POT-Creation-Date: 2015-12-01 18:23+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,6 +65,9 @@ msgid   "Activate a package"
 msgstr  ""
 
 msgid   "Activate a package that has previously been deactivated. If the package is already activated, do nothing."
+msgstr  ""
+
+msgid   "Add an assertion to the assertion database"
 msgstr  ""
 
 msgid   "All background processes will be killed when you leave this shell"
@@ -343,6 +346,9 @@ msgstr  ""
 msgid   "The configuration for the given install"
 msgstr  ""
 
+msgid   "The file containing the assertion to add"
+msgstr  ""
+
 msgid   "The hardware device path (e.g. /dev/ttyUSB0)"
 msgstr  ""
 
@@ -397,6 +403,9 @@ msgstr  ""
 #. TRANSLATORS: the %s an architecture string
 #, c-format
 msgid   "architecture: %s\n"
+msgstr  ""
+
+msgid   "assertion file is required"
 msgstr  ""
 
 #. TRANSLATORS: the %s is a size


### PR DESCRIPTION
NB targeting a demo branch

ultimately this would be available in some form under snap/snapd