### PR TITLE
asserts: FindMany() and double check read assertion type

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -53,14 +53,14 @@ func (ak *AccountKey) Fingerprint() string {
 	return ak.pubKey.Fingerprint()
 }
 
-// IsValidAt returns whether the account key is valid at 'when' time.
-func (ak *AccountKey) IsValidAt(when time.Time) bool {
+// isKeyValidAt returns whether the account key is valid at 'when' time.
+func (ak *AccountKey) isKeyValidAt(when time.Time) bool {
 	return (when.After(ak.since) || when.Equal(ak.since)) && when.Before(ak.until)
 }
 
-// Verify verifies signature is valid for content using the account key.
-func (ak *AccountKey) Verify(content []byte, sig Signature) error {
-	return ak.pubKey.Verify(content, sig)
+// publicKey returns the underlying public key of the account key.
+func (ak *AccountKey) publicKey() PublicKey {
+	return ak.pubKey
 }
 
 func checkPublicKey(ab *assertionBase, fingerprintName string) (PublicKey, error) {

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -226,14 +226,13 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAt(c *C) {
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
 
-	accKey, ok := a.(asserts.PublicKey)
-	c.Assert(ok, Equals, true)
+	accKey := a.(*asserts.AccountKey)
 
-	c.Check(accKey.IsValidAt(aks.since), Equals, true)
-	c.Check(accKey.IsValidAt(aks.since.AddDate(0, 0, -1)), Equals, false)
-	c.Check(accKey.IsValidAt(aks.since.AddDate(0, 0, 1)), Equals, true)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.since), Equals, true)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.since.AddDate(0, 0, -1)), Equals, false)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.since.AddDate(0, 0, 1)), Equals, true)
 
-	c.Check(accKey.IsValidAt(aks.until), Equals, false)
-	c.Check(accKey.IsValidAt(aks.until.AddDate(0, -1, 0)), Equals, true)
-	c.Check(accKey.IsValidAt(aks.until.AddDate(0, 1, 0)), Equals, false)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.until), Equals, false)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.until.AddDate(0, -1, 0)), Equals, true)
+	c.Check(asserts.AccountKeyIsKeyValidAt(accKey, aks.until.AddDate(0, 1, 0)), Equals, false)
 }

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -167,8 +167,8 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path: rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {asserts.OpenPGPPublicKey(&trustedKey.PublicKey)},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	db, err := asserts.OpenDatabase(cfg)
@@ -194,8 +194,8 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path: rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {asserts.OpenPGPPublicKey(&trustedKey.PublicKey)},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	db, err := asserts.OpenDatabase(cfg)

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -190,6 +190,14 @@ func decodeSignature(signature []byte) (Signature, error) {
 	return openpgpSignature{sig}, nil
 }
 
