### PR TITLE
asserts: in memory keypair mgr and choosable keypair mgrs

### DIFF
--- a/asserts/database.go
+++ b/asserts/database.go
@@ -62,14 +62,14 @@ type Backstore interface {
 
 // KeypairManager is a manager and backstore for private/public key pairs.
 type KeypairManager interface {
-	// ImportKey stores the given private/public key pair for identity and
+	// Import stores the given private/public key pair for identity and
 	// returns its fingerprint
-	ImportKey(authorityID string, privKey PrivateKey) (fingerprint string, err error)
-	// Key returns the private/public key pair with the given fingeprint.
-	Key(authorityID, fingeprint string) (PrivateKey, error)
-	// FindKey finds the private/public key pair with the given fingeprint suffix.
-	// FindKey will return an error if not eactly one key pair is found.
-	FindKey(authorityID, fingerprintSuffix string) (PrivateKey, error)
+	Import(authorityID string, privKey PrivateKey) (fingerprint string, err error)
+	// Get returns the private/public key pair with the given fingeprint.
+	Get(authorityID, fingeprint string) (PrivateKey, error)
+	// Find finds the private/public key pair with the given fingeprint suffix.
+	// Find will return an error if not eactly one key pair is found.
+	Find(authorityID, fingerprintSuffix string) (PrivateKey, error)
 }
 
 // TODO: for more flexibility plugging the keypair manager make PrivatKey private encoding methods optional, and add an explicit sign method.
@@ -163,13 +163,13 @@ func (db *Database) GenerateKey(authorityID string) (fingerprint string, err err
 		return "", fmt.Errorf("failed to generate private key: %v", err)
 	}
 
-	return db.keypairMgr.ImportKey(authorityID, OpenPGPPrivateKey(privKey))
+	return db.keypairMgr.Import(authorityID, OpenPGPPrivateKey(privKey))
 }
 
 // ImportKey stores the given private/public key pair for identity and
 // returns its fingerprint
 func (db *Database) ImportKey(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
-	return db.keypairMgr.ImportKey(authorityID, privKey)
+	return db.keypairMgr.Import(authorityID, privKey)
 }
 
 var (
@@ -184,7 +184,7 @@ func (db *Database) PublicKey(authorityID string, fingerprintSuffix string) (Pub
 	if !fingerprintLike.MatchString(fingerprintSuffix) {
 		return nil, fmt.Errorf("fingerprint suffix contains unexpected chars: %q", fingerprintSuffix)
 	}
-	privKey, err := db.keypairMgr.FindKey(authorityID, fingerprintSuffix)
+	privKey, err := db.keypairMgr.Find(authorityID, fingerprintSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (db *Database) Sign(assertType AssertionType, headers map[string]string, bo
 	if err != nil {
 		return nil, err
 	}
-	privKey, err := db.keypairMgr.Key(authorityID, fingerprint)
+	privKey, err := db.keypairMgr.Get(authorityID, fingerprint)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -106,8 +106,6 @@ type Database struct {
 	trustedKeys map[string][]*AccountKey
 }
 
-const ()
-
 // OpenDatabase opens the assertion database based on the configuration.
 func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 	be := cfg.Backstore

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -103,7 +103,6 @@ type consistencyChecker interface {
 type Database struct {
 	be          Backstore
 	keypairMgr  KeypairManager
-	root        string
 	trustedKeys map[string][]*AccountKey
 }
 
@@ -116,6 +115,7 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 
 	// falling back to at least one of the filesytem backstores,
 	// ensure the main directory cfg.Path
+	// TODO: decide what should be the final defaults/fallbacks
 	if be == nil || keypairMgr == nil {
 		err := os.MkdirAll(cfg.Path, 0775)
 		if err != nil {
@@ -148,7 +148,6 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 		trustedKeys[authID] = append(trustedKeys[authID], accKey)
 	}
 	return &Database{
-		root:        cfg.Path,
 		be:          be,
 		keypairMgr:  keypairMgr,
 		trustedKeys: trustedKeys,

--- a/asserts/fskeypairmgr.go
+++ b/asserts/fskeypairmgr.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// the default simple filesystem based keypair manager/backstore
+
+const (
+	privateKeysLayoutVersion = "v0"
+	privateKeysRoot          = "private-keys-" + privateKeysLayoutVersion
+)
+
+type filesystemKeypairManager struct {
+	top string
+}
+
+func newFilesystemKeypairMananager(path string) *filesystemKeypairManager {
+	return &filesystemKeypairManager{top: filepath.Join(path, privateKeysRoot)}
+}
+
+func (fskm *filesystemKeypairManager) ImportKey(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
+	encoded, err := encodePrivateKey(privKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to store private key: %v", err)
+	}
+
+	fingerp := privKey.PublicKey().Fingerprint()
+	err = atomicWriteEntry(encoded, true, fskm.top, authorityID, fingerp)
+	if err != nil {
+		return "", fmt.Errorf("failed to store private key: %v", err)
+	}
+	return fingerp, nil
+}
+
+// findPrivateKey will return an error if not eactly one private key is found
+func (fskm *filesystemKeypairManager) findPrivateKey(authorityID, fingerprintWildcard string) (PrivateKey, error) {
+	keyPath := ""
+	foundPrivKeyCb := func(relpath string) error {
+		if keyPath != "" {
+			return fmt.Errorf("ambiguous search, more than one key pair found: %q and %q", keyPath, relpath)
+
+		}
+		keyPath = relpath
+		return nil
+	}
+	err := findWildcard(fskm.top, []string{authorityID, fingerprintWildcard}, foundPrivKeyCb)
+	if err != nil {
+		return nil, err
+	}
+	if keyPath == "" {
+		return nil, fmt.Errorf("no matching key pair found")
+	}
+	encoded, err := readEntry(fskm.top, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key pair: %v", err)
+	}
+	privKey, err := decodePrivateKey(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode key pair: %v", err)
+	}
+	return privKey, nil
+}
+
+func (fskm *filesystemKeypairManager) Key(authorityID, fingeprint string) (PrivateKey, error) {
+	return fskm.findPrivateKey(authorityID, fingeprint)
+}
+
+func (fskm *filesystemKeypairManager) FindKey(authorityID, fingerprintSuffix string) (PrivateKey, error) {
+	return fskm.findPrivateKey(authorityID, "*"+fingerprintSuffix)
+}

--- a/asserts/fskeypairmgr.go
+++ b/asserts/fskeypairmgr.go
@@ -41,7 +41,7 @@ func newFilesystemKeypairMananager(path string) *filesystemKeypairManager {
 	return &filesystemKeypairManager{top: filepath.Join(path, privateKeysRoot)}
 }
 
-func (fskm *filesystemKeypairManager) ImportKey(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
+func (fskm *filesystemKeypairManager) Import(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
 	encoded, err := encodePrivateKey(privKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to store private key: %v", err)
@@ -86,10 +86,10 @@ func (fskm *filesystemKeypairManager) findPrivateKey(authorityID, fingerprintWil
 	return privKey, nil
 }
 
-func (fskm *filesystemKeypairManager) Key(authorityID, fingeprint string) (PrivateKey, error) {
+func (fskm *filesystemKeypairManager) Get(authorityID, fingeprint string) (PrivateKey, error) {
 	return fskm.findPrivateKey(authorityID, fingeprint)
 }
 
-func (fskm *filesystemKeypairManager) FindKey(authorityID, fingerprintSuffix string) (PrivateKey, error) {
+func (fskm *filesystemKeypairManager) Find(authorityID, fingerprintSuffix string) (PrivateKey, error) {
 	return fskm.findPrivateKey(authorityID, "*"+fingerprintSuffix)
 }

--- a/asserts/fskeypairmgr.go
+++ b/asserts/fskeypairmgr.go
@@ -21,6 +21,7 @@ package asserts
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 )
 
@@ -46,7 +47,7 @@ func (fskm *filesystemKeypairManager) ImportKey(authorityID string, privKey Priv
 	}
 
 	fingerp := privKey.PublicKey().Fingerprint()
-	err = atomicWriteEntry(encoded, true, fskm.top, authorityID, fingerp)
+	err = atomicWriteEntry(encoded, true, fskm.top, url.QueryEscape(authorityID), fingerp)
 	if err != nil {
 		return "", fmt.Errorf("failed to store private key: %v", err)
 	}
@@ -64,7 +65,7 @@ func (fskm *filesystemKeypairManager) findPrivateKey(authorityID, fingerprintWil
 		keyPath = relpath
 		return nil
 	}
-	err := findWildcard(fskm.top, []string{authorityID, fingerprintWildcard}, foundPrivKeyCb)
+	err := findWildcard(fskm.top, []string{url.QueryEscape(authorityID), fingerprintWildcard}, foundPrivKeyCb)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/fskeypairmgr.go
+++ b/asserts/fskeypairmgr.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -54,6 +55,8 @@ func (fskm *filesystemKeypairManager) ImportKey(authorityID string, privKey Priv
 	return fingerp, nil
 }
 
+var errKeypairNotFound = errors.New("no matching key pair found")
+
 // findPrivateKey will return an error if not eactly one private key is found
 func (fskm *filesystemKeypairManager) findPrivateKey(authorityID, fingerprintWildcard string) (PrivateKey, error) {
 	keyPath := ""
@@ -70,7 +73,7 @@ func (fskm *filesystemKeypairManager) findPrivateKey(authorityID, fingerprintWil
 		return nil, err
 	}
 	if keyPath == "" {
-		return nil, fmt.Errorf("no matching key pair found")
+		return nil, errKeypairNotFound
 	}
 	encoded, err := readEntry(fskm.top, keyPath)
 	if err != nil {

--- a/asserts/memkeypairmgr.go
+++ b/asserts/memkeypairmgr.go
@@ -35,7 +35,7 @@ func NewMemoryKeypairMananager() KeypairManager {
 	}
 }
 
-func (mskm memoryKeypairManager) ImportKey(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
+func (mskm memoryKeypairManager) Import(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
 	fingerp := privKey.PublicKey().Fingerprint()
 	perAuthID := mskm.pairs[authorityID]
 	if perAuthID == nil {
@@ -46,9 +46,7 @@ func (mskm memoryKeypairManager) ImportKey(authorityID string, privKey PrivateKe
 	return fingerp, nil
 }
 
-// return fmt.Errorf("ambiguous search, more than one key pair found: %q and %q", keyPath, relpath)
-
-func (mskm memoryKeypairManager) Key(authorityID, fingeprint string) (PrivateKey, error) {
+func (mskm memoryKeypairManager) Get(authorityID, fingeprint string) (PrivateKey, error) {
 	privKey := mskm.pairs[authorityID][fingeprint]
 	if privKey == nil {
 		return nil, errKeypairNotFound
@@ -56,7 +54,7 @@ func (mskm memoryKeypairManager) Key(authorityID, fingeprint string) (PrivateKey
 	return privKey, nil
 }
 
-func (mskm memoryKeypairManager) FindKey(authorityID, fingerprintSuffix string) (PrivateKey, error) {
+func (mskm memoryKeypairManager) Find(authorityID, fingerprintSuffix string) (PrivateKey, error) {
 	var found PrivateKey
 	for fingerp, privKey := range mskm.pairs[authorityID] {
 		if strings.HasSuffix(fingerp, fingerprintSuffix) {

--- a/asserts/memkeypairmgr.go
+++ b/asserts/memkeypairmgr.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"fmt"
+	"strings"
+)
+
+type memoryKeypairManager struct {
+	pairs map[string]map[string]PrivateKey
+}
+
+// NewMemoryKeypairMananager creates a new key pair manager with a memory backstore.
+func NewMemoryKeypairMananager() KeypairManager {
+	return memoryKeypairManager{
+		pairs: make(map[string]map[string]PrivateKey),
+	}
+}
+
+func (mskm memoryKeypairManager) ImportKey(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
+	fingerp := privKey.PublicKey().Fingerprint()
+	perAuthID := mskm.pairs[authorityID]
+	if perAuthID == nil {
+		perAuthID = make(map[string]PrivateKey)
+		mskm.pairs[authorityID] = perAuthID
+	}
+	perAuthID[fingerp] = privKey
+	return fingerp, nil
+}
+
+// return fmt.Errorf("ambiguous search, more than one key pair found: %q and %q", keyPath, relpath)
+
+func (mskm memoryKeypairManager) Key(authorityID, fingeprint string) (PrivateKey, error) {
+	privKey := mskm.pairs[authorityID][fingeprint]
+	if privKey == nil {
+		return nil, errKeypairNotFound
+	}
+	return privKey, nil
+}
+
+func (mskm memoryKeypairManager) FindKey(authorityID, fingerprintSuffix string) (PrivateKey, error) {
+	var found PrivateKey
+	for fingerp, privKey := range mskm.pairs[authorityID] {
+		if strings.HasSuffix(fingerp, fingerprintSuffix) {
+			if found == nil {
+				found = privKey
+			} else {
+				return nil, fmt.Errorf("ambiguous search, more than one key pair found: %q and %q", found.PublicKey().Fingerprint(), privKey.PublicKey().Fingerprint())
+			}
+		}
+	}
+	if found == nil {
+		return nil, errKeypairNotFound
+	}
+	return found, nil
+}

--- a/asserts/memkeypairmgr_test.go
+++ b/asserts/memkeypairmgr_test.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/asserts"
+)
+
+type memKeypairMgtSuite struct {
+	keypairMgr asserts.KeypairManager
+}
+
+var _ = Suite(&memKeypairMgtSuite{})
+
+func (mkms *memKeypairMgtSuite) SetUpTest(c *C) {
+	mkms.keypairMgr = asserts.NewMemoryKeypairMananager()
+}
+
+func (mkms *memKeypairMgtSuite) TestImportAndKey(c *C) {
+	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
+	fingerp, err := mkms.keypairMgr.ImportKey("auth-id1", pk1)
+	c.Assert(err, IsNil)
+	c.Check(fingerp, Equals, pk1.PublicKey().Fingerprint())
+
+	got, err := mkms.keypairMgr.Key("auth-id1", fingerp)
+	c.Assert(err, IsNil)
+	c.Assert(got, NotNil)
+	c.Check(got.PublicKey().Fingerprint(), Equals, fingerp)
+}
+
+func (mkms *memKeypairMgtSuite) TestKeyNotFound(c *C) {
+	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
+	fingerp := pk1.PublicKey().Fingerprint()
+
+	got, err := mkms.keypairMgr.Key("auth-id1", fingerp)
+	c.Check(got, IsNil)
+	c.Check(err, ErrorMatches, "no matching key pair found")
+
+	_, err = mkms.keypairMgr.ImportKey("auth-id1", pk1)
+	c.Assert(err, IsNil)
+
+	got, err = mkms.keypairMgr.Key("auth-id1", "")
+	c.Check(got, IsNil)
+	c.Check(err, ErrorMatches, "no matching key pair found")
+}
+
+func (mkms *memKeypairMgtSuite) TestFindKey(c *C) {
+	fingerp, err := mkms.keypairMgr.ImportKey("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
+	c.Assert(err, IsNil)
+
+	got, err := mkms.keypairMgr.FindKey("auth-id1", fingerp[len(fingerp)-4:])
+	c.Assert(err, IsNil)
+	c.Assert(got, NotNil)
+	c.Check(got.PublicKey().Fingerprint(), Equals, fingerp)
+}
+
+func (mkms *memKeypairMgtSuite) TestFindKeyNotFound(c *C) {
+	got, err := mkms.keypairMgr.FindKey("auth-id1", "f")
+	c.Check(got, IsNil)
+	c.Check(err, ErrorMatches, "no matching key pair found")
+
+	_, err = mkms.keypairMgr.ImportKey("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
+	c.Assert(err, IsNil)
+
+	got, err = mkms.keypairMgr.FindKey("auth-id1", "z")
+	c.Check(got, IsNil)
+	c.Check(err, ErrorMatches, "no matching key pair found")
+}
+
+func (mkms *memKeypairMgtSuite) TestFindKeyAmbiguous(c *C) {
+	_, err := mkms.keypairMgr.ImportKey("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
+	c.Assert(err, IsNil)
+	_, err = mkms.keypairMgr.ImportKey("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey2))
+	c.Assert(err, IsNil)
+
+	got, err := mkms.keypairMgr.FindKey("auth-id1", "")
+	c.Check(got, IsNil)
+	c.Check(err, ErrorMatches, "ambiguous search, more than one key pair found:.*")
+}

--- a/asserts/memkeypairmgr_test.go
+++ b/asserts/memkeypairmgr_test.go
@@ -35,64 +35,64 @@ func (mkms *memKeypairMgtSuite) SetUpTest(c *C) {
 	mkms.keypairMgr = asserts.NewMemoryKeypairMananager()
 }
 
-func (mkms *memKeypairMgtSuite) TestImportAndKey(c *C) {
+func (mkms *memKeypairMgtSuite) TestImportAndGet(c *C) {
 	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
-	fingerp, err := mkms.keypairMgr.ImportKey("auth-id1", pk1)
+	fingerp, err := mkms.keypairMgr.Import("auth-id1", pk1)
 	c.Assert(err, IsNil)
 	c.Check(fingerp, Equals, pk1.PublicKey().Fingerprint())
 
-	got, err := mkms.keypairMgr.Key("auth-id1", fingerp)
+	got, err := mkms.keypairMgr.Get("auth-id1", fingerp)
 	c.Assert(err, IsNil)
 	c.Assert(got, NotNil)
 	c.Check(got.PublicKey().Fingerprint(), Equals, fingerp)
 }
 
-func (mkms *memKeypairMgtSuite) TestKeyNotFound(c *C) {
+func (mkms *memKeypairMgtSuite) TestGetNotFound(c *C) {
 	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
 	fingerp := pk1.PublicKey().Fingerprint()
 
-	got, err := mkms.keypairMgr.Key("auth-id1", fingerp)
+	got, err := mkms.keypairMgr.Get("auth-id1", fingerp)
 	c.Check(got, IsNil)
 	c.Check(err, ErrorMatches, "no matching key pair found")
 
-	_, err = mkms.keypairMgr.ImportKey("auth-id1", pk1)
+	_, err = mkms.keypairMgr.Import("auth-id1", pk1)
 	c.Assert(err, IsNil)
 
-	got, err = mkms.keypairMgr.Key("auth-id1", "")
+	got, err = mkms.keypairMgr.Get("auth-id1", "")
 	c.Check(got, IsNil)
 	c.Check(err, ErrorMatches, "no matching key pair found")
 }
 
-func (mkms *memKeypairMgtSuite) TestFindKey(c *C) {
-	fingerp, err := mkms.keypairMgr.ImportKey("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
+func (mkms *memKeypairMgtSuite) TestFind(c *C) {
+	fingerp, err := mkms.keypairMgr.Import("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 
-	got, err := mkms.keypairMgr.FindKey("auth-id1", fingerp[len(fingerp)-4:])
+	got, err := mkms.keypairMgr.Find("auth-id1", fingerp[len(fingerp)-4:])
 	c.Assert(err, IsNil)
 	c.Assert(got, NotNil)
 	c.Check(got.PublicKey().Fingerprint(), Equals, fingerp)
 }
 
-func (mkms *memKeypairMgtSuite) TestFindKeyNotFound(c *C) {
-	got, err := mkms.keypairMgr.FindKey("auth-id1", "f")
+func (mkms *memKeypairMgtSuite) TestFindNotFound(c *C) {
+	got, err := mkms.keypairMgr.Find("auth-id1", "f")
 	c.Check(got, IsNil)
 	c.Check(err, ErrorMatches, "no matching key pair found")
 
-	_, err = mkms.keypairMgr.ImportKey("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
+	_, err = mkms.keypairMgr.Import("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 
-	got, err = mkms.keypairMgr.FindKey("auth-id1", "z")
+	got, err = mkms.keypairMgr.Find("auth-id1", "z")
 	c.Check(got, IsNil)
 	c.Check(err, ErrorMatches, "no matching key pair found")
 }
 
-func (mkms *memKeypairMgtSuite) TestFindKeyAmbiguous(c *C) {
-	_, err := mkms.keypairMgr.ImportKey("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
+func (mkms *memKeypairMgtSuite) TestFindAmbiguous(c *C) {
+	_, err := mkms.keypairMgr.Import("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
-	_, err = mkms.keypairMgr.ImportKey("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey2))
+	_, err = mkms.keypairMgr.Import("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey2))
 	c.Assert(err, IsNil)
 
-	got, err := mkms.keypairMgr.FindKey("auth-id1", "")
+	got, err := mkms.keypairMgr.Find("auth-id1", "")
 	c.Check(got, IsNil)
 	c.Check(err, ErrorMatches, "ambiguous search, more than one key pair found:.*")
 }


### PR DESCRIPTION
make the key pair managers/backstore choosable/pluggable

implement an in-memory variant,

non-goal for now:  make it possible to write these outside of the package, but see TODOs for what that likely needs;

requires #263