### PR TITLE
Make the progress less chatty

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -106,8 +106,6 @@ func NewTextProgress() *TextProgress {
 
 // Start starts showing progress
 func (t *TextProgress) Start(pkg string, total float64) {
-	fmt.Println("Starting download of", pkg)
-
 	// TODO go to New64 once we update the pb package.
 	t.pbar = pb.New(0)
 	t.pbar.Total = int64(total)
@@ -131,7 +129,6 @@ func (t *TextProgress) Finished() {
 	if t.pbar != nil {
 		t.pbar.Finish()
 	}
-	fmt.Println("Done")
 }
 
 // Write is there so that progress can implment a Writer and can be


### PR DESCRIPTION
As discussed during the sprint we present some unneeded information
in the progress dialog (like starting and done).

This should probably only land after "mvo5:bugfix/remove-store-icon-download" has landed, otherwise the output looks like:
```
$ sudo ./snappy install docker
Installing docker
8.36 MB / 8.36 MB [======================================] 100.00 % 1.10 MB/s 7s
21.58 KB / 21.58 KB [===================================] 100.00 % 332.24 KB/s 0
```
The second line for the icon download is confusing here.