### PR TITLE
Bool file symlinks

### DIFF
--- a/caps/types.go
+++ b/caps/types.go
@@ -98,8 +98,10 @@ func (t *BoolFileType) Sanitize(c *Capability) error {
 func (t *BoolFileType) SecuritySnippet(c *Capability, securitySystem SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case SecurityApparmor:
-		// TODO: switch to the real path later
-		path := c.Attrs["path"]
+		path, err := t.dereferencedPath(c)
+		if err != nil {
+			return nil, err
+		}
 		// Allow read, write and lock on the file designated by the path.
 		return []byte(fmt.Sprintf("%s rwl,\n", path)), nil
 	case SecuritySeccomp:

--- a/caps/types_test.go
+++ b/caps/types_test.go
@@ -68,13 +68,16 @@ func (s *BoolFileTypeSuite) TestSanitizeMissingPath(c *C) {
 }
 
 func (s *BoolFileTypeSuite) TestSecuritySnippet(c *C) {
+	MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+		return "real-path", nil
+	})
 	cap := &Capability{
 		TypeName: "bool-file",
 		Attrs:    map[string]string{"path": "path"},
 	}
 	snippet, err := s.t.SecuritySnippet(cap, SecurityApparmor)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, []byte("path rwl,\n"))
+	c.Assert(snippet, DeepEquals, []byte("real-path rwl,\n"))
 	snippet, err = s.t.SecuritySnippet(cap, SecuritySeccomp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)


### PR DESCRIPTION
This branch contains support for dereferencing symbolic links in bool-file's security code. This is required to effectively allow "/sys/class/leds/$something/brightness" which translates to "/sys/devices/pci.../usb.../something/etc".