### PR TITLE
Replace caps.Type struct with an interface

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -33,7 +33,7 @@ type Capability struct {
 	// the behavior allowed and expected from providers and consumers of that
 	// capability, and also which information should be exchanged by these
 	// parties.
-	Type *Type `json:"type"`
+	TypeName string `json:"type"`
 	// Attrs are key-value pairs that provide type-specific capability details.
 	Attrs map[string]string `json:"attrs,omitempty"`
 }

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -32,14 +32,13 @@ func Test(t *testing.T) {
 type CapabilitySuite struct{}
 
 var _ = Suite(&CapabilitySuite{})
-var testCapability = &Capability{
-	Name:  "test-name",
-	Label: "test-label",
-	Type:  testType,
-	Attrs: nil,
-}
 
 func (s *CapabilitySuite) TestString(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: testType}
-	c.Assert(cap.String(), Equals, "name")
+	cap := &Capability{
+		Name:     "test-name",
+		Label:    "test-label",
+		TypeName: "test-type",
+		Attrs:    nil,
+	}
+	c.Assert(cap.String(), Equals, "test-name")
 }

--- a/caps/misc_test.go
+++ b/caps/misc_test.go
@@ -21,8 +21,6 @@ package caps
 
 import (
 	. "gopkg.in/check.v1"
-
-	"github.com/ubuntu-core/snappy/testutil"
 )
 
 type MiscSuite struct{}
@@ -42,8 +40,9 @@ func (s *MiscSuite) TestLoadBuiltInTypes(c *C) {
 	repo := NewRepository()
 	err := LoadBuiltInTypes(repo)
 	c.Assert(err, IsNil)
-	c.Assert(repo.types, testutil.Contains, BoolFileType)
-	c.Assert(repo.types, HasLen, 1) // Update this whenever new built-in type is added
+	c.Assert(repo.types, DeepEquals, []Type{
+		&BoolFileType{},
+	})
 	err = LoadBuiltInTypes(repo)
 	c.Assert(err, ErrorMatches, `cannot add type "bool-file": name already exists`)
 }

