### PR TITLE
add OS/Kernel to install.yaml

### DIFF
--- a/provisioning/provisioning.go
+++ b/provisioning/provisioning.go
@@ -49,9 +49,7 @@ func (e *ErrNoInstallYaml) Error() string {
 
 // InstallMeta encapsulates the metadata for a system install.
 type InstallMeta struct {
-	Timestamp         time.Time
-	InitialVersion    string `yaml:"initial-version"`
-	SystemImageServer string `yaml:"system-image-server"`
+	Timestamp time.Time
 }
 
 // InstallTool encapsulates metadata on the tool used to create the
@@ -70,6 +68,8 @@ type InstallOptions struct {
 	Channel       string
 	DevicePart    string `yaml:"device-part,omitempty"`
 	Gadget        string
+	OS            string
+	Kernel        string
 	DeveloperMode bool `yaml:"developer-mode,omitempty"`
 }
 

--- a/provisioning/provisioning_test.go
+++ b/provisioning/provisioning_test.go
@@ -39,8 +39,6 @@ var _ = Suite(&ProvisioningTestSuite{})
 var yamlData = `
 meta:
   timestamp: 2015-04-20T14:15:39.013515821+01:00
-  initial-revision: r345
-  system-image-server: http://system-image.ubuntu.com
 
 tool:
   name: ubuntu-device-flash
@@ -59,8 +57,6 @@ options:
 var yamlDataNoDevicePart = `
 meta:
   timestamp: 2015-04-20T14:15:39.013515821+01:00
-  initial-revision: r345
-  system-image-server: http://system-image.ubuntu.com
 
 tool:
   name: ubuntu-device-flash


### PR DESCRIPTION
Trivial branch that removes bits from "install.yaml" that are no longer relevant (like system-image bits) and adds new relevant OS/Kernel to it.