### PR TITLE
Hotfix/15.04 systemd enable

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -166,8 +166,8 @@ func (s *systemd) Enable(serviceName string) error {
 		return nil
 	}
 
-	// important, do nt use the s.rootDir here as this is the
-	// real name (oldname)
+	// Do not use s.rootDir here. The link must point to the
+	// real (internal) path.
 	serviceFilename := filepath.Join(snapServicesDir, serviceName)
 	return os.Symlink(serviceFilename, enableSymlink)
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -161,13 +161,15 @@ func (*systemd) DaemonReload() error {
 func (s *systemd) Enable(serviceName string) error {
 	enableSymlink := filepath.Join(s.rootDir, snapServicesDir, servicesSystemdTarget+".wants", serviceName)
 
-	serviceFilename := filepath.Join(s.rootDir, snapServicesDir, serviceName)
 	// already enabled
 	if _, err := os.Lstat(enableSymlink); err == nil {
 		return nil
 	}
 
-	return os.Symlink(serviceFilename[len(s.rootDir):], enableSymlink)
+	// important, do nt use the s.rootDir here as this is the
+	// real name (oldname)
+	serviceFilename := filepath.Join(snapServicesDir, serviceName)
+	return os.Symlink(serviceFilename, enableSymlink)
 }
 
 // Disable the given service


### PR DESCRIPTION
This fixes the symlink creation of "systemd.Enable()" to point to the right target file (instead of to etc/... without the leading "/").