### PR TITLE
Do not unpack the kernel/initrd on a grub system

### DIFF
--- a/snappy/kernel.go
+++ b/snappy/kernel.go
@@ -66,6 +66,14 @@ func extractKernelAssets(s *SnapPart, inter progress.Meter, flags InstallFlags) 
 		return fmt.Errorf("can not extract kernel assets from snap type %q", s.Type())
 	}
 
+	// check if we are on a "grub" system. if so, no need to unpack
+	// the kernel
+	if oem, err := getOem(); err == nil {
+		if oem.OEM.Hardware.Bootloader == "grub" {
+			return nil
+		}
+	}
+
 	// FIXME: feels wrong to use the basedir here, need something better
 	//
 	// now do the kernel specific bits

--- a/snappy/oem.go
+++ b/snappy/oem.go
@@ -39,13 +39,17 @@ import (
 // OEM represents the structure inside the package.yaml for the oem component
 // of an oem package type.
 type OEM struct {
-	Store    Store `yaml:"store,omitempty"`
-	Hardware struct {
-		Assign     []HardwareAssign `yaml:"assign,omitempty"`
-		BootAssets *BootAssets      `yaml:"boot-assets,omitempty"`
-	} `yaml:"hardware,omitempty"`
+	Store                Store    `yaml:"store,omitempty"`
+	Hardware             Hardware `yaml:"hardware,omitempty"`
 	Software             Software `yaml:"software,omitempty"`
 	SkipIfupProvisioning bool     `yaml:"skip-ifup-provisioning"`
+}
+
+// Hardware describes the hardware provided by the gadget snap
+type Hardware struct {
+	Assign     []HardwareAssign `yaml:"assign,omitempty"`
+	BootAssets *BootAssets      `yaml:"boot-assets,omitempty"`
+	Bootloader string           `yaml:"bootloader,omitempty"`
 }
 
 // Store holds information relevant to the store provided by an OEM snap


### PR DESCRIPTION
On a grub system we load the kernel and the inird.img directly
from the squashfs via the grub loop mount support. So there is
no reason to unpack the kernel assets for grub.