### PR TITLE
classic/run.go: do not kill all processes when exiting classic

### DIFF
--- a/classic/run_test.go
+++ b/classic/run_test.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package classic
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type RunTestSuite struct {
+}
+
+var _ = Suite(&RunTestSuite{})
+
+func (t *RunTestSuite) TestGenScopeName(c *C) {
+	name := genClassicScopeName()
+	c.Assert(name, Matches, "snappy-classic_[0-9-]+_[0-9:]+_[a-zA-Z]+.scope")
+}

--- a/cmd/snappy/cmd_shell.go
+++ b/cmd/snappy/cmd_shell.go
@@ -52,7 +52,7 @@ func (x *cmdShell) Execute(args []string) error {
 Use "sudo snappy enable-classic" to enable it.`))
 		}
 
-		fmt.Println(i18n.G(`All background processes will be killed when you leave this shell`))
+		fmt.Println(i18n.G(`Entering classic dimension`))
 		return classic.RunShell()
 	}
 

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2015-12-02 11:46+0100\n"
+        "POT-Creation-Date: 2015-12-08 16:02+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -68,9 +68,6 @@ msgid   "Activate a package that has previously been deactivated. If the package
 msgstr  ""
 
 msgid   "Add a capability to the system"
-msgstr  ""
-
-msgid   "All background processes will be killed when you leave this shell"
 msgstr  ""
 
 msgid   "Allows rollback of a snap to a previous installed version. Without any arguments, the previous installed version is selected. It is also possible to specify the version to rollback to as a additional argument.\n"
@@ -138,6 +135,9 @@ msgid   "Enable the ubuntu classic dimension."
 msgstr  ""
 
 msgid   "Ensures system is running with latest parts"
+msgstr  ""
+
+msgid   "Entering classic dimension"
 msgstr  ""
 
 msgid   "First boot has already run"


### PR DESCRIPTION
As discussed on the sprint the classic mode will not kill all
processes that got started in the "snappy shell classic". Only
processes in the current terminal control group get killed.

We still run everything in a cgroup that is easy to identify
in order to allow the user to easily stop all processes via
"systemctl stop" though.