### PR TITLE
Fix test until all-snap lands

### DIFF
--- a/integration-tests/tests/build_test.go
+++ b/integration-tests/tests/build_test.go
@@ -52,8 +52,11 @@ func (s *buildSuite) TestBuildBasicSnapOnSnappy(c *check.C) {
 		".*Signature check failed, but installing anyway as requested\n" +
 		"Name +Date +Version +Developer \n" +
 		".*\n" +
-		data.BasicSnapName + " +.* +.* +sideload  \n" +
-		".*\n"
+		data.BasicSnapName + " +.* +.* +sideload  \n"
+
+	//FIXME: once we have a base image with gadget snap support
+	//       this line should be uncommented
+	// + ".*\n"
 
 	c.Check(installOutput, check.Matches, expected)
 }


### PR DESCRIPTION
The build test expects a line with the OEM snap after the freshly
build snap got installed. However we no longer support the OEM
snap. Once the all-snap images land with gadget snaps this line
will come back. Until then disable looking for it.