### PR TITLE
fix tests with empty groups

### DIFF
--- a/osutil/group_linux_test.go
+++ b/osutil/group_linux_test.go
@@ -54,7 +54,9 @@ func getgrnamForking(name string) (grp Group, err error) {
 	grp.Name = parsed[0]
 	grp.Passwd = parsed[1]
 	grp.Gid = uint(gid)
-	grp.Mem = strings.Split(parsed[3], ",")
+	if parsed[3] != "" {
+		grp.Mem = strings.Split(parsed[3], ",")
+	}
 
 	return grp, nil
 }
@@ -71,4 +73,12 @@ func (s *groupTestSuite) TestGetgrnamNoSuchGroup(c *C) {
 	needle := "no-such-group-really-no-no"
 	_, err := Getgrnam(needle)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("group \"%s\" not found", needle))
+}
+
+func (s *groupTestSuite) TestGetgrnamEmptyGroup(c *C) {
+	expected, err := getgrnamForking("floppy")
+	c.Assert(err, IsNil)
+	groups, err := Getgrnam("floppy")
+	c.Assert(err, IsNil)
+	c.Assert(groups, DeepEquals, expected)
 }


### PR DESCRIPTION
This fixes a silly bug in the getgrnamForking() code when there is no group membership (like on the buildds). This fixes a FTBFS on the image.