### PR TITLE
Ensure that "{enable,destroy}-classic" are run as root

### DIFF
--- a/cmd/snappy/cmd_classic.go
+++ b/cmd/snappy/cmd_classic.go
@@ -21,13 +21,11 @@ package main
 
 import (
 	"fmt"
-	sys "syscall"
 
 	"github.com/ubuntu-core/snappy/classic"
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/progress"
-	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdEnableClassic struct{}
@@ -52,12 +50,12 @@ func init() {
 }
 
 func (x *cmdEnableClassic) Execute(args []string) (err error) {
+	return withMutexAndRetry(x.doEnable)
+}
+
+func (x *cmdEnableClassic) doEnable() (err error) {
 	if classic.Enabled() {
 		return fmt.Errorf(i18n.G("Classic dimension is already enabled."))
-	}
-
-	if sys.Getuid() != 0 {
-		return snappy.ErrNeedRoot
 	}
 
 	pbar := progress.NewTextProgress()
@@ -71,12 +69,12 @@ Use “snappy shell classic” to enter the classic dimension.`))
 }
 
 func (x *cmdDestroyClassic) Execute(args []string) (err error) {
+	return withMutexAndRetry(x.doDisable)
+}
+
+func (x *cmdDestroyClassic) doDisable() (err error) {
 	if !classic.Enabled() {
 		return fmt.Errorf(i18n.G("Classic dimension is not enabled."))
-	}
-
-	if sys.Getuid() != 0 {
-		return snappy.ErrNeedRoot
 	}
 
 	if err := classic.Destroy(); err != nil {

--- a/cmd/snappy/cmd_classic.go
+++ b/cmd/snappy/cmd_classic.go
@@ -21,11 +21,13 @@ package main
 
 import (
 	"fmt"
+	sys "syscall"
 
 	"github.com/ubuntu-core/snappy/classic"
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdEnableClassic struct{}
@@ -54,6 +56,10 @@ func (x *cmdEnableClassic) Execute(args []string) (err error) {
 		return fmt.Errorf(i18n.G("Classic dimension is already enabled."))
 	}
 
+	if sys.Getuid() != 0 {
+		return snappy.ErrNeedRoot
+	}
+
 	pbar := progress.NewTextProgress()
 	if err := classic.Create(pbar); err != nil {
 		return err
@@ -67,6 +73,10 @@ Use “snappy shell classic” to enter the classic dimension.`))
 func (x *cmdDestroyClassic) Execute(args []string) (err error) {
 	if !classic.Enabled() {
 		return fmt.Errorf(i18n.G("Classic dimension is not enabled."))
+	}
+
+	if sys.Getuid() != 0 {
+		return snappy.ErrNeedRoot
 	}
 
 	if err := classic.Destroy(); err != nil {


### PR DESCRIPTION
Trivial branch that just ensures that enable/destroy classic are run as root. Silly me for forgetting that check in the first place.
Fixes https://bugs.launchpad.net/bugs/1530826