### PR TITLE
Rewrite capabilities to use interfaces

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -19,26 +19,50 @@
 
 package caps
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // Capability holds information about a capability that a snap may request
 // from a snappy system to do its job while running on it.
-type Capability struct {
+type Capability interface {
+	fmt.Stringer
+	json.Marshaler
+
 	// Name is a key that identifies the capability. It must be unique within
 	// its context, which may be either a snap or a snappy runtime.
-	Name string `json:"name"`
+	Name() string
 	// Label provides an optional title for the capability to help a human tell
 	// which physical device this capability is referring to. It might say
 	// "Front USB", or "Green Serial Port", for example.
-	Label string `json:"label"`
-	// Type defines the type of this capability. The capability type defines
-	// the behavior allowed and expected from providers and consumers of that
-	// capability, and also which information should be exchanged by these
-	// parties.
-	Type *Type `json:"type"`
-	// Attrs are key-value pairs that provide type-specific capability details.
-	Attrs map[string]string `json:"attrs,omitempty"`
+	Label() string
+	// TypeName defines the type of this capability. The capability type
+	// defines the behavior allowed and expected from providers and consumers
+	// of that capability, and also which information should be exchanged by
+	// these parties.
+	TypeName() string
+	// AttrMap returns a copy of all the key-value pairs that provide
+	// type-specific capability details.
+	AttrMap() map[string]string
+	// Validate checks whether capability has correct internal data
+	Validate() error
 }
 
-// String representation of a capability.
-func (c Capability) String() string {
-	return c.Name
+// CapabilityInfo is the public description of a capability suitable for serialization.
+type CapabilityInfo struct {
+	Name     string            `json:"name"`
+	Label    string            `json:"label"`
+	TypeName string            `json:"type"`
+	AttrMap  map[string]string `json:"attrs,omitempty"`
+}
+
+// Info creates capability information from any capability
+func Info(cap Capability) *CapabilityInfo {
+	return &CapabilityInfo{
+		Name:     cap.Name(),
+		Label:    cap.Label(),
+		TypeName: cap.TypeName(),
+		AttrMap:  cap.AttrMap(),
+	}
 }

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -28,18 +28,3 @@ import (
 func Test(t *testing.T) {
 	TestingT(t)
 }
-
-type CapabilitySuite struct{}
-
-var _ = Suite(&CapabilitySuite{})
-var testCapability = &Capability{
-	Name:  "test-name",
-	Label: "test-label",
-	Type:  testType,
-	Attrs: nil,
-}
-
-func (s *CapabilitySuite) TestString(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: testType}
-	c.Assert(cap.String(), Equals, "name")
-}

--- a/caps/misc.go
+++ b/caps/misc.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/misc.go
+++ b/caps/misc.go
@@ -60,3 +60,7 @@ func LoadBuiltInTypes(r *Repository) error {
 	}
 	return nil
 }
+
+var builtInTypes = [...]Type{
+	&boolFileType{},
+}

--- a/caps/misc_test.go
+++ b/caps/misc_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/misc_test.go
+++ b/caps/misc_test.go
@@ -21,8 +21,6 @@ package caps
 
 import (
 	. "gopkg.in/check.v1"
-
-	"github.com/ubuntu-core/snappy/testutil"
 )
 
 type MiscSuite struct{}
@@ -42,8 +40,9 @@ func (s *MiscSuite) TestLoadBuiltInTypes(c *C) {
 	repo := NewRepository()
 	err := LoadBuiltInTypes(repo)
 	c.Assert(err, IsNil)
-	c.Assert(repo.types, testutil.Contains, BoolFileType)
 	c.Assert(repo.types, HasLen, 1) // Update this whenever new built-in type is added
+	// Ensure that each type is correctly registered
+	c.Check(repo.types["bool-file"], DeepEquals, &boolFileType{})
 	err = LoadBuiltInTypes(repo)
-	c.Assert(err, ErrorMatches, `cannot add type "bool-file": name already exists`)
+	c.Check(err, ErrorMatches, `cannot add type "bool-file": name already exists`)
 }

--- a/caps/repo.go
+++ b/caps/repo.go
@@ -1,20 +1,20 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+* Copyright (C) 2015 Canonical Ltd
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License version 3 as
+* published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
  */
 
 package caps
@@ -29,97 +29,76 @@ import (
 type Repository struct {
 	// Protects the internals from concurrent access.
 	m sync.Mutex
-	// Map of capabilities, indexed by Capability.Name
-	caps map[string]*Capability
-	// A slice of types that are recognized and accepted
-	types []*Type
+	// Map of capabilities, indexed by name
+	caps map[string]Capability
+	// Map of capability types, indexed by name
+	types map[string]Type
 }
 
 // NewRepository creates an empty capability repository
 func NewRepository() *Repository {
 	return &Repository{
-		caps:  make(map[string]*Capability),
-		types: make([]*Type, 0),
+		caps:  make(map[string]Capability),
+		types: make(map[string]Type),
 	}
+}
+
+// MakeCap creates a new capability from a specification.
+// The capability is *not* added to the repository, use Add() for that.
+func (r *Repository) MakeCap(name, label, typeName string, attrs map[string]string) (Capability, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if t, ok := r.types[typeName]; ok {
+		return t.Make(name, label, attrs)
+	}
+	return nil, fmt.Errorf("unknown capability type: %q", typeName)
+}
+
+// MakeCapFromInfo creates a new capability from capability info.
+// The capability is *not* added to the repository, use Add() for that.
+func (r *Repository) MakeCapFromInfo(info *CapabilityInfo) (Capability, error) {
+	return r.MakeCap(info.Name, info.Label, info.TypeName, info.AttrMap)
 }
 
 // Add a capability to the repository.
 // Capability names must be valid snap names, as defined by ValidateName, and
 // must be unique within the repository.  An error is returned if this
 // constraint is violated.
-func (r *Repository) Add(cap *Capability) error {
+func (r *Repository) Add(cap Capability) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
+	name := cap.Name()
+	typeName := cap.TypeName()
+
 	// Reject capabilities with invalid names
-	if err := ValidateName(cap.Name); err != nil {
+	if err := ValidateName(name); err != nil {
 		return err
 	}
 	// Reject capabilities with duplicate names
-	if _, ok := r.caps[cap.Name]; ok {
-		return fmt.Errorf("cannot add capability %q: name already exists", cap.Name)
+	if _, ok := r.caps[name]; ok {
+		return fmt.Errorf("cannot add capability %q: name already exists", name)
 	}
 	// Reject capabilities with unknown types
-	if !r.hasType(cap.Type) {
-		return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.Type)
+	if _, ok := r.types[typeName]; !ok {
+		return fmt.Errorf("cannot add capability %q: type %q is unknown", name, typeName)
 	}
 	// Reject capabilities that don't pass type-specific validation
-	if err := cap.Type.Validate(cap); err != nil {
+	if err := cap.Validate(); err != nil {
 		return err
 	}
-	r.caps[cap.Name] = cap
-	return nil
-}
-
-// hasType checks whether the repository contains the given type.
-func (r *Repository) hasType(t *Type) bool {
-	for _, tt := range r.types {
-		if tt == t {
-			return true
-		}
-	}
-	return false
-}
-
-// Type finds and returns the Type with the given name or nil if
-// it's not found
-func (r *Repository) Type(name string) *Type {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	for _, t := range r.types {
-		if t.Name == name {
-			return t
-		}
-	}
+	r.caps[name] = cap
 	return nil
 }
 
 // Capability finds and returns the Capability with the given name or nil if it
 // is not found.
-func (r *Repository) Capability(name string) *Capability {
+func (r *Repository) Capability(name string) Capability {
 	r.m.Lock()
 	defer r.m.Unlock()
 
 	return r.caps[name]
-}
-
-// AddType adds a capability type to the repository.
-// It's an error to add the same capability type more than once.
-func (r *Repository) AddType(t *Type) error {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	if err := ValidateName(t.String()); err != nil {
-		return err
-	}
-	for _, otherT := range r.types {
-		if t.Name == otherT.Name {
-			return fmt.Errorf("cannot add type %q: name already exists", t)
-		}
-	}
-	r.types = append(r.types, t)
-	return nil
 }
 
 // Remove removes the capability with the provided name.
@@ -151,24 +130,11 @@ func (r *Repository) Names() []string {
 	return keys
 }
 
-// TypeNames returns all type names in the repository in lexicographical order.
-func (r *Repository) TypeNames() []string {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	types := make([]string, len(r.types))
-	for i, t := range r.types {
-		types[i] = t.String()
-	}
-	sort.Strings(types)
-	return types
-}
-
 type byName []Capability
 
 func (c byName) Len() int           { return len(c) }
 func (c byName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
-func (c byName) Less(i, j int) bool { return c[i].Name < c[j].Name }
+func (c byName) Less(i, j int) bool { return c[i].Name() < c[j].Name() }
 
 // All returns all capabilities ordered by name.
 func (r *Repository) All() []Capability {
@@ -178,7 +144,7 @@ func (r *Repository) All() []Capability {
 	caps := make([]Capability, len(r.caps))
 	i := 0
 	for _, capability := range r.caps {
-		caps[i] = *capability
+		caps[i] = capability
 		i++
 	}
 	sort.Sort(byName(caps))
@@ -186,13 +152,54 @@ func (r *Repository) All() []Capability {
 }
 
 // Caps returns a shallow copy of the map of capabilities.
-func (r *Repository) Caps() map[string]*Capability {
+func (r *Repository) Caps() map[string]Capability {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	caps := make(map[string]*Capability, len(r.caps))
+	caps := make(map[string]Capability, len(r.caps))
 	for k, v := range r.caps {
 		caps[k] = v
 	}
 	return caps
+}
+
+// AddType adds a capability type to the repository.
+// It's an error to add the same capability type more than once.
+func (r *Repository) AddType(t Type) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	typeName := t.Name()
+	if err := ValidateName(typeName); err != nil {
+		return err
+	}
+	if _, ok := r.types[typeName]; ok {
+		return fmt.Errorf("cannot add type %q: name already exists", typeName)
+	}
+	r.types[typeName] = t
+	return nil
+}
+
+// Type finds and returns the Type with the given name or nil if it is not
+// found.
+func (r *Repository) Type(name string) Type {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	return r.types[name]
+}
+
+// TypeNames returns all type names in the repository in lexicographical order.
+func (r *Repository) TypeNames() []string {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	keys := make([]string, len(r.types))
+	i := 0
+	for key := range r.types {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/caps/repo.go
+++ b/caps/repo.go
@@ -1,20 +1,20 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
-* Copyright (C) 2015 Canonical Ltd
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License version 3 as
-* published by the Free Software Foundation.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*
+ * Copyright (C) 2015-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 package caps

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -22,90 +22,103 @@ package caps
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/ubuntu-core/snappy/testutil"
+	//	"github.com/ubuntu-core/snappy/testutil"
 )
 
 type RepositorySuite struct {
-	// Repository pre-populated with testType
+	testType Type
+	// Repository pre-populated with mock capability type
 	testRepo *Repository
 	// Empty repository
 	emptyRepo *Repository
 }
 
-var _ = Suite(&RepositorySuite{})
+var _ = Suite(&RepositorySuite{
+	testType: &MockType{},
+})
 
 func (s *RepositorySuite) SetUpTest(c *C) {
 	s.testRepo = NewRepository()
-	err := s.testRepo.AddType(testType)
+	err := s.testRepo.AddType(s.testType)
 	c.Assert(err, IsNil)
 	s.emptyRepo = NewRepository()
 }
 
+func (s *RepositorySuite) TestMakeCap(c *C) {
+	// The test repository can make the mock capability
+	cap1, err1 := s.testRepo.MakeCap("name", "label", "mock", map[string]string{"k": "v"})
+	c.Assert(err1, IsNil)
+	c.Assert(cap1.Name(), Equals, "name")
+	c.Assert(cap1.Label(), Equals, "label")
+	c.Assert(cap1.TypeName(), Equals, "mock")
+	c.Assert(cap1.AttrMap(), DeepEquals, map[string]string{"k": "v"})
+	// The empty repository cannot make the mock capability
+	cap2, err2 := s.emptyRepo.MakeCap("name", "label", "mock", map[string]string{"k": "v"})
+	c.Assert(err2, ErrorMatches, `unknown capability type: "mock"`)
+	c.Assert(cap2, IsNil)
+}
+
+// TODO: add test for MakeCapFromInfo()
+
 func (s *RepositorySuite) TestAdd(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: testType}
-	c.Assert(s.testRepo.Names(), Not(testutil.Contains), cap.Name)
-	err := s.testRepo.Add(cap)
+	cap, err := s.testRepo.MakeCap("name", "label", "mock", nil)
 	c.Assert(err, IsNil)
-	c.Assert(s.testRepo.Names(), DeepEquals, []string{"name"})
-	c.Assert(s.testRepo.Names(), testutil.Contains, cap.Name)
+	c.Assert(s.testRepo.caps[cap.Name()], IsNil)
+	err2 := s.testRepo.Add(cap)
+	c.Assert(err2, IsNil)
+	c.Assert(s.testRepo.caps[cap.Name()], Equals, cap)
 }
 
 func (s *RepositorySuite) TestAddClash(c *C) {
-	cap1 := &Capability{Name: "name", Label: "label 1", Type: testType}
+	cap1 := &Mock{name: "name", label: "label 1"}
+	cap2 := &Mock{name: "name", label: "label 2"}
 	err := s.testRepo.Add(cap1)
 	c.Assert(err, IsNil)
-	cap2 := &Capability{Name: "name", Label: "label 2", Type: testType}
 	err = s.testRepo.Add(cap2)
 	c.Assert(err, ErrorMatches,
 		`cannot add capability "name": name already exists`)
-	c.Assert(s.testRepo.Names(), DeepEquals, []string{"name"})
-	c.Assert(s.testRepo.Names(), testutil.Contains, cap1.Name)
+	c.Assert(s.testRepo.caps[cap1.name], Equals, cap1)
 }
 
 func (s *RepositorySuite) TestAddInvalidName(c *C) {
-	cap := &Capability{Name: "bad-name-", Label: "label", Type: testType}
+	cap := &Mock{name: "bad-name-"}
 	err := s.testRepo.Add(cap)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
-	c.Assert(s.testRepo.Names(), DeepEquals, []string{})
-	c.Assert(s.testRepo.Names(), Not(testutil.Contains), cap.Name)
+	c.Assert(s.testRepo.caps[cap.name], IsNil)
 }
 
 func (s *RepositorySuite) TestAddType(c *C) {
-	t := &Type{Name: "foo"}
+	t := &MockType{CustomName: "custom"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, IsNil)
-	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"foo"})
-	c.Assert(s.emptyRepo.TypeNames(), testutil.Contains, "foo")
+	c.Assert(s.emptyRepo.types["custom"], Equals, t)
 }
 
 func (s *RepositorySuite) TestAddTypeClash(c *C) {
-	t1 := &Type{Name: "foo"}
-	t2 := &Type{Name: "foo"}
+	t1 := &MockType{CustomName: "custom"}
+	t2 := &MockType{CustomName: "custom"}
 	err := s.emptyRepo.AddType(t1)
 	c.Assert(err, IsNil)
 	err = s.emptyRepo.AddType(t2)
-	c.Assert(err, ErrorMatches,
-		`cannot add type "foo": name already exists`)
-	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"foo"})
-	c.Assert(s.emptyRepo.TypeNames(), testutil.Contains, "foo")
+	c.Assert(err, ErrorMatches, `cannot add type "custom": name already exists`)
+	c.Assert(s.emptyRepo.types["custom"], Equals, t1)
 }
 
 func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
-	t := &Type{Name: "bad-name-"}
+	t := &MockType{CustomName: "bad-name-"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
-	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
-	c.Assert(s.emptyRepo.TypeNames(), Not(testutil.Contains), t.String())
+	c.Assert(s.emptyRepo.types[t.Name()], IsNil)
 }
 
 func (s *RepositorySuite) TestRemoveGood(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: testType}
+	cap := &Mock{name: "name", label: "label"}
 	err := s.testRepo.Add(cap)
 	c.Assert(err, IsNil)
-	err = s.testRepo.Remove(cap.Name)
+	err = s.testRepo.Remove("name")
 	c.Assert(err, IsNil)
-	c.Assert(s.testRepo.Names(), HasLen, 0)
-	c.Assert(s.testRepo.Names(), Not(testutil.Contains), cap.Name)
+	c.Assert(s.testRepo.caps, HasLen, 0)
+	c.Assert(s.testRepo.caps["name"], IsNil)
 }
 
 func (s *RepositorySuite) TestRemoveNoSuchCapability(c *C) {
@@ -114,71 +127,55 @@ func (s *RepositorySuite) TestRemoveNoSuchCapability(c *C) {
 }
 
 func (s *RepositorySuite) TestNames(c *C) {
-	// Note added in non-sorted order
-	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
-	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
-	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
-	c.Assert(err, IsNil)
+	s.addABC(c)
 	c.Assert(s.testRepo.Names(), DeepEquals, []string{"a", "b", "c"})
 }
 
 func (s *RepositorySuite) TestTypeNames(c *C) {
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
-	s.emptyRepo.AddType(&Type{Name: "a"})
-	s.emptyRepo.AddType(&Type{Name: "b"})
-	s.emptyRepo.AddType(&Type{Name: "c"})
+	// Note added in non-sorted order
+	s.emptyRepo.AddType(&MockType{CustomName: "a"})
+	s.emptyRepo.AddType(&MockType{CustomName: "c"})
+	s.emptyRepo.AddType(&MockType{CustomName: "b"})
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"a", "b", "c"})
 }
 
 func (s *RepositorySuite) TestAll(c *C) {
-	// Note added in non-sorted order
-	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
-	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
-	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
-	c.Assert(err, IsNil)
+	s.addABC(c)
 	c.Assert(s.testRepo.All(), DeepEquals, []Capability{
-		Capability{Name: "a", Label: "label-a", Type: testType},
-		Capability{Name: "b", Label: "label-b", Type: testType},
-		Capability{Name: "c", Label: "label-c", Type: testType},
+		&Mock{name: "a"}, &Mock{name: "b"}, &Mock{name: "c"},
 	})
 }
 
 func (s *RepositorySuite) TestType(c *C) {
-	c.Assert(s.emptyRepo.Type(testType.Name), IsNil)
-	c.Assert(s.testRepo.Type(testType.Name), Equals, testType)
+	name := s.testType.Name()
+	c.Assert(s.emptyRepo.Type(name), IsNil)
+	c.Assert(s.testRepo.Type(name), Equals, s.testType)
 }
 
 func (s *RepositorySuite) TestCapability(c *C) {
-	err := s.testRepo.Add(testCapability)
+	cap := &Mock{name: "name"}
+	err := s.testRepo.Add(cap)
 	c.Assert(err, IsNil)
-	c.Assert(s.emptyRepo.Capability(testCapability.Name), IsNil)
-	c.Assert(s.testRepo.Capability(testCapability.Name), Equals, testCapability)
-}
-
-func (s *RepositorySuite) TestHasType(c *C) {
-	// hasType works as expected when the object is exactly the one that was
-	// added earlier.
-	c.Assert(s.emptyRepo.hasType(testType), Equals, false)
-	c.Assert(s.testRepo.hasType(testType), Equals, true)
-	// hasType doesn't do deep equality checks so even though the types are
-	// otherwise identical, the test fails.
-	c.Assert(s.testRepo.hasType(&Type{Name: testType.Name}), Equals, false)
+	c.Assert(s.emptyRepo.Capability("name"), IsNil)
+	c.Assert(s.testRepo.Capability("name"), Equals, cap)
 }
 
 func (s *RepositorySuite) TestCaps(c *C) {
-	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
-	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
-	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
-	c.Assert(err, IsNil)
-	c.Assert(s.testRepo.Caps(), DeepEquals, map[string]*Capability{
-		"a": &Capability{Name: "a", Label: "label-a", Type: testType},
-		"b": &Capability{Name: "b", Label: "label-b", Type: testType},
-		"c": &Capability{Name: "c", Label: "label-c", Type: testType},
+	s.addABC(c)
+	c.Assert(s.testRepo.Caps(), DeepEquals, map[string]Capability{
+		"a": &Mock{name: "a"},
+		"b": &Mock{name: "b"},
+		"c": &Mock{name: "c"},
 	})
+}
+
+func (s *RepositorySuite) addABC(c *C) {
+	// Note added in non-sorted order
+	err := s.testRepo.Add(&Mock{name: "a"})
+	c.Assert(err, IsNil)
+	err = s.testRepo.Add(&Mock{name: "c"})
+	c.Assert(err, IsNil)
+	err = s.testRepo.Add(&Mock{name: "b"})
+	c.Assert(err, IsNil)
 }

--- a/caps/type_bool_file.go
+++ b/caps/type_bool_file.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/type_bool_file.go
+++ b/caps/type_bool_file.go
@@ -1,0 +1,109 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	// Name of the capability type.
+	boolFileName = "bool-file"
+	// Name of the attribute referring to the boolean file on the filesystem.
+	boolFilePath = "path"
+)
+
+// boolFile is a capability for accessing a "boolean file".
+// A "boolean file" is any device that reacts when either '0' or '1' is written to it.
+// Typical examples include LEDs and GPIOs.
+type boolFile struct {
+	name     string
+	label    string
+	path     string
+	realPath string
+	attrs    map[string]string
+}
+
+func (c *boolFile) Name() string {
+	return c.name
+}
+
+func (c *boolFile) Label() string {
+	return c.label
+}
+
+func (c *boolFile) TypeName() string {
+	return boolFileName
+}
+
+func (c *boolFile) AttrMap() map[string]string {
+	a := make(map[string]string)
+	for k, v := range c.attrs {
+		a[k] = v
+	}
+	a[boolFilePath] = c.path
+	return a
+}
+
+func (c *boolFile) Validate() error {
+	// TODO: validate path against allowed regexp
+	if c.path == "" {
+		return fmt.Errorf("%s must have the %s attribute", boolFileName, boolFilePath)
+	}
+	return nil
+}
+
+func (c *boolFile) String() string {
+	return c.Name()
+}
+
+func (c *boolFile) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Info(c))
+}
+
+type boolFileType struct{}
+
+func (t *boolFileType) String() string {
+	return boolFileName
+}
+
+func (t *boolFileType) Name() string {
+	return boolFileName
+}
+
+func (t *boolFileType) Make(name, label string, attrs map[string]string) (Capability, error) {
+	a := make(map[string]string)
+	for k, v := range attrs {
+		a[k] = v
+	}
+	delete(a, boolFilePath)
+	path := attrs[boolFilePath]
+	// TODO: resolve symlinks
+	realPath := path
+	c := &boolFile{
+		name:     name,
+		label:    label,
+		path:     path,
+		realPath: realPath,
+		attrs:    a,
+	}
+	return c, nil
+}

--- a/caps/type_bool_file_test.go
+++ b/caps/type_bool_file_test.go
@@ -1,0 +1,131 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"encoding/json"
+
+	. "gopkg.in/check.v1"
+)
+
+type BoolFileSuite struct {
+	t   Type
+	cap Capability
+}
+
+var _ = Suite(&BoolFileSuite{
+	t: &boolFileType{},
+	cap: &boolFile{
+		name:     "name",
+		label:    "label",
+		path:     "path",
+		realPath: "realPath",
+		attrs:    map[string]string{"k": "v"},
+	},
+})
+
+func (s *BoolFileSuite) TestName(c *C) {
+	c.Check(s.cap.Name(), Equals, "name")
+}
+
+func (s *BoolFileSuite) TestLabel(c *C) {
+	c.Check(s.cap.Label(), Equals, "label")
+}
+
+func (s *BoolFileSuite) TestTypeName(c *C) {
+	c.Check(s.cap.TypeName(), Equals, "bool-file")
+}
+
+func (s *BoolFileSuite) TestAttrMap(c *C) {
+	c.Check(s.cap.AttrMap(), DeepEquals, map[string]string{"path": "path", "k": "v"})
+}
+
+func (s *BoolFileSuite) TestValidate(c *C) {
+	// All good
+	cap1, err1 := s.t.Make("name", "label", map[string]string{"path": "path"})
+	c.Assert(err1, IsNil)
+	c.Assert(cap1, Not(IsNil))
+	c.Check(cap1.Validate(), IsNil)
+	// Without a path
+	cap2, err2 := s.t.Make("name", "label", map[string]string{"k": "v"})
+	c.Assert(err2, IsNil)
+	c.Assert(cap2, Not(IsNil))
+	c.Check(cap2.Validate(), ErrorMatches, "bool-file must have the path attribute")
+	// TODO: add test for path not matching allowed regexp
+}
+
+func (s *BoolFileSuite) TestMarshalJSON(c *C) {
+	b, err := s.cap.MarshalJSON()
+	c.Assert(err, IsNil)
+	var v map[string]interface{}
+	err = json.Unmarshal(b, &v)
+	c.Assert(err, IsNil)
+	c.Assert(v, DeepEquals, map[string]interface{}{
+		"name":  "name",
+		"label": "label",
+		"type":  "bool-file",
+		"attrs": map[string]interface{}{
+			"k":    "v",
+			"path": "path",
+		},
+	})
+}
+
+func (s *BoolFileSuite) TestString(c *C) {
+	c.Check(s.cap.String(), Equals, "name")
+}
+
+type BoolFileTypeSuite struct {
+	t Type
+}
+
+var _ = Suite(&BoolFileTypeSuite{
+	t: &boolFileType{},
+})
+
+func (s *BoolFileTypeSuite) TestString(c *C) {
+	c.Assert(s.t.String(), Equals, "bool-file")
+}
+
+func (s *BoolFileTypeSuite) TestName(c *C) {
+	c.Assert(s.t.Name(), Equals, "bool-file")
+}
+
+func (s *BoolFileTypeSuite) TestMake(c *C) {
+	// All good
+	cap1, err1 := s.t.Make("name", "label", map[string]string{"k": "v", "path": "path"})
+	c.Assert(err1, IsNil)
+	bf1 := cap1.(*boolFile)
+	c.Check(bf1.name, Equals, "name")
+	c.Check(bf1.label, Equals, "label")
+	c.Check(bf1.path, Equals, "path")
+	c.Check(bf1.realPath, Equals, "path") // TODO: mock symlink evaluation
+	c.Check(bf1.attrs, DeepEquals, map[string]string{"k": "v"})
+	// Without a path
+	cap2, err2 := s.t.Make("name", "label", map[string]string{"k": "v"})
+	c.Assert(err2, IsNil)
+	bf2 := cap2.(*boolFile)
+	c.Check(bf2.name, Equals, "name")
+	c.Check(bf2.label, Equals, "label")
+	c.Check(bf2.path, Equals, "")
+	c.Check(bf2.realPath, Equals, "") // TODO: mock symlink evaluation
+	c.Check(bf2.attrs, DeepEquals, map[string]string{"k": "v"})
+	// TODO: add test with symlink evaluation error
+}

--- a/caps/type_mock.go
+++ b/caps/type_mock.go
@@ -1,0 +1,107 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"encoding/json"
+)
+
+// Mock is a capability designed for testing.
+type Mock struct {
+	name       string            `json:"name"`
+	label      string            `json:"label"`
+	customName string            `json:"custom_name"`
+	attrs      map[string]string `json:"attrs"`
+}
+
+// Name returns the name of a mock capability.
+func (c *Mock) Name() string {
+	return c.name
+}
+
+// Label returns the human-readable label of a mock capability.
+func (c *Mock) Label() string {
+	return c.label
+}
+
+// TypeName returns either the custom capability type name or the string "mock".
+func (c *Mock) TypeName() string {
+	if c.customName != "" {
+		return c.customName
+	}
+	return "mock"
+}
+
+// AttrMap returns a copy of all the attributes.
+func (c *Mock) AttrMap() map[string]string {
+	a := make(map[string]string)
+	for k, v := range c.attrs {
+		a[k] = v
+	}
+	return a
+}
+
+// Validate does nothing, successfully.
+func (c *Mock) Validate() error {
+	return nil
+}
+
+// String returns the name of a mock capability.
+func (c *Mock) String() string {
+	return c.Name()
+}
+
+// MarshalJSON returns the JSON representation of a mock capability.
+func (c *Mock) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Info(c))
+}
+
+// MockType is the type definition of the mock capability.
+// This type is public because it is useful for testing, even outside of the package.
+type MockType struct {
+	// Custom name, defaults to "mock"
+	CustomName string
+}
+
+func (t *MockType) String() string {
+	return t.Name()
+}
+
+// Name returns either the custom capability type name or the string "mock"
+func (t *MockType) Name() string {
+	if t.CustomName != "" {
+		return t.CustomName
+	}
+	return "mock"
+}
+
+// Make creates a new Mock capability.
+func (t *MockType) Make(name, label string, attrs map[string]string) (Capability, error) {
+	a := make(map[string]string)
+	for k, v := range attrs {
+		a[k] = v
+	}
+	return &Mock{
+		name:       name,
+		label:      label,
+		customName: t.CustomName,
+		attrs:      a,
+	}, nil
+}

