### PR TITLE
Fixup toolbelt to use exposed key ID.

### DIFF
--- a/asserts/toolbelt/main.go
+++ b/asserts/toolbelt/main.go
@@ -187,7 +187,6 @@ func (x *snapBuild) Execute(args []string) error {
 	}
 	snapDecl, err := db.Sign(asserts.SnapBuildType, headers, nil, authKey.ID())
 	if err != nil {
-		panic(err)
 		return err
 	}
 	os.Stdout.Write(asserts.Encode(snapDecl))

--- a/asserts/toolbelt/main.go
+++ b/asserts/toolbelt/main.go
@@ -22,7 +22,6 @@ package main
 
 import (
 	"crypto"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -84,7 +83,7 @@ func (x *generateKey) Execute(args []string) error {
 func findPublicKey(db *asserts.Database, id string) (asserts.PublicKey, error) {
 	parts := strings.SplitN(id, "/", 2)
 	if len(parts) != 2 {
-		return nil, errors.New("id should be name/key-id")
+		return fmt.Errorf(`invalid public key specification: %q (expected "account-name/key-id")`, id)
 	}
 	return db.PublicKey(parts[0], parts[1])
 }

--- a/asserts/toolbelt/main.go
+++ b/asserts/toolbelt/main.go
@@ -83,7 +83,7 @@ func (x *generateKey) Execute(args []string) error {
 func findPublicKey(db *asserts.Database, id string) (asserts.PublicKey, error) {
 	parts := strings.SplitN(id, "/", 2)
 	if len(parts) != 2 {
-		return fmt.Errorf(`invalid public key specification: %q (expected "account-name/key-id")`, id)
+		return nil, fmt.Errorf(`invalid public key specification: %q (expected "account-name/key-id")`, id)
 	}
 	return db.PublicKey(parts[0], parts[1])
 }


### PR DESCRIPTION
The asserts API now requires the key ID to find a public key and to sign
a new assertion.

Hijacks the commands' existing positional args to include the key ID by
using the syntax <name>/<keyid>.