### PR TITLE
remove user-visible support for installing clickdebs or building clickdebs

### DIFF
--- a/cmd/snappy/cmd_build.go
+++ b/cmd/snappy/cmd_build.go
@@ -56,12 +56,7 @@ func (x *cmdBuild) Execute(args []string) (err error) {
 		args = []string{"."}
 	}
 
-	var snapPackage string
-	if x.BuildSquashfs {
-		snapPackage, err = snappy.BuildSquashfsSnap(args[0], x.Output)
-	} else {
-		snapPackage, err = snappy.BuildLegacySnap(args[0], x.Output)
-	}
+	snapPackage, err := snappy.BuildSquashfsSnap(args[0], x.Output)
 	if err != nil {
 		return err
 	}

--- a/snap/clickdeb/deb.go
+++ b/snap/clickdeb/deb.go
@@ -49,14 +49,6 @@ var (
 	ErrMemberNotFound = errors.New("member not found")
 )
 
-func init() {
-	// we need to wrap "Open()" here because stock Open returns
-	// a *ClickDeb and not a snap.File
-	snap.RegisterFormat([]byte("!<arch>\ndebian"), func(path string) (snap.File, error) {
-		return Open(path)
-	})
-}
-
 // ErrUnpackFailed is the error type for a snap unpack problem.
 type ErrUnpackFailed struct {
 	snapFile string

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -41,6 +41,15 @@ import (
 	"github.com/ubuntu-core/snappy/timeout"
 )
 
+// FIXME: kill once all the tests are ported to clickdeb or killed
+func init() {
+	// we need to wrap "Open()" here because stock Open returns
+	// a *ClickDeb and not a snap.File
+	snap.RegisterFormat([]byte("!<arch>\ndebian"), func(path string) (snap.File, error) {
+		return clickdeb.Open(path)
+	})
+}
+
 func (s *SnapTestSuite) TestReadManifest(c *C) {
 	manifestData := []byte(`{
    "description": "This is a simple hello world example.",


### PR DESCRIPTION
Minimal amount of work needed to make clickdebs not installable or buildable.

The rational for this branch is that its short and easy to review. With that I can prepare the final all-snap images. The remaining removal that is done in the followup branch can then happen later (and once it got proper review). 