### PR TITLE
Allow types to hand out security snippets

### DIFF
--- a/caps/security.go
+++ b/caps/security.go
@@ -27,9 +27,12 @@ import (
 type SecuritySystem string
 
 const (
-	securityApparmor SecuritySystem = "apparmor"
-	securitySeccomp  SecuritySystem = "seccomp"
-	securityDBus     SecuritySystem = "dbus"
+	// Identifier of the apparmor security system.
+	SecurityApparmor SecuritySystem = "apparmor"
+	// Identifier of the seccomp security system.
+	SecuritySeccomp SecuritySystem = "seccomp"
+	// Identifier for the DBus security system.
+	SecurityDBus SecuritySystem = "dbus"
 )
 
 // ErrUnknownSecurity is the error reported for unknown security systems.

--- a/caps/security.go
+++ b/caps/security.go
@@ -23,10 +23,7 @@ package caps
 type SecuritySystem string
 
 const (
-	// Identifier of the apparmor security system.
-	SecurityApparmor SecuritySystem = "apparmor"
-	// Identifier of the seccomp security system.
-	SecuritySeccomp SecuritySystem = "seccomp"
-	// Identifier for the DBus security system.
-	SecurityDBus SecuritySystem = "dbus"
+	securityApparmor SecuritySystem = "apparmor"
+	securitySeccomp  SecuritySystem = "seccomp"
+	securityDBus     SecuritySystem = "dbus"
 )

--- a/caps/security.go
+++ b/caps/security.go
@@ -27,11 +27,11 @@ import (
 type SecuritySystem string
 
 const (
-	// Identifier of the apparmor security system.
+	// SecurityApparmor identifies the apparmor security system.
 	SecurityApparmor SecuritySystem = "apparmor"
-	// Identifier of the seccomp security system.
+	// SecuritySeccomp identifies the seccomp security system.
 	SecuritySeccomp SecuritySystem = "seccomp"
-	// Identifier for the DBus security system.
+	// SecurityDBus identifies the DBus security system.
 	SecurityDBus SecuritySystem = "dbus"
 )
 

--- a/caps/security.go
+++ b/caps/security.go
@@ -22,7 +22,6 @@ package caps
 // SecuritySystem is a name of a security system.
 type SecuritySystem string
 
-// NOTE: all the security constants are used by Type.SecuritySnippet()
 const (
 	// Identifier of the apparmor security system.
 	SecurityApparmor SecuritySystem = "apparmor"

--- a/caps/security.go
+++ b/caps/security.go
@@ -19,6 +19,10 @@
 
 package caps
 
+import (
+	"fmt"
+)
+
 // SecuritySystem is a name of a security system.
 type SecuritySystem string
 
@@ -27,3 +31,13 @@ const (
 	securitySeccomp  SecuritySystem = "seccomp"
 	securityDBus     SecuritySystem = "dbus"
 )
+
+// ErrUnknownSecurity is the error reported for unknown security systems.
+type ErrUnknownSecurity struct {
+	// SecuritySystem is the name of the unknown security system.
+	SecuritySystem SecuritySystem
+}
+
+func (err *ErrUnknownSecurity) Error() string {
+	return fmt.Sprintf("unknown security system %q", err.SecuritySystem)
+}

--- a/caps/security.go
+++ b/caps/security.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package caps
+
+// NOTE: all the security constants are used by Type.SecuritySnippet()
+const (
+	// Identifier of the apparmor security system.
+	SecurityApparmor = "apparmor"
+	// Identifier of the seccomp security system.
+	SecuritySeccomp = "seccomp"
+	// Identifier for the DBus security system.
+	SecurityDBus = "dbus"
+)

--- a/caps/security.go
+++ b/caps/security.go
@@ -20,7 +20,7 @@
 package caps
 
 import (
-	"fmt"
+	"errors"
 )
 
 // SecuritySystem is a name of a security system.
@@ -35,12 +35,7 @@ const (
 	SecurityDBus SecuritySystem = "dbus"
 )
 
-// UnknownSecurityError is the error reported for unknown security systems.
-type UnknownSecurityError struct {
-	// SecuritySystem is the name of the unknown security system.
-	SecuritySystem SecuritySystem
-}
-
-func (err *UnknownSecurityError) Error() string {
-	return fmt.Sprintf("unknown security system %q", err.SecuritySystem)
-}
+var (
+	// ErrUnknownSecurity is reported when an unknown security system is encountered.
+	ErrUnknownSecurity = errors.New("unknown security system")
+)

--- a/caps/security.go
+++ b/caps/security.go
@@ -19,12 +19,15 @@
 
 package caps
 
+// SecuritySystem is a name of a security system.
+type SecuritySystem string
+
 // NOTE: all the security constants are used by Type.SecuritySnippet()
 const (
 	// Identifier of the apparmor security system.
-	SecurityApparmor = "apparmor"
+	SecurityApparmor SecuritySystem = "apparmor"
 	// Identifier of the seccomp security system.
-	SecuritySeccomp = "seccomp"
+	SecuritySeccomp SecuritySystem = "seccomp"
 	// Identifier for the DBus security system.
-	SecurityDBus = "dbus"
+	SecurityDBus SecuritySystem = "dbus"
 )

--- a/caps/security.go
+++ b/caps/security.go
@@ -35,12 +35,12 @@ const (
 	SecurityDBus SecuritySystem = "dbus"
 )
 
-// ErrUnknownSecurity is the error reported for unknown security systems.
-type ErrUnknownSecurity struct {
+// UnknownSecurityError is the error reported for unknown security systems.
+type UnknownSecurityError struct {
 	// SecuritySystem is the name of the unknown security system.
 	SecuritySystem SecuritySystem
 }
 
-func (err *ErrUnknownSecurity) Error() string {
+func (err *UnknownSecurityError) Error() string {
 	return fmt.Sprintf("unknown security system %q", err.SecuritySystem)
 }

--- a/caps/types.go
+++ b/caps/types.go
@@ -71,14 +71,14 @@ func (t *BoolFileType) Sanitize(c *Capability) error {
 // Consumers gain permission to read, write and lock the designated file.
 func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case securityApparmor:
+	case SecurityApparmor:
 		// TODO: switch to the real path later
 		path := c.Attrs["path"]
 		// Allow read, write and lock on the file designated by the path.
 		return ([]byte)(fmt.Sprintf("%s rwl,\n", path)), nil
-	case securitySeccomp:
+	case SecuritySeccomp:
 		return nil, nil
-	case securityDBus:
+	case SecurityDBus:
 		return nil, nil
 	default:
 		return nil, &ErrUnknownSecurity{SecuritySystem: securitySystem}
@@ -119,11 +119,11 @@ func (t *TestType) Sanitize(c *Capability) error {
 // Consumers don't gain any extra permissions.
 func (t *TestType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case securityApparmor:
+	case SecurityApparmor:
 		fallthrough
-	case securitySeccomp:
+	case SecuritySeccomp:
 		fallthrough
-	case securityDBus:
+	case SecurityDBus:
 		return nil, nil
 	default:
 		return nil, &ErrUnknownSecurity{SecuritySystem: securitySystem}

--- a/caps/types.go
+++ b/caps/types.go
@@ -68,7 +68,7 @@ func (t *BoolFileType) Sanitize(c *Capability) error {
 func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) (string, error) {
 	switch securitySystem {
 	case securityApparmor:
-		// TODO: switch to the absolute path later
+		// TODO: switch to the real path later
 		path := c.Attrs["path"]
 		// Allow read, write and lock on the file designated by the path.
 		return fmt.Sprintf("%s rwl,\n", path), nil

--- a/caps/types.go
+++ b/caps/types.go
@@ -67,7 +67,7 @@ func (t *BoolFileType) Sanitize(c *Capability) error {
 	return nil
 }
 
-// SecuritySnippet for bool-file capability type.
+// SecuritySnippet returns the configuration snippet required to use a bool-file capability.
 // Consumers gain permission to read, write and lock the designated file.
 func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) ([]byte, error) {
 	switch securitySystem {
@@ -115,19 +115,10 @@ func (t *TestType) Sanitize(c *Capability) error {
 	return nil
 }
 
-// SecuritySnippet for test capability type.
+// SecuritySnippet returns the configuration snippet "required" to use a test capability.
 // Consumers don't gain any extra permissions.
 func (t *TestType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case SecurityApparmor:
-		fallthrough
-	case SecuritySeccomp:
-		fallthrough
-	case SecurityDBus:
-		return nil, nil
-	default:
-		return nil, &ErrUnknownSecurity{SecuritySystem: securitySystem}
-	}
+	return nil, nil
 }
 
 var builtInTypes = [...]Type{

--- a/caps/types.go
+++ b/caps/types.go
@@ -33,7 +33,7 @@ type Type interface {
 	Sanitize(c *Capability) error
 	// Obtain the security snippet for the given security system.
 	// If no security snippet is needed, hand out empty string.
-	SecuritySnippet(c *Capability, securitySystem string) (string, error)
+	SecuritySnippet(c *Capability, securitySystem SecuritySystem) (string, error)
 }
 
 // BoolFileType is the type of all the bool-file capabilities.
@@ -65,7 +65,7 @@ func (t *BoolFileType) Sanitize(c *Capability) error {
 
 // SecuritySnippet for bool-file capability type.
 // Consumers gain permission to read, write and lock the designated file.
-func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem string) (string, error) {
+func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) (string, error) {
 	switch securitySystem {
 	case SecurityApparmor:
 		// TODO: switch to the absolute path later
@@ -113,7 +113,7 @@ func (t *TestType) Sanitize(c *Capability) error {
 
 // SecuritySnippet for test capability type.
 // Consumers don't gain any extra permissions.
-func (t *TestType) SecuritySnippet(c *Capability, securitySystem string) (string, error) {
+func (t *TestType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) (string, error) {
 	switch securitySystem {
 	case SecurityApparmor:
 		fallthrough

--- a/caps/types.go
+++ b/caps/types.go
@@ -81,7 +81,7 @@ func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySys
 	case SecurityDBus:
 		return nil, nil
 	default:
-		return nil, &ErrUnknownSecurity{SecuritySystem: securitySystem}
+		return nil, &UnknownSecurityError{SecuritySystem: securitySystem}
 	}
 }
 

--- a/caps/types.go
+++ b/caps/types.go
@@ -67,14 +67,14 @@ func (t *BoolFileType) Sanitize(c *Capability) error {
 // Consumers gain permission to read, write and lock the designated file.
 func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) (string, error) {
 	switch securitySystem {
-	case SecurityApparmor:
+	case securityApparmor:
 		// TODO: switch to the absolute path later
 		path := c.Attrs["path"]
 		// Allow read,write and lock on the file designated by the path.
 		return fmt.Sprintf("%s rwl,\n", path), nil
-	case SecuritySeccomp:
+	case securitySeccomp:
 		return "", nil
-	case SecurityDBus:
+	case securityDBus:
 		return "", nil
 	default:
 		return "", fmt.Errorf("unknown security system %q", securitySystem)
@@ -115,11 +115,11 @@ func (t *TestType) Sanitize(c *Capability) error {
 // Consumers don't gain any extra permissions.
 func (t *TestType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) (string, error) {
 	switch securitySystem {
-	case SecurityApparmor:
+	case securityApparmor:
 		fallthrough
-	case SecuritySeccomp:
+	case securitySeccomp:
 		fallthrough
-	case SecurityDBus:
+	case securityDBus:
 		return "", nil
 	default:
 		return "", fmt.Errorf("unknown security system %q", securitySystem)

--- a/caps/types.go
+++ b/caps/types.go
@@ -81,7 +81,7 @@ func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySys
 	case SecurityDBus:
 		return nil, nil
 	default:
-		return nil, &UnknownSecurityError{SecuritySystem: securitySystem}
+		return nil, ErrUnknownSecurity
 	}
 }
 

--- a/caps/types.go
+++ b/caps/types.go
@@ -75,7 +75,7 @@ func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySys
 		// TODO: switch to the real path later
 		path := c.Attrs["path"]
 		// Allow read, write and lock on the file designated by the path.
-		return ([]byte)(fmt.Sprintf("%s rwl,\n", path)), nil
+		return []byte(fmt.Sprintf("%s rwl,\n", path)), nil
 	case SecuritySeccomp:
 		return nil, nil
 	case SecurityDBus:

--- a/caps/types.go
+++ b/caps/types.go
@@ -70,7 +70,7 @@ func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySys
 	case securityApparmor:
 		// TODO: switch to the absolute path later
 		path := c.Attrs["path"]
-		// Allow read,write and lock on the file designated by the path.
+		// Allow read, write and lock on the file designated by the path.
 		return fmt.Sprintf("%s rwl,\n", path), nil
 	case securitySeccomp:
 		return "", nil

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -64,6 +64,25 @@ func (s *BoolFileTypeSuite) TestSanitizeMissingPath(c *C) {
 	c.Assert(err, ErrorMatches, "bool-file must contain the path attribute")
 }
 
+func (s *BoolFileTypeSuite) TestSecuritySnippet(c *C) {
+	cap := &Capability{
+		TypeName: "bool-file",
+		Attrs:    map[string]string{"path": "path"},
+	}
+	snippet, err := s.t.SecuritySnippet(cap, SecurityApparmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Equals, "path rwl,\n")
+	snippet, err = s.t.SecuritySnippet(cap, SecuritySeccomp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Equals, "")
+	snippet, err = s.t.SecuritySnippet(cap, SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Equals, "")
+	snippet, err = s.t.SecuritySnippet(cap, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system "foo"`)
+	c.Assert(snippet, Equals, "")
+}
+
 // TestType
 
 type TestTypeSuite struct {
@@ -110,4 +129,23 @@ func (s *TestTypeSuite) TestSanitizeWrongType(c *C) {
 	}
 	err := s.t.Sanitize(cap)
 	c.Assert(err, ErrorMatches, "capability is not of type \"mock\"")
+}
+
+// TestType hands out empty security snippets
+func (s *TestTypeSuite) TestSecuritySnippet(c *C) {
+	cap := &Capability{
+		TypeName: "mock",
+	}
+	snippet, err := s.t.SecuritySnippet(cap, SecurityApparmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Equals, "")
+	snippet, err = s.t.SecuritySnippet(cap, SecuritySeccomp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Equals, "")
+	snippet, err = s.t.SecuritySnippet(cap, SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Equals, "")
+	snippet, err = s.t.SecuritySnippet(cap, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system "foo"`)
+	c.Assert(snippet, Equals, "")
 }

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -71,16 +71,17 @@ func (s *BoolFileTypeSuite) TestSecuritySnippet(c *C) {
 	}
 	snippet, err := s.t.SecuritySnippet(cap, securityApparmor)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Equals, "path rwl,\n")
+	c.Assert(snippet, DeepEquals, []byte("path rwl,\n"))
 	snippet, err = s.t.SecuritySnippet(cap, securitySeccomp)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Equals, "")
+	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, securityDBus)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Equals, "")
+	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, "foo")
 	c.Assert(err, ErrorMatches, `unknown security system "foo"`)
-	c.Assert(snippet, Equals, "")
+	c.Assert(err, FitsTypeOf, &ErrUnknownSecurity{})
+	c.Assert(snippet, IsNil)
 }
 
 // TestType
@@ -138,14 +139,15 @@ func (s *TestTypeSuite) TestSecuritySnippet(c *C) {
 	}
 	snippet, err := s.t.SecuritySnippet(cap, securityApparmor)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Equals, "")
+	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, securitySeccomp)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Equals, "")
+	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, securityDBus)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Equals, "")
+	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, "foo")
 	c.Assert(err, ErrorMatches, `unknown security system "foo"`)
-	c.Assert(snippet, Equals, "")
+	c.Assert(err, FitsTypeOf, &ErrUnknownSecurity{})
+	c.Assert(snippet, IsNil)
 }

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -80,7 +80,7 @@ func (s *BoolFileTypeSuite) TestSecuritySnippet(c *C) {
 	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, "foo")
 	c.Assert(err, ErrorMatches, `unknown security system "foo"`)
-	c.Assert(err, FitsTypeOf, &ErrUnknownSecurity{})
+	c.Assert(err, FitsTypeOf, &UnknownSecurityError{})
 	c.Assert(snippet, IsNil)
 }
 

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -79,8 +79,7 @@ func (s *BoolFileTypeSuite) TestSecuritySnippet(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, "foo")
-	c.Assert(err, ErrorMatches, `unknown security system "foo"`)
-	c.Assert(err, FitsTypeOf, &UnknownSecurityError{})
+	c.Assert(err, ErrorMatches, `unknown security system`)
 	c.Assert(snippet, IsNil)
 }
 

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -147,7 +147,6 @@ func (s *TestTypeSuite) TestSecuritySnippet(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, "foo")
-	c.Assert(err, ErrorMatches, `unknown security system "foo"`)
-	c.Assert(err, FitsTypeOf, &ErrUnknownSecurity{})
+	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -69,13 +69,13 @@ func (s *BoolFileTypeSuite) TestSecuritySnippet(c *C) {
 		TypeName: "bool-file",
 		Attrs:    map[string]string{"path": "path"},
 	}
-	snippet, err := s.t.SecuritySnippet(cap, SecurityApparmor)
+	snippet, err := s.t.SecuritySnippet(cap, securityApparmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Equals, "path rwl,\n")
-	snippet, err = s.t.SecuritySnippet(cap, SecuritySeccomp)
+	snippet, err = s.t.SecuritySnippet(cap, securitySeccomp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Equals, "")
-	snippet, err = s.t.SecuritySnippet(cap, SecurityDBus)
+	snippet, err = s.t.SecuritySnippet(cap, securityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Equals, "")
 	snippet, err = s.t.SecuritySnippet(cap, "foo")
@@ -136,13 +136,13 @@ func (s *TestTypeSuite) TestSecuritySnippet(c *C) {
 	cap := &Capability{
 		TypeName: "mock",
 	}
-	snippet, err := s.t.SecuritySnippet(cap, SecurityApparmor)
+	snippet, err := s.t.SecuritySnippet(cap, securityApparmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Equals, "")
-	snippet, err = s.t.SecuritySnippet(cap, SecuritySeccomp)
+	snippet, err = s.t.SecuritySnippet(cap, securitySeccomp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Equals, "")
-	snippet, err = s.t.SecuritySnippet(cap, SecurityDBus)
+	snippet, err = s.t.SecuritySnippet(cap, securityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Equals, "")
 	snippet, err = s.t.SecuritySnippet(cap, "foo")

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -69,13 +69,13 @@ func (s *BoolFileTypeSuite) TestSecuritySnippet(c *C) {
 		TypeName: "bool-file",
 		Attrs:    map[string]string{"path": "path"},
 	}
-	snippet, err := s.t.SecuritySnippet(cap, securityApparmor)
+	snippet, err := s.t.SecuritySnippet(cap, SecurityApparmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte("path rwl,\n"))
-	snippet, err = s.t.SecuritySnippet(cap, securitySeccomp)
+	snippet, err = s.t.SecuritySnippet(cap, SecuritySeccomp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.t.SecuritySnippet(cap, securityDBus)
+	snippet, err = s.t.SecuritySnippet(cap, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, "foo")
@@ -137,13 +137,13 @@ func (s *TestTypeSuite) TestSecuritySnippet(c *C) {
 	cap := &Capability{
 		TypeName: "mock",
 	}
-	snippet, err := s.t.SecuritySnippet(cap, securityApparmor)
+	snippet, err := s.t.SecuritySnippet(cap, SecurityApparmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.t.SecuritySnippet(cap, securitySeccomp)
+	snippet, err = s.t.SecuritySnippet(cap, SecuritySeccomp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.t.SecuritySnippet(cap, securityDBus)
+	snippet, err = s.t.SecuritySnippet(cap, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.t.SecuritySnippet(cap, "foo")


### PR DESCRIPTION
This patch commences the work on the security side of capabilities. Each
capability type now has a way to hand out "snippets" of security
information applicable to a given security system. The information
describes alterations of the security system needed to consume a given
capability.

The patch defines three security system names:
 - apparmor
 - seccomp
 - dbus