### PR TITLE
Re-add some support for /oem and the OEM snap type

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -42,6 +42,10 @@ var (
 	SnapLockFile              string
 	SnapdSocket               string
 
+	// SnapLegacyOemDir points to the legacy /oem snaps dir
+	// FIXME: remove once we moved to all-snaps
+	SnapLegacyOemDir string
+
 	SnapAssertsDBDir      string
 	SnapTrustedAccountKey string
 
@@ -103,4 +107,7 @@ func SetRootDir(rootdir string) {
 
 	LocaleDir = filepath.Join(rootdir, "/usr/share/locale")
 	ClassicDir = filepath.Join(rootdir, "/writable/classic")
+
+	// FIXME: remove once we moved to all-snaps
+	SnapLegacyOemDir = filepath.Join(rootdir, "/oem")
 }

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -36,6 +36,10 @@ const (
 	TypeGadget    Type = "gadget"
 	TypeOS        Type = "os"
 	TypeKernel    Type = "kernel"
+
+	// TypeLegacyOem is the old legacy OEM snap type
+	// FIXME: remove once we move to all-snaps
+	TypeLegacyOem Type = "oem"
 )
 
 // MarshalJSON returns *m as the JSON encoding of m.

--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -167,6 +167,9 @@ func NewMetaLocalRepository() *MetaRepository {
 	if repo := NewLocalSnapRepository(dirs.SnapGadgetDir); repo != nil {
 		m.all = append(m.all, repo)
 	}
+	if repo := NewLocalSnapRepository(dirs.SnapLegacyOemDir); repo != nil {
+		m.all = append(m.all, repo)
+	}
 
 	return m
 }

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -186,6 +186,11 @@ func (s *SnapPart) Type() pkg.Type {
 		return s.m.Type
 	}
 
+	// FIXME: remove once we move to all-snaps
+	if s.m.Type == pkg.TypeLegacyOem {
+		return pkg.TypeGadget
+	}
+
 	// if not declared its a app
 	return "app"
 }


### PR DESCRIPTION
We recently moved from OEM to gadget everywhere. This is great,
however some users will still have the oem snap installed and our
tests are currently relying on those too. This branch adds enough
support for the oem snap to support this use-case.

Note that once we move to the all-snap world fully we do not need
this branch anymore. The all-snap gadget snaps are already type
gadget and users will have to start with a fresh image anyway
here. In this light, *maybe* we should just ignore this commit
and wait until all-snap is real.