### PR TITLE
Refactor/provisioning cleanup

### DIFF
--- a/provisioning/provisioning.go
+++ b/provisioning/provisioning.go
@@ -110,35 +110,6 @@ func parseInstallYamlData(yamlData []byte) (*InstallYaml, error) {
 	return &i, nil
 }
 
-// IsSideLoaded determines if the system was installed using a
-// custom enablement part.
-func IsSideLoaded(bootloaderDir string) bool {
-	file := filepath.Join(bootloaderDir, InstallYamlFile)
-
-	if !helpers.FileExists(file) {
-		// the system may have been sideloaded, but we have no
-		// way of knowing :-(
-		return false
-	}
-
-	InstallYaml, err := parseInstallYaml(file)
-	if err != nil {
-		logger.Noticef("Kernel sideload cannot be read, assuming sideload: %s", err)
-		// file isn't parseable, so let's assume system is sideloaded
-		return true
-	}
-
-	if InstallYaml.InstallOptions.DevicePart != "" {
-		// system was created with something like:
-		//
-		//  "ubuntu-device-flash [...] --device-part=unofficial-assets.tar.xz ..."
-		//
-		return true
-	}
-
-	return false
-}
-
 // InDeveloperMode returns true if the image was build with --developer-mode
 func InDeveloperMode() bool {
 	file := filepath.Join(bootloaderDir, InstallYamlFile)

--- a/provisioning/provisioning.go
+++ b/provisioning/provisioning.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/partition"
 
 	"gopkg.in/yaml.v2"
 )
@@ -36,6 +37,13 @@ const (
 	//
 	// XXX: Public for ubuntu-device-flash(1)
 	InstallYamlFile = "install.yaml"
+)
+
+var (
+	// FIXME: this is a bit terrible, we really need a single
+	//        bootloader dir like /boot or /boot/loader
+	//        instead of having to query the partition code
+	bootloaderDir = partition.BootloaderDir()
 )
 
 // ErrNoInstallYaml is emitted when InstallYamlFile does not exist.
@@ -132,7 +140,7 @@ func IsSideLoaded(bootloaderDir string) bool {
 }
 
 // InDeveloperMode returns true if the image was build with --developer-mode
-func InDeveloperMode(bootloaderDir string) bool {
+func InDeveloperMode() bool {
 	file := filepath.Join(bootloaderDir, InstallYamlFile)
 
 	if !helpers.FileExists(file) {

--- a/provisioning/provisioning_test.go
+++ b/provisioning/provisioning_test.go
@@ -32,6 +32,8 @@ func Test(t *testing.T) { TestingT(t) }
 type ProvisioningTestSuite struct {
 	mockBootDir  string
 	mockYamlFile string
+
+	realBootloaderDir string
 }
 
 var _ = Suite(&ProvisioningTestSuite{})
@@ -76,6 +78,13 @@ var garbageData = `Fooled you!?`
 func (ts *ProvisioningTestSuite) SetUpTest(c *C) {
 	ts.mockBootDir = c.MkDir()
 	ts.mockYamlFile = filepath.Join(ts.mockBootDir, "install.yaml")
+	ts.realBootloaderDir = bootloaderDir
+
+	bootloaderDir = ts.mockBootDir
+}
+
+func (ts *ProvisioningTestSuite) TearDownTest(c *C) {
+	bootloaderDir = ts.realBootloaderDir
 }
 
 func (ts *ProvisioningTestSuite) TestSideLoadedSystemNoInstallYaml(c *C) {
@@ -157,7 +166,8 @@ func (ts *ProvisioningTestSuite) TestParseInstallYamlData(c *C) {
 }
 
 func (ts *ProvisioningTestSuite) TestInDeveloperModeEmpty(c *C) {
-	c.Assert(InDeveloperMode(""), Equals, false)
+	bootloaderDir = ""
+	c.Assert(InDeveloperMode(), Equals, false)
 }
 
 func (ts *ProvisioningTestSuite) TestInDeveloperModeWithDevModeOn(c *C) {
@@ -166,7 +176,8 @@ options:
  developer-mode: true
 `), 0644)
 	c.Assert(err, IsNil)
-	c.Assert(InDeveloperMode(ts.mockBootDir), Equals, true)
+	bootloaderDir = ts.mockBootDir
+	c.Assert(InDeveloperMode(), Equals, true)
 }
 
 func (ts *ProvisioningTestSuite) TestInDeveloperModeWithDevModeOff(c *C) {
@@ -175,5 +186,6 @@ options:
  developer-mode: false
 `), 0644)
 	c.Assert(err, IsNil)
-	c.Assert(InDeveloperMode(ts.mockBootDir), Equals, false)
+	bootloaderDir = ts.mockBootDir
+	c.Assert(InDeveloperMode(), Equals, false)
 }

--- a/provisioning/provisioning_test.go
+++ b/provisioning/provisioning_test.go
@@ -19,7 +19,6 @@ package provisioning
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -85,48 +84,6 @@ func (ts *ProvisioningTestSuite) SetUpTest(c *C) {
 
 func (ts *ProvisioningTestSuite) TearDownTest(c *C) {
 	bootloaderDir = ts.realBootloaderDir
-}
-
-func (ts *ProvisioningTestSuite) TestSideLoadedSystemNoInstallYaml(c *C) {
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, false)
-}
-
-func (ts *ProvisioningTestSuite) TestSideLoadedSystem(c *C) {
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, false)
-
-	err := ioutil.WriteFile(ts.mockYamlFile, []byte(yamlData), 0750)
-	c.Assert(err, IsNil)
-
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, true)
-
-	os.Remove(ts.mockYamlFile)
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, false)
-}
-
-func (ts *ProvisioningTestSuite) TestSideLoadedSystemNoDevicePart(c *C) {
-
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, false)
-
-	err := ioutil.WriteFile(ts.mockYamlFile, []byte(yamlDataNoDevicePart), 0750)
-	c.Assert(err, IsNil)
-
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, false)
-
-	os.Remove(ts.mockYamlFile)
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, false)
-}
-
-func (ts *ProvisioningTestSuite) TestSideLoadedSystemGarbageInstallYaml(c *C) {
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, false)
-
-	err := ioutil.WriteFile(ts.mockYamlFile, []byte(garbageData), 0750)
-	c.Assert(err, IsNil)
-
-	// we assume sideloaded if the file isn't parseable
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, true)
-
-	os.Remove(ts.mockYamlFile)
-	c.Assert(IsSideLoaded(ts.mockBootDir), Equals, false)
 }
 
 func (ts *ProvisioningTestSuite) TestParseInstallYaml(c *C) {

--- a/snappy/install.go
+++ b/snappy/install.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/ubuntu-core/snappy/logger"
-	"github.com/ubuntu-core/snappy/partition"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/provisioning"
 )
@@ -167,11 +166,7 @@ func doInstall(name string, flags InstallFlags, meter progress.Meter) (snapName 
 	if fi, err := os.Stat(name); err == nil && fi.Mode().IsRegular() {
 		// we allow unauthenticated package when in developer
 		// mode
-		//
-		// FIXME: this is terrible, we really need a single
-		//        bootloader dir like /boot or /boot/loader
-		//        instead of having to query the partition code
-		if provisioning.InDeveloperMode(partition.BootloaderDir()) {
+		if provisioning.InDeveloperMode() {
 			flags |= AllowUnauthenticated
 		}
 


### PR DESCRIPTION
Trivial branch that does a tiny bit of cleanup in the provisioning code. 

It simplifies the call to provisioning.InDeveloperMode() and also removes the no longer needed IsSideLoaded() function.