### PR TITLE
Add and use cap typeattrs

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -19,9 +19,16 @@
 
 package caps
 
+import (
+	"fmt"
+	"sync"
+)
+
 // Capability holds information about a capability that a snap may request
 // from a snappy system to do its job while running on it.
 type Capability struct {
+	// Protects the internals from concurrent access.
+	m sync.Mutex
 	// Name is a key that identifies the capability. It must be unique within
 	// its context, which may be either a snap or a snappy runtime.
 	Name string `json:"name"`
@@ -41,4 +48,45 @@ type Capability struct {
 // String representation of a capability.
 func (c Capability) String() string {
 	return c.Name
+}
+
+func (c *Capability) setAttr(name string, value interface{}) {
+	if c.Attrs == nil {
+		c.Attrs = make(map[string]interface{})
+	}
+	c.Attrs[name] = value
+}
+
+func (c *Capability) getAttr(name string) (interface{}, error) {
+	if value, ok := c.Attrs[name]; ok {
+		return value, nil
+	}
+	return nil, fmt.Errorf("%s is not set", name)
+}
+
+// SetAttr sets capability attribute to a given value.
+func (c *Capability) SetAttr(name string, value string) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	attrType := c.Type.Attrs[name]
+	if attrType != nil {
+		// If attribute type is known, perform type-specific verification
+		realValue, err := attrType.CheckValue(value)
+		if err != nil {
+			return err
+		}
+		c.setAttr(name, realValue)
+	} else {
+		c.setAttr(name, value)
+	}
+	return nil
+}
+
+// GetAttr gets capability attribute with a given name.
+func (c *Capability) GetAttr(name string) (interface{}, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	return c.getAttr(name)
 }

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -46,7 +46,7 @@ type Capability struct {
 }
 
 // String representation of a capability.
-func (c Capability) String() string {
+func (c *Capability) String() string {
 	return c.Name
 }
 

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -35,7 +35,7 @@ type Capability struct {
 	// parties.
 	Type *Type `json:"type"`
 	// Attrs are key-value pairs that provide type-specific capability details.
-	Attrs map[string]string `json:"attrs,omitempty"`
+	Attrs map[string]interface{} `json:"attrs,omitempty"`
 }
 
 // String representation of a capability.

--- a/caps/mock.go
+++ b/caps/mock.go
@@ -20,27 +20,21 @@
 package caps
 
 import (
-	"path/filepath"
+	"github.com/ubuntu-core/snappy/testutil"
 )
 
 type evalSymlinksFn func(string) (string, error)
 
-// evalSymlinks is either filepath.EvalSymlinks or a mocked function for
-// applicable for testing.
-var evalSymlinks = filepath.EvalSymlinks
-
 // MockEvalSymlinks mocks the path/filepath.EvalSymlinks function for the
-// purpose of the capability package.
-func MockEvalSymlinks(fn evalSymlinksFn) {
+// purpose of the capability package. The original function is automatically
+// restored at the end of the test.
+func MockEvalSymlinks(s *testutil.BaseTest, fn evalSymlinksFn) {
+	oldEvalSymlinks := evalSymlinks
 	evalSymlinks = fn
+	s.AddCleanup(func() { evalSymlinks = oldEvalSymlinks })
 }
 
 // IgnoreSymbolicLinks is a no-op version of filepath.EvalSymlinks.
 func IgnoreSymbolicLinks(path string) (string, error) {
 	return path, nil
-}
-
-// RestoreEvalSymlinks restores the real behavior of filepath.EvalSymlinks.
-func RestoreEvalSymlinks() {
-	evalSymlinks = filepath.EvalSymlinks
 }

--- a/caps/mock.go
+++ b/caps/mock.go
@@ -29,7 +29,8 @@ type evalSymlinksFn func(string) (string, error)
 // applicable for testing.
 var evalSymlinks = filepath.EvalSymlinks
 
-// Mock EvalSymlinks function for the purpose of the capability package.
+// MockEvalSymlinks mocks the path/filepath.EvalSymlinks function for the
+// purpose of the capability package.
 func MockEvalSymlinks(fn evalSymlinksFn) {
 	evalSymlinks = fn
 }

--- a/caps/mock.go
+++ b/caps/mock.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"path/filepath"
+)
+
+type evalSymlinksFn func(string) (string, error)
+
+// evalSymlinks is either filepath.EvalSymlinks or a mocked function for
+// applicable for testing.
+var evalSymlinks = filepath.EvalSymlinks
+
+// Mock EvalSymlinks function for the purpose of the capability package.
+func MockEvalSymlinks(fn evalSymlinksFn) {
+	evalSymlinks = fn
+}
+
+// IgnoreSymbolicLinks is a no-op version of filepath.EvalSymlinks.
+func IgnoreSymbolicLinks(path string) (string, error) {
+	return path, nil
+}
+
+// RestoreEvalSymlinks restores the real behavior of filepath.EvalSymlinks.
+func RestoreEvalSymlinks() {
+	evalSymlinks = filepath.EvalSymlinks
+}

--- a/caps/repo.go
+++ b/caps/repo.go
@@ -164,21 +164,21 @@ func (r *Repository) TypeNames() []string {
 	return types
 }
 
-type byName []Capability
+type byName []*Capability
 
 func (c byName) Len() int           { return len(c) }
 func (c byName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 func (c byName) Less(i, j int) bool { return c[i].Name < c[j].Name }
 
 // All returns all capabilities ordered by name.
-func (r *Repository) All() []Capability {
+func (r *Repository) All() []*Capability {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	caps := make([]Capability, len(r.caps))
+	caps := make([]*Capability, len(r.caps))
 	i := 0
 	for _, capability := range r.caps {
-		caps[i] = *capability
+		caps[i] = capability
 		i++
 	}
 	sort.Sort(byName(caps))

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -140,10 +140,10 @@ func (s *RepositorySuite) TestAll(c *C) {
 	c.Assert(err, IsNil)
 	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
 	c.Assert(err, IsNil)
-	c.Assert(s.testRepo.All(), DeepEquals, []Capability{
-		Capability{Name: "a", Label: "label-a", Type: testType},
-		Capability{Name: "b", Label: "label-b", Type: testType},
-		Capability{Name: "c", Label: "label-c", Type: testType},
+	c.Assert(s.testRepo.All(), DeepEquals, []*Capability{
+		&Capability{Name: "a", Label: "label-a", Type: testType},
+		&Capability{Name: "b", Label: "label-b", Type: testType},
+		&Capability{Name: "c", Label: "label-c", Type: testType},
 	})
 }
 

--- a/caps/typeattr.go
+++ b/caps/typeattr.go
@@ -1,0 +1,29 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+// TypeAttr describes the type of a capability attribute.
+// All capability attributes are assigned with a string value. Internally the
+// attribute type can perform type conversion, value validation and value
+// transformation, as required by the intended semantics.
+type TypeAttr interface {
+	// CheckValue checks if the value is correct.
+	CheckValue(value interface{}) (interface{}, error)
+}

--- a/caps/typeattr_path.go
+++ b/caps/typeattr_path.go
@@ -21,8 +21,13 @@ package caps
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 )
+
+// evalSymlinks is either filepath.EvalSymlinks or a mocked function for
+// applicable for testing.
+var evalSymlinks = filepath.EvalSymlinks
 
 // pathAttr is a type for storing filesystem paths in capability attributes.
 //

--- a/caps/typeattr_path.go
+++ b/caps/typeattr_path.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// pathAttr is a type for storing filesystem paths in capability attributes.
+//
+// Path is validated by matching it against several regular expressions.  At
+// least one regular expression must match for the assignment to succeed.  If
+// the stored path contains symbolic links then they are resolved so that the
+// final value has no symbolic links (at the time of assignment).
+type pathAttr struct {
+	// errorHint is a part of the error message when path is invalid.
+	// This is better than showing regular expressions to the user.
+	errorHint string
+	// allowedPatterns describe the set of valid values of path
+	allowedPatterns []*regexp.Regexp
+}
+
+func (a *pathAttr) CheckValue(value interface{}) (interface{}, error) {
+	switch value.(type) {
+	case string:
+		const errPrefix = "invalid path"
+		value := value.(string)
+		realValue, err := evalSymlinks(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s, cannot traverse symbolic links: %s", errPrefix, err)
+		}
+		valid := false
+		for _, pattern := range a.allowedPatterns {
+			if pattern.MatchString(value) {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return nil, fmt.Errorf("%s, %s", errPrefix, a.errorHint)
+		}
+		return realValue, nil
+	default:
+		return nil, fmt.Errorf("unexpected value of type %T", value)
+	}
+}

--- a/caps/typeattr_path_test.go
+++ b/caps/typeattr_path_test.go
@@ -24,9 +24,12 @@ import (
 	"regexp"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/testutil"
 )
 
 type pathSuite struct {
+	testutil.BaseTest
 	pathAttr    TypeAttr
 	devPathAttr TypeAttr
 	capType     *Type
@@ -57,19 +60,16 @@ func (s *pathSuite) SetUpSuite(c *C) {
 }
 
 func (s *pathSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
 	// For testing, mock the filepath.EvalSymlinks function to a simple
 	// identity function that never fails. Individual tests can replace that
-	// with anything they want, the tear-down function recovers the original.
-	MockEvalSymlinks(IgnoreSymbolicLinks)
+	// with anything they want.
+	MockEvalSymlinks(&s.BaseTest, IgnoreSymbolicLinks)
 	// Give each test a fresh capability object
 	s.cap = &Capability{
 		Name: "cap",
 		Type: s.capType,
 	}
-}
-
-func (s *pathSuite) TearDownTest(c *C) {
-	RestoreEvalSymlinks()
 }
 
 func (s *pathSuite) TestSetAttr(c *C) {
@@ -79,7 +79,7 @@ func (s *pathSuite) TestSetAttr(c *C) {
 }
 
 func (s *pathSuite) TestSetAttrEvaluatesSymlinks(c *C) {
-	MockEvalSymlinks(func(path string) (string, error) {
+	MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "real", nil
 	})
 	err := s.cap.SetAttr("path", "symbolic")
@@ -88,7 +88,7 @@ func (s *pathSuite) TestSetAttrEvaluatesSymlinks(c *C) {
 }
 
 func (s *pathSuite) TestSetAttrHandlesSymlinkErrors(c *C) {
-	MockEvalSymlinks(func(path string) (string, error) {
+	MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "", fmt.Errorf("broken symbolic link")
 	})
 	err := s.cap.SetAttr("path", "symbolic")

--- a/caps/typeattr_path_test.go
+++ b/caps/typeattr_path_test.go
@@ -1,0 +1,132 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"fmt"
+	"regexp"
+
+	. "gopkg.in/check.v1"
+)
+
+type pathSuite struct {
+	pathAttr    TypeAttr
+	devPathAttr TypeAttr
+	capType     *Type
+	cap         *Capability
+}
+
+var _ = Suite(&pathSuite{})
+
+func (s *pathSuite) SetUpSuite(c *C) {
+	// A path attribute that accepts any path
+	s.pathAttr = &pathAttr{
+		errorHint:       "path cannot be empty",
+		allowedPatterns: []*regexp.Regexp{regexp.MustCompile(".*")},
+	}
+	// A path attribute restricted to files in /dev/
+	s.devPathAttr = &pathAttr{
+		errorHint:       "devPath must point to something in /dev/",
+		allowedPatterns: []*regexp.Regexp{regexp.MustCompile("^/dev/.+$")},
+	}
+	// An test capability and capability type using attributes
+	s.capType = &Type{
+		Name: "type",
+		Attrs: map[string]TypeAttr{
+			"path":    s.pathAttr,
+			"devPath": s.devPathAttr,
+		},
+	}
+}
+
+func (s *pathSuite) SetUpTest(c *C) {
+	// For testing, mock the filepath.EvalSymlinks function to a simple
+	// identity function that never fails. Individual tests can replace that
+	// with anything they want, the tear-down function recovers the original.
+	MockEvalSymlinks(IgnoreSymbolicLinks)
+	// Give each test a fresh capability object
+	s.cap = &Capability{
+		Name: "cap",
+		Type: s.capType,
+	}
+}
+
+func (s *pathSuite) TearDownTest(c *C) {
+	RestoreEvalSymlinks()
+}
+
+func (s *pathSuite) TestSetAttr(c *C) {
+	err := s.cap.SetAttr("path", "/some/path")
+	c.Assert(err, IsNil)
+	c.Assert(s.cap.Attrs["path"], Equals, "/some/path")
+}
+
+func (s *pathSuite) TestSetAttrEvaluatesSymlinks(c *C) {
+	MockEvalSymlinks(func(path string) (string, error) {
+		return "real", nil
+	})
+	err := s.cap.SetAttr("path", "symbolic")
+	c.Assert(err, IsNil)
+	c.Assert(s.cap.Attrs["path"], Equals, "real")
+}
+
+func (s *pathSuite) TestSetAttrHandlesSymlinkErrors(c *C) {
+	MockEvalSymlinks(func(path string) (string, error) {
+		return "", fmt.Errorf("broken symbolic link")
+	})
+	err := s.cap.SetAttr("path", "symbolic")
+	c.Assert(err, ErrorMatches, "invalid path, cannot traverse symbolic links: broken symbolic link")
+	value, ok := s.cap.Attrs["path"]
+	c.Assert(value, Equals, nil)
+	c.Assert(ok, Equals, false)
+}
+
+func (s *pathSuite) TestSetAttrChecksForValidValue(c *C) {
+	err := s.cap.SetAttr("devPath", "/etc/passwd")
+	c.Assert(err, ErrorMatches, "invalid path, devPath must point to something in /dev/")
+	value, ok := s.cap.Attrs["devPath"]
+	c.Assert(value, Equals, nil)
+	c.Assert(ok, Equals, false)
+}
+
+func (s *pathSuite) TestGetAttrWhenUnset(c *C) {
+	value, err := s.cap.GetAttr("path")
+	c.Assert(err, ErrorMatches, "path is not set")
+	c.Assert(value, IsNil)
+}
+
+func (s *pathSuite) TestGetAttrWhenSet(c *C) {
+	err := s.cap.SetAttr("path", "/some/path")
+	c.Assert(err, IsNil)
+	value, err := s.cap.GetAttr("path")
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "/some/path")
+}
+
+func (s *pathSuite) TestSmoke(c *C) {
+	value, err := s.cap.GetAttr("path")
+	c.Assert(value, Equals, nil)
+	c.Assert(err, ErrorMatches, "path is not set")
+	err = s.cap.SetAttr("path", "/some/path")
+	c.Assert(err, IsNil)
+	value, err = s.cap.GetAttr("path")
+	c.Assert(value, Equals, "/some/path")
+	c.Assert(err, IsNil)
+}

--- a/caps/typeattr_path_test.go
+++ b/caps/typeattr_path_test.go
@@ -39,7 +39,7 @@ func (s *pathSuite) SetUpSuite(c *C) {
 	// A path attribute that accepts any path
 	s.pathAttr = &pathAttr{
 		errorHint:       "path cannot be empty",
-		allowedPatterns: []*regexp.Regexp{regexp.MustCompile(".*")},
+		allowedPatterns: []*regexp.Regexp{regexp.MustCompile(".+")},
 	}
 	// A path attribute restricted to files in /dev/
 	s.devPathAttr = &pathAttr{

--- a/caps/typeattr_string.go
+++ b/caps/typeattr_string.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"fmt"
+)
+
+// stringAttr is a type for storing arbitrary strings in capability attributes.
+type stringAttr struct {
+}
+
+func (*stringAttr) CheckValue(value interface{}) (interface{}, error) {
+	switch value.(type) {
+	case string:
+		return value, nil
+	default:
+		return nil, fmt.Errorf("unexpected value of type %T", value)
+	}
+}

--- a/caps/typeattr_string_test.go
+++ b/caps/typeattr_string_test.go
@@ -1,0 +1,77 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type stringSuite struct {
+	attr    TypeAttr
+	cap     *Capability
+	capType *Type
+}
+
+var _ = Suite(&stringSuite{})
+
+func (s *stringSuite) SetUpTest(c *C) {
+	s.attr = &stringAttr{}
+	// An test capability and capability type using attributes
+	s.capType = &Type{
+		Name: "type",
+		Attrs: map[string]TypeAttr{
+			"attr": s.attr,
+		},
+	}
+	s.cap = &Capability{
+		Name: "cap",
+		Type: s.capType,
+	}
+}
+
+func (s *stringSuite) TestSetAttr(c *C) {
+	err := s.cap.SetAttr("attr", "value")
+	c.Assert(err, IsNil)
+	c.Assert(s.cap.Attrs["attr"], Equals, "value")
+}
+
+func (s *stringSuite) TestGetAttrWhenUnset(c *C) {
+	value, err := s.cap.GetAttr("attr")
+	c.Assert(err, ErrorMatches, "attr is not set")
+	c.Assert(value, IsNil)
+}
+
+func (s *stringSuite) TestGetAttrWhenSet(c *C) {
+	s.cap.setAttr("attr", "value")
+	value, err := s.cap.GetAttr("attr")
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "value")
+}
+
+func (s *stringSuite) TestSmoke(c *C) {
+	value, err := s.cap.GetAttr("attr")
+	c.Assert(value, Equals, nil)
+	c.Assert(err, ErrorMatches, "attr is not set")
+	err = s.cap.SetAttr("attr", "value")
+	c.Assert(err, IsNil)
+	value, err = s.cap.GetAttr("attr")
+	c.Assert(value, Equals, "value")
+	c.Assert(err, IsNil)
+}

--- a/caps/types.go
+++ b/caps/types.go
@@ -34,6 +34,8 @@ type Type struct {
 	// RequiredAttrs contains names of attributes that are required by
 	// capability of this type.
 	RequiredAttrs []string
+	// Attrs contains a description of each attribute type
+	Attrs map[string]TypeAttr
 }
 
 var (
@@ -67,6 +69,16 @@ func (t *Type) Validate(c *Capability) error {
 	for _, attr := range t.RequiredAttrs {
 		if _, ok := c.Attrs[attr]; !ok {
 			return fmt.Errorf("capabilities of type %q must provide a %q attribute", t, attr)
+		}
+	}
+	// Check that the type of each attribute is correct
+	for attrName, attrType := range t.Attrs {
+		attrValue, ok := c.Attrs[attrName]
+		if !ok {
+			return fmt.Errorf("capabilities of type %q must provide a %q attribute", t, attrName)
+		}
+		if _, err := attrType.CheckValue(attrValue); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/caps/types.go
+++ b/caps/types.go
@@ -38,19 +38,6 @@ type Type struct {
 	Attrs map[string]TypeAttr
 }
 
-var (
-	// BoolFileType is a built-in capability type for files that follow a
-	// simple boolean protocol. The file can be read, which yields ASCII '0'
-	// (zero) or ASCII '1' (one). The same can be done for writing.
-	//
-	// This capability type can be used to describe many boolean flags exposed
-	// in sysfs, including certain hardware like exported GPIO pins.
-	BoolFileType = &Type{
-		Name:          "bool-file",
-		RequiredAttrs: []string{"path"},
-	}
-)
-
 var builtInTypes = [...]*Type{
 	BoolFileType,
 }

--- a/caps/types_bool_file.go
+++ b/caps/types_bool_file.go
@@ -19,6 +19,10 @@
 
 package caps
 
+import (
+	"regexp"
+)
+
 // BoolFileType is a built-in capability type for files that follow a
 // simple boolean protocol. The file can be read, which yields ASCII '0'
 // (zero) or ASCII '1' (one). The same can be done for writing.
@@ -26,6 +30,17 @@ package caps
 // This capability type can be used to describe many boolean flags exposed
 // in sysfs, including certain hardware like exported GPIO pins.
 var BoolFileType = &Type{
-	Name:          "bool-file",
-	RequiredAttrs: []string{"path"},
+	Name: "bool-file",
+	Attrs: map[string]TypeAttr{
+		"path": &pathAttr{
+			errorHint: "only LED brightness or GPIO value is allowed",
+			// Allowed devices include:
+			allowedPatterns: []*regexp.Regexp{
+				// The brightness of standard LED class device
+				regexp.MustCompile("^/sys/class/leds/[^/]+/brightness$"),
+				// The value of standard exported GPIO
+				regexp.MustCompile("^/sys/class/gpio/gpio[0-9]+/value$"),
+			},
+		},
+	},
 }

--- a/caps/types_bool_file.go
+++ b/caps/types_bool_file.go
@@ -1,0 +1,31 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+// BoolFileType is a built-in capability type for files that follow a
+// simple boolean protocol. The file can be read, which yields ASCII '0'
+// (zero) or ASCII '1' (one). The same can be done for writing.
+//
+// This capability type can be used to describe many boolean flags exposed
+// in sysfs, including certain hardware like exported GPIO pins.
+var BoolFileType = &Type{
+	Name:          "bool-file",
+	RequiredAttrs: []string{"path"},
+}

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -76,7 +76,7 @@ func (s *TypeSuite) TestValidateAttributesRequiredAttrsSatisfied(c *C) {
 		Name:  "name",
 		Label: "label",
 		Type:  t,
-		Attrs: map[string]string{"k": "v"},
+		Attrs: map[string]interface{}{"k": "v"},
 	}
 	err := t.Validate(cap)
 	c.Assert(err, IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1164,6 +1164,9 @@ func (s *apiSuite) TestInstallLicensedIntegration(c *check.C) {
 
 func (s *apiSuite) TestGetCapabilities(c *check.C) {
 	d := newTestDaemon()
+	// Don't check symbolic links when analyzing the capability below
+	caps.MockEvalSymlinks(caps.IgnoreSymbolicLinks)
+	defer caps.RestoreEvalSymlinks()
 	d.capRepo.Add(&caps.Capability{
 		Name:  "caps-lock-led",
 		Label: "Caps Lock LED",
@@ -1202,6 +1205,9 @@ func (s *apiSuite) TestGetCapabilities(c *check.C) {
 func (s *apiSuite) TestAddCapabilitiesGood(c *check.C) {
 	// Setup
 	d := newTestDaemon()
+	// Don't check symbolic links when analyzing the capability below
+	caps.MockEvalSymlinks(caps.IgnoreSymbolicLinks)
+	defer caps.RestoreEvalSymlinks()
 	cap := &caps.Capability{
 		Name:  "name",
 		Label: "label",
@@ -1229,6 +1235,9 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 	// Setup
 	// Start with one capability named 'name' in the repository
 	d := newTestDaemon()
+	// Don't check symbolic links when analyzing the capability below
+	caps.MockEvalSymlinks(caps.IgnoreSymbolicLinks)
+	defer caps.RestoreEvalSymlinks()
 	cap := &caps.Capability{
 		Name:  "name",
 		Label: "label",

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1228,7 +1228,7 @@ func (s *apiSuite) TestAddCapabilitiesGood(c *check.C) {
 	c.Check(rsp.Status, check.Equals, http.StatusCreated)
 	c.Check(rsp.Result, check.DeepEquals, map[string]string{"resource": "/1.0/capabilities/name"})
 	// Verify (internal)
-	c.Check(d.capRepo.All(), testutil.DeepContains, *cap)
+	c.Check(d.capRepo.All(), testutil.DeepContains, cap)
 }
 
 func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
@@ -1269,8 +1269,8 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result.(*errorResult).Msg, check.Matches, `can't add capability`)
 	// Verify (internal)
-	c.Check(d.capRepo.All(), testutil.DeepContains, *cap)
-	c.Check(d.capRepo.All(), check.Not(testutil.DeepContains), *capClashing)
+	c.Check(d.capRepo.All(), testutil.DeepContains, cap)
+	c.Check(d.capRepo.All(), check.Not(testutil.DeepContains), capClashing)
 }
 
 func (s *apiSuite) TestAddCapabilitiesUnintelligible(c *check.C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1168,7 +1168,7 @@ func (s *apiSuite) TestGetCapabilities(c *check.C) {
 		Name:  "caps-lock-led",
 		Label: "Caps Lock LED",
 		Type:  caps.BoolFileType,
-		Attrs: map[string]string{
+		Attrs: map[string]interface{}{
 			"path": "/sys/class/leds/input::capslock/brightness",
 		},
 	})
@@ -1206,7 +1206,9 @@ func (s *apiSuite) TestAddCapabilitiesGood(c *check.C) {
 		Name:  "name",
 		Label: "label",
 		Type:  caps.BoolFileType,
-		Attrs: map[string]string{"path": "/nonexistent"},
+		Attrs: map[string]interface{}{
+			"path": "/nonexistent",
+		},
 	}
 	text, err := json.Marshal(cap)
 	c.Assert(err, check.IsNil)
@@ -1231,7 +1233,9 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 		Name:  "name",
 		Label: "label",
 		Type:  caps.BoolFileType,
-		Attrs: map[string]string{"path": "/nonexistent"},
+		Attrs: map[string]interface{}{
+			"path": "/nonexistent",
+		},
 	}
 	err := d.capRepo.Add(cap)
 	c.Assert(err, check.IsNil)
@@ -1240,7 +1244,9 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 		Name:  "name",
 		Label: "second label",
 		Type:  caps.BoolFileType,
-		Attrs: map[string]string{"path": "/nonexistent"},
+		Attrs: map[string]interface{}{
+			"path": "/nonexistent",
+		},
 	}
 	text, err := json.Marshal(capClashing)
 	c.Assert(err, check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1213,7 +1213,7 @@ func (s *apiSuite) TestAddCapabilitiesGood(c *check.C) {
 		Label: "label",
 		Type:  caps.BoolFileType,
 		Attrs: map[string]interface{}{
-			"path": "/nonexistent",
+			"path": "/sys/class/leds/input::capslock/brightness",
 		},
 	}
 	text, err := json.Marshal(cap)
@@ -1243,7 +1243,7 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 		Label: "label",
 		Type:  caps.BoolFileType,
 		Attrs: map[string]interface{}{
-			"path": "/nonexistent",
+			"path": "/sys/class/leds/input::capslock/brightness",
 		},
 	}
 	err := d.capRepo.Add(cap)
@@ -1254,7 +1254,7 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 		Label: "second label",
 		Type:  caps.BoolFileType,
 		Attrs: map[string]interface{}{
-			"path": "/nonexistent",
+			"path": "/sys/class/leds/input::capslock/brightness",
 		},
 	}
 	text, err := json.Marshal(capClashing)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -51,6 +51,7 @@ import (
 )
 
 type apiSuite struct {
+	testutil.BaseTest
 	parts []snappy.Part
 	err   error
 	vars  map[string]string
@@ -89,6 +90,8 @@ func (s *apiSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *apiSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapLockFile), 0755), check.IsNil)
 
@@ -99,6 +102,8 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 
 func (s *apiSuite) TearDownTest(c *check.C) {
 	findServices = snappy.FindServices
+
+	s.BaseTest.TearDownTest(c)
 }
 
 func (s *apiSuite) mkInstalled(c *check.C, name, origin, version string, active bool, extraYaml string) {
@@ -1165,8 +1170,7 @@ func (s *apiSuite) TestInstallLicensedIntegration(c *check.C) {
 func (s *apiSuite) TestGetCapabilities(c *check.C) {
 	d := newTestDaemon()
 	// Don't check symbolic links when analyzing the capability below
-	caps.MockEvalSymlinks(caps.IgnoreSymbolicLinks)
-	defer caps.RestoreEvalSymlinks()
+	caps.MockEvalSymlinks(&s.BaseTest, caps.IgnoreSymbolicLinks)
 	d.capRepo.Add(&caps.Capability{
 		Name:  "caps-lock-led",
 		Label: "Caps Lock LED",
@@ -1206,8 +1210,7 @@ func (s *apiSuite) TestAddCapabilitiesGood(c *check.C) {
 	// Setup
 	d := newTestDaemon()
 	// Don't check symbolic links when analyzing the capability below
-	caps.MockEvalSymlinks(caps.IgnoreSymbolicLinks)
-	defer caps.RestoreEvalSymlinks()
+	caps.MockEvalSymlinks(&s.BaseTest, caps.IgnoreSymbolicLinks)
 	cap := &caps.Capability{
 		Name:  "name",
 		Label: "label",
@@ -1236,8 +1239,7 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 	// Start with one capability named 'name' in the repository
 	d := newTestDaemon()
 	// Don't check symbolic links when analyzing the capability below
-	caps.MockEvalSymlinks(caps.IgnoreSymbolicLinks)
-	defer caps.RestoreEvalSymlinks()
+	caps.MockEvalSymlinks(&s.BaseTest, caps.IgnoreSymbolicLinks)
 	cap := &caps.Capability{
 		Name:  "name",
 		Label: "label",


### PR DESCRIPTION
This branch introduces the typeattr concept (a type of an attribute of a capability) and refines the bool-file to use it. One of the patches , namely, 589b23b needs sign-off from @jdstrand and his team as it affects system security.