### PR TITLE
Retrieve icons from the `snapd` API

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -36,10 +36,12 @@ import (
 func Test(t *testing.T) { check.TestingT(t) }
 
 type clientSuite struct {
-	cli *client.Client
-	req *http.Request
-	rsp string
-	err error
+	cli    *client.Client
+	req    *http.Request
+	rsp    string
+	err    error
+	header http.Header
+	status int
 }
 
 var _ = check.Suite(&clientSuite{})
@@ -50,11 +52,17 @@ func (cs *clientSuite) SetUpTest(c *check.C) {
 	cs.err = nil
 	cs.rsp = ""
 	cs.req = nil
+	cs.header = nil
+	cs.status = http.StatusOK
 }
 
 func (cs *clientSuite) Do(req *http.Request) (*http.Response, error) {
 	cs.req = req
-	rsp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(cs.rsp))}
+	rsp := &http.Response{
+		Body:       ioutil.NopCloser(strings.NewReader(cs.rsp)),
+		Header:     cs.header,
+		StatusCode: cs.status,
+	}
 	return rsp, cs.err
 }
 

--- a/client/icons.go
+++ b/client/icons.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+)
+
+// Icon represents the icon of an installed Package
+type Icon struct {
+	Filename string
+	Content  []byte
+}
+
+// Icon returns the Icon belonging to an installed Package
+func (c *Client) Icon(pkgID string) (Icon, error) {
+	const errPrefix = "cannot retrieve icon"
+
+	response, err := c.raw("GET", fmt.Sprintf("/1.0/icons/%s/icon", pkgID), nil)
+	if err != nil {
+		return Icon{}, fmt.Errorf("%s: failed to communicate with server: %s", errPrefix, err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return Icon{}, fmt.Errorf("%s: Not Found", errPrefix)
+	}
+
+	re := regexp.MustCompile(`attachment; filename=(.+)`)
+	matches := re.FindStringSubmatch(response.Header.Get("Content-Disposition"))
+
+	if matches == nil || matches[1] == "" {
+		return Icon{}, fmt.Errorf("%s: cannot determine filename", errPrefix)
+	}
+
+	content, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return Icon{}, fmt.Errorf("%s: %s", errPrefix, err)
+	}
+
+	icon := Icon{
+		Filename: matches[1],
+		Content:  content,
+	}
+
+	return icon, nil
+}

--- a/client/icons_test.go
+++ b/client/icons_test.go
@@ -1,0 +1,65 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+)
+
+const (
+	pkgID = "chatroom.ogra"
+)
+
+func (cs *clientSuite) TestClientIconCallsEndpoint(c *C) {
+	_, _ = cs.cli.Icon(pkgID)
+	c.Assert(cs.req.Method, Equals, "GET")
+	c.Assert(cs.req.URL.Path, Equals, fmt.Sprintf("/1.0/icons/%s/icon", pkgID))
+}
+
+func (cs *clientSuite) TestClientIconHttpError(c *C) {
+	cs.err = errors.New("fail")
+	_, err := cs.cli.Icon(pkgID)
+	c.Assert(err, ErrorMatches, ".*server: fail")
+}
+
+func (cs *clientSuite) TestClientIconResponseNotFound(c *C) {
+	cs.status = http.StatusNotFound
+	_, err := cs.cli.Icon(pkgID)
+	c.Assert(err, ErrorMatches, `.*Not Found`)
+}
+
+func (cs *clientSuite) TestClientIconInvalidContentDisposition(c *C) {
+	cs.header = http.Header{"Content-Disposition": {"invalid"}}
+	_, err := cs.cli.Icon(pkgID)
+	c.Assert(err, ErrorMatches, `.*cannot determine filename`)
+}
+
+func (cs *clientSuite) TestClientIcon(c *C) {
+	cs.rsp = "pixels"
+	cs.header = http.Header{"Content-Disposition": {"attachment; filename=myicon.png"}}
+	icon, err := cs.cli.Icon(pkgID)
+	c.Assert(err, IsNil)
+	c.Assert(icon.Filename, Equals, "myicon.png")
+	c.Assert(icon.Content, DeepEquals, []byte("pixels"))
+}


### PR DESCRIPTION
First cut at providing a client interface to the icons endpoint in the `snapd` API.

I'm not sure wether an `io.Reader` would be better than `[]byte` for the icon content but it's time to quit for Christmas :santa: :snowman: :christmas_tree: 