--- a/caps/type_mock_test.go
+++ b/caps/type_mock_test.go
@@ -1,0 +1,116 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+import (
+	"encoding/json"
+
+	. "gopkg.in/check.v1"
+)
+
+type MockSuite struct {
+	t   Type
+	cap Capability
+}
+
+var _ = Suite(&MockSuite{
+	t: &MockType{},
+	cap: &Mock{
+		name:  "name",
+		label: "label",
+		attrs: map[string]string{"k": "v"},
+	},
+})
+
+func (s *MockSuite) TestName(c *C) {
+	c.Check(s.cap.Name(), Equals, "name")
+}
+
+func (s *MockSuite) TestLabel(c *C) {
+	c.Check(s.cap.Label(), Equals, "label")
+}
+
+func (s *MockSuite) TestTypeName(c *C) {
+	c.Check(s.cap.TypeName(), Equals, "mock")
+}
+
+func (s *MockSuite) TestAttrMap(c *C) {
+	c.Check(s.cap.AttrMap(), DeepEquals, map[string]string{"k": "v"})
+}
+
+func (s *MockSuite) TestValidate(c *C) {
+	c.Check(s.cap.Validate(), IsNil)
+}
+
+func (s *MockSuite) TestString(c *C) {
+	c.Check(s.cap.String(), Equals, "name")
+}
+
+func (s *MockSuite) TestMarshalJSON(c *C) {
+	b, err := s.cap.MarshalJSON()
+	c.Assert(err, IsNil)
+	var v map[string]interface{}
+	err = json.Unmarshal(b, &v)
+	c.Assert(err, IsNil)
+	c.Assert(v, DeepEquals, map[string]interface{}{
+		"name":  "name",
+		"label": "label",
+		"type":  "mock",
+		"attrs": map[string]interface{}{
+			"k": "v",
+		},
+	})
+}
+
+type MockTypeSuite struct {
+	t, customT Type
+}
+
+var _ = Suite(&MockTypeSuite{
+	t:       &MockType{},
+	customT: &MockType{CustomName: "custom"},
+})
+
+func (s *MockTypeSuite) TestString(c *C) {
+	c.Assert(s.t.String(), Equals, "mock") // default name
+	c.Assert(s.customT.String(), Equals, "custom")
+}
+
+func (s *MockTypeSuite) TestName(c *C) {
+	c.Assert(s.t.Name(), Equals, "mock") // default name
+	c.Assert(s.customT.Name(), Equals, "custom")
+}
+
+func (s *MockTypeSuite) TestMake(c *C) {
+	cap1, err1 := s.t.Make("name", "label", map[string]string{"k": "v"})
+	c.Assert(err1, IsNil)
+	mock1 := cap1.(*Mock)
+	c.Check(mock1.name, Equals, "name")
+	c.Check(mock1.customName, Equals, "")
+	c.Check(mock1.label, Equals, "label")
+	c.Check(mock1.attrs, DeepEquals, map[string]string{"k": "v"})
+	cap2, err2 := s.customT.Make("name", "label", map[string]string{"k": "v"})
+	c.Assert(err2, IsNil)
+	mock2 := cap2.(*Mock)
+	c.Check(mock2.name, Equals, "name")
+	c.Check(mock2.customName, Equals, "custom")
+	c.Check(mock2.label, Equals, "label")
+	c.Check(mock2.attrs, DeepEquals, map[string]string{"k": "v"})
+}

