### PR TITLE
asserts: simplify KeypairManager interface basing it on keyids only

### DIFF
--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -48,7 +48,7 @@ func (aks *accountKeySuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	aks.fp = pk.PublicKey().Fingerprint()
 	aks.keyid = pk.PublicKey().ID()
-	pubKey, err := accDb.PublicKey("acc-id1", aks.fp)
+	pubKey, err := accDb.PublicKey("acc-id1", aks.keyid)
 	c.Assert(err, IsNil)
 	pubKeyEncoded, err := asserts.EncodePublicKey(pubKey)
 	c.Assert(err, IsNil)

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -44,10 +44,11 @@ func (aks *accountKeySuite) SetUpSuite(c *C) {
 	accDb, err := asserts.OpenDatabase(cfg1)
 	c.Assert(err, IsNil)
 	pk := asserts.OpenPGPPrivateKey(testPrivKey1)
-	_, err = accDb.ImportKey("acc-id1", pk)
+	err = accDb.ImportKey("acc-id1", pk)
 	c.Assert(err, IsNil)
 	aks.fp = pk.PublicKey().Fingerprint()
 	aks.keyid = pk.PublicKey().ID()
+
 	pubKey, err := accDb.PublicKey("acc-id1", aks.keyid)
 	c.Assert(err, IsNil)
 	pubKeyEncoded, err := asserts.EncodePublicKey(pubKey)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -157,8 +157,7 @@ func (db *Database) GenerateKey(authorityID string) (keyID string, err error) {
 		return "", fmt.Errorf("failed to generate private key: %v", err)
 	}
 
-	pk := OpenPGPPrivateKey(privKey)
-	return db.ImportKey(authorityID, pk)
+	return db.ImportKey(authorityID, OpenPGPPrivateKey(privKey))
 }
 
 // ImportKey stores the given private/public key pair for identity and

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -185,7 +185,7 @@ func (db *Database) safeGetPrivateKey(authorityID, keyID string) (PrivateKey, er
 	return db.keypairMgr.Get(authorityID, keyID)
 }
 
-// PublicKey exports the public part of a stored key pair for identity and key id.
+// PublicKey returns the public key owned by authorityID that has the given key id.
 func (db *Database) PublicKey(authorityID string, keyID string) (PublicKey, error) {
 	privKey, err := db.safeGetPrivateKey(authorityID, keyID)
 	if err != nil {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -158,21 +158,16 @@ func (db *Database) GenerateKey(authorityID string) (keyID string, err error) {
 	}
 
 	pk := OpenPGPPrivateKey(privKey)
-	_, err = db.ImportKey(authorityID, pk)
+	err = db.ImportKey(authorityID, pk)
 	if err != nil {
 		return "", err
 	}
 	return pk.PublicKey().ID(), nil
 }
 
-// ImportKey stores the given private/public key pair for identity and
-// returns its key id.
-func (db *Database) ImportKey(authorityID string, privKey PrivateKey) (keyID string, err error) {
-	err = db.keypairMgr.Put(authorityID, privKey)
-	if err != nil {
-		return "", err
-	}
-	return privKey.PublicKey().ID(), nil
+// ImportKey stores the given private/public key pair for identity.
+func (db *Database) ImportKey(authorityID string, privKey PrivateKey) error {
+	return db.keypairMgr.Put(authorityID, privKey)
 }
 
 var (

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -162,7 +162,7 @@ func (db *Database) GenerateKey(authorityID string) (keyID string, err error) {
 }
 
 // ImportKey stores the given private/public key pair for identity and
-// returns its keyID
+// returns its key id.
 func (db *Database) ImportKey(authorityID string, privKey PrivateKey) (keyID string, err error) {
 	err = db.keypairMgr.Put(authorityID, privKey)
 	if err != nil {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -56,14 +56,14 @@ type Backstore interface {
 
 // KeypairManager is a manager and backstore for private/public key pairs.
 type KeypairManager interface {
-	// Import stores the given private/public key pair for identity and
-	// returns its fingerprint
-	Import(authorityID string, privKey PrivateKey) (fingerprint string, err error)
-	// Get returns the private/public key pair with the given fingeprint.
-	Get(authorityID, fingeprint string) (PrivateKey, error)
-	// Find finds the private/public key pair with the given fingeprint suffix.
-	// Find will return an error if not eactly one key pair is found.
-	Find(authorityID, fingerprintSuffix string) (PrivateKey, error)
+	// Put stores the given private/public key pair for identity,
+	// making sure it can be later retrieved by authority-id and
+	// key id with Get().
+	// Trying to store a key with an already present key id should
+	// result in an error.
+	Put(authorityID string, privKey PrivateKey) error
+	// Get returns the private/public key pair with the given key id.
+	Get(authorityID, keyID string) (PrivateKey, error)
 }
 
 // TODO: for more flexibility plugging the keypair manager make PrivatKey private encoding methods optional, and add an explicit sign method.
@@ -147,8 +147,8 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 }
 
 // GenerateKey generates a private/public key pair for identity and
-// stores it returning its fingerprint.
-func (db *Database) GenerateKey(authorityID string) (fingerprint string, err error) {
+// stores it returning its key id.
+func (db *Database) GenerateKey(authorityID string) (keyID string, err error) {
 	// TODO: optionally delegate the whole thing to the keypair mgr
 
 	// TODO: support specifying different key types/algorithms
@@ -157,13 +157,18 @@ func (db *Database) GenerateKey(authorityID string) (fingerprint string, err err
 		return "", fmt.Errorf("failed to generate private key: %v", err)
 	}
 
-	return db.keypairMgr.Import(authorityID, OpenPGPPrivateKey(privKey))
+	pk := OpenPGPPrivateKey(privKey)
+	return db.ImportKey(authorityID, pk)
 }
 
 // ImportKey stores the given private/public key pair for identity and
-// returns its fingerprint
-func (db *Database) ImportKey(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
-	return db.keypairMgr.Import(authorityID, privKey)
+// returns its keyID
+func (db *Database) ImportKey(authorityID string, privKey PrivateKey) (keyID string, err error) {
+	err = db.keypairMgr.Put(authorityID, privKey)
+	if err != nil {
+		return "", err
+	}
+	return privKey.PublicKey().ID(), nil
 }
 
 var (
@@ -171,14 +176,19 @@ var (
 	fingerprintLike = regexp.MustCompile("^[0-9a-f]*$")
 )
 
-// PublicKey exports the public part of a stored key pair for identity
-// by matching the given fingerprint suffix, it is an error if no or more
-// than one key pair is found.
-func (db *Database) PublicKey(authorityID string, fingerprintSuffix string) (PublicKey, error) {
-	if !fingerprintLike.MatchString(fingerprintSuffix) {
-		return nil, fmt.Errorf("fingerprint suffix contains unexpected chars: %q", fingerprintSuffix)
+func (db *Database) safeGetPrivateKey(authorityID, keyID string) (PrivateKey, error) {
+	if keyID == "" {
+		return nil, fmt.Errorf("key id is empty")
 	}
-	privKey, err := db.keypairMgr.Find(authorityID, fingerprintSuffix)
+	if !fingerprintLike.MatchString(keyID) {
+		return nil, fmt.Errorf("key id contains unexpected chars: %q", keyID)
+	}
+	return db.keypairMgr.Get(authorityID, keyID)
+}
+
+// PublicKey exports the public part of a stored key pair for identity and key id.
+func (db *Database) PublicKey(authorityID string, keyID string) (PublicKey, error) {
+	privKey, err := db.safeGetPrivateKey(authorityID, keyID)
 	if err != nil {
 		return nil, err
 	}
@@ -186,19 +196,13 @@ func (db *Database) PublicKey(authorityID string, fingerprintSuffix string) (Pub
 }
 
 // Sign builds an assertion with the provided information and signs it
-// with the private key from `headers["authority-id"]` that has the provided fingerprint.
-func (db *Database) Sign(assertType AssertionType, headers map[string]string, body []byte, fingerprint string) (Assertion, error) {
-	if fingerprint == "" {
-		return nil, fmt.Errorf("fingerprint is empty")
-	}
-	if !fingerprintLike.MatchString(fingerprint) {
-		return nil, fmt.Errorf("fingerprint contains unexpected chars: %q", fingerprint)
-	}
+// with the private key from `headers["authority-id"]` that has the provided key id.
+func (db *Database) Sign(assertType AssertionType, headers map[string]string, body []byte, keyID string) (Assertion, error) {
 	authorityID, err := checkMandatory(headers, "authority-id")
 	if err != nil {
 		return nil, err
 	}
-	privKey, err := db.keypairMgr.Get(authorityID, fingerprint)
+	privKey, err := db.safeGetPrivateKey(authorityID, keyID)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -157,7 +157,12 @@ func (db *Database) GenerateKey(authorityID string) (keyID string, err error) {
 		return "", fmt.Errorf("failed to generate private key: %v", err)
 	}
 
-	return db.ImportKey(authorityID, OpenPGPPrivateKey(privKey))
+	pk := OpenPGPPrivateKey(privKey)
+	_, err = db.ImportKey(authorityID, pk)
+	if err != nil {
+		return "", err
+	}
+	return pk.PublicKey().ID(), nil
 }
 
 // ImportKey stores the given private/public key pair for identity and

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -102,7 +102,7 @@ func (dbs *databaseSuite) TestImportKey(c *C) {
 	expectedFingerprint := hex.EncodeToString(testPrivKey1.PublicKey.Fingerprint[:])
 	expectedKeyID := hex.EncodeToString(testPrivKey1.PublicKey.Fingerprint[12:])
 
-	_, err := dbs.db.ImportKey("account0", asserts.OpenPGPPrivateKey(testPrivKey1))
+	err := dbs.db.ImportKey("account0", asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 
 	keyPath := filepath.Join(dbs.rootDir, "private-keys-v0/account0", expectedKeyID)
@@ -120,10 +120,10 @@ func (dbs *databaseSuite) TestImportKey(c *C) {
 }
 
 func (dbs *databaseSuite) TestImportKeyAlreadyExists(c *C) {
-	_, err := dbs.db.ImportKey("account0", asserts.OpenPGPPrivateKey(testPrivKey1))
+	err := dbs.db.ImportKey("account0", asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 
-	_, err = dbs.db.ImportKey("account0", asserts.OpenPGPPrivateKey(testPrivKey1))
+	err = dbs.db.ImportKey("account0", asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Check(err, ErrorMatches, "key pair with given key id already exists")
 }
 
@@ -139,7 +139,7 @@ func (dbs *databaseSuite) TestPublicKey(c *C) {
 	pk := asserts.OpenPGPPrivateKey(testPrivKey1)
 	fingerp := pk.PublicKey().Fingerprint()
 	keyid := pk.PublicKey().ID()
-	_, err := dbs.db.ImportKey("account0", pk)
+	err := dbs.db.ImportKey("account0", pk)
 	c.Assert(err, IsNil)
 
 	pubk, err := dbs.db.PublicKey("account0", keyid)
@@ -166,7 +166,7 @@ func (dbs *databaseSuite) TestPublicKeyNotFound(c *C) {
 	_, err := dbs.db.PublicKey("account0", keyID)
 	c.Check(err, ErrorMatches, "no matching key pair found")
 
-	_, err = dbs.db.ImportKey("account0", pk)
+	err = dbs.db.ImportKey("account0", pk)
 	c.Assert(err, IsNil)
 
 	_, err = dbs.db.PublicKey("account0", "ff"+keyID)
@@ -252,7 +252,7 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 	safs.signingDB = db0
 
 	pk := asserts.OpenPGPPrivateKey(testPrivKey0)
-	_, err = db0.ImportKey("canonical", pk)
+	err = db0.ImportKey("canonical", pk)
 	c.Assert(err, IsNil)
 	safs.signingKeyID = pk.PublicKey().ID()
 

--- a/asserts/fsentryutils.go
+++ b/asserts/fsentryutils.go
@@ -43,6 +43,11 @@ func atomicWriteEntry(data []byte, secret bool, top string, subpath ...string) e
 	return helpers.AtomicWriteFile(fpath, data, os.FileMode(fperm), 0)
 }
 
+func entryExists(top string, subpath ...string) bool {
+	fpath := filepath.Join(top, filepath.Join(subpath...))
+	return helpers.FileExists(fpath)
+}
+
 func readEntry(top string, subpath ...string) ([]byte, error) {
 	fpath := filepath.Join(top, filepath.Join(subpath...))
 	return ioutil.ReadFile(fpath)

--- a/asserts/memkeypairmgr.go
+++ b/asserts/memkeypairmgr.go
@@ -19,11 +19,6 @@
 
 package asserts
 
-import (
-	"fmt"
-	"strings"
-)
-
 type memoryKeypairManager struct {
 	pairs map[string]map[string]PrivateKey
 }
@@ -35,38 +30,23 @@ func NewMemoryKeypairMananager() KeypairManager {
 	}
 }
 
-func (mskm memoryKeypairManager) Import(authorityID string, privKey PrivateKey) (fingerprint string, err error) {
-	fingerp := privKey.PublicKey().Fingerprint()
+func (mskm memoryKeypairManager) Put(authorityID string, privKey PrivateKey) error {
+	keyID := privKey.PublicKey().ID()
 	perAuthID := mskm.pairs[authorityID]
 	if perAuthID == nil {
 		perAuthID = make(map[string]PrivateKey)
 		mskm.pairs[authorityID] = perAuthID
+	} else if perAuthID[keyID] != nil {
+		return errKeypairAlreadyExists
 	}
-	perAuthID[fingerp] = privKey
-	return fingerp, nil
+	perAuthID[keyID] = privKey
+	return nil
 }
 
-func (mskm memoryKeypairManager) Get(authorityID, fingeprint string) (PrivateKey, error) {
-	privKey := mskm.pairs[authorityID][fingeprint]
+func (mskm memoryKeypairManager) Get(authorityID, keyID string) (PrivateKey, error) {
+	privKey := mskm.pairs[authorityID][keyID]
 	if privKey == nil {
 		return nil, errKeypairNotFound
 	}
 	return privKey, nil
-}
-
-func (mskm memoryKeypairManager) Find(authorityID, fingerprintSuffix string) (PrivateKey, error) {
-	var found PrivateKey
-	for fingerp, privKey := range mskm.pairs[authorityID] {
-		if strings.HasSuffix(fingerp, fingerprintSuffix) {
-			if found == nil {
-				found = privKey
-			} else {
-				return nil, fmt.Errorf("ambiguous search, more than one key pair found: %q and %q", found.PublicKey().Fingerprint(), privKey.PublicKey().Fingerprint())
-			}
-		}
-	}
-	if found == nil {
-		return nil, errKeypairNotFound
-	}
-	return found, nil
 }

--- a/asserts/memkeypairmgr_test.go
+++ b/asserts/memkeypairmgr_test.go
@@ -35,64 +35,39 @@ func (mkms *memKeypairMgtSuite) SetUpTest(c *C) {
 	mkms.keypairMgr = asserts.NewMemoryKeypairMananager()
 }
 
-func (mkms *memKeypairMgtSuite) TestImportAndGet(c *C) {
+func (mkms *memKeypairMgtSuite) TestPutAndGet(c *C) {
 	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
-	fingerp, err := mkms.keypairMgr.Import("auth-id1", pk1)
+	keyID := pk1.PublicKey().ID()
+	err := mkms.keypairMgr.Put("auth-id1", pk1)
 	c.Assert(err, IsNil)
-	c.Check(fingerp, Equals, pk1.PublicKey().Fingerprint())
 
-	got, err := mkms.keypairMgr.Get("auth-id1", fingerp)
+	got, err := mkms.keypairMgr.Get("auth-id1", keyID)
 	c.Assert(err, IsNil)
 	c.Assert(got, NotNil)
-	c.Check(got.PublicKey().Fingerprint(), Equals, fingerp)
+	c.Check(got.PublicKey().Fingerprint(), Equals, pk1.PublicKey().Fingerprint())
+}
+
+func (mkms *memKeypairMgtSuite) TestPutAlreadyExists(c *C) {
+	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
+	err := mkms.keypairMgr.Put("auth-id1", pk1)
+	c.Assert(err, IsNil)
+
+	err = mkms.keypairMgr.Put("auth-id1", pk1)
+	c.Check(err, ErrorMatches, "key pair with given key id already exists")
 }
 
 func (mkms *memKeypairMgtSuite) TestGetNotFound(c *C) {
 	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
-	fingerp := pk1.PublicKey().Fingerprint()
+	keyID := pk1.PublicKey().ID()
 
-	got, err := mkms.keypairMgr.Get("auth-id1", fingerp)
+	got, err := mkms.keypairMgr.Get("auth-id1", keyID)
 	c.Check(got, IsNil)
 	c.Check(err, ErrorMatches, "no matching key pair found")
 
-	_, err = mkms.keypairMgr.Import("auth-id1", pk1)
+	err = mkms.keypairMgr.Put("auth-id1", pk1)
 	c.Assert(err, IsNil)
 
-	got, err = mkms.keypairMgr.Get("auth-id1", "")
+	got, err = mkms.keypairMgr.Get("auth-id1", keyID+"x")
 	c.Check(got, IsNil)
 	c.Check(err, ErrorMatches, "no matching key pair found")
-}
-
-func (mkms *memKeypairMgtSuite) TestFind(c *C) {
-	fingerp, err := mkms.keypairMgr.Import("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
-	c.Assert(err, IsNil)
-
-	got, err := mkms.keypairMgr.Find("auth-id1", fingerp[len(fingerp)-4:])
-	c.Assert(err, IsNil)
-	c.Assert(got, NotNil)
-	c.Check(got.PublicKey().Fingerprint(), Equals, fingerp)
-}
-
-func (mkms *memKeypairMgtSuite) TestFindNotFound(c *C) {
-	got, err := mkms.keypairMgr.Find("auth-id1", "f")
-	c.Check(got, IsNil)
-	c.Check(err, ErrorMatches, "no matching key pair found")
-
-	_, err = mkms.keypairMgr.Import("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
-	c.Assert(err, IsNil)
-
-	got, err = mkms.keypairMgr.Find("auth-id1", "z")
-	c.Check(got, IsNil)
-	c.Check(err, ErrorMatches, "no matching key pair found")
-}
-
-func (mkms *memKeypairMgtSuite) TestFindAmbiguous(c *C) {
-	_, err := mkms.keypairMgr.Import("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey1))
-	c.Assert(err, IsNil)
-	_, err = mkms.keypairMgr.Import("auth-id1", asserts.OpenPGPPrivateKey(testPrivKey2))
-	c.Assert(err, IsNil)
-
-	got, err := mkms.keypairMgr.Find("auth-id1", "")
-	c.Check(got, IsNil)
-	c.Check(err, ErrorMatches, "ambiguous search, more than one key pair found:.*")
 }

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -109,9 +109,9 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
 	accFingerp := pk1.PublicKey().Fingerprint()
 	accKeyID := pk1.PublicKey().ID()
-	keyid, err := accSignDB.ImportKey(accountID, asserts.OpenPGPPrivateKey(testPrivKey1))
+	_, err = accSignDB.ImportKey(accountID, asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
-	pubKey, err := accSignDB.PublicKey(accountID, keyid)
+	pubKey, err := accSignDB.PublicKey(accountID, accKeyID)
 	c.Assert(err, IsNil)
 	pubKeyEncoded, err := asserts.EncodePublicKey(pubKey)
 	c.Assert(err, IsNil)
@@ -139,7 +139,7 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 	err = checkDB.Add(accKey)
 	c.Assert(err, IsNil)
 
-	return keyid, accSignDB, checkDB
+	return accKeyID, accSignDB, checkDB
 }
 
 func (sds *snapBuildSuite) TestSnapBuildCheck(c *C) {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -107,10 +107,11 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 	accSignDB, err := asserts.OpenDatabase(cfg1)
 	c.Assert(err, IsNil)
 	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
+	err = accSignDB.ImportKey(accountID, asserts.OpenPGPPrivateKey(testPrivKey1))
+	c.Assert(err, IsNil)
 	accFingerp := pk1.PublicKey().Fingerprint()
 	accKeyID := pk1.PublicKey().ID()
-	_, err = accSignDB.ImportKey(accountID, asserts.OpenPGPPrivateKey(testPrivKey1))
-	c.Assert(err, IsNil)
+
 	pubKey, err := accSignDB.PublicKey(accountID, accKeyID)
 	c.Assert(err, IsNil)
 	pubKeyEncoded, err := asserts.EncodePublicKey(pubKey)

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -59,7 +59,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 		"since":                  "2015-11-20T15:04:00Z",
 		"until":                  "2500-11-20T15:04:00Z",
 	}
-	trustedAccKey, err := db0.Sign(asserts.AccountKeyType, headers, trustedPubKeyEncoded, trustedFingerp)
+	trustedAccKey, err := db0.Sign(asserts.AccountKeyType, headers, trustedPubKeyEncoded, keyid)
 	c.Assert(err, IsNil)
 
 	fakeRoot := filepath.Join(tmpdir, "root")
@@ -76,7 +76,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
-	sdbs.probeAssert, err = db0.Sign(asserts.AssertionType("test-only"), headers, nil, trustedFingerp)
+	sdbs.probeAssert, err = db0.Sign(asserts.AssertionType("test-only"), headers, nil, keyid)
 	c.Assert(err, IsNil)
 }
 

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -42,10 +42,11 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 	db0, err := asserts.OpenDatabase(cfg0)
 	c.Assert(err, IsNil)
 	pk := asserts.OpenPGPPrivateKey(testPrivKey0)
+	err = db0.ImportKey("canonical", pk)
+	c.Assert(err, IsNil)
 	trustedFingerp := pk.PublicKey().Fingerprint()
 	trustedKeyID := pk.PublicKey().ID()
-	_, err = db0.ImportKey("canonical", pk)
-	c.Assert(err, IsNil)
+
 	trustedPubKey, err := db0.PublicKey("canonical", trustedKeyID)
 	c.Assert(err, IsNil)
 	trustedPubKeyEncoded, err := asserts.EncodePublicKey(trustedPubKey)

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -44,9 +44,9 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 	pk := asserts.OpenPGPPrivateKey(testPrivKey0)
 	trustedFingerp := pk.PublicKey().Fingerprint()
 	trustedKeyID := pk.PublicKey().ID()
-	keyid, err := db0.ImportKey("canonical", pk)
+	_, err = db0.ImportKey("canonical", pk)
 	c.Assert(err, IsNil)
-	trustedPubKey, err := db0.PublicKey("canonical", keyid)
+	trustedPubKey, err := db0.PublicKey("canonical", trustedKeyID)
 	c.Assert(err, IsNil)
 	trustedPubKeyEncoded, err := asserts.EncodePublicKey(trustedPubKey)
 	c.Assert(err, IsNil)
@@ -59,7 +59,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 		"since":                  "2015-11-20T15:04:00Z",
 		"until":                  "2500-11-20T15:04:00Z",
 	}
-	trustedAccKey, err := db0.Sign(asserts.AccountKeyType, headers, trustedPubKeyEncoded, keyid)
+	trustedAccKey, err := db0.Sign(asserts.AccountKeyType, headers, trustedPubKeyEncoded, trustedKeyID)
 	c.Assert(err, IsNil)
 
 	fakeRoot := filepath.Join(tmpdir, "root")
@@ -76,7 +76,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
-	sdbs.probeAssert, err = db0.Sign(asserts.AssertionType("test-only"), headers, nil, keyid)
+	sdbs.probeAssert, err = db0.Sign(asserts.AssertionType("test-only"), headers, nil, trustedKeyID)
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
so it only has Put() and Get(), the latter taking an exact key id