### PR TITLE
Use "mask/unmask" when enabling/disabling the snappy-autopilot.timer

### DIFF
--- a/coreconfig/config.go
+++ b/coreconfig/config.go
@@ -51,7 +51,7 @@ var (
 const (
 	autopilotTimer         string = "snappy-autopilot.timer"
 	autopilotTimerEnabled  string = "enabled"
-	autopilotTimerDisabled string = "disabled"
+	autopilotTimerDisabled string = "masked"
 )
 
 var (
@@ -538,9 +538,17 @@ var getAutopilot = func() (state bool, err error) {
 
 // for testing purposes
 var (
-	cmdEnableAutopilot  = []string{"enable", autopilotTimer}
-	cmdStartAutopilot   = []string{"start", autopilotTimer}
-	cmdDisableAutopilot = []string{"disable", autopilotTimer}
+	// We use systemctl mask/unmask to enable/disable
+	// the systemd units because of the way that the
+	// writable path system works.
+	cmdEnableAutopilot = []string{"unmask", autopilotTimer}
+	cmdStartAutopilot  = []string{"start", autopilotTimer}
+	// "systemctl disable" is not enough, because disable will
+	// remove the systemd unit file. however because the unit file
+	// is on the writable partition and on the base-os when its
+	// missing it will get created again. "systemctl mask" will
+	// create a symlink to /dev/null so all is fine.
+	cmdDisableAutopilot = []string{"mask", autopilotTimer}
 	cmdStopAutopilot    = []string{"stop", autopilotTimer}
 )
 

--- a/coreconfig/config_test.go
+++ b/coreconfig/config_test.go
@@ -78,7 +78,7 @@ func (cts *ConfigTestSuite) SetUpTest(c *C) {
 	os.Setenv(tzPathEnvironment, tzPath)
 
 	cmdSystemctl = "/bin/sh"
-	cmdAutopilotEnabled = []string{"-c", "echo disabled"}
+	cmdAutopilotEnabled = []string{"-c", "echo masked"}
 	cmdEnableAutopilot = []string{"-c", "/bin/true"}
 	cmdStartAutopilot = []string{"-c", "/bin/true"}
 


### PR DESCRIPTION
The snappy-autopilot.timer file is available on the system-[ab]
partition and also on the writable partition. This mean that when
running systemctl disable the symlink for the snappy-autopilot.timer
gets removed from the writable space. However on the next boot
the symlink is re-created from the writable-path logic that detects
that the OS has a file that is missing in the writable space.

By using mask/unmask this is fixed because with these commands
the files are kept on writable and they are linked to dev/null.