### PR TITLE
trivial fix for most recent ftbfs

### DIFF
--- a/debian/ubuntu-snappy.install
+++ b/debian/ubuntu-snappy.install
@@ -2,5 +2,3 @@ debian/*.service /lib/systemd/system/
 debian/*.socket /lib/systemd/system/
 debian/*.target /lib/systemd/system/
 debian/*.timer /lib/systemd/system/
-# grub.d/09_snappy for compatiblity with older systems
-etc/grub.d


### PR DESCRIPTION
the debian package build is currently failing because etc/grub.d got removed but the .install file was not cleaned.