### PR TITLE
Extract helper method for `snapd` client

### DIFF
--- a/client/caps.go
+++ b/client/caps.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/client/caps.go
+++ b/client/caps.go
@@ -46,56 +46,36 @@ type Capability struct {
 
 // Capabilities returns the capabilities currently available for snaps to consume.
 func (client *Client) Capabilities() (map[string]Capability, error) {
-	const errPrefix = "cannot obtain capabilities"
-	var rsp response
-	if err := client.do("GET", "/1.0/capabilities", nil, &rsp); err != nil {
-		return nil, fmt.Errorf("%s: failed to communicate with server: %s", errPrefix, err)
-	}
-	if err := rsp.err(); err != nil {
-		return nil, err
-	}
-	if rsp.Type != "sync" {
-		return nil, fmt.Errorf("%s: expected sync response, got %q", errPrefix, rsp.Type)
-	}
 	var resultOk map[string]map[string]Capability
-	if err := json.Unmarshal(rsp.Result, &resultOk); err != nil {
-		return nil, fmt.Errorf("%s: failed to unmarshal response: %v", errPrefix, err)
+
+	if err := client.doSync("GET", "/1.0/capabilities", nil, &resultOk); err != nil {
+		return nil, fmt.Errorf("cannot obtain capabilities: %s", err)
 	}
+
 	return resultOk["capabilities"], nil
 }
 
 // AddCapability adds one capability to the system
 func (client *Client) AddCapability(c *Capability) error {
-	errPrefix := "cannot add capability"
 	b, err := json.Marshal(c)
 	if err != nil {
 		return err
 	}
-	var rsp response
-	if err := client.do("POST", "/1.0/capabilities", bytes.NewReader(b), &rsp); err != nil {
-		return err
+
+	var rsp interface{}
+	if err := client.doSync("POST", "/1.0/capabilities", bytes.NewReader(b), &rsp); err != nil {
+		return fmt.Errorf("cannot add capability: %s", err)
 	}
-	if err := rsp.err(); err != nil {
-		return err
-	}
-	if rsp.Type != "sync" {
-		return fmt.Errorf("%s: expected sync response, got %q", errPrefix, rsp.Type)
-	}
+
 	return nil
 }
 
 // RemoveCapability removes one capability from the system
 func (client *Client) RemoveCapability(name string) error {
-	errPrefix := "cannot remove capability"
-	var rsp response
-	if err := client.do("DELETE", fmt.Sprintf("/1.0/capabilities/%s", name), nil, &rsp); err != nil {
-		return err
+	var rsp interface{}
+	if err := client.doSync("DELETE", fmt.Sprintf("/1.0/capabilities/%s", name), nil, &rsp); err != nil {
+		return fmt.Errorf("cannot remove capability: %s", err)
 	}
-	if err := rsp.err(); err != nil {
-		return err
-	}
-	if rsp.Type != "sync" {
-		return fmt.Errorf("%s: expected sync response, got %q", errPrefix, rsp.Type)
-	}
+
 	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -99,7 +99,7 @@ func (cs *clientSuite) TestClientSysInfo(c *check.C) {
 func (cs *clientSuite) TestClientReportsOpError(c *check.C) {
 	cs.rsp = `{"type": "error", "status": "potatoes"}`
 	_, err := cs.cli.SysInfo()
-	c.Check(err, check.ErrorMatches, `server error: "potatoes"`)
+	c.Check(err, check.ErrorMatches, `.*server error: "potatoes"`)
 }
 
 func (cs *clientSuite) TestClientReportsOpErrorStr(c *check.C) {
@@ -110,25 +110,25 @@ func (cs *clientSuite) TestClientReportsOpErrorStr(c *check.C) {
 		"type": "error"
 	}`
 	_, err := cs.cli.SysInfo()
-	c.Check(err, check.ErrorMatches, `server error: "Bad Request"`)
+	c.Check(err, check.ErrorMatches, `.*server error: "Bad Request"`)
 }
 
 func (cs *clientSuite) TestClientReportsBadType(c *check.C) {
 	cs.rsp = `{"type": "what"}`
 	_, err := cs.cli.SysInfo()
-	c.Check(err, check.ErrorMatches, `unexpected result type "what"`)
+	c.Check(err, check.ErrorMatches, `.*expected sync response, got "what"`)
 }
 
 func (cs *clientSuite) TestClientReportsOuterJSONError(c *check.C) {
 	cs.rsp = "this isn't really json is it"
 	_, err := cs.cli.SysInfo()
-	c.Check(err, check.ErrorMatches, `invalid character .*`)
+	c.Check(err, check.ErrorMatches, `.*invalid character .*`)
 }
 
 func (cs *clientSuite) TestClientReportsInnerJSONError(c *check.C) {
 	cs.rsp = `{"type": "sync", "result": "this isn't really json is it"}`
 	_, err := cs.cli.SysInfo()
-	c.Check(err, check.ErrorMatches, `bad sysinfo result .*`)
+	c.Check(err, check.ErrorMatches, `.*failed to unmarshal.*`)
 }
 
 func (cs *clientSuite) TestClientCapabilities(c *check.C) {
@@ -211,7 +211,7 @@ func (cs *clientSuite) TestClientRemoveCapabilityNotFound(c *check.C) {
 		}
 	}`
 	err := cs.cli.RemoveCapability("n")
-	c.Check(err, check.ErrorMatches, `can't remove capability \"n\", no such capability`)
+	c.Check(err, check.ErrorMatches, `.*can't remove capability \"n\", no such capability`)
 	c.Check(cs.req.Body, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "DELETE")
 	c.Check(cs.req.URL.Path, check.Equals, "/1.0/capabilities/n")

--- a/client/packages.go
+++ b/client/packages.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/client/packages.go
+++ b/client/packages.go
@@ -55,20 +55,9 @@ const (
 func (client *Client) Packages() (map[string]Package, error) {
 	const errPrefix = "cannot list packages"
 
-	var rsp response
-	if err := client.do("GET", "/1.0/packages", nil, &rsp); err != nil {
-		return nil, fmt.Errorf("%s: failed to communicate with server: %s", errPrefix, err)
-	}
-	if err := rsp.err(); err != nil {
-		return nil, err
-	}
-	if rsp.Type != "sync" {
-		return nil, fmt.Errorf("%s: expected sync response, got %q", errPrefix, rsp.Type)
-	}
-
 	var result map[string]json.RawMessage
-	if err := json.Unmarshal(rsp.Result, &result); err != nil {
-		return nil, fmt.Errorf("%s: failed to unmarshal response: %v", errPrefix, err)
+	if err := client.doSync("GET", "/1.0/packages", nil, &result); err != nil {
+		return nil, fmt.Errorf("%s: %s", errPrefix, err)
 	}
 
 	packagesJSON := result["packages"]

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -20,8 +20,6 @@
 package client_test
 
 import (
-	"errors"
-
 	"gopkg.in/check.v1"
 
 	"github.com/ubuntu-core/snappy/client"
@@ -31,38 +29,6 @@ func (cs *clientSuite) TestClientPackagesCallsEndpoint(c *check.C) {
 	_, _ = cs.cli.Packages()
 	c.Check(cs.req.Method, check.Equals, "GET")
 	c.Check(cs.req.URL.Path, check.Equals, "/1.0/packages")
-}
-
-func (cs *clientSuite) TestClientPackagesHttpError(c *check.C) {
-	cs.err = errors.New("fail")
-	_, err := cs.cli.Packages()
-	c.Check(err, check.ErrorMatches, ".*server: fail")
-}
-
-func (cs *clientSuite) TestClientPackagesResponseError(c *check.C) {
-	cs.rsp = `{
-		"result": {},
-		"status": "Bad Request",
-		"status_code": 400,
-		"type": "error"
-	}`
-	_, err := cs.cli.Packages()
-	c.Check(err, check.ErrorMatches, `server error: "Bad Request"`)
-}
-
-func (cs *clientSuite) TestClientPackagesInvalidResponseType(c *check.C) {
-	cs.rsp = `{"type": "async"}`
-	_, err := cs.cli.Packages()
-	c.Check(err, check.ErrorMatches, `.*expected sync response.*`)
-}
-
-func (cs *clientSuite) TestClientPackagesInvalidResultJSON(c *check.C) {
-	cs.rsp = `{
-		"type": "sync",
-		"result": "not a JSON object"
-	}`
-	_, err := cs.cli.Packages()
-	c.Check(err, check.ErrorMatches, `.*failed to unmarshal response.*`)
 }
 
 func (cs *clientSuite) TestClientPackagesResultJSONHasNoPackages(c *check.C) {


### PR DESCRIPTION
As discussed with @mvo5; extract the boilerplate into a helper.

Will reduce the volume of code and tests to introduce with #270 and #278.