### PR TITLE
Do not bind mount /etc/sudoers.d/ into classic mode

### DIFF
--- a/classic/run.go
+++ b/classic/run.go
@@ -42,7 +42,6 @@ var bindMountDirs = []bindMount{
 	{"/dev", "/dev", ""},
 	{"/var/lib/extrausers", "/var/lib/extrausers", "ro"},
 	{"/etc/sudoers", "/etc/sudoers", "ro"},
-	{"/etc/sudoers.d", "/etc/sudoers.d", "ro"},
 	{"/", "/snappy", ""},
 }
 


### PR DESCRIPTION
Packages that get installed in classic mode will write into
/etc/sudoers.d/ so we can not bind mount it without breaking
installation of these packages (among them is ubuntu-snappy-cli).

Since livecd-rootfs 2.360 the default ubuntu user in
snappy is part of the sudo group so there is no need
to have the content of /etc/sudoers.d/ in classic.