### PR TITLE
List packages via `snapd` REST API

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Package represents a Snap package
+type Package struct {
+	Description   string `json:"description"`
+	DownloadSize  int64  `json:"download_size,string"`
+	Icon          string `json:"icon"`
+	InstalledSize int64  `json:"installed_size,string"`
+	Name          string `json:"name"`
+	Origin        string `json:"origin"`
+	Status        string `json:"status"`
+	Type          string `json:"type"`
+	Version       string `json:"version"`
+}
+
+// Statuses and types a Package may have
+const (
+	StatusNotInstalled = "not installed"
+	StatusInstalled    = "installed"
+	StatusActive       = "active"
+	StatusRemoved      = "removed"
+
+	TypeApp       = "app"
+	TypeFramework = "framework"
+	TypeKernel    = "kernel"
+	TypeGadget    = "gadget"
+	TypeOS        = "os"
+)
+
+// Packages returns the list of packages the system can handle
+func (client *Client) Packages() (map[string]Package, error) {
+	const errPrefix = "cannot list packages"
+
+	var rsp response
+	if err := client.do("GET", "/1.0/packages", nil, &rsp); err != nil {
+		return nil, fmt.Errorf("%s: failed to communicate with server: %s", errPrefix, err)
+	}
+	if err := rsp.err(); err != nil {
+		return nil, err
+	}
+	if rsp.Type != "sync" {
+		return nil, fmt.Errorf("%s: expected sync response, got %q", errPrefix, rsp.Type)
+	}
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(rsp.Result, &result); err != nil {
+		return nil, fmt.Errorf("%s: failed to unmarshal response: %v", errPrefix, err)
+	}
+
+	packagesJSON := result["packages"]
+	if packagesJSON == nil {
+		return nil, fmt.Errorf("%s: response has no packages", errPrefix)
+	}
+
+	var packages map[string]Package
+	if err := json.Unmarshal(packagesJSON, &packages); err != nil {
+		return nil, fmt.Errorf("%s: failed to unmarshal packages: %v", errPrefix, err)
+	}
+
+	return packages, nil
+}

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -1,0 +1,123 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"errors"
+
+	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/client"
+)
+
+func (cs *clientSuite) TestClientPackagesCallsEndpoint(c *check.C) {
+	_, _ = cs.cli.Packages()
+	c.Check(cs.req.Method, check.Equals, "GET")
+	c.Check(cs.req.URL.Path, check.Equals, "/1.0/packages")
+}
+
+func (cs *clientSuite) TestClientPackagesHttpError(c *check.C) {
+	cs.err = errors.New("fail")
+	_, err := cs.cli.Packages()
+	c.Check(err, check.ErrorMatches, ".*server: fail")
+}
+
+func (cs *clientSuite) TestClientPackagesResponseError(c *check.C) {
+	cs.rsp = `{
+		"result": {},
+		"status": "Bad Request",
+		"status_code": 400,
+		"type": "error"
+	}`
+	_, err := cs.cli.Packages()
+	c.Check(err, check.ErrorMatches, `server error: "Bad Request"`)
+}
+
+func (cs *clientSuite) TestClientPackagesInvalidResponseType(c *check.C) {
+	cs.rsp = `{"type": "async"}`
+	_, err := cs.cli.Packages()
+	c.Check(err, check.ErrorMatches, `.*expected sync response.*`)
+}
+
+func (cs *clientSuite) TestClientPackagesInvalidResultJSON(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": "not a JSON object"
+	}`
+	_, err := cs.cli.Packages()
+	c.Check(err, check.ErrorMatches, `.*failed to unmarshal response.*`)
+}
+
+func (cs *clientSuite) TestClientPackagesResultJSONHasNoPackages(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": {}
+	}`
+	_, err := cs.cli.Packages()
+	c.Check(err, check.ErrorMatches, `.*no packages`)
+}
+
+func (cs *clientSuite) TestClientPackagesInvalidPackagesJSON(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": {
+			"packages": "not a list of packages"
+		}
+	}`
+	_, err := cs.cli.Packages()
+	c.Check(err, check.ErrorMatches, `.*failed to unmarshal packages.*`)
+}
+
+func (cs *clientSuite) TestClientPackages(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": {
+			"packages": {
+				"hello-world.canonical": {
+					"description": "hello-world",
+					"download_size": "22212",
+					"icon": "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
+					"installed_size": "-1",
+					"name": "hello-world",
+					"origin": "canonical",
+					"resource": "/1.0/packages/hello-world.canonical",
+					"status": "not installed",
+					"type": "app",
+					"version": "1.0.18"
+				}
+			}
+		}
+	}`
+	applications, err := cs.cli.Packages()
+	c.Check(err, check.IsNil)
+	c.Check(applications, check.DeepEquals, map[string]client.Package{
+		"hello-world.canonical": client.Package{
+			Description:   "hello-world",
+			DownloadSize:  22212,
+			Icon:          "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
+			InstalledSize: -1,
+			Name:          "hello-world",
+			Origin:        "canonical",
+			Status:        client.StatusNotInstalled,
+			Type:          client.TypeApp,
+			Version:       "1.0.18",
+		},
+	})
+}


### PR DESCRIPTION
This is a first step in migrating **WebDM** to the `snapd` API and simply processes the response from the `/1.0/packages` endpoint.

Maybe a bit heavy handed when it comes to tests but there's a lot of error conditions...