--- a/caps/misc_test.go
+++ b/caps/misc_test.go
@@ -40,9 +40,7 @@ func (s *MiscSuite) TestLoadBuiltInTypes(c *C) {
 	repo := NewRepository()
 	err := LoadBuiltInTypes(repo)
 	c.Assert(err, IsNil)
-	c.Assert(repo.types, DeepEquals, []Type{
-		&BoolFileType{},
-	})
+	c.Assert(repo.Type("bool-file"), Not(IsNil))
 	err = LoadBuiltInTypes(repo)
 	c.Assert(err, ErrorMatches, `cannot add type "bool-file": name already exists`)
 }

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -35,7 +35,7 @@ type RepositorySuite struct {
 }
 
 var _ = Suite(&RepositorySuite{
-	t: &MockType{
+	t: &TestType{
 		TypeName: "type",
 	},
 })
@@ -82,7 +82,7 @@ func (s *RepositorySuite) TestAddInvalidName(c *C) {
 }
 
 func (s *RepositorySuite) TestAddType(c *C) {
-	t := &MockType{TypeName: "foo"}
+	t := &TestType{TypeName: "foo"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, IsNil)
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"foo"})
@@ -90,8 +90,8 @@ func (s *RepositorySuite) TestAddType(c *C) {
 }
 
 func (s *RepositorySuite) TestAddTypeClash(c *C) {
-	t1 := &MockType{TypeName: "foo"}
-	t2 := &MockType{TypeName: "foo"}
+	t1 := &TestType{TypeName: "foo"}
+	t2 := &TestType{TypeName: "foo"}
 	err := s.emptyRepo.AddType(t1)
 	c.Assert(err, IsNil)
 	err = s.emptyRepo.AddType(t2)
@@ -102,7 +102,7 @@ func (s *RepositorySuite) TestAddTypeClash(c *C) {
 }
 
 func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
-	t := &MockType{TypeName: "bad-name-"}
+	t := &TestType{TypeName: "bad-name-"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
@@ -137,9 +137,9 @@ func (s *RepositorySuite) TestNames(c *C) {
 
 func (s *RepositorySuite) TestTypeNames(c *C) {
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
-	s.emptyRepo.AddType(&MockType{TypeName: "a"})
-	s.emptyRepo.AddType(&MockType{TypeName: "b"})
-	s.emptyRepo.AddType(&MockType{TypeName: "c"})
+	s.emptyRepo.AddType(&TestType{TypeName: "a"})
+	s.emptyRepo.AddType(&TestType{TypeName: "b"})
+	s.emptyRepo.AddType(&TestType{TypeName: "c"})
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"a", "b", "c"})
 }
 
@@ -177,7 +177,7 @@ func (s *RepositorySuite) TestHasType(c *C) {
 	c.Assert(s.testRepo.hasType(s.t), Equals, true)
 	// hasType doesn't do deep equality checks so even though the types are
 	// otherwise identical, the test fails.
-	c.Assert(s.testRepo.hasType(&MockType{TypeName: s.t.Name()}), Equals, false)
+	c.Assert(s.testRepo.hasType(&TestType{TypeName: s.t.Name()}), Equals, false)
 }
 
 func (s *RepositorySuite) TestCaps(c *C) {

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -26,23 +26,34 @@ import (
 )
 
 type RepositorySuite struct {
-	// Repository pre-populated with testType
+	t   Type
+	cap *Capability
+	// Repository pre-populated with s.t
 	testRepo *Repository
 	// Empty repository
 	emptyRepo *Repository
 }
 
-var _ = Suite(&RepositorySuite{})
+var _ = Suite(&RepositorySuite{
+	t: &MockType{
+		TypeName: "type",
+	},
+})
 
 func (s *RepositorySuite) SetUpTest(c *C) {
+	s.cap = &Capability{
+		Name:     "name",
+		Label:    "label",
+		TypeName: "type",
+	}
 	s.testRepo = NewRepository()
-	err := s.testRepo.AddType(testType)
+	err := s.testRepo.AddType(s.t)
 	c.Assert(err, IsNil)
 	s.emptyRepo = NewRepository()
 }
 
 func (s *RepositorySuite) TestAdd(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: testType}
+	cap := &Capability{Name: "name", Label: "label", TypeName: "type"}
 	c.Assert(s.testRepo.Names(), Not(testutil.Contains), cap.Name)
 	err := s.testRepo.Add(cap)
 	c.Assert(err, IsNil)
@@ -51,10 +62,10 @@ func (s *RepositorySuite) TestAdd(c *C) {
 }
 
 func (s *RepositorySuite) TestAddClash(c *C) {
-	cap1 := &Capability{Name: "name", Label: "label 1", Type: testType}
+	cap1 := &Capability{Name: "name", Label: "label 1", TypeName: "type"}
 	err := s.testRepo.Add(cap1)
 	c.Assert(err, IsNil)
-	cap2 := &Capability{Name: "name", Label: "label 2", Type: testType}
+	cap2 := &Capability{Name: "name", Label: "label 2", TypeName: "type"}
 	err = s.testRepo.Add(cap2)
 	c.Assert(err, ErrorMatches,
 		`cannot add capability "name": name already exists`)
@@ -63,7 +74,7 @@ func (s *RepositorySuite) TestAddClash(c *C) {
 }
 
 func (s *RepositorySuite) TestAddInvalidName(c *C) {
-	cap := &Capability{Name: "bad-name-", Label: "label", Type: testType}
+	cap := &Capability{Name: "bad-name-", Label: "label", TypeName: "type"}
 	err := s.testRepo.Add(cap)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(s.testRepo.Names(), DeepEquals, []string{})
@@ -71,7 +82,7 @@ func (s *RepositorySuite) TestAddInvalidName(c *C) {
 }
 
 func (s *RepositorySuite) TestAddType(c *C) {
-	t := &Type{Name: "foo"}
+	t := &MockType{TypeName: "foo"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, IsNil)
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"foo"})
@@ -79,8 +90,8 @@ func (s *RepositorySuite) TestAddType(c *C) {
 }
 
 func (s *RepositorySuite) TestAddTypeClash(c *C) {
-	t1 := &Type{Name: "foo"}
-	t2 := &Type{Name: "foo"}
+	t1 := &MockType{TypeName: "foo"}
+	t2 := &MockType{TypeName: "foo"}
 	err := s.emptyRepo.AddType(t1)
 	c.Assert(err, IsNil)
 	err = s.emptyRepo.AddType(t2)
@@ -91,7 +102,7 @@ func (s *RepositorySuite) TestAddTypeClash(c *C) {
 }
 
 func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
-	t := &Type{Name: "bad-name-"}
+	t := &MockType{TypeName: "bad-name-"}
 	err := s.emptyRepo.AddType(t)
 	c.Assert(err, ErrorMatches, `"bad-name-" is not a valid snap name`)
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
@@ -99,7 +110,7 @@ func (s *RepositorySuite) TestAddTypeInvalidName(c *C) {
 }
 
 func (s *RepositorySuite) TestRemoveGood(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: testType}
+	cap := &Capability{Name: "name", Label: "label", TypeName: "type"}
 	err := s.testRepo.Add(cap)
 	c.Assert(err, IsNil)
 	err = s.testRepo.Remove(cap.Name)
@@ -115,70 +126,70 @@ func (s *RepositorySuite) TestRemoveNoSuchCapability(c *C) {
 
 func (s *RepositorySuite) TestNames(c *C) {
 	// Note added in non-sorted order
-	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
+	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", TypeName: "type"})
 	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
+	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", TypeName: "type"})
 	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
+	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", TypeName: "type"})
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.Names(), DeepEquals, []string{"a", "b", "c"})
 }
 
 func (s *RepositorySuite) TestTypeNames(c *C) {
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{})
-	s.emptyRepo.AddType(&Type{Name: "a"})
-	s.emptyRepo.AddType(&Type{Name: "b"})
-	s.emptyRepo.AddType(&Type{Name: "c"})
+	s.emptyRepo.AddType(&MockType{TypeName: "a"})
+	s.emptyRepo.AddType(&MockType{TypeName: "b"})
+	s.emptyRepo.AddType(&MockType{TypeName: "c"})
 	c.Assert(s.emptyRepo.TypeNames(), DeepEquals, []string{"a", "b", "c"})
 }
 
 func (s *RepositorySuite) TestAll(c *C) {
 	// Note added in non-sorted order
-	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
+	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", TypeName: "type"})
 	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
+	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", TypeName: "type"})
 	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
+	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", TypeName: "type"})
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.All(), DeepEquals, []Capability{
-		Capability{Name: "a", Label: "label-a", Type: testType},
-		Capability{Name: "b", Label: "label-b", Type: testType},
-		Capability{Name: "c", Label: "label-c", Type: testType},
+		Capability{Name: "a", Label: "label-a", TypeName: "type"},
+		Capability{Name: "b", Label: "label-b", TypeName: "type"},
+		Capability{Name: "c", Label: "label-c", TypeName: "type"},
 	})
 }
 
 func (s *RepositorySuite) TestType(c *C) {
-	c.Assert(s.emptyRepo.Type(testType.Name), IsNil)
-	c.Assert(s.testRepo.Type(testType.Name), Equals, testType)
+	c.Assert(s.emptyRepo.Type(s.t.Name()), IsNil)
+	c.Assert(s.testRepo.Type(s.t.Name()), Equals, s.t)
 }
 
 func (s *RepositorySuite) TestCapability(c *C) {
-	err := s.testRepo.Add(testCapability)
+	err := s.testRepo.Add(s.cap)
 	c.Assert(err, IsNil)
-	c.Assert(s.emptyRepo.Capability(testCapability.Name), IsNil)
-	c.Assert(s.testRepo.Capability(testCapability.Name), Equals, testCapability)
+	c.Assert(s.emptyRepo.Capability(s.cap.Name), IsNil)
+	c.Assert(s.testRepo.Capability(s.cap.Name), Equals, s.cap)
 }
 
 func (s *RepositorySuite) TestHasType(c *C) {
 	// hasType works as expected when the object is exactly the one that was
 	// added earlier.
-	c.Assert(s.emptyRepo.hasType(testType), Equals, false)
-	c.Assert(s.testRepo.hasType(testType), Equals, true)
+	c.Assert(s.emptyRepo.hasType(s.t), Equals, false)
+	c.Assert(s.testRepo.hasType(s.t), Equals, true)
 	// hasType doesn't do deep equality checks so even though the types are
 	// otherwise identical, the test fails.
-	c.Assert(s.testRepo.hasType(&Type{Name: testType.Name}), Equals, false)
+	c.Assert(s.testRepo.hasType(&MockType{TypeName: s.t.Name()}), Equals, false)
 }
 
 func (s *RepositorySuite) TestCaps(c *C) {
-	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", Type: testType})
+	err := s.testRepo.Add(&Capability{Name: "a", Label: "label-a", TypeName: "type"})
 	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", Type: testType})
+	err = s.testRepo.Add(&Capability{Name: "c", Label: "label-c", TypeName: "type"})
 	c.Assert(err, IsNil)
-	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", Type: testType})
+	err = s.testRepo.Add(&Capability{Name: "b", Label: "label-b", TypeName: "type"})
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.Caps(), DeepEquals, map[string]*Capability{
-		"a": &Capability{Name: "a", Label: "label-a", Type: testType},
-		"b": &Capability{Name: "b", Label: "label-b", Type: testType},
-		"c": &Capability{Name: "c", Label: "label-c", Type: testType},
+		"a": &Capability{Name: "a", Label: "label-a", TypeName: "type"},
+		"b": &Capability{Name: "b", Label: "label-b", TypeName: "type"},
+		"c": &Capability{Name: "c", Label: "label-c", TypeName: "type"},
 	})
 }

--- a/caps/types.go
+++ b/caps/types.go
@@ -27,8 +27,6 @@ import (
 // Types are managed centrally and act as a contract between system builders,
 // application developers and end users.
 type Type interface {
-	fmt.Stringer
-
 	// Unique and public name of this type.
 	Name() string
 	// Sanitize a capability (altering if necessary).

--- a/caps/types.go
+++ b/caps/types.go
@@ -60,9 +60,9 @@ func (t *BoolFileType) Sanitize(c *Capability) error {
 	return nil
 }
 
-// MockType is a type for various kind of tests.
+// TestType is a type for various kind of tests.
 // It is public so that it can be consumed from other packages.
-type MockType struct {
+type TestType struct {
 	// TypeName is the name of this type
 	TypeName string
 	// SanitizeCallback is the callback invoked inside Sanitize()
@@ -70,17 +70,17 @@ type MockType struct {
 }
 
 // String() returns the same value as Name().
-func (t *MockType) String() string {
+func (t *TestType) String() string {
 	return t.Name()
 }
 
 // Name returns the name of the mock type.
-func (t *MockType) Name() string {
+func (t *TestType) Name() string {
 	return t.TypeName
 }
 
 // Sanitize checks and possibly modifies a capability.
-func (t *MockType) Sanitize(c *Capability) error {
+func (t *TestType) Sanitize(c *Capability) error {
 	if t.Name() != c.TypeName {
 		return fmt.Errorf("capability is not of type %q", t)
 	}

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -64,23 +64,23 @@ func (s *BoolFileTypeSuite) TestSanitizeMissingPath(c *C) {
 	c.Assert(err, ErrorMatches, "bool-file must contain the path attribute")
 }
 
-// MockType
+// TestType
 
-type MockTypeSuite struct {
+type TestTypeSuite struct {
 	t Type
 }
 
-var _ = Suite(&MockTypeSuite{
-	t: &MockType{TypeName: "mock"},
+var _ = Suite(&TestTypeSuite{
+	t: &TestType{TypeName: "mock"},
 })
 
-// MockType has a working Name() function
-func (s *MockTypeSuite) TestName(c *C) {
+// TestType has a working Name() function
+func (s *TestTypeSuite) TestName(c *C) {
 	c.Assert(s.t.Name(), Equals, "mock")
 }
 
-// MockType doesn't do any sanitization by default
-func (s *MockTypeSuite) TestSanitizeOK(c *C) {
+// TestType doesn't do any sanitization by default
+func (s *TestTypeSuite) TestSanitizeOK(c *C) {
 	cap := &Capability{
 		TypeName: "mock",
 	}
@@ -88,9 +88,9 @@ func (s *MockTypeSuite) TestSanitizeOK(c *C) {
 	c.Assert(err, IsNil)
 }
 
-// MockType has provisions to customize sanitization
-func (s *MockTypeSuite) TestSanitizeError(c *C) {
-	t := &MockType{
+// TestType has provisions to customize sanitization
+func (s *TestTypeSuite) TestSanitizeError(c *C) {
+	t := &TestType{
 		TypeName: "mock",
 		SanitizeCallback: func(cap *Capability) error {
 			return fmt.Errorf("sanitize failed")
@@ -103,8 +103,8 @@ func (s *MockTypeSuite) TestSanitizeError(c *C) {
 	c.Assert(err, ErrorMatches, "sanitize failed")
 }
 
-// MockType sanitization still checks for type identity
-func (s *MockTypeSuite) TestSanitizeWrongType(c *C) {
+// TestType sanitization still checks for type identity
+func (s *TestTypeSuite) TestSanitizeWrongType(c *C) {
 	cap := &Capability{
 		TypeName: "other-type",
 	}

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -35,10 +35,6 @@ var _ = Suite(&BoolFileTypeSuite{
 	t: &BoolFileType{},
 })
 
-func (s *BoolFileTypeSuite) TestString(c *C) {
-	c.Assert(s.t.String(), Equals, "bool-file")
-}
-
 func (s *BoolFileTypeSuite) TestName(c *C) {
 	c.Assert(s.t.Name(), Equals, "bool-file")
 }
@@ -77,11 +73,6 @@ type MockTypeSuite struct {
 var _ = Suite(&MockTypeSuite{
 	t: &MockType{TypeName: "mock"},
 })
-
-// MockType has a working String() function
-func (s *MockTypeSuite) TestString(c *C) {
-	c.Assert(s.t.String(), Equals, "mock")
-}
 
 // MockType has a working Name() function
 func (s *MockTypeSuite) TestName(c *C) {

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -20,77 +20,103 @@
 package caps
 
 import (
-	"encoding/json"
+	"fmt"
 
 	. "gopkg.in/check.v1"
 )
 
-type TypeSuite struct{}
+// BoolFileType
 
-var _ = Suite(&TypeSuite{})
-
-// testType is only meant for testing. It is not useful in any way except
-// that it offers an simple capability type that will happily validate.
-var testType = &Type{
-	Name:          "test",
-	RequiredAttrs: nil,
+type BoolFileTypeSuite struct {
+	t Type
 }
 
-func (s *TypeSuite) TestTypeString(c *C) {
-	c.Assert(testType.String(), Equals, "test")
+var _ = Suite(&BoolFileTypeSuite{
+	t: &BoolFileType{},
+})
+
+func (s *BoolFileTypeSuite) TestString(c *C) {
+	c.Assert(s.t.String(), Equals, "bool-file")
 }
 
-func (s *TypeSuite) TestValidateMismatchedType(c *C) {
-	testType2 := &Type{Name: "test-two"} // Another test-like type that's not test itself
-	cap := &Capability{Name: "name", Label: "label", Type: testType2}
-	err := testType.Validate(cap)
-	c.Assert(err, ErrorMatches, `capability is not of type "test"`)
+func (s *BoolFileTypeSuite) TestName(c *C) {
+	c.Assert(s.t.Name(), Equals, "bool-file")
 }
 
-func (s *TypeSuite) TestValidateOK(c *C) {
-	cap := &Capability{Name: "name", Label: "label", Type: testType}
-	err := testType.Validate(cap)
+func (s *BoolFileTypeSuite) TestSanitizeOK(c *C) {
+	cap := &Capability{
+		TypeName: "bool-file",
+		Attrs:    map[string]string{"path": "path"},
+	}
+	err := s.t.Sanitize(cap)
 	c.Assert(err, IsNil)
 }
 
-func (s *TypeSuite) TestValidateAttributesRequiredAttrsMissing(c *C) {
-	t := &Type{
-		Name:          "t",
-		RequiredAttrs: []string{"k"},
+func (s *BoolFileTypeSuite) TestSanitizeWrongType(c *C) {
+	cap := &Capability{
+		TypeName: "other-type",
+	}
+	err := s.t.Sanitize(cap)
+	c.Assert(err, ErrorMatches, "capability is not of type \"bool-file\"")
+}
+
+func (s *BoolFileTypeSuite) TestSanitizeMissingPath(c *C) {
+	cap := &Capability{
+		TypeName: "bool-file",
+	}
+	err := s.t.Sanitize(cap)
+	c.Assert(err, ErrorMatches, "bool-file must contain the path attribute")
+}
+
+// MockType
+
+type MockTypeSuite struct {
+	t Type
+}
+
+var _ = Suite(&MockTypeSuite{
+	t: &MockType{TypeName: "mock"},
+})
+
+// MockType has a working String() function
+func (s *MockTypeSuite) TestString(c *C) {
+	c.Assert(s.t.String(), Equals, "mock")
+}
+
+// MockType has a working Name() function
+func (s *MockTypeSuite) TestName(c *C) {
+	c.Assert(s.t.Name(), Equals, "mock")
+}
+
+// MockType doesn't do any sanitization by default
+func (s *MockTypeSuite) TestSanitizeOK(c *C) {
+	cap := &Capability{
+		TypeName: "mock",
+	}
+	err := s.t.Sanitize(cap)
+	c.Assert(err, IsNil)
+}
+
+// MockType has provisions to customize sanitization
+func (s *MockTypeSuite) TestSanitizeError(c *C) {
+	t := &MockType{
+		TypeName: "mock",
+		SanitizeCallback: func(cap *Capability) error {
+			return fmt.Errorf("sanitize failed")
+		},
 	}
 	cap := &Capability{
-		Name:  "name",
-		Label: "label",
-		Type:  t,
+		TypeName: "mock",
 	}
-	err := t.Validate(cap)
-	c.Assert(err, ErrorMatches, `capabilities of type "t" must provide a "k" attribute`)
+	err := t.Sanitize(cap)
+	c.Assert(err, ErrorMatches, "sanitize failed")
 }
 
-func (s *TypeSuite) TestValidateAttributesRequiredAttrsSatisfied(c *C) {
-	t := &Type{
-		Name:          "t",
-		RequiredAttrs: []string{"k"},
-	}
+// MockType sanitization still checks for type identity
+func (s *MockTypeSuite) TestSanitizeWrongType(c *C) {
 	cap := &Capability{
-		Name:  "name",
-		Label: "label",
-		Type:  t,
-		Attrs: map[string]string{"k": "v"},
+		TypeName: "other-type",
 	}
-	err := t.Validate(cap)
-	c.Assert(err, IsNil)
-}
-
-func (s *TypeSuite) TestMarhshalJSON(c *C) {
-	b, err := json.Marshal(testType)
-	c.Assert(err, IsNil)
-	c.Assert(b, DeepEquals, []byte(`"test"`))
-}
-
-func (s *TypeSuite) TestUnmarhshalJSON(c *C) {
-	var t Type
-	err := json.Unmarshal([]byte(`"test"`), &t)
-	c.Assert(err, IsNil)
-	c.Assert(t.Name, Equals, "test")
+	err := s.t.Sanitize(cap)
+	c.Assert(err, ErrorMatches, "capability is not of type \"mock\"")
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -911,17 +911,16 @@ func getCapabilities(c *Command, r *http.Request) Response {
 func addCapability(c *Command, r *http.Request) Response {
 	decoder := json.NewDecoder(r.Body)
 	var newCap caps.Capability
-	if err := decoder.Decode(&newCap); err != nil || newCap.Type == nil {
+	if err := decoder.Decode(&newCap); err != nil || newCap.TypeName == "" {
 		return BadRequest(err, "can't decode request body into a capability")
 	}
 	// Re-construct the perfect type object knowing just the type name that is
 	// passed through the JSON representation.
-	newType := c.d.capRepo.Type(newCap.Type.Name)
+	newType := c.d.capRepo.Type(newCap.TypeName)
 	if newType == nil {
-		err := fmt.Errorf("unknown type name %q", newCap.Type.Name)
+		err := fmt.Errorf("unknown type name %q", newCap.TypeName)
 		return BadRequest(err, "can't add capability")
 	}
-	newCap.Type = newType
 	if err := c.d.capRepo.Add(&newCap); err != nil {
 		return BadRequest(err, "can't add capability")
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1165,9 +1165,9 @@ func (s *apiSuite) TestInstallLicensedIntegration(c *check.C) {
 func (s *apiSuite) TestGetCapabilities(c *check.C) {
 	d := newTestDaemon()
 	d.capRepo.Add(&caps.Capability{
-		Name:  "caps-lock-led",
-		Label: "Caps Lock LED",
-		Type:  caps.BoolFileType,
+		Name:     "caps-lock-led",
+		Label:    "Caps Lock LED",
+		TypeName: "bool-file",
 		Attrs: map[string]string{
 			"path": "/sys/class/leds/input::capslock/brightness",
 		},
@@ -1203,10 +1203,10 @@ func (s *apiSuite) TestAddCapabilitiesGood(c *check.C) {
 	// Setup
 	d := newTestDaemon()
 	cap := &caps.Capability{
-		Name:  "name",
-		Label: "label",
-		Type:  caps.BoolFileType,
-		Attrs: map[string]string{"path": "/nonexistent"},
+		Name:     "name",
+		Label:    "label",
+		TypeName: "bool-file",
+		Attrs:    map[string]string{"path": "/nonexistent"},
 	}
 	text, err := json.Marshal(cap)
 	c.Assert(err, check.IsNil)
@@ -1228,19 +1228,19 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 	// Start with one capability named 'name' in the repository
 	d := newTestDaemon()
 	cap := &caps.Capability{
-		Name:  "name",
-		Label: "label",
-		Type:  caps.BoolFileType,
-		Attrs: map[string]string{"path": "/nonexistent"},
+		Name:     "name",
+		Label:    "label",
+		TypeName: "bool-file",
+		Attrs:    map[string]string{"path": "/nonexistent"},
 	}
 	err := d.capRepo.Add(cap)
 	c.Assert(err, check.IsNil)
 	// Prepare for adding a second capability with the same name
 	capClashing := &caps.Capability{
-		Name:  "name",
-		Label: "second label",
-		Type:  caps.BoolFileType,
-		Attrs: map[string]string{"path": "/nonexistent"},
+		Name:     "name",
+		Label:    "second label",
+		TypeName: "bool-file",
+		Attrs:    map[string]string{"path": "/nonexistent"},
 	}
 	text, err := json.Marshal(capClashing)
 	c.Assert(err, check.IsNil)
@@ -1295,10 +1295,10 @@ func (s *apiSuite) TestAddCapabilitiesNotACapability(c *check.C) {
 func (s *apiSuite) TestDeleteCapabilityGood(c *check.C) {
 	// Setup
 	d := newTestDaemon()
-	t := &caps.Type{Name: "test"}
+	t := &caps.MockType{TypeName: "test"}
 	err := d.capRepo.AddType(t)
 	c.Assert(err, check.IsNil)
-	cap := &caps.Capability{Name: "name", Type: t}
+	cap := &caps.Capability{Name: "name", TypeName: "test"}
 	err = d.capRepo.Add(cap)
 	c.Assert(err, check.IsNil)
 	s.vars = map[string]string{"name": "name"}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1295,7 +1295,7 @@ func (s *apiSuite) TestAddCapabilitiesNotACapability(c *check.C) {
 func (s *apiSuite) TestDeleteCapabilityGood(c *check.C) {
 	// Setup
 	d := newTestDaemon()
-	t := &caps.MockType{TypeName: "test"}
+	t := &caps.TestType{TypeName: "test"}
 	err := d.capRepo.AddType(t)
 	c.Assert(err, check.IsNil)
 	cap := &caps.Capability{Name: "name", TypeName: "test"}


### PR DESCRIPTION
The capability type is now an interface. This allows each type to freely
define appropriate logic in a non-declarative way. Some small changes
related to that are the change of the Validate() method to Sanitize()
which can also explicitly mutate a capability (currently this is not
used yet).

Along with this change, caps.Capability.Type is replaced with .TypeName
which is simply a string so that capabilities can be serialized easily.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>