### PR TITLE
Packages API filtering and sorting

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -22,6 +22,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // Package represents a Snap package
@@ -95,6 +96,12 @@ func (client *Client) Packages() (Packages, error) {
 // IsInstalled returns true if the Package is currently installed
 func (p Package) IsInstalled() bool {
 	return p.Status == StatusInstalled || p.Status == StatusActive
+}
+
+// HasNameContaining returns true if the Package name contains the query. The
+// comparison is case-insensitive
+func (p Package) HasNameContaining(query string) bool {
+	return strings.Contains(strings.ToLower(p.Name), strings.ToLower(query))
 }
 
 // Installed returns the installed items from Packages

--- a/client/packages.go
+++ b/client/packages.go
@@ -96,3 +96,16 @@ func (client *Client) Packages() (Packages, error) {
 func (p Package) IsInstalled() bool {
 	return p.Status == StatusInstalled || p.Status == StatusActive
 }
+
+// Installed returns the installed items from Packages
+func (p Packages) Installed() Packages {
+	var packages Packages
+
+	for _, pkg := range p {
+		if pkg.IsInstalled() {
+			packages = append(packages, pkg)
+		}
+	}
+
+	return packages
+}

--- a/client/packages.go
+++ b/client/packages.go
@@ -142,3 +142,16 @@ func (p Packages) NamesContaining(query string) Packages {
 
 	return packages
 }
+
+// TypesInSet returns items from Packages with types contained in the given list
+func (p Packages) TypesInSet(types []string) Packages {
+	var packages Packages
+
+	for _, pkg := range p {
+		if pkg.HasTypeInSet(types) {
+			packages = append(packages, pkg)
+		}
+	}
+
+	return packages
+}

--- a/client/packages.go
+++ b/client/packages.go
@@ -116,3 +116,17 @@ func (p Packages) Installed() Packages {
 
 	return packages
 }
+
+// NamesContaining returns the items from Packages with names containing the
+// query
+func (p Packages) NamesContaining(query string) Packages {
+	var packages Packages
+
+	for _, pkg := range p {
+		if pkg.HasNameContaining(query) {
+			packages = append(packages, pkg)
+		}
+	}
+
+	return packages
+}

--- a/client/packages.go
+++ b/client/packages.go
@@ -91,3 +91,8 @@ func (client *Client) Packages() (Packages, error) {
 
 	return packages, nil
 }
+
+// IsInstalled returns true if the Package is currently installed
+func (p Package) IsInstalled() bool {
+	return p.Status == StatusInstalled || p.Status == StatusActive
+}

--- a/client/packages.go
+++ b/client/packages.go
@@ -37,6 +37,9 @@ type Package struct {
 	Version       string `json:"version"`
 }
 
+// Packages are collections of Package items
+type Packages []Package
+
 // Statuses and types a Package may have
 const (
 	StatusNotInstalled = "not installed"
@@ -52,7 +55,7 @@ const (
 )
 
 // Packages returns the list of packages the system can handle
-func (client *Client) Packages() (map[string]Package, error) {
+func (client *Client) Packages() (Packages, error) {
 	const errPrefix = "cannot list packages"
 
 	var rsp response
@@ -76,9 +79,14 @@ func (client *Client) Packages() (map[string]Package, error) {
 		return nil, fmt.Errorf("%s: response has no packages", errPrefix)
 	}
 
-	var packages map[string]Package
-	if err := json.Unmarshal(packagesJSON, &packages); err != nil {
+	var packageMap map[string]Package
+	if err := json.Unmarshal(packagesJSON, &packageMap); err != nil {
 		return nil, fmt.Errorf("%s: failed to unmarshal packages: %v", errPrefix, err)
+	}
+
+	var packages Packages
+	for _, pkg := range packageMap {
+		packages = append(packages, pkg)
 	}
 
 	return packages, nil

--- a/client/packages.go
+++ b/client/packages.go
@@ -104,6 +104,18 @@ func (p Package) HasNameContaining(query string) bool {
 	return strings.Contains(strings.ToLower(p.Name), strings.ToLower(query))
 }
 
+// HasTypeInSet returns true if the Package type is a member of the given list
+// of types
+func (p Package) HasTypeInSet(types []string) bool {
+	for _, t := range types {
+		if p.Type == t {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Installed returns the installed items from Packages
 func (p Packages) Installed() Packages {
 	var packages Packages

--- a/client/packages.go
+++ b/client/packages.go
@@ -22,6 +22,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -154,4 +155,20 @@ func (p Packages) TypesInSet(types []string) Packages {
 	}
 
 	return packages
+}
+
+type byName Packages
+
+func (n byName) Len() int           { return len(n) }
+func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
+
+// SortByName returns items from Packages sorted by name
+func (p Packages) SortByName() Packages {
+	sorted := make(Packages, len(p))
+
+	copy(sorted, p)
+	sort.Sort(byName(sorted))
+
+	return sorted
 }

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -147,3 +147,19 @@ func (cs *clientSuite) TestPackagesInstalled(c *check.C) {
 	c.Assert(installed, check.HasLen, 1)
 	c.Assert(installed[0].Name, check.Equals, "installed")
 }
+
+func (cs *clientSuite) TestPackageHasNameContaining(c *check.C) {
+	pkg := client.Package{Name: "my package"}
+
+	hasNameContainingTests := map[string]bool{
+		".*":   false,
+		"":     true,
+		"pack": true,
+		"MY":   true,
+		"myp":  false,
+	}
+
+	for query, result := range hasNameContainingTests {
+		c.Assert(pkg.HasNameContaining(query), check.Equals, result)
+	}
+}

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -135,3 +135,15 @@ func (cs *clientSuite) TestPackageIsInstalled(c *check.C) {
 		c.Assert(pkg.IsInstalled(), check.Equals, result)
 	}
 }
+
+func (cs *clientSuite) TestPackagesInstalled(c *check.C) {
+	packages := client.Packages{
+		client.Package{Name: "not installed", Status: client.StatusNotInstalled},
+		client.Package{Name: "installed", Status: client.StatusInstalled},
+		client.Package{Name: "removed", Status: client.StatusRemoved},
+	}
+
+	installed := packages.Installed()
+	c.Assert(installed, check.HasLen, 1)
+	c.Assert(installed[0].Name, check.Equals, "installed")
+}

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -205,3 +205,15 @@ func (cs *clientSuite) TestPackagesTypesInSet(c *check.C) {
 	c.Assert(matching, check.HasLen, 1)
 	c.Assert(matching[0].Name, check.Equals, "framework")
 }
+
+func (cs *clientSuite) TestPackagesSortByName(c *check.C) {
+	packages := client.Packages{
+		client.Package{Name: "c"},
+		client.Package{Name: "b"},
+		client.Package{Name: "a"},
+	}
+
+	sorted := packages.SortByName()
+
+	c.Assert(sorted, check.DeepEquals, client.Packages{{Name: "a"}, {Name: "b"}, {Name: "c"}})
+}

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -121,3 +121,17 @@ func (cs *clientSuite) TestClientPackages(c *check.C) {
 		},
 	})
 }
+
+func (cs *clientSuite) TestPackageIsInstalled(c *check.C) {
+	isInstalledTests := map[string]bool{
+		"": false,
+		client.StatusNotInstalled: false,
+		client.StatusInstalled:    true,
+		client.StatusActive:       true,
+	}
+
+	for status, result := range isInstalledTests {
+		pkg := client.Package{Status: status}
+		c.Assert(pkg.IsInstalled(), check.Equals, result)
+	}
+}

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -193,3 +193,15 @@ func (cs *clientSuite) TestPackageHasTypeInSet(c *check.C) {
 		c.Assert(pkg.HasTypeInSet(tt.types), check.Equals, tt.result)
 	}
 }
+
+func (cs *clientSuite) TestPackagesTypesInSet(c *check.C) {
+	packages := client.Packages{
+		client.Package{Name: "app", Type: client.TypeApp},
+		client.Package{Name: "framework", Type: client.TypeFramework},
+		client.Package{Name: "kernel", Type: client.TypeKernel},
+	}
+
+	matching := packages.TypesInSet([]string{client.TypeFramework})
+	c.Assert(matching, check.HasLen, 1)
+	c.Assert(matching[0].Name, check.Equals, "framework")
+}

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -107,8 +107,8 @@ func (cs *clientSuite) TestClientPackages(c *check.C) {
 	}`
 	applications, err := cs.cli.Packages()
 	c.Check(err, check.IsNil)
-	c.Check(applications, check.DeepEquals, map[string]client.Package{
-		"hello-world.canonical": client.Package{
+	c.Check(applications, check.DeepEquals, client.Packages{
+		client.Package{
 			Description:   "hello-world",
 			DownloadSize:  22212,
 			Icon:          "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -163,3 +163,15 @@ func (cs *clientSuite) TestPackageHasNameContaining(c *check.C) {
 		c.Assert(pkg.HasNameContaining(query), check.Equals, result)
 	}
 }
+
+func (cs *clientSuite) TestPackagesNamesContaining(c *check.C) {
+	packages := client.Packages{
+		client.Package{Name: "first app"},
+		client.Package{Name: "second app"},
+		client.Package{Name: "third app"},
+	}
+
+	matching := packages.NamesContaining("second")
+	c.Assert(matching, check.HasLen, 1)
+	c.Assert(matching[0].Name, check.Equals, "second app")
+}

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -217,3 +217,19 @@ func (cs *clientSuite) TestPackagesSortByName(c *check.C) {
 
 	c.Assert(sorted, check.DeepEquals, client.Packages{{Name: "a"}, {Name: "b"}, {Name: "c"}})
 }
+
+func (cs *clientSuite) TestPackagesChainedFilters(c *check.C) {
+	packages := client.Packages{
+		client.Package{Name: "app 1", Type: client.TypeApp, Status: client.StatusNotInstalled},
+		client.Package{Name: "app 2", Type: client.TypeApp, Status: client.StatusInstalled},
+		client.Package{Name: "framework 1", Type: client.TypeFramework, Status: client.StatusInstalled},
+	}
+
+	chainedResult := packages.Installed().
+		TypesInSet([]string{client.TypeApp}).
+		NamesContaining("app").
+		SortByName()
+
+	c.Assert(chainedResult, check.HasLen, 1)
+	c.Assert(chainedResult[0].Name, check.Equals, "app 2")
+}

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -175,3 +175,21 @@ func (cs *clientSuite) TestPackagesNamesContaining(c *check.C) {
 	c.Assert(matching, check.HasLen, 1)
 	c.Assert(matching[0].Name, check.Equals, "second app")
 }
+
+func (cs *clientSuite) TestPackageHasTypeInSet(c *check.C) {
+	pkg := client.Package{Type: client.TypeFramework}
+
+	hasTypeInSetTest := []struct {
+		types  []string
+		result bool
+	}{
+		{[]string{}, false},
+		{[]string{client.TypeFramework}, true},
+		{[]string{client.TypeApp, client.TypeFramework}, true},
+		{[]string{client.TypeKernel}, false},
+	}
+
+	for _, tt := range hasTypeInSetTest {
+		c.Assert(pkg.HasTypeInSet(tt.types), check.Equals, tt.result)
+	}
+}


### PR DESCRIPTION
The next effort to support the evisceration of the **snappy** code from **WebDM**.

This PR allows packages to be filtered by name, type and if they are installed. They can then be sorted (by name only for the time being).

All of these new methods can be chained together similar to how an ORM would be used. For example, all installed packages with names including the word _"docker"_ would be listed in alphabetical order thus:

```go
cli := client.New()
packages, err := cli.Packages()
results := packages.Installed().NamesMatching("docker").SortByName()
```

Any feedback on this, especially from a stylistic aspect, would be more than welcome!