### PR TITLE
Do not assume an order on the installed snaps.

### DIFF
--- a/integration-tests/tests/build_test.go
+++ b/integration-tests/tests/build_test.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -51,7 +51,7 @@ func (s *buildSuite) TestBuildBasicSnapOnSnappy(c *check.C) {
 		"Installing " + snapPath + "\n" +
 		".*Signature check failed, but installing anyway as requested\n" +
 		"Name +Date +Version +Developer \n" +
-		".*\n" +
+		".*" +
 		data.BasicSnapName + " +.* +.* +sideload  \n" +
 		".*"
 


### PR DESCRIPTION
We relaxed the regular expression to not assume that more snaps will appear after the one we installed. Here we are relaxing it a little more to not assume that there will be snaps before it.

With all snaps the list will be something like this:
Name               Date       Version      Developer
basic              2016-01-08 IJbaaNHLAcK sideload
canonical-linux-pc 2015-12-17 4.3.0-2-2    canonical
ubuntu-core        2015-12-21 16.04.0-4    canonical
canonical-pc       2015-12-17 2.1          canonical

But here we are not testing the ordering, nor the rest of the snaps installed. That needs to be checked in other tests.
