### PR TITLE
switch everything not in build to use helpers.AtomicWriteFile

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -301,7 +301,7 @@ func NewSideloadVersion() string {
 type AtomicWriteFlags uint
 
 const (
-	// AtomicWriteFollow makes AtomicWriteFile follows symlinks
+	// AtomicWriteFollow makes AtomicWriteFile follow symlinks
 	AtomicWriteFollow AtomicWriteFlags = 1 << iota
 )
 

--- a/pkg/clickdeb/deb.go
+++ b/pkg/clickdeb/deb.go
@@ -221,7 +221,7 @@ func (d *ClickDeb) ExtractHashes(dir string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(hashesFile, hashesData, 0644)
+	return helpers.AtomicWriteFile(hashesFile, hashesData, 0644, 0)
 }
 
 // Unpack unpacks the data.tar.{gz,bz2,xz} into the given target directory

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -518,7 +518,7 @@ func (m *packageYaml) addPackageServices(baseDir string, inhibitHooks bool, inte
 		}
 		serviceFilename := generateServiceFileName(m, service)
 		os.MkdirAll(filepath.Dir(serviceFilename), 0755)
-		if err := ioutil.WriteFile(serviceFilename, []byte(content), 0644); err != nil {
+		if err := helpers.AtomicWriteFile(serviceFilename, []byte(content), 0644, 0); err != nil {
 			return err
 		}
 		// Generate systemd socket file if needed
@@ -529,7 +529,7 @@ func (m *packageYaml) addPackageServices(baseDir string, inhibitHooks bool, inte
 			}
 			socketFilename := generateSocketFileName(m, service)
 			os.MkdirAll(filepath.Dir(socketFilename), 0755)
-			if err := ioutil.WriteFile(socketFilename, []byte(content), 0644); err != nil {
+			if err := helpers.AtomicWriteFile(socketFilename, []byte(content), 0644, 0); err != nil {
 				return err
 			}
 		}
@@ -542,7 +542,7 @@ func (m *packageYaml) addPackageServices(baseDir string, inhibitHooks bool, inte
 			}
 			policyFilename := generateBusPolicyFileName(m, service)
 			os.MkdirAll(filepath.Dir(policyFilename), 0755)
-			if err := ioutil.WriteFile(policyFilename, []byte(content), 0644); err != nil {
+			if err := helpers.AtomicWriteFile(policyFilename, []byte(content), 0644, 0); err != nil {
 				return err
 			}
 		}
@@ -650,7 +650,7 @@ func (m *packageYaml) addPackageBinaries(baseDir string) error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(generateBinaryName(m, binary), []byte(content), 0755); err != nil {
+		if err := helpers.AtomicWriteFile(generateBinaryName(m, binary), []byte(content), 0755, 0); err != nil {
 			return err
 		}
 	}
@@ -677,7 +677,7 @@ func (m *packageYaml) addOneSecurityPolicy(name string, sd SecurityDefinitions, 
 	}
 
 	fn := filepath.Join(dirs.SnapSeccompDir, profileName)
-	if err := ioutil.WriteFile(fn, content, 0644); err != nil {
+	if err := helpers.AtomicWriteFile(fn, content, 0644, 0); err != nil {
 		return err
 	}
 

--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -22,7 +22,6 @@ package snappy
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -139,7 +138,7 @@ func stampFirstBoot() error {
 		}
 	}
 
-	return ioutil.WriteFile(stampFile, []byte{}, 0644)
+	return helpers.AtomicWriteFile(stampFile, []byte{}, 0644, 0)
 }
 
 var globs = []string{"/sys/class/net/eth*", "/sys/class/net/en*"}

--- a/snappy/oem.go
+++ b/snappy/oem.go
@@ -25,13 +25,13 @@ package snappy
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/pkg"
 )
@@ -222,7 +222,7 @@ func writeOemHardwareUdevRules(m *packageYaml) error {
 			return err
 		}
 		outfile := filepath.Join(dirs.SnapUdevRulesDir, fmt.Sprintf("80-snappy_%s_%s.rules", m.Name, h.PartID))
-		if err := ioutil.WriteFile(outfile, []byte(rulesContent), 0644); err != nil {
+		if err := helpers.AtomicWriteFile(outfile, []byte(rulesContent), 0644, 0); err != nil {
 			return err
 		}
 	}
@@ -271,7 +271,7 @@ func writeApparmorAdditionalFile(m *packageYaml) error {
 
 	for _, h := range m.OEM.Hardware.Assign {
 		jsonAdditionalPath := filepath.Join(dirs.SnapAppArmorDir, fmt.Sprintf("%s.json.additional", h.PartID))
-		if err := ioutil.WriteFile(jsonAdditionalPath, []byte(apparmorAdditionalContent), 0644); err != nil {
+		if err := helpers.AtomicWriteFile(jsonAdditionalPath, []byte(apparmorAdditionalContent), 0644, 0); err != nil {
 			return err
 		}
 	}

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -31,6 +31,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/pkg"
 )
@@ -103,7 +104,7 @@ func handleApparmor(buildDir string, m *packageYaml, hookName string, s *Securit
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(buildDir, apparmorJSONFile), securityJSONContent, 0644); err != nil {
+	if err := helpers.AtomicWriteFile(filepath.Join(buildDir, apparmorJSONFile), securityJSONContent, 0644, 0); err != nil {
 		return err
 	}
 

--- a/snappy/snapp.go
+++ b/snappy/snapp.go
@@ -1616,7 +1616,7 @@ func (s *RemoteSnapPart) saveStoreManifest() error {
 	}
 
 	// don't worry about previous contents
-	return ioutil.WriteFile(RemoteManifestPath(s), content, 0644)
+	return helpers.AtomicWriteFile(RemoteManifestPath(s), content, 0644, 0)
 }
 
 // Install installs the snap


### PR DESCRIPTION
Ricardo reported an error that snappy will not rewrite /etc/systemd/system/$foo units when they are masked. Turns out that all we need to do is to cherry-pick the fix to use helpers.AtomicWriteFile consistently. 