### PR TITLE
Fix the list output after a "snappy update"

### DIFF
--- a/snappy/install.go
+++ b/snappy/install.go
@@ -60,6 +60,16 @@ func doUpdate(part Part, flags InstallFlags, meter progress.Meter) error {
 	return nil
 }
 
+// FIXME: This needs to go (and will go). We will have something
+//        like:
+//           remoteSnapType = GetUpdatesFromServer()
+//           localSnapType = DoUpdate(remoteSnaps)
+//           ShowUpdates(localSnaps)
+//        By using the different types (instead of the same interface)
+//        it will not be possilbe to pass remote snaps into the
+//        ShowUpdates() output.
+//
+//
 // convertToInstalledSnaps takes a slice of remote snaps that got
 // updated and returns the corresponding local snap parts.
 func convertToInstalledSnaps(remoteUpdates []Part) ([]Part, error) {

--- a/snappy/install.go
+++ b/snappy/install.go
@@ -60,8 +60,8 @@ func doUpdate(part Part, flags InstallFlags, meter progress.Meter) error {
 	return nil
 }
 
-// convertToInstalledSnaps takes a slcie of remote snaps that got
-// updated and finds the coresponding local snap parts and returns them
+// convertToInstalledSnaps takes a slice of remote snaps that got
+// updated and returns the corresponding local snap parts.
 func convertToInstalledSnaps(remoteUpdates []Part) ([]Part, error) {
 	installed, err := NewMetaLocalRepository().Installed()
 	if err != nil {
@@ -72,7 +72,7 @@ func convertToInstalledSnaps(remoteUpdates []Part) ([]Part, error) {
 	for _, part := range remoteUpdates {
 		localPart := FindSnapsByNameAndVersion(part.Name(), part.Version(), installed)
 		if len(localPart) != 1 {
-			return nil, fmt.Errorf("expected one local part for the update %v got %v", part, len(localPart))
+			return nil, fmt.Errorf("expected one local part for the update %v, got %v", part, len(localPart))
 		}
 		installedUpdates = append(installedUpdates, localPart[0])
 	}


### PR DESCRIPTION
After running "snappy update" with an all-snap system the output
is often incorrect. The reboot notification is not displayed, the
date of the install is wrong etc.

The reason for this is that the Update{,All}() calls return a list
of applied updates that is then displayed. However the list of
applied updates is for the remote snaps. We need to convert the
remote snaps to the locally installed ones instead to get the
correct date and the correct reboot-required checks.