### PR TITLE
Emulate tar behavior when unpacking symlinks

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -143,6 +143,12 @@ func UnpackTar(r io.Reader, targetDir string, fn UnpackTarTransformFunc) error {
 				return nil
 			}
 		case IsSymlink(mode):
+			// tar is also doing this!
+			if FileExists(path) {
+				if err := os.Remove(path); err != nil {
+					return err
+				}
+			}
 			if err := os.Symlink(hdr.Linkname, path); err != nil {
 				return err
 			}


### PR DESCRIPTION
This fixes an error that when unpacking over an already existing
directory an error like:
"symlink ld-2.21.so /apps/network-manager/0.5/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2: file exists"
happend as reported by Ricmm