### PR TITLE
deactivate does not fail on simple app trouble

### DIFF
--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -1058,7 +1058,7 @@ func (s *SnapPart) deactivate(inhibitHooks bool, inter interacter) error {
 
 	// remove generated services, binaries, clickHooks, security policy
 	// not bailing on error because the system might be wonky
-	if s.m.removePackageBinaries(s.basedir); err != nil {
+	if err := s.m.removePackageBinaries(s.basedir); err != nil {
 		inter.Notify(fmt.Sprintf("deactivate continuing despite being unable to remove binary: %v", err))
 	}
 

--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -1057,17 +1057,10 @@ func (s *SnapPart) deactivate(inhibitHooks bool, inter interacter) error {
 	}
 
 	// remove generated services, binaries, clickHooks, security policy
-	if err := s.m.removePackageBinaries(s.basedir); err != nil {
-		return err
-	}
-
-	if err := s.m.removePackageServices(s.basedir, inter); err != nil {
-		return err
-	}
-
-	if err := s.m.removeSecurityPolicy(s.basedir); err != nil {
-		return err
-	}
+	// not bailing on error because the system might be wonky
+	s.m.removePackageBinaries(s.basedir)
+	s.m.removePackageServices(s.basedir, inter)
+	s.m.removeSecurityPolicy(s.basedir)
 
 	if s.Type() == pkg.TypeFramework {
 		if err := policy.Remove(s.Name(), s.basedir, dirs.GlobalRootDir); err != nil {


### PR DESCRIPTION
This makes deactivate not fail if it can't remove binaries, can't stop services, or can't remove those things' security policies.

It can still fail if it fails to remove the click hooks. Maybe we should also make that one not fail.