### PR TITLE
asserts: reduce exported surface and separate AccountKey and PublicKey roles

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -53,14 +53,14 @@ func (ak *AccountKey) Fingerprint() string {
 	return ak.pubKey.Fingerprint()
 }
 
-// IsValidAt returns whether the account key is valid at 'when' time.
-func (ak *AccountKey) IsValidAt(when time.Time) bool {
+// isKeyValidAt returns whether the account key is valid at 'when' time.
+func (ak *AccountKey) isKeyValidAt(when time.Time) bool {
 	return (when.After(ak.since) || when.Equal(ak.since)) && when.Before(ak.until)
 }
 
-// Verify verifies signature is valid for content using the account key.
-func (ak *AccountKey) Verify(content []byte, sig Signature) error {
-	return ak.pubKey.Verify(content, sig)
+// publicKey returns the underlying public key of the account key.
+func (ak *AccountKey) publicKey() PublicKey {
+	return ak.pubKey
 }
 
 func checkPublicKey(ab *assertionBase, fingerprintName string) (PublicKey, error) {

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -226,14 +226,13 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAt(c *C) {
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
 
-	accKey, ok := a.(asserts.PublicKey)
-	c.Assert(ok, Equals, true)
+	accKey := a.(*asserts.AccountKey)
 
-	c.Check(accKey.IsValidAt(aks.since), Equals, true)
-	c.Check(accKey.IsValidAt(aks.since.AddDate(0, 0, -1)), Equals, false)
-	c.Check(accKey.IsValidAt(aks.since.AddDate(0, 0, 1)), Equals, true)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.since), Equals, true)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.since.AddDate(0, 0, -1)), Equals, false)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.since.AddDate(0, 0, 1)), Equals, true)
 
-	c.Check(accKey.IsValidAt(aks.until), Equals, false)
-	c.Check(accKey.IsValidAt(aks.until.AddDate(0, -1, 0)), Equals, true)
-	c.Check(accKey.IsValidAt(aks.until.AddDate(0, 1, 0)), Equals, false)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.until), Equals, false)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.until.AddDate(0, -1, 0)), Equals, true)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.until.AddDate(0, 1, 0)), Equals, false)
 }

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -166,10 +166,8 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
-		Path: rootDir,
-		TrustedKeys: map[string][]*asserts.AccountKey{
-			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
-		},
+		Path:        rootDir,
+		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
@@ -193,10 +191,8 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
-		Path: rootDir,
-		TrustedKeys: map[string][]*asserts.AccountKey{
-			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
-		},
+		Path:        rootDir,
+		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -167,8 +167,8 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path: rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {asserts.OpenPGPPublicKey(&trustedKey.PublicKey)},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	db, err := asserts.OpenDatabase(cfg)
@@ -194,8 +194,8 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path: rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {asserts.OpenPGPPublicKey(&trustedKey.PublicKey)},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	db, err := asserts.OpenDatabase(cfg)

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -190,6 +190,14 @@ func decodeSignature(signature []byte) (Signature, error) {
 	return openpgpSignature{sig}, nil
 }
 
