### PR TITLE
Add security system

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -19,6 +19,10 @@
 
 package caps
 
+import (
+	"fmt"
+)
+
 // Capability holds information about a capability that a snap may request
 // from a snappy system to do its job while running on it.
 type Capability struct {
@@ -41,4 +45,23 @@ type Capability struct {
 // String representation of a capability.
 func (c Capability) String() string {
 	return c.Name
+}
+
+// SetAttr sets capability attribute to a given value.
+// TODO: remove temporary function implementation once attrtypes are merged.
+func (c *Capability) SetAttr(name string, value string) error {
+	if c.Attrs == nil {
+		c.Attrs = make(map[string]string)
+	}
+	c.Attrs[name] = value
+	return nil
+}
+
+// GetAttr gets capability attribute with a given name.
+// TODO: remove temporary function implementation once attrtypes are merged.
+func (c *Capability) GetAttr(name string) (interface{}, error) {
+	if value, ok := c.Attrs[name]; ok {
+		return value, nil
+	}
+	return nil, fmt.Errorf("%s is not set", name)
 }

--- a/caps/security.go
+++ b/caps/security.go
@@ -1,0 +1,29 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+// securitySystem abstracts the implementation details of a given security
+// system (syccomp, apparmor, etc) from the point of view of a capability.
+type securitySystem interface {
+	// TODO: change snap to appropriate type after current transition
+	GrantPermissions(snapName string, cap *Capability) error
+	// TODO: change snap to appropriate type after current transition
+	RevokePermissions(snapName string, cap *Capability) error
+}

--- a/caps/security_legacy.go
+++ b/caps/security_legacy.go
@@ -28,11 +28,11 @@ import (
 // legacySecurtySystem aids in the ongoing work to transition capability system
 // from hwaccess API to a more direct approach. It allows particular capability
 // types to define a common interface that doesn't expose hwaccess API anymore.
-type legacySecurtySystem struct {
+type legacySecuritySystem struct {
 	AttrName string
 }
 
-func (sec *legacySecurtySystem) GrantPermissions(snapName string, cap *Capability) error {
+func (sec *legacySecuritySystem) GrantPermissions(snapName string, cap *Capability) error {
 	const errPrefix = "cannot grant permissions"
 	// Find the snap
 	snap := snappy.ActiveSnapByName(snapName)
@@ -52,7 +52,7 @@ func (sec *legacySecurtySystem) GrantPermissions(snapName string, cap *Capabilit
 	return nil
 }
 
-func (sec *legacySecurtySystem) RevokePermissions(snapName string, cap *Capability) error {
+func (sec *legacySecuritySystem) RevokePermissions(snapName string, cap *Capability) error {
 	const errPrefix = "cannot revoke permissions"
 	// Find the snap
 	snap := snappy.ActiveSnapByName(snapName)

--- a/caps/security_legacy.go
+++ b/caps/security_legacy.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"fmt"
+
+	"github.com/ubuntu-core/snappy/snappy"
+)
+
+// legacySecurtySystem aids in the ongoing work to transition capability system
+// from hwaccess API to a more direct approach. It allows particular capability
+// types to define a common interface that doesn't expose hwaccess API anymore.
+type legacySecurtySystem struct {
+	AttrName string
+}
+
+func (sec *legacySecurtySystem) GrantPermissions(snapName string, cap *Capability) error {
+	const errPrefix = "cannot grant permissions"
+	// Find the snap
+	snap := snappy.ActiveSnapByName(snapName)
+	if snap == nil {
+		return fmt.Errorf("%s, no such package", errPrefix)
+	}
+	// Fetch the attribute where the path is stored
+	path, err := cap.GetAttr(sec.AttrName)
+	if err != nil {
+		return fmt.Errorf("%s, cannot get required attribute: %q", errPrefix, err)
+	}
+	// Use hw-access layer to grant the permissions to access
+	qualName := snappy.QualifiedName(snap)
+	if err := snappy.AddHWAccess(qualName, path.(string)); err != nil {
+		return fmt.Errorf("%s, hw-access failed: %q", errPrefix, err)
+	}
+	return nil
+}
+
+func (sec *legacySecurtySystem) RevokePermissions(snapName string, cap *Capability) error {
+	const errPrefix = "cannot revoke permissions"
+	// Find the snap
+	snap := snappy.ActiveSnapByName(snapName)
+	if snap == nil {
+		return fmt.Errorf("%s, no such package", errPrefix)
+	}
+	// Fetch the attribute where the path is stored
+	path, err := cap.GetAttr(sec.AttrName)
+	if err != nil {
+		return fmt.Errorf("%s, cannot get required attribute: %q", errPrefix, err)
+	}
+	// Use hw-access layer to grant the permissions to access
+	qualName := snappy.QualifiedName(snap)
+	if err := snappy.RemoveHWAccess(qualName, path.(string)); err != nil {
+		return fmt.Errorf("%s, hw-access failed: %q", errPrefix, err)
+	}
+	return nil
+}

--- a/caps/security_mock.go
+++ b/caps/security_mock.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+const (
+	INITIAL = iota
+	GRANTED = iota
+	REVOKED = iota
+)
+
+type mockSecurity struct {
+	SecurityName   string
+	StateMap       map[string]int
+	GrantErrorMap  map[string]error
+	RevokeErrorMap map[string]error
+}
+
+func (sec *mockSecurity) GrantPermissions(snapName string, cap *Capability) error {
+	if err := sec.GrantErrorMap[snapName]; err != nil {
+		return err
+	}
+	if sec.StateMap == nil {
+		sec.StateMap = make(map[string]int)
+	}
+	sec.StateMap[snapName] = GRANTED
+	return nil
+}
+
+func (sec *mockSecurity) RevokePermissions(snapName string, cap *Capability) error {
+	if err := sec.RevokeErrorMap[snapName]; err != nil {
+		return err
+	}
+	if sec.StateMap == nil {
+		sec.StateMap = make(map[string]int)
+	}
+	sec.StateMap[snapName] = REVOKED
+	return nil
+}
+
+func (sec *mockSecurity) SetGrantPermissionsError(snapName string, err error) {
+	if sec.GrantErrorMap == nil {
+		sec.GrantErrorMap = make(map[string]error)
+	}
+	sec.GrantErrorMap[snapName] = err
+}
+
+func (sec *mockSecurity) SetRevokePermissionsError(snapName string, err error) {
+	if sec.RevokeErrorMap == nil {
+		sec.RevokeErrorMap = make(map[string]error)
+	}
+	sec.RevokeErrorMap[snapName] = err
+}

--- a/caps/security_mock.go
+++ b/caps/security_mock.go
@@ -20,9 +20,9 @@
 package caps
 
 const (
-	INITIAL = iota
-	GRANTED = iota
-	REVOKED = iota
+	mockSecurityInitial = iota
+	mockSecurityGranted = iota
+	mockSecurityRevoked = iota
 )
 
 type mockSecurity struct {
@@ -39,7 +39,7 @@ func (sec *mockSecurity) GrantPermissions(snapName string, cap *Capability) erro
 	if sec.StateMap == nil {
 		sec.StateMap = make(map[string]int)
 	}
-	sec.StateMap[snapName] = GRANTED
+	sec.StateMap[snapName] = mockSecurityGranted
 	return nil
 }
 
@@ -50,7 +50,7 @@ func (sec *mockSecurity) RevokePermissions(snapName string, cap *Capability) err
 	if sec.StateMap == nil {
 		sec.StateMap = make(map[string]int)
 	}
-	sec.StateMap[snapName] = REVOKED
+	sec.StateMap[snapName] = mockSecurityRevoked
 	return nil
 }
 

--- a/caps/security_mock_test.go
+++ b/caps/security_mock_test.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+)
+
+type MockSecuritySuite struct{}
+
+var _ = Suite(&MockSecuritySuite{})
+
+func (s *MockSecuritySuite) TestGrantPermissionSuccess(c *C) {
+	const snapName = "snap"
+	sec := &mockSecurity{}
+	err := sec.GrantPermissions(snapName, testCapability)
+	c.Assert(err, IsNil)
+	c.Assert(sec.StateMap[snapName], Equals, GRANTED)
+}
+
+func (s *MockSecuritySuite) TestGrantPermissionFailure(c *C) {
+	const snapName = "snap"
+	sec := &mockSecurity{}
+	sec.SetGrantPermissionsError(snapName, fmt.Errorf("boom"))
+	err := sec.GrantPermissions(snapName, testCapability)
+	c.Assert(err, ErrorMatches, "boom")
+	c.Assert(sec.StateMap[snapName], Equals, INITIAL)
+}
+
+func (s *MockSecuritySuite) TestRevokePermissionSuccess(c *C) {
+	const snapName = "snap"
+	sec := &mockSecurity{}
+	err := sec.RevokePermissions(snapName, testCapability)
+	c.Assert(err, IsNil)
+	c.Assert(sec.StateMap[snapName], Equals, REVOKED)
+}
+
+func (s *MockSecuritySuite) TestRevokePermissionFailure(c *C) {
+	const snapName = "snap"
+	sec := &mockSecurity{}
+	sec.SetRevokePermissionsError(snapName, fmt.Errorf("boom"))
+	err := sec.RevokePermissions(snapName, testCapability)
+	c.Assert(err, ErrorMatches, "boom")
+	c.Assert(sec.StateMap[snapName], Equals, INITIAL)
+}

--- a/caps/security_mock_test.go
+++ b/caps/security_mock_test.go
@@ -34,7 +34,7 @@ func (s *MockSecuritySuite) TestGrantPermissionSuccess(c *C) {
 	sec := &mockSecurity{}
 	err := sec.GrantPermissions(snapName, testCapability)
 	c.Assert(err, IsNil)
-	c.Assert(sec.StateMap[snapName], Equals, GRANTED)
+	c.Assert(sec.StateMap[snapName], Equals, mockSecurityGranted)
 }
 
 func (s *MockSecuritySuite) TestGrantPermissionFailure(c *C) {
@@ -43,7 +43,7 @@ func (s *MockSecuritySuite) TestGrantPermissionFailure(c *C) {
 	sec.SetGrantPermissionsError(snapName, fmt.Errorf("boom"))
 	err := sec.GrantPermissions(snapName, testCapability)
 	c.Assert(err, ErrorMatches, "boom")
-	c.Assert(sec.StateMap[snapName], Equals, INITIAL)
+	c.Assert(sec.StateMap[snapName], Equals, mockSecurityInitial)
 }
 
 func (s *MockSecuritySuite) TestRevokePermissionSuccess(c *C) {
@@ -51,7 +51,7 @@ func (s *MockSecuritySuite) TestRevokePermissionSuccess(c *C) {
 	sec := &mockSecurity{}
 	err := sec.RevokePermissions(snapName, testCapability)
 	c.Assert(err, IsNil)
-	c.Assert(sec.StateMap[snapName], Equals, REVOKED)
+	c.Assert(sec.StateMap[snapName], Equals, mockSecurityRevoked)
 }
 
 func (s *MockSecuritySuite) TestRevokePermissionFailure(c *C) {
@@ -60,5 +60,5 @@ func (s *MockSecuritySuite) TestRevokePermissionFailure(c *C) {
 	sec.SetRevokePermissionsError(snapName, fmt.Errorf("boom"))
 	err := sec.RevokePermissions(snapName, testCapability)
 	c.Assert(err, ErrorMatches, "boom")
-	c.Assert(sec.StateMap[snapName], Equals, INITIAL)
+	c.Assert(sec.StateMap[snapName], Equals, mockSecurityInitial)
 }

--- a/caps/types.go
+++ b/caps/types.go
@@ -87,8 +87,8 @@ func (t *Type) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &t.Name)
 }
 
-// GrantPermissions makes it possible for the package `snapName` to use hardware
-// described by the capability `cap`.
+// GrantPermissions makes it possible for the package `snapName` to use the
+// resource described by the capability `cap`.
 func (t *Type) GrantPermissions(snapName string, cap *Capability) error {
 	// Ensure that the capability is valid
 	if err := t.Validate(cap); err != nil {

--- a/caps/types.go
+++ b/caps/types.go
@@ -95,7 +95,7 @@ func (t *Type) GrantPermissions(snapName string, cap *Capability) error {
 		return err
 	}
 	// Grant all permissions required.
-	for i, _ := range cap.Type.SecuritySystems {
+	for i := range cap.Type.SecuritySystems {
 		sec := cap.Type.SecuritySystems[i]
 		if err := sec.GrantPermissions(snapName, cap); err != nil {
 			// If we already granted something, try to revoke that permission instead

--- a/caps/types.go
+++ b/caps/types.go
@@ -34,6 +34,9 @@ type Type struct {
 	// RequiredAttrs contains names of attributes that are required by
 	// capability of this type.
 	RequiredAttrs []string
+	// SecuritySystems contains the associated security systems that enable actual
+	// access to system resources needed by this capability.
+	SecuritySystems []securitySystem
 }
 
 var (

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -21,6 +21,7 @@ package caps
 
 import (
 	"encoding/json"
+	"fmt"
 
 	. "gopkg.in/check.v1"
 )
@@ -93,4 +94,127 @@ func (s *TypeSuite) TestUnmarhshalJSON(c *C) {
 	err := json.Unmarshal([]byte(`"test"`), &t)
 	c.Assert(err, IsNil)
 	c.Assert(t.Name, Equals, "test")
+}
+
+func (s *TypeSuite) TestGrantPermissionsSuccess(c *C) {
+	sec1 := &mockSecurity{}
+	sec2 := &mockSecurity{}
+	t := &Type{
+		Name:            "t",
+		SecuritySystems: []securitySystem{sec1, sec2},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+	}
+	snapName := "snap"
+	t.GrantPermissions(snapName, cap)
+	c.Assert(sec1.StateMap[snapName], Equals, GRANTED)
+	c.Assert(sec2.StateMap[snapName], Equals, GRANTED)
+}
+
+func (s *TypeSuite) TestGrantPermissionsFailure(c *C) {
+	sec1 := &mockSecurity{}
+	sec2 := &mockSecurity{}
+	t := &Type{
+		Name:            "t",
+		SecuritySystems: []securitySystem{sec1, sec2},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+	}
+	snapName := "snap"
+	// Configure mock security so that sec2 will fail the grant operation.
+	sec2.SetGrantPermissionsError(snapName, fmt.Errorf("boom"))
+	err := t.GrantPermissions(snapName, cap)
+	c.Assert(err, ErrorMatches, "boom")
+	c.Assert(sec1.StateMap[snapName], Equals, REVOKED)
+	c.Assert(sec2.StateMap[snapName], Equals, INITIAL)
+}
+
+func (s *TypeSuite) TestGrantPermissionsCatastrophicFailure(c *C) {
+	sec1 := &mockSecurity{}
+	sec2 := &mockSecurity{}
+	t := &Type{
+		Name:            "t",
+		SecuritySystems: []securitySystem{sec1, sec2},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+	}
+	snapName := "snap"
+	// Configure mock security so that sec2 will fail the grant operation
+	// and sec1 will fail the subsequent rollback (revoke) operation.
+	sec2.SetGrantPermissionsError(snapName, fmt.Errorf("boom-granting"))
+	sec1.SetRevokePermissionsError(snapName, fmt.Errorf("boom-revoking"))
+	c.Assert(func() { t.GrantPermissions(snapName, cap) }, PanicMatches,
+		`unable to revoke partially granted permissions: "boom-revoking"`)
+	c.Assert(sec1.StateMap[snapName], Equals, GRANTED)
+	c.Assert(sec2.StateMap[snapName], Equals, INITIAL)
+}
+
+func (s *TypeSuite) TestRevokePermissionsSuccess(c *C) {
+	sec1 := &mockSecurity{}
+	sec2 := &mockSecurity{}
+	t := &Type{
+		Name:            "t",
+		SecuritySystems: []securitySystem{sec1, sec2},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+	}
+	snapName := "snap"
+	t.RevokePermissions(snapName, cap)
+	c.Assert(sec1.StateMap[snapName], Equals, REVOKED)
+	c.Assert(sec2.StateMap[snapName], Equals, REVOKED)
+}
+
+func (s *TypeSuite) TestRevokePermissionsFailure(c *C) {
+	sec1 := &mockSecurity{}
+	sec2 := &mockSecurity{}
+	t := &Type{
+		Name:            "t",
+		SecuritySystems: []securitySystem{sec1, sec2},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+	}
+	snapName := "snap"
+	// Configure mock security so that sec2 will fail the revoke operation.
+	sec2.SetRevokePermissionsError(snapName, fmt.Errorf("boom"))
+	t.RevokePermissions(snapName, cap)
+	c.Assert(sec1.StateMap[snapName], Equals, GRANTED)
+	c.Assert(sec2.StateMap[snapName], Equals, INITIAL)
+}
+
+func (s *TypeSuite) TestRevokePermissionsCatastropicFailure(c *C) {
+	sec1 := &mockSecurity{}
+	sec2 := &mockSecurity{}
+	t := &Type{
+		Name:            "t",
+		SecuritySystems: []securitySystem{sec1, sec2},
+	}
+	cap := &Capability{
+		Name:  "name",
+		Label: "label",
+		Type:  t,
+	}
+	snapName := "snap"
+	// Configure mock security so that sec2 will fail the revoke operation
+	// and sec1 will fail the subsequent rollback (grant) operation.
+	sec2.SetRevokePermissionsError(snapName, fmt.Errorf("boom-revoking"))
+	sec1.SetGrantPermissionsError(snapName, fmt.Errorf("boom-granting"))
+	c.Assert(func() { t.RevokePermissions(snapName, cap) }, PanicMatches,
+		`unable to grant partially revoked permissions: "boom-granting"`)
+	c.Assert(sec1.StateMap[snapName], Equals, REVOKED)
+	c.Assert(sec2.StateMap[snapName], Equals, INITIAL)
 }

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -110,8 +110,8 @@ func (s *TypeSuite) TestGrantPermissionsSuccess(c *C) {
 	}
 	snapName := "snap"
 	t.GrantPermissions(snapName, cap)
-	c.Assert(sec1.StateMap[snapName], Equals, GRANTED)
-	c.Assert(sec2.StateMap[snapName], Equals, GRANTED)
+	c.Assert(sec1.StateMap[snapName], Equals, mockSecurityGranted)
+	c.Assert(sec2.StateMap[snapName], Equals, mockSecurityGranted)
 }
 
 func (s *TypeSuite) TestGrantPermissionsFailure(c *C) {
@@ -131,8 +131,8 @@ func (s *TypeSuite) TestGrantPermissionsFailure(c *C) {
 	sec2.SetGrantPermissionsError(snapName, fmt.Errorf("boom"))
 	err := t.GrantPermissions(snapName, cap)
 	c.Assert(err, ErrorMatches, "boom")
-	c.Assert(sec1.StateMap[snapName], Equals, REVOKED)
-	c.Assert(sec2.StateMap[snapName], Equals, INITIAL)
+	c.Assert(sec1.StateMap[snapName], Equals, mockSecurityRevoked)
+	c.Assert(sec2.StateMap[snapName], Equals, mockSecurityInitial)
 }
 
 func (s *TypeSuite) TestGrantPermissionsCatastrophicFailure(c *C) {
@@ -154,8 +154,8 @@ func (s *TypeSuite) TestGrantPermissionsCatastrophicFailure(c *C) {
 	sec1.SetRevokePermissionsError(snapName, fmt.Errorf("boom-revoking"))
 	c.Assert(func() { t.GrantPermissions(snapName, cap) }, PanicMatches,
 		`unable to revoke partially granted permissions: "boom-revoking"`)
-	c.Assert(sec1.StateMap[snapName], Equals, GRANTED)
-	c.Assert(sec2.StateMap[snapName], Equals, INITIAL)
+	c.Assert(sec1.StateMap[snapName], Equals, mockSecurityGranted)
+	c.Assert(sec2.StateMap[snapName], Equals, mockSecurityInitial)
 }
 
 func (s *TypeSuite) TestRevokePermissionsSuccess(c *C) {
@@ -172,8 +172,8 @@ func (s *TypeSuite) TestRevokePermissionsSuccess(c *C) {
 	}
 	snapName := "snap"
 	t.RevokePermissions(snapName, cap)
-	c.Assert(sec1.StateMap[snapName], Equals, REVOKED)
-	c.Assert(sec2.StateMap[snapName], Equals, REVOKED)
+	c.Assert(sec1.StateMap[snapName], Equals, mockSecurityRevoked)
+	c.Assert(sec2.StateMap[snapName], Equals, mockSecurityRevoked)
 }
 
 func (s *TypeSuite) TestRevokePermissionsFailure(c *C) {
@@ -192,8 +192,8 @@ func (s *TypeSuite) TestRevokePermissionsFailure(c *C) {
 	// Configure mock security so that sec2 will fail the revoke operation.
 	sec2.SetRevokePermissionsError(snapName, fmt.Errorf("boom"))
 	t.RevokePermissions(snapName, cap)
-	c.Assert(sec1.StateMap[snapName], Equals, GRANTED)
-	c.Assert(sec2.StateMap[snapName], Equals, INITIAL)
+	c.Assert(sec1.StateMap[snapName], Equals, mockSecurityGranted)
+	c.Assert(sec2.StateMap[snapName], Equals, mockSecurityInitial)
 }
 
 func (s *TypeSuite) TestRevokePermissionsCatastropicFailure(c *C) {
@@ -215,6 +215,6 @@ func (s *TypeSuite) TestRevokePermissionsCatastropicFailure(c *C) {
 	sec1.SetGrantPermissionsError(snapName, fmt.Errorf("boom-granting"))
 	c.Assert(func() { t.RevokePermissions(snapName, cap) }, PanicMatches,
 		`unable to grant partially revoked permissions: "boom-granting"`)
-	c.Assert(sec1.StateMap[snapName], Equals, REVOKED)
-	c.Assert(sec2.StateMap[snapName], Equals, INITIAL)
+	c.Assert(sec1.StateMap[snapName], Equals, mockSecurityRevoked)
+	c.Assert(sec2.StateMap[snapName], Equals, mockSecurityInitial)
 }


### PR DESCRIPTION
This branch sets the stage for pluggable security systems.

Each capability type can now refer to a list of security systems. The type can be asked to grant or revoke permission expressed by those systems. A trivial "legacy" hw-assign security system is provided.

The main intent of this branch is to discuss the interface as I have some code that uses this for apparmor and seccomp coming up.