### PR TITLE
asserts: export Assemble() + terminology consistency

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -90,7 +90,7 @@ func checkPublicKey(ab *assertionBase, fingerprintName, keyIDName string) (Publi
 	return pubKey, nil
 }
 
-func buildAccountKey(assert assertionBase) (Assertion, error) {
+func assembleAccountKey(assert assertionBase) (Assertion, error) {
 	_, err := checkMandatory(assert.headers, "account-id")
 	if err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func buildAccountKey(assert assertionBase) (Assertion, error) {
 
 func init() {
 	typeRegistry[AccountKeyType] = &assertionTypeRegistration{
-		builder:    buildAccountKey,
+		assembler:  assembleAccountKey,
 		primaryKey: []string{"account-id", "public-key-id"},
 	}
 }

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -188,7 +188,7 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 		"since":                  aks.since.Format(time.RFC3339),
 		"until":                  aks.until.Format(time.RFC3339),
 	}
-	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
+	accKey, err := asserts.AssembleAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
@@ -214,7 +214,7 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 		"since":                  aks.since.Format(time.RFC3339),
 		"until":                  aks.until.Format(time.RFC3339),
 	}
-	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
+	accKey, err := asserts.AssembleAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -194,7 +194,7 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path:        rootDir,
-		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
+		TrustedKeys: []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
@@ -220,7 +220,7 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path:        rootDir,
-		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
+		TrustedKeys: []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -233,7 +233,7 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 		return nil, fmt.Errorf("assertion: %v", err)
 	}
 
