### PR TITLE
asserts: explicit keyid on account keys used to match signature to signing keys

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -53,8 +53,8 @@ func (ak *AccountKey) PublicKeyID() string {
 	return ak.pubKey.KeyID()
 }
 
-// Fingerprint returns the fingerprint of the account key.
-func (ak *AccountKey) Fingerprint() string {
+// PublicKeyFingerprint returns the fingerprint of the account key.
+func (ak *AccountKey) PublicKeyFingerprint() string {
 	return ak.pubKey.Fingerprint()
 }
 

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -48,6 +48,11 @@ func (ak *AccountKey) Until() time.Time {
 	return ak.until
 }
 
+// PublicKeyID returns the key id (as used to match signatures to signing keys) for the account key.
+func (ak *AccountKey) PublicKeyID() string {
+	return ak.pubKey.KeyID()
+}
+
 // Fingerprint returns the fingerprint of the account key.
 func (ak *AccountKey) Fingerprint() string {
 	return ak.pubKey.Fingerprint()
@@ -63,7 +68,7 @@ func (ak *AccountKey) publicKey() PublicKey {
 	return ak.pubKey
 }
 
-func checkPublicKey(ab *assertionBase, fingerprintName string) (PublicKey, error) {
+func checkPublicKey(ab *assertionBase, fingerprintName, keyIDName string) (PublicKey, error) {
 	pubKey, err := decodePublicKey(ab.Body())
 	if err != nil {
 		return nil, err
@@ -74,6 +79,13 @@ func checkPublicKey(ab *assertionBase, fingerprintName string) (PublicKey, error
 	}
 	if fp != pubKey.Fingerprint() {
 		return nil, fmt.Errorf("public key does not match provided fingerprint")
+	}
+	keyid, err := checkMandatory(ab.headers, keyIDName)
+	if err != nil {
+		return nil, err
+	}
+	if keyid != pubKey.KeyID() {
+		return nil, fmt.Errorf("public key does not match provided key id")
 	}
 	return pubKey, nil
 }
@@ -94,7 +106,7 @@ func buildAccountKey(assert assertionBase) (Assertion, error) {
 	if !until.After(since) {
 		return nil, fmt.Errorf("invalid 'since' and 'until' times (no gap after 'since' till 'until')")
 	}
-	pubk, err := checkPublicKey(&assert, "fingerprint")
+	pubk, err := checkPublicKey(&assert, "fingerprint", "public-key-id")
 	if err != nil {
 		return nil, err
 	}
@@ -110,6 +122,6 @@ func buildAccountKey(assert assertionBase) (Assertion, error) {
 func init() {
 	typeRegistry[AccountKeyType] = &assertionTypeRegistration{
 		builder:    buildAccountKey,
-		primaryKey: []string{"account-id", "fingerprint"},
+		primaryKey: []string{"account-id", "public-key-id"},
 	}
 }

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -50,7 +50,7 @@ func (ak *AccountKey) Until() time.Time {
 
 // PublicKeyID returns the key id (as used to match signatures to signing keys) for the account key.
 func (ak *AccountKey) PublicKeyID() string {
-	return ak.pubKey.KeyID()
+	return ak.pubKey.ID()
 }
 
 // PublicKeyFingerprint returns the fingerprint of the account key.
@@ -84,7 +84,7 @@ func checkPublicKey(ab *assertionBase, fingerprintName, keyIDName string) (Publi
 	if err != nil {
 		return nil, err
 	}
-	if keyID != pubKey.KeyID() {
+	if keyID != pubKey.ID() {
 		return nil, fmt.Errorf("public key does not match provided key id")
 	}
 	return pubKey, nil

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -80,11 +80,11 @@ func checkPublicKey(ab *assertionBase, fingerprintName, keyIDName string) (Publi
 	if fp != pubKey.Fingerprint() {
 		return nil, fmt.Errorf("public key does not match provided fingerprint")
 	}
-	keyid, err := checkMandatory(ab.headers, keyIDName)
+	keyID, err := checkMandatory(ab.headers, keyIDName)
 	if err != nil {
 		return nil, err
 	}
-	if keyid != pubKey.KeyID() {
+	if keyID != pubKey.KeyID() {
 		return nil, fmt.Errorf("public key does not match provided key id")
 	}
 	return pubKey, nil

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -106,7 +106,7 @@ func buildAccountKey(assert assertionBase) (Assertion, error) {
 	if !until.After(since) {
 		return nil, fmt.Errorf("invalid 'since' and 'until' times (no gap after 'since' till 'until')")
 	}
-	pubk, err := checkPublicKey(&assert, "fingerprint", "public-key-id")
+	pubk, err := checkPublicKey(&assert, "public-key-fingerprint", "public-key-id")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -47,7 +47,7 @@ func (aks *accountKeySuite) SetUpSuite(c *C) {
 	_, err = accDb.ImportKey("acc-id1", pk)
 	c.Assert(err, IsNil)
 	aks.fp = pk.PublicKey().Fingerprint()
-	aks.keyid = pk.PublicKey().KeyID()
+	aks.keyid = pk.PublicKey().ID()
 	pubKey, err := accDb.PublicKey("acc-id1", aks.fp)
 	c.Assert(err, IsNil)
 	pubKeyEncoded, err := asserts.EncodePublicKey(pubKey)

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -66,7 +66,7 @@ func (aks *accountKeySuite) TestDecodeOK(c *C) {
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
-		"fingerprint: " + aks.fp + "\n" +
+		"public-key-fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine +
 		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n\n" +
@@ -92,7 +92,7 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
-		"fingerprint: " + aks.fp + "\n" +
+		"public-key-fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine +
 		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n\n" +
@@ -106,7 +106,7 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 		{aks.sinceLine, "since: 12:30\n", `"since" header is not a RFC3339 date: .*`},
 		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
 		{"public-key-id: " + aks.keyid + "\n", "", `"public-key-id" header is mandatory`},
-		{"fingerprint: " + aks.fp + "\n", "", `"fingerprint" header is mandatory`},
+		{"public-key-fingerprint: " + aks.fp + "\n", "", `"public-key-fingerprint" header is mandatory`},
 	}
 
 	for _, test := range invalidHeaderTests {
@@ -121,7 +121,7 @@ func (aks *accountKeySuite) TestDecodeInvalidPublicKey(c *C) {
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
-		"fingerprint: " + aks.fp + "\n" +
+		"public-key-fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine
 
@@ -149,7 +149,7 @@ func (aks *accountKeySuite) TestDecodeFingerprintMismatch(c *C) {
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
-		"fingerprint: 00\n" +
+		"public-key-fingerprint: 00\n" +
 		aks.sinceLine +
 		aks.untilLine +
 		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n\n" +
@@ -165,7 +165,7 @@ func (aks *accountKeySuite) TestDecodeKeyIDMismatch(c *C) {
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: aa\n" +
-		"fingerprint: " + aks.fp + "\n" +
+		"public-key-fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine +
 		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n\n" +
@@ -180,12 +180,12 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 	trustedKey := testPrivKey0
 
 	headers := map[string]string{
-		"authority-id":  "canonical",
-		"account-id":    "acc-id1",
-		"public-key-id": aks.keyid,
-		"fingerprint":   aks.fp,
-		"since":         aks.since.Format(time.RFC3339),
-		"until":         aks.until.Format(time.RFC3339),
+		"authority-id":           "canonical",
+		"account-id":             "acc-id1",
+		"public-key-id":          aks.keyid,
+		"public-key-fingerprint": aks.fp,
+		"since":                  aks.since.Format(time.RFC3339),
+		"until":                  aks.until.Format(time.RFC3339),
 	}
 	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)
@@ -206,12 +206,12 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	trustedKey := testPrivKey0
 
 	headers := map[string]string{
-		"authority-id":  "canonical",
-		"account-id":    "acc-id1",
-		"public-key-id": aks.keyid,
-		"fingerprint":   aks.fp,
-		"since":         aks.since.Format(time.RFC3339),
-		"until":         aks.until.Format(time.RFC3339),
+		"authority-id":           "canonical",
+		"account-id":             "acc-id1",
+		"public-key-id":          aks.keyid,
+		"public-key-fingerprint": aks.fp,
+		"since":                  aks.since.Format(time.RFC3339),
+		"until":                  aks.until.Format(time.RFC3339),
 	}
 	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)
@@ -241,7 +241,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAt(c *C) {
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
-		"fingerprint: " + aks.fp + "\n" +
+		"public-key-fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine +
 		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n\n" +

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -77,7 +77,7 @@ func (aks *accountKeySuite) TestDecodeOK(c *C) {
 	c.Check(a.Type(), Equals, asserts.AccountKeyType)
 	accKey := a.(*asserts.AccountKey)
 	c.Check(accKey.AccountID(), Equals, "acc-id1")
-	c.Check(accKey.Fingerprint(), Equals, aks.fp)
+	c.Check(accKey.PublicKeyFingerprint(), Equals, aks.fp)
 	c.Check(accKey.PublicKeyID(), Equals, aks.keyid)
 	c.Check(accKey.Since(), Equals, aks.since)
 	c.Check(accKey.Until(), Equals, aks.until)

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -43,9 +43,11 @@ func (aks *accountKeySuite) SetUpSuite(c *C) {
 	cfg1 := &asserts.DatabaseConfig{Path: filepath.Join(c.MkDir(), "asserts-db1")}
 	accDb, err := asserts.OpenDatabase(cfg1)
 	c.Assert(err, IsNil)
-	aks.fp, err = accDb.ImportKey("acc-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
-	aks.keyid = aks.fp[len(aks.fp)-16:]
+	pk := asserts.OpenPGPPrivateKey(testPrivKey1)
+	_, err = accDb.ImportKey("acc-id1", pk)
 	c.Assert(err, IsNil)
+	aks.fp = pk.PublicKey().Fingerprint()
+	aks.keyid = pk.PublicKey().KeyID()
 	pubKey, err := accDb.PublicKey("acc-id1", aks.fp)
 	c.Assert(err, IsNil)
 	pubKeyEncoded, err := asserts.EncodePublicKey(pubKey)

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -32,7 +32,7 @@ import (
 
 type accountKeySuite struct {
 	pubKeyBody           string
-	fp                   string
+	fp, keyid            string
 	since, until         time.Time
 	sinceLine, untilLine string
 }
@@ -44,6 +44,7 @@ func (aks *accountKeySuite) SetUpSuite(c *C) {
 	accDb, err := asserts.OpenDatabase(cfg1)
 	c.Assert(err, IsNil)
 	aks.fp, err = accDb.ImportKey("acc-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
+	aks.keyid = aks.fp[len(aks.fp)-16:]
 	c.Assert(err, IsNil)
 	pubKey, err := accDb.PublicKey("acc-id1", aks.fp)
 	c.Assert(err, IsNil)
@@ -62,6 +63,7 @@ func (aks *accountKeySuite) TestDecodeOK(c *C) {
 	encoded := "type: account-key\n" +
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
+		"public-key-id: " + aks.keyid + "\n" +
 		"fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine +
@@ -74,6 +76,7 @@ func (aks *accountKeySuite) TestDecodeOK(c *C) {
 	accKey := a.(*asserts.AccountKey)
 	c.Check(accKey.AccountID(), Equals, "acc-id1")
 	c.Check(accKey.Fingerprint(), Equals, aks.fp)
+	c.Check(accKey.PublicKeyID(), Equals, aks.keyid)
 	c.Check(accKey.Since(), Equals, aks.since)
 	c.Check(accKey.Until(), Equals, aks.until)
 }
@@ -86,6 +89,7 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 	encoded := "type: account-key\n" +
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
+		"public-key-id: " + aks.keyid + "\n" +
 		"fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine +
@@ -99,6 +103,7 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 		{aks.untilLine, "", `"until" header is mandatory`},
 		{aks.sinceLine, "since: 12:30\n", `"since" header is not a RFC3339 date: .*`},
 		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
+		{"public-key-id: " + aks.keyid + "\n", "", `"public-key-id" header is mandatory`},
 		{"fingerprint: " + aks.fp + "\n", "", `"fingerprint" header is mandatory`},
 	}
 
@@ -113,6 +118,7 @@ func (aks *accountKeySuite) TestDecodeInvalidPublicKey(c *C) {
 	headers := "type: account-key\n" +
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
+		"public-key-id: " + aks.keyid + "\n" +
 		"fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine
@@ -140,6 +146,7 @@ func (aks *accountKeySuite) TestDecodeFingerprintMismatch(c *C) {
 	invalid := "type: account-key\n" +
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
+		"public-key-id: " + aks.keyid + "\n" +
 		"fingerprint: 00\n" +
 		aks.sinceLine +
 		aks.untilLine +
@@ -151,15 +158,32 @@ func (aks *accountKeySuite) TestDecodeFingerprintMismatch(c *C) {
 	c.Check(err, ErrorMatches, accKeyErrPrefix+"public key does not match provided fingerprint")
 }
 
+func (aks *accountKeySuite) TestDecodeKeyIDMismatch(c *C) {
+	invalid := "type: account-key\n" +
+		"authority-id: canonical\n" +
+		"account-id: acc-id1\n" +
+		"public-key-id: aa\n" +
+		"fingerprint: " + aks.fp + "\n" +
+		aks.sinceLine +
+		aks.untilLine +
+		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n\n" +
+		aks.pubKeyBody + "\n\n" +
+		"openpgp c2ln"
+
+	_, err := asserts.Decode([]byte(invalid))
+	c.Check(err, ErrorMatches, accKeyErrPrefix+"public key does not match provided key id")
+}
+
 func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 	trustedKey := testPrivKey0
 
 	headers := map[string]string{
-		"authority-id": "canonical",
-		"account-id":   "acc-id1",
-		"fingerprint":  aks.fp,
-		"since":        aks.since.Format(time.RFC3339),
-		"until":        aks.until.Format(time.RFC3339),
+		"authority-id":  "canonical",
+		"account-id":    "acc-id1",
+		"public-key-id": aks.keyid,
+		"fingerprint":   aks.fp,
+		"since":         aks.since.Format(time.RFC3339),
+		"until":         aks.until.Format(time.RFC3339),
 	}
 	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)
@@ -180,11 +204,12 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	trustedKey := testPrivKey0
 
 	headers := map[string]string{
-		"authority-id": "canonical",
-		"account-id":   "acc-id1",
-		"fingerprint":  aks.fp,
-		"since":        aks.since.Format(time.RFC3339),
-		"until":        aks.until.Format(time.RFC3339),
+		"authority-id":  "canonical",
+		"account-id":    "acc-id1",
+		"public-key-id": aks.keyid,
+		"fingerprint":   aks.fp,
+		"since":         aks.since.Format(time.RFC3339),
+		"until":         aks.until.Format(time.RFC3339),
 	}
 	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)
@@ -201,8 +226,8 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	c.Assert(err, IsNil)
 
 	found, err := db.Find(asserts.AccountKeyType, map[string]string{
-		"account-id":  "acc-id1",
-		"fingerprint": aks.fp,
+		"account-id":    "acc-id1",
+		"public-key-id": aks.keyid,
 	})
 	c.Assert(err, IsNil)
 	c.Assert(found, NotNil)
@@ -213,6 +238,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAt(c *C) {
 	encoded := "type: account-key\n" +
 		"authority-id: canonical\n" +
 		"account-id: acc-id1\n" +
+		"public-key-id: " + aks.keyid + "\n" +
 		"fingerprint: " + aks.fp + "\n" +
 		aks.sinceLine +
 		aks.untilLine +

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -191,8 +191,8 @@ func decodeSignature(signature []byte) (Signature, error) {
 type PublicKey interface {
 	// Fingerprint returns the key fingerprint.
 	Fingerprint() string
-	// KeyId returns the key id used to match signatures to their signing key.
-	KeyID() string
+	// ID returns the id of the key as used to match signatures to their signing key.
+	ID() string
 
 	// verify verifies signature is valid for content using the key.
 	verify(content []byte, sig Signature) error
@@ -209,7 +209,8 @@ func (opgPubKey *openpgpPubKey) Fingerprint() string {
 	return opgPubKey.fp
 }
 
-func (opgPubKey *openpgpPubKey) KeyID() string {
+func (opgPubKey *openpgpPubKey) ID() string {
+	// the key id is defined as the 64 bits suffix of the 160 bits fingerprint
 	return opgPubKey.fp[24:40]
 }
 

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -191,6 +191,8 @@ func decodeSignature(signature []byte) (Signature, error) {
 type PublicKey interface {
 	// Fingerprint returns the key fingerprint.
 	Fingerprint() string
+	// KeyId returns the key id used to match signatures to their signing key.
+	KeyID() string
 
 	// verify verifies signature is valid for content using the key.
 	verify(content []byte, sig Signature) error
@@ -205,6 +207,10 @@ type openpgpPubKey struct {
 
 func (opgPubKey *openpgpPubKey) Fingerprint() string {
 	return opgPubKey.fp
+}
+
+func (opgPubKey *openpgpPubKey) KeyID() string {
+	return opgPubKey.fp[24:40]
 }
 
 func (opgPubKey *openpgpPubKey) verify(content []byte, sig Signature) error {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -46,17 +46,12 @@ type Backstore interface {
 	// Get loads an assertion with the given unique primaryPath.
 	// If none is present it returns ErrNotFound.
 	Get(assertType AssertionType, primaryPath []string) (Assertion, error)
-	// SearchByHeaders searches for assertions matching the given headers.
+	// Search searches for assertions matching the given headers.
 	// It invokes foundCb for each found assertion.
 	// pathHint is an incomplete primary path pattern (with ""
 	// representing omitted components) that covers a superset of
 	// the results, it can be used for the search if helpful.
-	SearchByHeaders(assertType AssertionType, headers map[string]string, pathHint []string, foundCb func(Assertion)) error
-	// SearchBySuffix searches for assertions matching the given
-	// partial primary path without the last component plus
-	// suffixOfLast being a suffix of that last component.
-	// It invokes foundCb for each found assertion.
-	SearchBySuffix(assertType AssertionType, primaryPathWithoutLast []string, suffixOflast string, foundCb func(Assertion)) error
+	Search(assertType AssertionType, headers map[string]string, pathHint []string, foundCb func(Assertion)) error
 }
 
 // KeypairManager is a manager and backstore for private/public key pairs.
@@ -225,8 +220,8 @@ func (db *Database) findAccountKeys(authorityID, keyID string) ([]*AccountKey, e
 	foundKeyCb := func(a Assertion) {
 		res = append(res, a.(*AccountKey))
 	}
-	err := db.bs.SearchByHeaders(AccountKeyType, map[string]string{
-		"account-id": authorityID,
+	err := db.bs.Search(AccountKeyType, map[string]string{
+		"account-id":    authorityID,
 		"public-key-id": keyID,
 	}, []string{authorityID, keyID}, foundKeyCb)
 	if err != nil {
@@ -345,7 +340,7 @@ func (db *Database) FindMany(assertionType AssertionType, headers map[string]str
 	foundCb := func(assert Assertion) {
 		res = append(res, assert)
 	}
-	err = db.bs.SearchByHeaders(assertionType, headers, primaryKey, foundCb)
+	err = db.bs.Search(assertionType, headers, primaryKey, foundCb)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 	"time"
 )
 
@@ -211,23 +210,14 @@ func (db *Database) Sign(assertType AssertionType, headers map[string]string, bo
 	return buildAndSign(assertType, headers, body, privKey)
 }
 
-// use a generalized matching style along what PGP does where keys can be
-// retrieved by giving suffixes of their fingerprint,
-// for safety suffix must be at least 64 bits though
+// find account keys exactly by account id and key id
 // TODO: may need more details about the kind of key we are looking for
 // and use an interface for the results.
-func (db *Database) findAccountKeys(authorityID, fingerprintSuffix string) ([]*AccountKey, error) {
-	suffixLen := len(fingerprintSuffix)
-	if suffixLen%2 == 1 {
-		return nil, fmt.Errorf("key id/fingerprint suffix cannot specify a half byte")
-	}
-	if suffixLen < 16 {
-		return nil, fmt.Errorf("key id/fingerprint suffix must be at least 64 bits")
-	}
+func (db *Database) findAccountKeys(authorityID, keyID string) ([]*AccountKey, error) {
 	res := make([]*AccountKey, 0, 1)
 	cands := db.trustedKeys[authorityID]
 	for _, cand := range cands {
-		if strings.HasSuffix(cand.Fingerprint(), fingerprintSuffix) {
+		if cand.PublicKeyID() == keyID {
 			res = append(res, cand)
 		}
 	}
@@ -235,7 +225,10 @@ func (db *Database) findAccountKeys(authorityID, fingerprintSuffix string) ([]*A
 	foundKeyCb := func(a Assertion) {
 		res = append(res, a.(*AccountKey))
 	}
-	err := db.bs.SearchBySuffix(AccountKeyType, []string{authorityID}, fingerprintSuffix, foundKeyCb)
+	err := db.bs.SearchByHeaders(AccountKeyType, map[string]string{
+		"account-id": authorityID,
+		"public-key-id": keyID,
+	}, []string{authorityID, keyID}, foundKeyCb)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -118,7 +118,7 @@ func (fsbs *filesystemBackstore) search(assertType AssertionType, diskPattern []
 	return nil
 }
 
-func (fsbs *filesystemBackstore) SearchByHeaders(assertType AssertionType, headers map[string]string, pathHint []string, foundCb func(Assertion)) error {
+func (fsbs *filesystemBackstore) Search(assertType AssertionType, headers map[string]string, pathHint []string, foundCb func(Assertion)) error {
 	diskPattern := make([]string, len(pathHint))
 	for i, comp := range pathHint {
 		if comp == "" {
@@ -134,14 +134,4 @@ func (fsbs *filesystemBackstore) SearchByHeaders(assertType AssertionType, heade
 		}
 	}
 	return fsbs.search(assertType, diskPattern, candCb)
-}
-
-func (fsbs *filesystemBackstore) SearchBySuffix(assertType AssertionType, primaryPathWithoutLast []string, suffixOflast string, foundCb func(Assertion)) error {
-	diskPattern := make([]string, len(primaryPathWithoutLast)+1)
-	for i, comp := range primaryPathWithoutLast {
-		diskPattern[i] = url.QueryEscape(comp)
-	}
-	diskPattern[len(diskPattern)-1] = "*" + suffixOflast
-
-	return fsbs.search(assertType, diskPattern, foundCb)
 }

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -115,11 +115,12 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (accFingerp string
 	accPubKeyBody := string(pubKeyEncoded)
 
 	headers := map[string]string{
-		"authority-id": "canonical",
-		"account-id":   accountID,
-		"fingerprint":  accFingerp,
-		"since":        "2015-11-20T15:04:00Z",
-		"until":        "2500-11-20T15:04:00Z",
+		"authority-id":  "canonical",
+		"account-id":    accountID,
+		"public-key-id": accFingerp[24:40],
+		"fingerprint":   accFingerp,
+		"since":         "2015-11-20T15:04:00Z",
+		"until":         "2500-11-20T15:04:00Z",
 	}
 	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(accPubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -118,12 +118,12 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 	accPubKeyBody := string(pubKeyEncoded)
 
 	headers := map[string]string{
-		"authority-id":  "canonical",
-		"account-id":    accountID,
-		"public-key-id": accKeyID,
-		"fingerprint":   accFingerp,
-		"since":         "2015-11-20T15:04:00Z",
-		"until":         "2500-11-20T15:04:00Z",
+		"authority-id":           "canonical",
+		"account-id":             accountID,
+		"public-key-id":          accKeyID,
+		"public-key-fingerprint": accFingerp,
+		"since":                  "2015-11-20T15:04:00Z",
+		"until":                  "2500-11-20T15:04:00Z",
 	}
 	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(accPubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -108,7 +108,7 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 	c.Assert(err, IsNil)
 	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
 	accFingerp := pk1.PublicKey().Fingerprint()
-	accKeyID := pk1.PublicKey().KeyID()
+	accKeyID := pk1.PublicKey().ID()
 	keyid, err := accSignDB.ImportKey(accountID, asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 	pubKey, err := accSignDB.PublicKey(accountID, keyid)

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -41,9 +41,12 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 	cfg0 := &asserts.DatabaseConfig{Path: filepath.Join(tmpdir, "asserts-db0")}
 	db0, err := asserts.OpenDatabase(cfg0)
 	c.Assert(err, IsNil)
-	trustedFingerp, err := db0.ImportKey("canonical", asserts.OpenPGPPrivateKey(testPrivKey0))
+	pk := asserts.OpenPGPPrivateKey(testPrivKey0)
+	trustedFingerp := pk.PublicKey().Fingerprint()
+	trustedKeyID := pk.PublicKey().KeyID()
+	keyid, err := db0.ImportKey("canonical", pk)
 	c.Assert(err, IsNil)
-	trustedPubKey, err := db0.PublicKey("canonical", trustedFingerp)
+	trustedPubKey, err := db0.PublicKey("canonical", keyid)
 	c.Assert(err, IsNil)
 	trustedPubKeyEncoded, err := asserts.EncodePublicKey(trustedPubKey)
 	c.Assert(err, IsNil)
@@ -51,7 +54,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 	headers := map[string]string{
 		"authority-id":  "canonical",
 		"account-id":    "canonical",
-		"public-key-id": trustedFingerp[24:40],
+		"public-key-id": trustedKeyID,
 		"fingerprint":   trustedFingerp,
 		"since":         "2015-11-20T15:04:00Z",
 		"until":         "2500-11-20T15:04:00Z",

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -49,11 +49,12 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	// self-signed
 	headers := map[string]string{
-		"authority-id": "canonical",
-		"account-id":   "canonical",
-		"fingerprint":  trustedFingerp,
-		"since":        "2015-11-20T15:04:00Z",
-		"until":        "2500-11-20T15:04:00Z",
+		"authority-id":  "canonical",
+		"account-id":    "canonical",
+		"public-key-id": trustedFingerp[24:40],
+		"fingerprint":   trustedFingerp,
+		"since":         "2015-11-20T15:04:00Z",
+		"until":         "2500-11-20T15:04:00Z",
 	}
 	trustedAccKey, err := db0.Sign(asserts.AccountKeyType, headers, trustedPubKeyEncoded, trustedFingerp)
 	c.Assert(err, IsNil)

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -43,7 +43,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	pk := asserts.OpenPGPPrivateKey(testPrivKey0)
 	trustedFingerp := pk.PublicKey().Fingerprint()
-	trustedKeyID := pk.PublicKey().KeyID()
+	trustedKeyID := pk.PublicKey().ID()
 	keyid, err := db0.ImportKey("canonical", pk)
 	c.Assert(err, IsNil)
 	trustedPubKey, err := db0.PublicKey("canonical", keyid)

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -52,12 +52,12 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	// self-signed
 	headers := map[string]string{
-		"authority-id":  "canonical",
-		"account-id":    "canonical",
-		"public-key-id": trustedKeyID,
-		"fingerprint":   trustedFingerp,
-		"since":         "2015-11-20T15:04:00Z",
-		"until":         "2500-11-20T15:04:00Z",
+		"authority-id":           "canonical",
+		"account-id":             "canonical",
+		"public-key-id":          trustedKeyID,
+		"public-key-fingerprint": trustedFingerp,
+		"since":                  "2015-11-20T15:04:00Z",
+		"until":                  "2500-11-20T15:04:00Z",
 	}
 	trustedAccKey, err := db0.Sign(asserts.AccountKeyType, headers, trustedPubKeyEncoded, trustedFingerp)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Introduce an explicit key id with the public-key-id field on AccountKey assertions, use it directly together with account id to map/match signatures to their signing keys,  based on this start simplifying the Backstore interface (SearchBySuffix goes away).

Rename but keep the fingerprint field to public-key-fingerprint and still use it to more fully sanity check the embedded public key.

Start not assuming that ImportKey returns a fingerprint, mostly because it was interfering a bit in some tests. Simplifying even more Backstore and simplifying/switching KeypairManager to be keyid based is for subsequent branches.