--- a/caps/types.go
+++ b/caps/types.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/types.go
+++ b/caps/types.go
@@ -19,67 +19,12 @@
 
 package caps
 
-import (
-	"encoding/json"
-	"fmt"
-)
+import "fmt"
 
-// Type describes a group of interchangeable capabilities with common features.
-// Types are managed centrally and act as a contract between system builders,
-// application developers and end users.
-type Type struct {
-	// Name is a key that identifies the capability type. It must be unique
-	// within the whole OS. The name forms a part of the stable system API.
-	Name string
-	// RequiredAttrs contains names of attributes that are required by
-	// capability of this type.
-	RequiredAttrs []string
-}
+// Type binds type name to a maker function that creates capabilities of that type.
+type Type interface {
+	fmt.Stringer
 
-var (
-	// BoolFileType is a built-in capability type for files that follow a
-	// simple boolean protocol. The file can be read, which yields ASCII '0'
-	// (zero) or ASCII '1' (one). The same can be done for writing.
-	//
-	// This capability type can be used to describe many boolean flags exposed
-	// in sysfs, including certain hardware like exported GPIO pins.
-	BoolFileType = &Type{
-		Name:          "bool-file",
-		RequiredAttrs: []string{"path"},
-	}
-)
-
-var builtInTypes = [...]*Type{
-	BoolFileType,
-}
-
-// String returns a string representation for the capability type.
-func (t *Type) String() string {
-	return t.Name
-}
-
-// Validate whether a capability is correct according to the given type.
-func (t *Type) Validate(c *Capability) error {
-	if t != c.Type {
-		return fmt.Errorf("capability is not of type %q", t)
-	}
-	// Check that all required attributes are present
-	for _, attr := range t.RequiredAttrs {
-		if _, ok := c.Attrs[attr]; !ok {
-			return fmt.Errorf("capabilities of type %q must provide a %q attribute", t, attr)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON encodes a Type object as the name of the type.
-func (t *Type) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Name)
-}
-
-// UnmarshalJSON decodes the name of a Type object.
-// NOTE: In the future, when more properties are added, those properties will
-// not be decoded and will be left over as empty values.
-func (t *Type) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &t.Name)
+	Make(name, label string, attrs map[string]string) (Capability, error)
+	Name() string
 }

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -20,77 +20,9 @@
 package caps
 
 import (
-	"encoding/json"
-
 	. "gopkg.in/check.v1"
 )
 
 type TypeSuite struct{}
 
 var _ = Suite(&TypeSuite{})
