### PR TITLE
Exclude "integration-tests" from the package build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,7 @@
 export DH_OPTIONS
 export DH_GOPKG := github.com/ubuntu-core/snappy
 #export DEB_BUILD_OPTIONS=nocheck
+export DH_GOLANG_EXCLUDES=integration-tests
 
 RELEASE = $(shell lsb_release -c -s)
 


### PR DESCRIPTION
Trivial branch that fixes the recent FTBFS