### PR TITLE
Reverted the change that puts common test commands in the init.

### DIFF
--- a/integration-tests/tests/base_test.go
+++ b/integration-tests/tests/base_test.go
@@ -25,26 +25,9 @@ import (
 	"os"
 	"testing"
 
-	"gopkg.in/check.v1"
-
-	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
-	"github.com/ubuntu-core/snappy/integration-tests/testutils/partition"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/report"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/runner"
-	"github.com/ubuntu-core/snappy/integration-tests/testutils/wait"
 )
-
-func init() {
-	c := &check.C{}
-	// Workaround for bug https://bugs.launchpad.net/snappy/+bug/1498293
-	// TODO remove once the bug is fixed
-	// originally added by elopio - 2015-09-30 to the rollback test, moved
-	// here by --fgimenez - 2015-10-15
-	wait.ForFunction(c, "regular", partition.Mode)
-
-	cli.ExecCommand(c, "sudo", "systemctl", "stop", "snappy-autopilot.timer")
-	cli.ExecCommand(c, "sudo", "systemctl", "disable", "snappy-autopilot.timer")
-}
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {

--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -70,7 +70,7 @@ func (s *SnappySuite) SetUpSuite(c *check.C) {
 
 	// Workaround for bug https://bugs.launchpad.net/snappy/+bug/1498293
 	// TODO remove once the bug is fixed
-	wait.ForFunction(c, "regular", partition.Mode)	
+	wait.ForFunction(c, "regular", partition.Mode)
 
 	var err error
 	Cfg, err = config.ReadConfig(

--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/config"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/partition"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/wait"
 	"github.com/ubuntu-core/snappy/testutil"
 )
 
@@ -61,9 +62,16 @@ type SnappySuite struct {
 	testutil.BaseTest
 }
 
-// SetUpSuite disables the snappy autopilot. It will run before all the
-// integration suites.
+// SetUpSuite disables the snappy autopilot and handles the real update and
+// rollback scenarios. It will run before all the integration suites.
 func (s *SnappySuite) SetUpSuite(c *check.C) {
+	cli.ExecCommand(c, "sudo", "systemctl", "stop", "snappy-autopilot.timer")
+	cli.ExecCommand(c, "sudo", "systemctl", "disable", "snappy-autopilot.timer")
+
+	// Workaround for bug https://bugs.launchpad.net/snappy/+bug/1498293
+	// TODO remove once the bug is fixed
+	wait.ForFunction(c, "regular", partition.Mode)	
+
 	var err error
 	Cfg, err = config.ReadConfig(
 		"integration-tests/data/output/testconfig.json")


### PR DESCRIPTION
Some time ago we moved some commands from SetUpSuite to init to save a few seconds on the execution.
Now this seems like a bad idea. The certification team needs a list of the tests, and if we have steps in the init they will run when before we can list the tests.