### PR TITLE
Change wrapper to use /root instead of $HOME if run as root.

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -32,6 +32,7 @@ var (
 	SnapBlobDir               string
 	SnapGadgetDir             string
 	SnapDataDir               string
+	SnapDataRootHomeDir       string
 	SnapDataHomeGlob          string
 	SnapAppArmorDir           string
 	SnapAppArmorAdditionalDir string
@@ -78,6 +79,7 @@ func SetRootDir(rootdir string) {
 	SnapAppsDir = filepath.Join(rootdir, "/apps")
 	SnapGadgetDir = filepath.Join(rootdir, "/gadget")
 	SnapDataDir = filepath.Join(rootdir, "/var/lib/apps")
+	SnapDataRootHomeDir = filepath.Join(rootdir, "/root/apps/")
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/apps/")
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -428,6 +428,16 @@ func GetUserSnapEnvVars(desc interface{}) []string {
 	})
 }
 
+// GetRootSnapEnvVars is GetUserSnapEnvVars where the user is root.
+// Despite this being a bit snap-specific, this is in helpers.go because it's
+// used by so many other modules, we run into circular dependencies if it's
+// somewhere more reasonable like the snappy module.
+func GetRootSnapEnvVars(desc interface{}) []string {
+	return fillSnapEnvVars(desc, []string{
+		"SNAP_APP_USER_DATA_PATH=/root{{.AppPath}}",
+	})
+}
+
 // GetDeprecatedBasicSnapEnvVars returns the app-level deprecated environment
 // variables for a snap.
 // Despite this being a bit snap-specific, this is in helpers.go because it's
@@ -450,6 +460,17 @@ func GetDeprecatedBasicSnapEnvVars(desc interface{}) []string {
 func GetDeprecatedUserSnapEnvVars(desc interface{}) []string {
 	return fillSnapEnvVars(desc, []string{
 		"SNAPP_APP_USER_DATA_PATH={{.Home}}{{.AppPath}}",
+	})
+}
+
+// GetDeprecatedRootSnapEnvVars is GetDeprecatedUserSnapEnvVars where the user
+// is root.
+// Despite this being a bit snap-specific, this is in helpers.go because it's
+// used by so many other modules, we run into circular dependencies if it's
+// somewhere more reasonable like the snappy module.
+func GetDeprecatedRootSnapEnvVars(desc interface{}) []string {
+	return fillSnapEnvVars(desc, []string{
+		"SNAPP_APP_USER_DATA_PATH=/root{{.AppPath}}",
 	})
 }
 


### PR DESCRIPTION
Currently Snappy services (which are run as root) use `/root/apps/` for `$SNAP_APP_USER_DATA_PATH`. However, Snappy binaries always use `$HOME/apps/`, which resolves to the real user's home even if run with sudo.

This PR fixes this inconsistency by having Snappy binaries behave more like Snappy services, and making sure that `/root/apps/` is handled the same way as `/home/*/apps/` when it comes to upgrades
etc.

Fixes LP: [#1466234](https://bugs.launchpad.net/snappy/+bug/1466234)