-
-// testType is only meant for testing. It is not useful in any way except
-// that it offers an simple capability type that will happily validate.
-var testType = &Type{
-	Name:          "test",
-	RequiredAttrs: nil,
-}
-
-func (s *TypeSuite) TestTypeString(c *C) {
-	c.Assert(testType.String(), Equals, "test")
-}
-
-func (s *TypeSuite) TestValidateMismatchedType(c *C) {
-	testType2 := &Type{Name: "test-two"} // Another test-like type that's not test itself
-	cap := &Capability{Name: "name", Label: "label", Type: testType2}
-	err := testType.Validate(cap)
-	c.Assert(err, ErrorMatches, `capability is not of type "test"`)
-}
-
-func (s *TypeSuite) TestValidateOK(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: testType}
-	err := testType.Validate(cap)
-	c.Assert(err, IsNil)
-}
-
-func (s *TypeSuite) TestValidateAttributesRequiredAttrsMissing(c *C) {
-	t := &Type{
-		Name:          "t",
-		RequiredAttrs: []string{"k"},
-	}
-	cap := &Capability{
-		Name:  "name",
-		Label: "label",
-		Type:  t,
-	}
-	err := t.Validate(cap)
-	c.Assert(err, ErrorMatches, `capabilities of type "t" must provide a "k" attribute`)
-}
-
-func (s *TypeSuite) TestValidateAttributesRequiredAttrsSatisfied(c *C) {
-	t := &Type{
-		Name:          "t",
-		RequiredAttrs: []string{"k"},
-	}
-	cap := &Capability{
-		Name:  "name",
-		Label: "label",
-		Type:  t,
-		Attrs: map[string]string{"k": "v"},
-	}
-	err := t.Validate(cap)
-	c.Assert(err, IsNil)
-}
-
-func (s *TypeSuite) TestMarhshalJSON(c *C) {
-	b, err := json.Marshal(testType)
-	c.Assert(err, IsNil)
-	c.Assert(b, DeepEquals, []byte(`"test"`))
-}
-
-func (s *TypeSuite) TestUnmarhshalJSON(c *C) {
-	var t Type
-	err := json.Unmarshal([]byte(`"test"`), &t)
-	c.Assert(err, IsNil)
-	c.Assert(t.Name, Equals, "test")
-}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -910,26 +910,22 @@ func getCapabilities(c *Command, r *http.Request) Response {
 
 func addCapability(c *Command, r *http.Request) Response {
 	decoder := json.NewDecoder(r.Body)
-	var newCap caps.Capability
-	if err := decoder.Decode(&newCap); err != nil || newCap.Type == nil {
+	var capInfo caps.CapabilityInfo
+	if err := decoder.Decode(&capInfo); err != nil || capInfo.TypeName == "" {
 		return BadRequest(err, "can't decode request body into a capability")
 	}
-	// Re-construct the perfect type object knowing just the type name that is
-	// passed through the JSON representation.
-	newType := c.d.capRepo.Type(newCap.Type.Name)
-	if newType == nil {
-		err := fmt.Errorf("unknown type name %q", newCap.Type.Name)
-		return BadRequest(err, "can't add capability")
+	newCap, err := c.d.capRepo.MakeCapFromInfo(&capInfo)
+	if err != nil {
+		return BadRequest(err, "can't make capability")
 	}
-	newCap.Type = newType
-	if err := c.d.capRepo.Add(&newCap); err != nil {
+	if err := c.d.capRepo.Add(newCap); err != nil {
 		return BadRequest(err, "can't add capability")
 	}
 	return &resp{
 		Type:   ResponseTypeSync,
 		Status: http.StatusCreated,
 		Result: map[string]string{
-			"resource": fmt.Sprintf("/1.0/capabilities/%s", newCap.Name),
+			"resource": fmt.Sprintf("/1.0/capabilities/%s", newCap.Name()),
 		},
 	}
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
This large change discards the declarative capability types.
A caps.Capability is now an interface type
A caps.Type is now an interface type.

Concrete capabilities are separate go types (structs).  Capability type
knows how to make instances of that type using the caps.Type.Make()
function. To aid in serialization each Capability can now marshal itself
in a way that can be unmarshaled as CapabilityInfo. CapabilityInfo is
generic and simply expresses the public information about any
capability. The caps.Repository.MakeCapFromInfo() function can be used
to make a proper (typed) category.

The advantage of this model is that capabilities are self-contained
types with arbitrary code (not declarations) where appropriate.