### PR TITLE
Bugfix/remove store icon download

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -236,13 +236,8 @@ func webify(result map[string]string, resource string) map[string]string {
 	var route *mux.Route
 	var args []string
 
-	if strings.HasPrefix(icon, dirs.SnapIconsDir) {
-		route = metaIconCmd.d.router.Get(metaIconCmd.Path)
-		args = []string{"icon", icon[len(dirs.SnapIconsDir)+1:]}
-	} else {
-		route = appIconCmd.d.router.Get(appIconCmd.Path)
-		args = []string{"name", result["name"], "origin", result["origin"]}
-	}
+	route = appIconCmd.d.router.Get(appIconCmd.Path)
+	args = []string{"name", result["name"], "origin", result["origin"]}
 
 	if route != nil {
 		url, err := route.URL(args...)
@@ -887,20 +882,7 @@ func getLogs(c *Command, r *http.Request) Response {
 	return SyncResponse(logs)
 }
 
-func metaIconGet(c *Command, r *http.Request) Response {
-	vars := muxVars(r)
-	name := vars["icon"]
-
-	path := filepath.Join(dirs.SnapIconsDir, name)
-
-	return FileResponse(path)
-}
-
-func appIconGet(c *Command, r *http.Request) Response {
-	vars := muxVars(r)
-	name := vars["name"]
-	origin := vars["origin"]
-
+func iconGet(name, origin string) Response {
 	lock, err := lockfile.Lock(dirs.SnapLockFile, true)
 	if err != nil {
 		return InternalError(err, "Unable to acquire lock")
@@ -923,6 +905,25 @@ func appIconGet(c *Command, r *http.Request) Response {
 	}
 
 	return FileResponse(path)
+}
+
+// FXIME: can we kill this? all icons are always availble via the canonical
+//        /1.0/icons/$name.$origin/icon
+func metaIconGet(c *Command, r *http.Request) Response {
+	vars := muxVars(r)
+	nameAndOrigin := vars["icon"]
+
+	name, origin := snappy.SplitOrigin(nameAndOrigin)
+
+	return iconGet(name, origin)
+}
+
+func appIconGet(c *Command, r *http.Request) Response {
+	vars := muxVars(r)
+	name := vars["name"]
+	origin := vars["origin"]
+
+	return iconGet(name, origin)
 }
 
 func getCapabilities(c *Command, r *http.Request) Response {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -51,7 +51,6 @@ const apiCompatLevel = "1"
 var api = []*Command{
 	rootCmd,
 	v1Cmd,
-	metaIconCmd,
 	appIconCmd,
 	packagesCmd,
 	packageCmd,
@@ -75,12 +74,6 @@ var (
 		Path:    "/1.0",
 		GuestOK: true,
 		GET:     v1Get,
-	}
-
-	metaIconCmd = &Command{
-		Path:   "/1.0/icons/{icon}",
-		UserOK: true,
-		GET:    metaIconGet,
 	}
 
 	appIconCmd = &Command{
@@ -899,17 +892,6 @@ func iconGet(name, origin string) Response {
 	}
 
 	return FileResponse(path)
-}
-
-// FXIME: can we kill this? all icons are always availble via the canonical
-//        /1.0/icons/$name.$origin/icon
-func metaIconGet(c *Command, r *http.Request) Response {
-	vars := muxVars(r)
-	nameAndOrigin := vars["icon"]
-
-	name, origin := snappy.SplitOrigin(nameAndOrigin)
-
-	return iconGet(name, origin)
 }
 
 func appIconGet(c *Command, r *http.Request) Response {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -230,17 +230,11 @@ func webify(result map[string]string, resource string) map[string]string {
 	if icon == "" || strings.HasPrefix(icon, "http") {
 		return result
 	}
-
 	result["icon"] = ""
 
-	var route *mux.Route
-	var args []string
-
-	route = appIconCmd.d.router.Get(appIconCmd.Path)
-	args = []string{"name", result["name"], "origin", result["origin"]}
-
+	route := appIconCmd.d.router.Get(appIconCmd.Path)
 	if route != nil {
-		url, err := route.URL(args...)
+		url, err := route.URL("name", result["name"], "origin", result["origin"])
 		if err == nil {
 			result["icon"] = url.String()
 		}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -108,6 +108,8 @@ func (s *apiSuite) mkInstalled(c *check.C, name, origin, version string, active 
 	metadir := filepath.Join(dirs.SnapAppsDir, fullname, version, "meta")
 	c.Assert(os.MkdirAll(metadir, 0755), check.IsNil)
 
+	c.Check(ioutil.WriteFile(filepath.Join(metadir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
+
 	content := fmt.Sprintf(`
 name: %s
 version: %s
@@ -148,7 +150,7 @@ func (s *apiSuite) TestPackageInfoOneIntegration(c *check.C) {
 		origin:       "bar",
 		isInstalled:  true,
 		isActive:     true,
-		icon:         filepath.Join(dirs.SnapIconsDir, "icon.png"),
+		icon:         "meta/icon.svg",
 		_type:        pkg.TypeApp,
 		downloadSize: 2,
 	}}
@@ -177,7 +179,7 @@ func (s *apiSuite) TestPackageInfoOneIntegration(c *check.C) {
 			"description":        "description",
 			"origin":             "bar",
 			"status":             "active",
-			"icon":               "/1.0/icons/icon.png",
+			"icon":               "/1.0/icons/foo.bar/icon",
 			"type":               string(pkg.TypeApp),
 			"vendor":             "",
 			"download_size":      "2",
@@ -944,12 +946,10 @@ func (s *apiSuite) TestServiceLogs(c *check.C) {
 }
 
 func (s *apiSuite) TestMetaIconGet(c *check.C) {
-	// have an “icon” on the system
-	c.Check(os.MkdirAll(dirs.SnapIconsDir, 0755), check.IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(dirs.SnapIconsDir, "yadda"), []byte("yadda icon"), 0644), check.IsNil)
+	s.mkInstalled(c, "foo", "bar", "v1", true, "icon: meta/icon.svg")
 
-	s.vars = map[string]string{"icon": "yadda"}
-	req, err := http.NewRequest("GET", "/1.0/icons/yadda", nil)
+	s.vars = map[string]string{"icon": "foo.bar"}
+	req, err := http.NewRequest("GET", "/1.0/icons/foo.bar", nil)
 	c.Assert(err, check.IsNil)
 
 	rec := httptest.NewRecorder()
@@ -963,10 +963,6 @@ func (s *apiSuite) TestMetaIconGetNoCheating(c *check.C) {
 	d := newTestDaemon()
 	// a test server
 	server := httptest.NewServer(d.router)
-
-	// write something one up from the icons
-	c.Check(os.MkdirAll(dirs.SnapIconsDir, 0755), check.IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(dirs.SnapIconsDir, "..", "yadda"), []byte("yadda cheat"), 0644), check.IsNil)
 
 	// try to get at the thing
 	req, err := http.NewRequest("GET", server.URL+"/1.0/icons/../yadda", nil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -945,36 +945,6 @@ func (s *apiSuite) TestServiceLogs(c *check.C) {
 	})
 }
 
-func (s *apiSuite) TestMetaIconGet(c *check.C) {
-	s.mkInstalled(c, "foo", "bar", "v1", true, "icon: meta/icon.svg")
-
-	s.vars = map[string]string{"icon": "foo.bar"}
-	req, err := http.NewRequest("GET", "/1.0/icons/foo.bar", nil)
-	c.Assert(err, check.IsNil)
-
-	rec := httptest.NewRecorder()
-
-	metaIconCmd.GET(metaIconCmd, req).ServeHTTP(rec, req)
-	c.Check(rec.Code, check.Equals, 200)
-	c.Check(rec.Body.String(), check.Equals, "yadda icon")
-}
-
-func (s *apiSuite) TestMetaIconGetNoCheating(c *check.C) {
-	d := newTestDaemon()
-	// a test server
-	server := httptest.NewServer(d.router)
-
-	// try to get at the thing
-	req, err := http.NewRequest("GET", server.URL+"/1.0/icons/../yadda", nil)
-	c.Assert(err, check.IsNil)
-
-	res, err := http.DefaultClient.Do(req)
-	c.Assert(err, check.IsNil)
-
-	// the response is a 4xx
-	c.Check(res.StatusCode/100, check.Equals, 4)
-}
-
 func (s *apiSuite) TestAppIconGet(c *check.C) {
 	// have an active foo.bar in the system
 	s.mkInstalled(c, "foo", "bar", "v1", true, "icon: icon.ick")

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -38,7 +38,6 @@ var (
 	SnapSeccompDir            string
 	SnapUdevRulesDir          string
 	LocaleDir                 string
-	SnapIconsDir              string
 	SnapMetaDir               string
 	SnapLockFile              string
 	SnapdSocket               string
@@ -83,7 +82,6 @@ func SetRootDir(rootdir string) {
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")
 	SnapSeccompDir = filepath.Join(rootdir, snappyDir, "seccomp", "profiles")
-	SnapIconsDir = filepath.Join(rootdir, snappyDir, "icons")
 	SnapMetaDir = filepath.Join(rootdir, snappyDir, "meta")
 	SnapLockFile = filepath.Join(rootdir, "/run/snappy.lock")
 	SnapBlobDir = filepath.Join(rootdir, snappyDir, "snaps")

--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -368,12 +368,6 @@ func PackageNameActive(name string) bool {
 	return ActiveSnapByName(name) != nil
 }
 
-// iconPath returns the would be path for the local icon
-func iconPath(s Part) string {
-	// TODO: care about extension ever being different than png
-	return filepath.Join(dirs.SnapIconsDir, fmt.Sprintf("%s_%s.png", QualifiedName(s), s.Version()))
-}
-
 // RemoteManifestPath returns the would be path for the store manifest meta data
 func RemoteManifestPath(s Part) string {
 	return filepath.Join(dirs.SnapMetaDir, fmt.Sprintf("%s_%s.manifest", QualifiedName(s), s.Version()))

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -243,10 +243,6 @@ func (s *SnapPart) Channel() string {
 
 // Icon returns the path to the icon
 func (s *SnapPart) Icon() string {
-	if helpers.FileExists(iconPath(s)) {
-		return iconPath(s)
-	}
-
 	if s.m.Icon == "" {
 		return ""
 	}
@@ -680,13 +676,6 @@ func (s *SnapPart) remove(inter interacter) (err error) {
 	if s.m.Type == pkg.TypeKernel {
 		if err := removeKernelAssets(s, inter); err != nil {
 			logger.Noticef("removing kernel assets failed with %s", err)
-		}
-	}
-
-	// don't fail if icon can't be removed
-	if helpers.FileExists(iconPath(s)) {
-		if err := os.Remove(iconPath(s)); err != nil {
-			logger.Noticef("Failed to remove store icon %s: %s", iconPath(s), err)
 		}
 	}
 

--- a/snappy/snap_remote.go
+++ b/snappy/snap_remote.go
@@ -176,34 +176,6 @@ func (s *RemoteSnapPart) Download(pbar progress.Meter) (string, error) {
 	return w.Name(), w.Sync()
 }
 
-func (s *RemoteSnapPart) downloadIcon(pbar progress.Meter) error {
-	if err := os.MkdirAll(dirs.SnapIconsDir, 0755); err != nil {
-		return err
-	}
-
-	iconPath := iconPath(s)
-	if helpers.FileExists(iconPath) {
-		return nil
-	}
-
-	req, err := http.NewRequest("GET", s.Icon(), nil)
-	if err != nil {
-		return err
-	}
-
-	w, err := os.OpenFile(iconPath, os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		return err
-	}
-	defer w.Close()
-
-	if err := download("icon for package", w, req, pbar); err != nil {
-		return err
-	}
-
-	return w.Sync()
-}
-
 func (s *RemoteSnapPart) saveStoreManifest() error {
 	content, err := yaml.Marshal(s.pkg)
 	if err != nil {
@@ -225,10 +197,6 @@ func (s *RemoteSnapPart) Install(pbar progress.Meter, flags InstallFlags) (strin
 		return "", err
 	}
 	defer os.Remove(downloadedSnap)
-
-	if err := s.downloadIcon(pbar); err != nil {
-		return "", err
-	}
 
 	if err := s.saveStoreManifest(); err != nil {
 		return "", err

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -666,14 +666,10 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryInstallRemoteSnap(c *C) {
 	snapR, err := os.Open(snapPackage)
 	c.Assert(err, IsNil)
 
-	iconContent := "this is an icon"
-
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/snap":
 			io.Copy(w, snapR)
-		case "/icon":
-			fmt.Fprintf(w, iconContent)
 		default:
 			panic("unexpected url path: " + r.URL.Path)
 		}
@@ -695,14 +691,13 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryInstallRemoteSnap(c *C) {
 	c.Check(name, Equals, "foo")
 	st, err := os.Stat(snapPackage)
 	c.Assert(err, IsNil)
-	c.Assert(p.written, Equals, int(st.Size())+len(iconContent))
+	c.Assert(p.written, Equals, int(st.Size()))
 
 	installed, err := ListInstalled()
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
 
-	iconPath := filepath.Join(dirs.SnapIconsDir, "foo.bar_1.0.png")
-	c.Check(installed[0].Icon(), Equals, iconPath)
+	c.Check(installed[0].Icon(), Matches, ".*/apps/foo.bar/1.0/foo.svg")
 	c.Check(installed[0].Origin(), Equals, "bar")
 	c.Check(installed[0].Description(), Equals, "this is a description")
 


### PR DESCRIPTION
As discussed during the sprint we do not want to download icons from the store anymore. The snaps themself are always the source of the icon. This branch removes the icon downloading from the store.

A careful look at the daemon/ part by @chipaca is welcome, I'm not sure I fully understood the code. I.e. I don't know why we have /icons/[icon] instead of just /icons/[name]/icon. I assume we use that so that the json for "list" can just return "icon: my-crazy-icon-name.png" (?) but even then we could just normalize that in list and only use a single /icons/[name]/icon call. I'm probably missing something here :)