### PR TITLE
Ignore the download messages when checking the license.

### DIFF
--- a/integration-tests/tests/examples_test.go
+++ b/integration-tests/tests/examples_test.go
@@ -219,10 +219,8 @@ func (s *licensedExampleSuite) TestDeclineLicenseMustNotInstallSnap(c *check.C) 
 
 func (s *licensedExampleSuite) assertLicense(c *check.C, f *os.File) {
 	output := s.readUntilPrompt(c, f)
-	expected := "Installing licensed.canonical" +
-		"Starting download of licensed" +
+	expected := "(?s)Installing licensed.canonical" +
 		".*" +
-		"Done" +
 		"licensed requires that you accept the following license before continuing" +
 		"This product is meant for educational purposes only. .* No other warranty expressed or implied."
 	c.Assert(output, check.Matches, expected)


### PR DESCRIPTION
@fgimenez I finished some things earlier, so I quickly made the change and checked that it still passes.

This test was sometimes failing because the Done message was printed before the download stats. This is anyway going away in #239, so relaxing the regexp is needed anyway.