+// PublicKey is the public part of a cryptographic private/public key pair.
+type PublicKey interface {
+	// Fingerprint returns the key fingerprint.
+	Fingerprint() string
+	// verify verifies signature is valid for content using the key.
+	verify(content []byte, sig Signature) error
+}
+
 type openpgpPubKey struct {
 	pubKey *packet.PublicKey
 	fp     string

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -191,6 +191,7 @@ func decodeSignature(signature []byte) (Signature, error) {
 type PublicKey interface {
 	// Fingerprint returns the key fingerprint.
 	Fingerprint() string
+
 	// verify verifies signature is valid for content using the key.
 	verify(content []byte, sig Signature) error
 

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -195,10 +195,6 @@ type openpgpPubKey struct {
 	fp     string
 }
 
-func (opgPubKey *openpgpPubKey) IsValidAt(time time.Time) bool {
-	return true
-}
-
 func (opgPubKey *openpgpPubKey) Fingerprint() string {
 	return opgPubKey.fp
 }

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -199,7 +199,7 @@ func (opgPubKey *openpgpPubKey) Fingerprint() string {
 	return opgPubKey.fp
 }
 
-func (opgPubKey *openpgpPubKey) Verify(content []byte, sig Signature) error {
+func (opgPubKey *openpgpPubKey) verify(content []byte, sig Signature) error {
 	return verifyContentSignature(content, sig, opgPubKey.pubKey)
 }
 

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -274,8 +274,8 @@ func (db *Database) Check(assert Assertion) error {
 	now := time.Now()
 	var lastErr error
 	for _, accKey := range accKeys {
-		if accKey.IsValidAt(now) {
-			err := accKey.Verify(content, sig)
+		if accKey.isKeyValidAt(now) {
+			err := accKey.publicKey().Verify(content, sig)
 			if err == nil {
 				// see if the assertion requires further checks
 				if checker, ok := assert.(consistencyChecker); ok {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -54,7 +54,7 @@ type DatabaseConfig struct {
 	// database backstore path
 	Path string
 	// trusted keys maps authority-ids to list of trusted keys.
-	TrustedKeys map[string][]PublicKey
+	TrustedKeys map[string][]*AccountKey
 }
 
 // Well-known errors

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -41,8 +41,6 @@ type PublicKey interface {
 	Fingerprint() string
 	// Verify verifies signature is valid for content using the key.
 	Verify(content []byte, sig Signature) error
-	// IsValidAt returns whether the public key is valid at 'when' time.
-	IsValidAt(when time.Time) bool
 }
 
 // TODO/XXX: make PublicKey minimal, only Fingerprint exported

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -35,14 +35,6 @@ import (
 	"github.com/ubuntu-core/snappy/helpers"
 )
 
-// PublicKey is a public key as used by the assertion database.
-type PublicKey interface {
-	// Fingerprint returns the key fingerprint.
-	Fingerprint() string
-	// verify verifies signature is valid for content using the key.
-	verify(content []byte, sig Signature) error
-}
-
 // TODO/XXX: make PublicKey minimal, only Fingerprint exported
 // have a few more internal only methods, to address encodeOpenpgp for example
 // then for now use AccountKey directly for TrustedKeys in DatabaseConfig

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -35,10 +35,6 @@ import (
 	"github.com/ubuntu-core/snappy/helpers"
 )
 
-// TODO/XXX: make PublicKey minimal, only Fingerprint exported
-// have a few more internal only methods, to address encodeOpenpgp for example
-// then for now use AccountKey directly for TrustedKeys in DatabaseConfig
-
 // DatabaseConfig for an assertion database.
 type DatabaseConfig struct {
 	// database backstore path

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -39,8 +39,8 @@ import (
 type DatabaseConfig struct {
 	// database backstore path
 	Path string
-	// trusted keys maps authority-ids to list of trusted keys.
-	TrustedKeys map[string][]*AccountKey
+	// trusted account keys
+	TrustedKeys []*AccountKey
 }
 
 // Well-known errors
@@ -57,8 +57,8 @@ type consistencyChecker interface {
 // Database holds assertions and can be used to sign or check
 // further assertions.
 type Database struct {
-	root string
-	cfg  DatabaseConfig
+	root        string
+	trustedKeys map[string][]*AccountKey
 }
 
 const (
@@ -81,7 +81,12 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 	if info.Mode().Perm()&0002 != 0 {
 		return nil, fmt.Errorf("assert database root unexpectedly world-writable: %v", cfg.Path)
 	}
-	return &Database{root: cfg.Path, cfg: *cfg}, nil
+	trustedKeys := make(map[string][]*AccountKey)
+	for _, accKey := range cfg.TrustedKeys {
+		authID := accKey.AccountID()
+		trustedKeys[authID] = append(trustedKeys[authID], accKey)
+	}
+	return &Database{root: cfg.Path, trustedKeys: trustedKeys}, nil
 }
 
 func (db *Database) atomicWriteEntry(data []byte, secret bool, subpath ...string) error {
@@ -214,7 +219,7 @@ func (db *Database) findAccountKeys(authorityID, fingerprintSuffix string) ([]*A
 		return nil, fmt.Errorf("key id/fingerprint suffix must be at least 64 bits")
 	}
 	res := make([]*AccountKey, 0, 1)
-	cands := db.cfg.TrustedKeys[authorityID]
+	cands := db.trustedKeys[authorityID]
 	for _, cand := range cands {
 		if strings.HasSuffix(cand.Fingerprint(), fingerprintSuffix) {
 			res = append(res, cand)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -39,8 +39,8 @@ import (
 type PublicKey interface {
 	// Fingerprint returns the key fingerprint.
 	Fingerprint() string
-	// Verify verifies signature is valid for content using the key.
-	Verify(content []byte, sig Signature) error
+	// verify verifies signature is valid for content using the key.
+	verify(content []byte, sig Signature) error
 }
 
 // TODO/XXX: make PublicKey minimal, only Fingerprint exported
@@ -273,7 +273,7 @@ func (db *Database) Check(assert Assertion) error {
 	var lastErr error
 	for _, accKey := range accKeys {
 		if accKey.isKeyValidAt(now) {
-			err := accKey.publicKey().Verify(content, sig)
+			err := accKey.publicKey().verify(content, sig)
 			if err == nil {
 				// see if the assertion requires further checks
 				if checker, ok := assert.(consistencyChecker); ok {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -180,10 +180,8 @@ func (chks *checkSuite) TestCheckForgery(c *C) {
 	trustedKey := testPrivKey0
 
 	cfg := &asserts.DatabaseConfig{
-		Path: chks.rootDir,
-		TrustedKeys: map[string][]*asserts.AccountKey{
-			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
-		},
+		Path:        chks.rootDir,
+		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
@@ -233,10 +231,8 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	trustedKey := testPrivKey0
 	cfg := &asserts.DatabaseConfig{
-		Path: rootDir,
-		TrustedKeys: map[string][]*asserts.AccountKey{
-			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
-		},
+		Path:        rootDir,
+		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -177,12 +177,12 @@ func (chks *checkSuite) TestCheckNoPubKey(c *C) {
 }
 
 func (chks *checkSuite) TestCheckForgery(c *C) {
-	dbTrustedKey := asserts.OpenPGPPublicKey(&testPrivKey0.PublicKey)
+	trustedKey := testPrivKey0
 
 	cfg := &asserts.DatabaseConfig{
 		Path: chks.rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {dbTrustedKey},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	db, err := asserts.OpenDatabase(cfg)
@@ -231,11 +231,11 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
-	dbTrustedKey := asserts.OpenPGPPublicKey(&testPrivKey0.PublicKey)
+	trustedKey := testPrivKey0
 	cfg := &asserts.DatabaseConfig{
 		Path: rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {dbTrustedKey},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	db, err := asserts.OpenDatabase(cfg)

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -19,6 +19,12 @@
 
 package asserts
 
+import (
+	"time"
+
+	"golang.org/x/crypto/openpgp/packet"
+)
+
 // expose test-only things here
 
 // generatePrivateKey exposed for tests
@@ -29,6 +35,20 @@ var BuildAndSignInTest = buildAndSign
 
 // decodePrivateKey exposed for tests
 var DecodePrivateKeyInTest = decodePrivateKey
+
+func BuildBootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
+	return &AccountKey{
+		assertionBase: assertionBase{
+			headers: map[string]string{
+				"authority-id": authorityID,
+				"account-id":   authorityID,
+			},
+		},
+		since:  time.Time{},
+		until:  time.Time{}.UTC().AddDate(9999, 0, 0),
+		pubKey: OpenPGPPublicKey(pubKey),
+	}
+}
 
 // define dummy assertion types to use in the tests
 

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -66,3 +66,8 @@ func init() {
 		primaryKey: []string{"primary-key"},
 	}
 }
+
+// AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests
+func AccountKeyIsKeyValidAt(ak *AccountKey, when time.Time) bool {
+	return ak.isKeyValidAt(when)
+}

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -59,7 +59,7 @@ func (snapdcl *SnapDeclaration) Timestamp() time.Time {
 
 // implement further consistency checks
 func (snapdcl *SnapDeclaration) checkConsistency(db *Database, acck *AccountKey) error {
-	if !acck.IsValidAt(snapdcl.timestamp) {
+	if !acck.isKeyValidAt(snapdcl.timestamp) {
 		return fmt.Errorf("snap-declaration timestamp outside of signing key validity")
 	}
 	return nil

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -58,8 +58,8 @@ func (snapdcl *SnapDeclaration) Timestamp() time.Time {
 }
 
 // implement further consistency checks
-func (snapdcl *SnapDeclaration) checkConsistency(db *Database, pubk PublicKey) error {
-	if !pubk.IsValidAt(snapdcl.timestamp) {
+func (snapdcl *SnapDeclaration) checkConsistency(db *Database, acck *AccountKey) error {
+	if !acck.IsValidAt(snapdcl.timestamp) {
 		return fmt.Errorf("snap-declaration timestamp outside of signing key validity")
 	}
 	return nil

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -124,8 +124,8 @@ func makeSignAndCheckDbWithAccountKey(c *C) (accFingerp string, accSignDB, check
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path: rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {asserts.OpenPGPPublicKey(&trustedKey.PublicKey)},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	checkDB, err = asserts.OpenDatabase(cfg)

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -123,10 +123,8 @@ func makeSignAndCheckDbWithAccountKey(c *C) (accFingerp string, accSignDB, check
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
-		Path: rootDir,
-		TrustedKeys: map[string][]*asserts.AccountKey{
-			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
-		},
+		Path:        rootDir,
+		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	checkDB, err = asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/sysdb.go
+++ b/asserts/sysdb.go
@@ -38,20 +38,16 @@ func OpenSysDatabase() (*Database, error) {
 	}
 
 	var trustedKey *AccountKey
-	var authorityID string
 	switch accKey := trustedAccKey.(type) {
 	case *AccountKey:
-		authorityID = accKey.AccountID()
 		trustedKey = accKey
 	default:
 		return nil, fmt.Errorf("trusted account key is %T, not an account-key", trustedAccKey)
 	}
 
 	cfg := &DatabaseConfig{
-		Path: dirs.SnapAssertsDBDir,
-		TrustedKeys: map[string][]*AccountKey{
-			authorityID: {trustedKey},
-		},
+		Path:        dirs.SnapAssertsDBDir,
+		TrustedKeys: []*AccountKey{trustedKey},
 	}
 
 	return OpenDatabase(cfg)

--- a/asserts/sysdb.go
+++ b/asserts/sysdb.go
@@ -37,7 +37,7 @@ func OpenSysDatabase() (*Database, error) {
 		return nil, fmt.Errorf("failed to decode trusted account key: %v", err)
 	}
 
-	var trustedKey PublicKey
+	var trustedKey *AccountKey
 	var authorityID string
 	switch accKey := trustedAccKey.(type) {
 	case *AccountKey:
@@ -49,7 +49,7 @@ func OpenSysDatabase() (*Database, error) {
 
 	cfg := &DatabaseConfig{
 		Path: dirs.SnapAssertsDBDir,
-		TrustedKeys: map[string][]PublicKey{
+		TrustedKeys: map[string][]*AccountKey{
 			authorityID: {trustedKey},
 		},
 	}


### PR DESCRIPTION
* for now base database.go verification work on concrete AccountKeys, can re-introduce later an internal interface if/when we need to deal with more carriers of public keys and their metadata,
* that enables to reduce the exported surface of AccountKey, its role and details wrt verification are internal 
* cut down PublicKey exported surface to just be Fingerprint()
* PublicKey verify() is now internal
* move PublicKey with PrivateKey and Signature in crypto.go
* cleanup the way we encode keys in crypto.go