+// PublicKey is the public part of a cryptographic private/public key pair.
+type PublicKey interface {
+	// Fingerprint returns the key fingerprint.
+	Fingerprint() string
+	// verify verifies signature is valid for content using the key.
+	verify(content []byte, sig Signature) error
+}
+
 type openpgpPubKey struct {
 	pubKey *packet.PublicKey
 	fp     string

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -195,10 +195,6 @@ type openpgpPubKey struct {
 	fp     string
 }
 
-func (opgPubKey *openpgpPubKey) IsValidAt(time time.Time) bool {
-	return true
-}
-
 func (opgPubKey *openpgpPubKey) Fingerprint() string {
 	return opgPubKey.fp
 }

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -199,7 +199,7 @@ func (opgPubKey *openpgpPubKey) Fingerprint() string {
 	return opgPubKey.fp
 }
 
-func (opgPubKey *openpgpPubKey) Verify(content []byte, sig Signature) error {
+func (opgPubKey *openpgpPubKey) verify(content []byte, sig Signature) error {
 	return verifyContentSignature(content, sig, opgPubKey.pubKey)
 }
 

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -274,8 +274,8 @@ func (db *Database) Check(assert Assertion) error {
 	now := time.Now()
 	var lastErr error
 	for _, accKey := range accKeys {
-		if accKey.IsValidAt(now) {
-			err := accKey.Verify(content, sig)
+		if accKey.isKeyValidAt(now) {
+			err := accKey.publicKey().Verify(content, sig)
 			if err == nil {
 				// see if the assertion requires further checks
 				if checker, ok := assert.(consistencyChecker); ok {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -54,7 +54,7 @@ type DatabaseConfig struct {
 	// database backstore path
 	Path string
 	// trusted keys maps authority-ids to list of trusted keys.
-	TrustedKeys map[string][]PublicKey
+	TrustedKeys map[string][]*AccountKey
 }
 
 // Well-known errors

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -41,8 +41,6 @@ type PublicKey interface {
 	Fingerprint() string
 	// Verify verifies signature is valid for content using the key.
 	Verify(content []byte, sig Signature) error
-	// IsValidAt returns whether the public key is valid at 'when' time.
-	IsValidAt(when time.Time) bool
 }
 
 // TODO/XXX: make PublicKey minimal, only Fingerprint exported

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -35,14 +35,6 @@ import (
 	"github.com/ubuntu-core/snappy/helpers"
 )
 
-// PublicKey is a public key as used by the assertion database.
-type PublicKey interface {
-	// Fingerprint returns the key fingerprint.
-	Fingerprint() string
-	// verify verifies signature is valid for content using the key.
-	verify(content []byte, sig Signature) error
-}
-
 // TODO/XXX: make PublicKey minimal, only Fingerprint exported
 // have a few more internal only methods, to address encodeOpenpgp for example
 // then for now use AccountKey directly for TrustedKeys in DatabaseConfig

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -332,7 +332,7 @@ func (db *Database) Add(assert Assertion) error {
 	return nil
 }
 
-func (db *Database) checkHit(assertionType AssertionType, headers map[string]string, primaryPath string) (Assertion, error) {
+func (db *Database) confirmSearchHit(assertionType AssertionType, headers map[string]string, primaryPath string) (Assertion, error) {
 	assert, err := db.readAssertion(assertionType, primaryPath)
 	if err != nil {
 		return nil, err
@@ -364,7 +364,7 @@ func (db *Database) Find(assertionType AssertionType, headers map[string]string)
 		primaryKey[i] = url.QueryEscape(keyVal)
 	}
 	primaryPath := filepath.Join(primaryKey...)
-	return db.checkHit(assertionType, headers, primaryPath)
+	return db.confirmSearchHit(assertionType, headers, primaryPath)
 }
 
 // FindMany finds assertions based on arbitrary headers.
@@ -387,7 +387,7 @@ func (db *Database) FindMany(assertionType AssertionType, headers map[string]str
 
 	assertTypeTop := filepath.Join(db.root, assertionsRoot, string(assertionType))
 	foundCb := func(primaryPath string) error {
-		a, err := db.checkHit(assertionType, headers, primaryPath)
+		a, err := db.confirmSearchHit(assertionType, headers, primaryPath)
 		if err == ErrNotFound {
 			return nil
 		}
@@ -399,7 +399,7 @@ func (db *Database) FindMany(assertionType AssertionType, headers map[string]str
 	}
 	err = findWildcard(assertTypeTop, primaryKey, foundCb)
 	if err != nil {
-		return nil, fmt.Errorf("broken assertion storage, scanning for %s: %v", assertionType, err)
+		return nil, fmt.Errorf("broken assertion storage, searching for %s: %v", assertionType, err)
 	}
 
 	if len(res) == 0 {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -39,8 +39,8 @@ import (
 type PublicKey interface {
 	// Fingerprint returns the key fingerprint.
 	Fingerprint() string
-	// Verify verifies signature is valid for content using the key.
-	Verify(content []byte, sig Signature) error
+	// verify verifies signature is valid for content using the key.
+	verify(content []byte, sig Signature) error
 }
 
 // TODO/XXX: make PublicKey minimal, only Fingerprint exported
@@ -273,7 +273,7 @@ func (db *Database) Check(assert Assertion) error {
 	var lastErr error
 	for _, accKey := range accKeys {
 		if accKey.isKeyValidAt(now) {
-			err := accKey.publicKey().Verify(content, sig)
+			err := accKey.publicKey().verify(content, sig)
 			if err == nil {
 				// see if the assertion requires further checks
 				if checker, ok := assert.(consistencyChecker); ok {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -265,6 +265,54 @@ func (safs *signAddFindSuite) TestSignEmptyFingerprint(c *C) {
 	c.Check(a1, IsNil)
 }
 
+func (safs *signAddFindSuite) TestSignMissingAuthorityId(c *C) {
+	headers := map[string]string{
+		"primary-key": "a",
+	}
+	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingFingerprint)
+	c.Assert(err, ErrorMatches, `"authority-id" header is mandatory`)
+	c.Check(a1, IsNil)
+}
+
+func (safs *signAddFindSuite) TestSignMissingPrimaryKey(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+	}
+	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingFingerprint)
+	c.Assert(err, ErrorMatches, `"primary-key" header is mandatory`)
+	c.Check(a1, IsNil)
+}
+
+func (safs *signAddFindSuite) TestSignNoPrivateKey(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "a",
+	}
+	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, "abcd")
+	c.Assert(err, ErrorMatches, "no matching key pair found")
+	c.Check(a1, IsNil)
+}
+
+func (safs *signAddFindSuite) TestSignUnknowType(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+	}
+	a1, err := safs.signingDB.Sign(asserts.AssertionType("xyz"), headers, nil, safs.signingFingerprint)
+	c.Assert(err, ErrorMatches, `unknown assertion type: xyz`)
+	c.Check(a1, IsNil)
+}
+
+func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "a",
+		"revision":     "zzz",
+	}
+	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingFingerprint)
+	c.Assert(err, ErrorMatches, `"revision" header is not an integer: zzz`)
+	c.Check(a1, IsNil)
+}
+
 func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -177,12 +177,12 @@ func (chks *checkSuite) TestCheckNoPubKey(c *C) {
 }
 
 func (chks *checkSuite) TestCheckForgery(c *C) {
-	dbTrustedKey := asserts.OpenPGPPublicKey(&testPrivKey0.PublicKey)
+	trustedKey := testPrivKey0
 
 	cfg := &asserts.DatabaseConfig{
 		Path: chks.rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {dbTrustedKey},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	db, err := asserts.OpenDatabase(cfg)
@@ -231,11 +231,11 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
-	dbTrustedKey := asserts.OpenPGPPublicKey(&testPrivKey0.PublicKey)
+	trustedKey := testPrivKey0
 	cfg := &asserts.DatabaseConfig{
 		Path: rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {dbTrustedKey},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	db, err := asserts.OpenDatabase(cfg)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"syscall"
 	"testing"
 	"time"
@@ -401,4 +402,70 @@ func (safs *signAddFindSuite) TestFindPrimaryLeftOut(c *C) {
 	retrieved1, err := safs.db.Find(asserts.AssertionType("test-only"), map[string]string{})
 	c.Assert(err, ErrorMatches, "must provide primary key: primary-key")
 	c.Check(retrieved1, IsNil)
+}
+
+func (safs *signAddFindSuite) TestFindMany(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "a",
+		"other":        "other-x",
+	}
+	aa, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingFingerprint)
+	c.Assert(err, IsNil)
+	err = safs.db.Add(aa)
+	c.Assert(err, IsNil)
+
+	headers = map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "b",
+		"other":        "other-y",
+	}
+	ab, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingFingerprint)
+	c.Assert(err, IsNil)
+	err = safs.db.Add(ab)
+	c.Assert(err, IsNil)
+
+	headers = map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "c",
+		"other":        "other-x",
+	}
+	ac, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingFingerprint)
+	c.Assert(err, IsNil)
+	err = safs.db.Add(ac)
+	c.Assert(err, IsNil)
+
+	res, err := safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{
+		"other": "other-x",
+	})
+	c.Assert(err, IsNil)
+	c.Assert(res, HasLen, 2)
+	primKeys := []string{res[0].Header("primary-key"), res[1].Header("primary-key")}
+	sort.Strings(primKeys)
+	c.Check(primKeys, DeepEquals, []string{"a", "c"})
+
+	res, err = safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{
+		"other": "other-y",
+	})
+	c.Assert(err, IsNil)
+	c.Assert(res, HasLen, 1)
+	c.Check(res[0].Header("primary-key"), Equals, "b")
+
+	res, err = safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{})
+	c.Assert(err, IsNil)
+	c.Assert(res, HasLen, 3)
+
+	res, err = safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{
+		"primary-key": "b",
+		"other":       "other-y",
+	})
+	c.Assert(err, IsNil)
+	c.Assert(res, HasLen, 1)
+
+	res, err = safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{
+		"primary-key": "b",
+		"other":       "other-x",
+	})
+	c.Assert(res, HasLen, 0)
+	c.Check(err, Equals, asserts.ErrNotFound)
 }

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -147,6 +147,17 @@ func (dbs *databaseSuite) TestPublicKey(c *C) {
 	c.Assert(pubKey.Fingerprint, DeepEquals, testPrivKey1.PublicKey.Fingerprint)
 }
 
+func (dbs *databaseSuite) TestPublicKeyAmbiguous(c *C) {
+	_, err := dbs.db.ImportKey("account0", asserts.OpenPGPPrivateKey(testPrivKey1))
+	c.Assert(err, IsNil)
+	_, err = dbs.db.ImportKey("account0", asserts.OpenPGPPrivateKey(testPrivKey2))
+	c.Assert(err, IsNil)
+
+	pubk, err := dbs.db.PublicKey("account0", "")
+	c.Assert(err, ErrorMatches, `ambiguous search, more than one key pair found:.*`)
+	c.Check(pubk, IsNil)
+}
+
 type checkSuite struct {
 	rootDir string
 	a       asserts.Assertion

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -313,6 +313,17 @@ func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
 	c.Check(a1, IsNil)
 }
 
+func (safs *signAddFindSuite) TestSignBuilderError(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "a",
+		"count":        "zzz",
+	}
+	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingFingerprint)
+	c.Assert(err, ErrorMatches, `cannot build assertion test-only: "count" header is not an integer: zzz`)
+	c.Check(a1, IsNil)
+}
+
 func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -57,6 +57,10 @@ type TestOnly struct {
 }
 
 func buildTestOnly(assert assertionBase) (Assertion, error) {
+	// for testing error cases
+	if _, err := checkInteger(assert.headers, "count", 0); err != nil {
+		return nil, err
+	}
 	return &TestOnly{assert}, nil
 }
 

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -19,6 +19,12 @@
 
 package asserts
 
