### PR TITLE
Relaxed the regular expression on basic build test.

### DIFF
--- a/integration-tests/tests/build_test.go
+++ b/integration-tests/tests/build_test.go
@@ -53,7 +53,7 @@ func (s *buildSuite) TestBuildBasicSnapOnSnappy(c *check.C) {
 		"Name +Date +Version +Developer \n" +
 		".*\n" +
 		data.BasicSnapName + " +.* +.* +sideload  \n" +
-		".*\n"
+		".*"
 
 	c.Check(installOutput, check.Matches, expected)
 }


### PR DESCRIPTION
The regular expression was assuming that one more snap was installed after the basic snap we installed during the test. That's not related to what we are testing here, so it's ok to relax the regexp to only check if the basic snap appears, with optional trailing text.