### PR TITLE
Make "snappy info" work again

### DIFF
--- a/cmd/snappy/cmd_info.go
+++ b/cmd/snappy/cmd_info.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/pkg"
+	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/snappy"
 )
 
@@ -103,17 +104,9 @@ func snapInfo(pkgname string, includeStore, verbose bool) error {
 	return nil
 }
 
-func ubuntuCoreChannel() string {
-	parts, err := snappy.ActiveSnapsByType(pkg.TypeCore)
-	if len(parts) == 1 && err == nil {
-		return parts[0].Channel()
-	}
-
-	return "unknown"
-}
-
 func info() error {
-	release := ubuntuCoreChannel()
+	rel := release.Get()
+	release := fmt.Sprintf("%s/%s", rel.Flavor, rel.Series)
 	frameworks, _ := snappy.ActiveSnapIterByType(snappy.FullName, pkg.TypeFramework)
 	apps, _ := snappy.ActiveSnapIterByType(snappy.FullName, pkg.TypeApp)
 


### PR DESCRIPTION
The "snappy info" command returns "unknown" currently. This breaks
some integration tests. This branch makes them work again.

The output is slightly different, the old one used:
 release: ubuntu-core/rolling/edge
the new one just:
 release: core/rolling
because there is no global default channel in 16.04.