+import (
+	"time"
+
+	"golang.org/x/crypto/openpgp/packet"
+)
+
 // expose test-only things here
 
 // generatePrivateKey exposed for tests
@@ -29,6 +35,20 @@ var BuildAndSignInTest = buildAndSign
 
 // decodePrivateKey exposed for tests
 var DecodePrivateKeyInTest = decodePrivateKey
+
+func BuildBootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
+	return &AccountKey{
+		assertionBase: assertionBase{
+			headers: map[string]string{
+				"authority-id": authorityID,
+				"account-id":   authorityID,
+			},
+		},
+		since:  time.Time{},
+		until:  time.Time{}.UTC().AddDate(9999, 0, 0),
+		pubKey: OpenPGPPublicKey(pubKey),
+	}
+}
 
 // define dummy assertion types to use in the tests
 

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -66,3 +66,8 @@ func init() {
 		primaryKey: []string{"primary-key"},
 	}
 }
+
+// AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests
+func AccountKeyIsKeyValidAt(ak *AccountKey, when time.Time) bool {
+	return ak.isKeyValidAt(when)
+}

--- a/asserts/privkeys_for_test.go
+++ b/asserts/privkeys_for_test.go
@@ -31,6 +31,7 @@ import (
 var (
 	testPrivKey0 = genTestPrivKey()
 	testPrivKey1 = genTestPrivKey()
+	testPrivKey2 = genTestPrivKey()
 )
 
 func genTestPrivKey() *packet.PrivateKey {

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -59,7 +59,7 @@ func (snapdcl *SnapDeclaration) Timestamp() time.Time {
 
 // implement further consistency checks
 func (snapdcl *SnapDeclaration) checkConsistency(db *Database, acck *AccountKey) error {
-	if !acck.IsValidAt(snapdcl.timestamp) {
+	if !acck.isKeyValidAt(snapdcl.timestamp) {
 		return fmt.Errorf("snap-declaration timestamp outside of signing key validity")
 	}
 	return nil

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -58,8 +58,8 @@ func (snapdcl *SnapDeclaration) Timestamp() time.Time {
 }
 
 // implement further consistency checks
-func (snapdcl *SnapDeclaration) checkConsistency(db *Database, pubk PublicKey) error {
-	if !pubk.IsValidAt(snapdcl.timestamp) {
+func (snapdcl *SnapDeclaration) checkConsistency(db *Database, acck *AccountKey) error {
+	if !acck.IsValidAt(snapdcl.timestamp) {
 		return fmt.Errorf("snap-declaration timestamp outside of signing key validity")
 	}
 	return nil

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -124,8 +124,8 @@ func makeSignAndCheckDbWithAccountKey(c *C) (accFingerp string, accSignDB, check
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path: rootDir,
-		TrustedKeys: map[string][]asserts.PublicKey{
-			"canonical": {asserts.OpenPGPPublicKey(&trustedKey.PublicKey)},
+		TrustedKeys: map[string][]*asserts.AccountKey{
+			"canonical": {asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 		},
 	}
 	checkDB, err = asserts.OpenDatabase(cfg)

--- a/asserts/sysdb.go
+++ b/asserts/sysdb.go
@@ -37,7 +37,7 @@ func OpenSysDatabase() (*Database, error) {
 		return nil, fmt.Errorf("failed to decode trusted account key: %v", err)
 	}
 
-	var trustedKey PublicKey
+	var trustedKey *AccountKey
 	var authorityID string
 	switch accKey := trustedAccKey.(type) {
 	case *AccountKey:
@@ -49,7 +49,7 @@ func OpenSysDatabase() (*Database, error) {
 
 	cfg := &DatabaseConfig{
 		Path: dirs.SnapAssertsDBDir,
-		TrustedKeys: map[string][]PublicKey{
+		TrustedKeys: map[string][]*AccountKey{
 			authorityID: {trustedKey},
 		},
 	}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+ubuntu-snappy (1.7.2ubuntu1) xenial; urgency=medium
+
+  * New upstream release:
+    - bin-path integration
+    - assertions/capability work
+    - fix squashfs based snap building
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Fri, 04 Dec 2015 08:46:35 +0100
+
 ubuntu-snappy (1.7.1ubuntu1) xenial; urgency=medium
 
   * New upstream release:


### PR DESCRIPTION
* implement db.FindMany()
* make sure db.readAssertion guarantees the returned assertion type, by double checking and using the construction of Decode()

on top of #243 