### PR TITLE
Use "go 1.5" in .travis.yml because that is the version in 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: go
 go:
-  - tip
+  - 1.5
 env:
   global:
     # Encrypted Coveralls token. The secret token for your repository can be found at the bottom of


### PR DESCRIPTION
Trivial branch that should fix the segfault in go vet we have right now in trunk.