-	assert, err := reg.builder(assertionBase{
+	assert, err := reg.assembler(assertionBase{
 		headers:   headers,
 		body:      body,
 		revision:  revision,
@@ -253,7 +253,7 @@ func writeHeader(buf *bytes.Buffer, headers map[string]string, name string) {
 	buf.WriteString(headers[name])
 }
 
-func buildAndSign(assertType AssertionType, headers map[string]string, body []byte, privKey PrivateKey) (Assertion, error) {
+func assembleAndSign(assertType AssertionType, headers map[string]string, body []byte, privKey PrivateKey) (Assertion, error) {
 	finalHeaders := make(map[string]string, len(headers))
 	for name, value := range headers {
 		finalHeaders[name] = value
@@ -335,7 +335,7 @@ func buildAndSign(assertType AssertionType, headers map[string]string, body []by
 	// be 'cat' friendly, add a ignored newline to the signature which is the last part of the encoded assertion
 	signature = append(signature, '\n')
 
-	assert, err := reg.builder(assertionBase{
+	assert, err := reg.assembler(assertionBase{
 		headers:   finalHeaders,
 		body:      finalBody,
 		revision:  revision,
@@ -343,15 +343,15 @@ func buildAndSign(assertType AssertionType, headers map[string]string, body []by
 		signature: signature,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot build assertion %v: %v", assertType, err)
+		return nil, fmt.Errorf("cannot assemble assertion %v: %v", assertType, err)
 	}
 	return assert, nil
 }
 
-// registry for assertion types describing how to build them etc...
+// registry for assertion types describing how to assemble them etc...
 
 type assertionTypeRegistration struct {
-	builder    func(assert assertionBase) (Assertion, error)
+	assembler  func(assert assertionBase) (Assertion, error)
 	primaryKey []string
 }
 

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -190,7 +190,7 @@ func Decode(serializedAssertion []byte) (Assertion, error) {
 		return nil, fmt.Errorf("empty assertion signature")
 	}
 
-	return buildAssertion(headers, body, content, signature)
+	return Assemble(headers, body, content, signature)
 }
 
 func checkRevision(headers map[string]string) (int, error) {
@@ -204,7 +204,8 @@ func checkRevision(headers map[string]string) (int, error) {
 	return revision, nil
 }
 
-func buildAssertion(headers map[string]string, body, content, signature []byte) (Assertion, error) {
+// Assemble assembles an assertion from its components.
+func Assemble(headers map[string]string, body, content, signature []byte) (Assertion, error) {
 	length, err := checkInteger(headers, "body-length", 0)
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -53,6 +53,9 @@ type Assertion interface {
 	// Header retrieves the header with name
 	Header(name string) string
 
+	// Headers returns the complete headers
+	Headers() map[string]string
+
 	// Body returns the body of this assertion
 	Body() []byte
 
@@ -90,6 +93,15 @@ func (ab *assertionBase) AuthorityID() string {
 // Header returns the value of an header by name.
 func (ab *assertionBase) Header(name string) string {
 	return ab.headers[name]
+}
+
+// Headers returns the complete headers.
+func (ab *assertionBase) Headers() map[string]string {
+	res := make(map[string]string, len(ab.headers))
+	for name, v := range ab.headers {
+		res[name] = v
+	}
+	return res
 }
 
 // Body returns the body of the assertion.

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -215,9 +215,44 @@ func (as *assertsSuite) TestAssembleRoundtrip(c *C) {
 	a, err := asserts.Decode(encoded)
 	c.Assert(err, IsNil)
 
+	hs := a.Headers()
+	c.Check(hs, DeepEquals, map[string]string{
+		"type":         "test-only",
+		"authority-id": "auth-id2",
+		"primary-key1": "key1",
+		"primary-key2": "key2",
+		"revision":     "5",
+		"header1":      "value1",
+		"header2":      "value2",
+		"body-length":  "8",
+	})
+
+	// casual later res mutation doesn't trip us
+	delete(hs, "primary-key1")
+	c.Check(a.Header("primary-key1"), Equals, "key1")
+}
+
+func (as *assertsSuite) TestHeaders(c *C) {
+	encoded := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key1: key1\n" +
+		"primary-key2: key2\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"openpgp c2ln")
+	a, err := asserts.Decode(encoded)
+	c.Assert(err, IsNil)
+
 	cont, sig := a.Signature()
 	reassembled, err := asserts.Assemble(a.Headers(), a.Body(), cont, sig)
 	c.Assert(err, IsNil)
+
+	c.Check(reassembled.Headers(), DeepEquals, a.Headers())
+	c.Check(reassembled.Body(), DeepEquals, a.Body())
 
 	reassembledEncoded := asserts.Encode(reassembled)
 	c.Check(reassembledEncoded, DeepEquals, encoded)

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -178,7 +178,7 @@ func (as *assertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
-	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, asserts.OpenPGPPrivateKey(testPrivKey1))
+	a, err := asserts.AssembleAndSignInTest(asserts.AssertionType("test-only"), headers, nil, asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 
 	_, err = asserts.Decode(asserts.Encode(a))
@@ -191,7 +191,7 @@ func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 		"primary-key":  "0",
 	}
 	body := []byte("THE-BODY")
-	a, err := asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, body, asserts.OpenPGPPrivateKey(testPrivKey1))
+	a, err := asserts.AssembleAndSignInTest(asserts.AssertionType("test-only"), headers, body, asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 	c.Check(a.Body(), DeepEquals, body)
 

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -199,3 +199,26 @@ func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(decoded.Body(), DeepEquals, body)
 }
+
+func (as *assertsSuite) TestAssembleRoundtrip(c *C) {
+	encoded := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key1: key1\n" +
+		"primary-key2: key2\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"openpgp c2ln")
+	a, err := asserts.Decode(encoded)
+	c.Assert(err, IsNil)
+
+	cont, sig := a.Signature()
+	reassembled, err := asserts.Assemble(a.Headers(), a.Body(), cont, sig)
+	c.Assert(err, IsNil)
+
+	reassembledEncoded := asserts.Encode(reassembled)
+	c.Check(reassembledEncoded, DeepEquals, encoded)
+}

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -200,7 +200,7 @@ func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 	c.Check(decoded.Body(), DeepEquals, body)
 }
 
-func (as *assertsSuite) TestAssembleRoundtrip(c *C) {
+func (as *assertsSuite) TestHeaders(c *C) {
 	encoded := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
 		"primary-key1: key1\n" +
@@ -226,13 +226,30 @@ func (as *assertsSuite) TestAssembleRoundtrip(c *C) {
 		"header2":      "value2",
 		"body-length":  "8",
 	})
+}
 
-	// casual later res mutation doesn't trip us
+func (as *assertsSuite) TestHeadersReturnsCopy(c *C) {
+	encoded := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key1: key1\n" +
+		"primary-key2: key2\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"openpgp c2ln")
+	a, err := asserts.Decode(encoded)
+	c.Assert(err, IsNil)
+
+	hs := a.Headers()
+	// casual later result mutation doesn't trip us
 	delete(hs, "primary-key1")
 	c.Check(a.Header("primary-key1"), Equals, "key1")
 }
 
-func (as *assertsSuite) TestHeaders(c *C) {
+func (as *assertsSuite) TestAssembleRoundtrip(c *C) {
 	encoded := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
 		"primary-key1: key1\n" +

--- a/asserts/checkers.go
+++ b/asserts/checkers.go
@@ -25,7 +25,7 @@ import (
 	"time"
 )
 
-// common checkers used when decoding/building assertions
+// common checkers used when decoding/assembling assertions
 
 func checkMandatory(headers map[string]string, name string) (string, error) {
 	value, ok := headers[name]

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -183,7 +183,7 @@ func (db *Database) PublicKey(authorityID string, keyID string) (PublicKey, erro
 	return privKey.PublicKey(), nil
 }
 
-// Sign builds an assertion with the provided information and signs it
+// Sign assembles an assertion with the provided information and signs it
 // with the private key from `headers["authority-id"]` that has the provided key id.
 func (db *Database) Sign(assertType AssertionType, headers map[string]string, body []byte, keyID string) (Assertion, error) {
 	authorityID, err := checkMandatory(headers, "authority-id")
@@ -194,7 +194,7 @@ func (db *Database) Sign(assertType AssertionType, headers map[string]string, bo
 	if err != nil {
 		return nil, err
 	}
-	return buildAndSign(assertType, headers, body, privKey)
+	return assembleAndSign(assertType, headers, body, privKey)
 }
 
 // find account keys exactly by account id and key id

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -29,16 +29,10 @@ import (
 	"time"
 )
 
-// BuilderFromComps can build an assertion from its components.
-type BuilderFromComps func(headers map[string]string, body, content, signature []byte) (Assertion, error)
-
 // Backstore is a backstore for assertions. It can store and retrieve
 // assertions by type under primary paths (tuples of strings). Plus it
 // supports more general searches.
 type Backstore interface {
-	// Init initializes the backstore. It is provided with a function
-	// to build assertions from their components.
-	Init(buildAssert BuilderFromComps) error
 	// Put stores an assertion under the given unique primaryPath.
 	// It is responsible for checking that assert is newer than a
 	// previously stored revision.
@@ -127,11 +121,6 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 		if keypairMgr == nil {
 			keypairMgr = newFilesystemKeypairMananager(cfg.Path)
 		}
-	}
-
-	err := bs.Init(buildAssertion)
-	if err != nil {
-		return nil, err
 	}
 
 	trustedKeys := make(map[string][]*AccountKey)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -207,7 +207,7 @@ func (chks *checkSuite) TestCheckForgery(c *C) {
 
 	cfg := &asserts.DatabaseConfig{
 		Path:        chks.rootDir,
-		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
+		TrustedKeys: []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
@@ -260,7 +260,7 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 	trustedKey := testPrivKey0
 	cfg := &asserts.DatabaseConfig{
 		Path:        rootDir,
-		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
+		TrustedKeys: []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -189,7 +189,7 @@ func (chks *checkSuite) SetUpTest(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
-	chks.a, err = asserts.BuildAndSignInTest(asserts.AssertionType("test-only"), headers, nil, asserts.OpenPGPPrivateKey(testPrivKey0))
+	chks.a, err = asserts.AssembleAndSignInTest(asserts.AssertionType("test-only"), headers, nil, asserts.OpenPGPPrivateKey(testPrivKey0))
 	c.Assert(err, IsNil)
 }
 
@@ -337,14 +337,14 @@ func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
 	c.Check(a1, IsNil)
 }
 
-func (safs *signAddFindSuite) TestSignBuilderError(c *C) {
+func (safs *signAddFindSuite) TestSignAssemblerError(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"count":        "zzz",
 	}
 	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
-	c.Assert(err, ErrorMatches, `cannot build assertion test-only: "count" header is not an integer: zzz`)
+	c.Assert(err, ErrorMatches, `cannot assemble assertion test-only: "count" header is not an integer: zzz`)
 	c.Check(a1, IsNil)
 }
 

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -36,7 +36,7 @@ var AssembleAndSignInTest = assembleAndSign
 // decodePrivateKey exposed for tests
 var DecodePrivateKeyInTest = decodePrivateKey
 
-func BuildBootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
+func BootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
 	return &AccountKey{
 		assertionBase: assertionBase{
 			headers: map[string]string{

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -30,8 +30,8 @@ import (
 // generatePrivateKey exposed for tests
 var GeneratePrivateKeyInTest = generatePrivateKey
 
-// buildAndSignInTest exposed for tests
-var BuildAndSignInTest = buildAndSign
+// assembleAndSign exposed for tests
+var AssembleAndSignInTest = assembleAndSign
 
 // decodePrivateKey exposed for tests
 var DecodePrivateKeyInTest = decodePrivateKey
@@ -56,7 +56,7 @@ type TestOnly struct {
 	assertionBase
 }
 
-func buildTestOnly(assert assertionBase) (Assertion, error) {
+func assembleTestOnly(assert assertionBase) (Assertion, error) {
 	// for testing error cases
 	if _, err := checkInteger(assert.headers, "count", 0); err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func buildTestOnly(assert assertionBase) (Assertion, error) {
 
 func init() {
 	typeRegistry[AssertionType("test-only")] = &assertionTypeRegistration{
-		builder:    buildTestOnly,
+		assembler:  assembleTestOnly,
 		primaryKey: []string{"primary-key"},
 	}
 }

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -41,10 +41,6 @@ func newFilesystemBackstore(path string) *filesystemBackstore {
 	return &filesystemBackstore{top: filepath.Join(path, assertionsRoot)}
 }
 
-func (fsbs *filesystemBackstore) Init(_ BuilderFromComps) error {
-	return nil
-}
-
 // guarantees that result assertion is of the expected type (both in the AssertionType and go type sense)
 func (fsbs *filesystemBackstore) readAssertion(assertType AssertionType, diskPrimaryPath string) (Assertion, error) {
 	encoded, err := readEntry(fsbs.top, string(assertType), diskPrimaryPath)

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -66,7 +66,7 @@ func (snapdcl *SnapBuild) checkConsistency(db *Database, acck *AccountKey) error
 	return nil
 }
 
-func buildSnapBuild(assert assertionBase) (Assertion, error) {
+func assembleSnapBuild(assert assertionBase) (Assertion, error) {
 	_, err := checkMandatory(assert.headers, "snap-id")
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (assert *SnapRevision) checkConsistency(db *Database, acck *AccountKey) err
 	return nil
 }
 
-func buildSnapRevision(assert assertionBase) (Assertion, error) {
+func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 	_, err := checkMandatory(assert.headers, "snap-id")
 	if err != nil {
 		return nil, err
@@ -193,11 +193,11 @@ func buildSnapRevision(assert assertionBase) (Assertion, error) {
 
 func init() {
 	typeRegistry[SnapBuildType] = &assertionTypeRegistration{
-		builder:    buildSnapBuild,
+		assembler:  assembleSnapBuild,
 		primaryKey: []string{"snap-id", "snap-digest"},
 	}
 	typeRegistry[SnapRevisionType] = &assertionTypeRegistration{
-		builder:    buildSnapRevision,
+		assembler:  assembleSnapRevision,
 		primaryKey: []string{"snap-id", "snap-digest"},
 	}
 }

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -132,7 +132,7 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")
 	cfg := &asserts.DatabaseConfig{
 		Path:        rootDir,
-		TrustedKeys: []*asserts.AccountKey{asserts.BuildBootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
+		TrustedKeys: []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", &trustedKey.PublicKey)},
 	}
 	checkDB, err = asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -126,7 +126,7 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 		"since":                  "2015-11-20T15:04:00Z",
 		"until":                  "2500-11-20T15:04:00Z",
 	}
-	accKey, err := asserts.BuildAndSignInTest(asserts.AccountKeyType, headers, []byte(accPubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
+	accKey, err := asserts.AssembleAndSignInTest(asserts.AccountKeyType, headers, []byte(accPubKeyBody), asserts.OpenPGPPrivateKey(trustedKey))
 	c.Assert(err, IsNil)
 
 	rootDir := filepath.Join(c.MkDir(), "asserts-db")


### PR DESCRIPTION
export Assemble (which was buildAssertion), so there's not need anymore for Backstore.Init to pass it in,

for consistency with Assemble() use assemble... where we were using build... for assertions

happy test for Assemble(), shows we need a Headers() for completeness/symmetry that the Backstores may need to use as well (I considered also having Headers() return only the names as []string but then it's tempting to do that in the serialisation order and then it adds complexity quickly)