### PR TITLE
Cap grant revoke

### DIFF
--- a/caps/capabilities.go
+++ b/caps/capabilities.go
@@ -22,9 +22,8 @@ package caps
 // Capability holds information about a capability that a snap may request
 // from a snappy system to do its job while running on it.
 type Capability struct {
-	// Name is a key that identifies the capability. It must be unique within
-	// its context, which may be either a snap or a snappy runtime.
-	Name string `json:"name"`
+	// ID is a pair of strings (snapName, capName) that identifies the capability.
+	ID CapabilityID `json:"id"`
 	// Label provides an optional title for the capability to help a human tell
 	// which physical device this capability is referring to. It might say
 	// "Front USB", or "Green Serial Port", for example.
@@ -40,5 +39,18 @@ type Capability struct {
 
 // String representation of a capability.
 func (c Capability) String() string {
-	return c.Name
+	return c.ID.String()
+}
+
+// CapabilityID is a pair of names (snap, capability) that identifies a capability.
+type CapabilityID struct {
+	// SnapName is the name of a snap.
+	SnapName string `json:"snap"`
+	// CapabilityName is the name of a capability local to the snap.
+	CapName string `json:"capability"`
+}
+
+// String representation of a capability identifier.
+func (id CapabilityID) String() string {
+	return id.SnapName + "." + id.CapName
 }

--- a/caps/capabilities_test.go
+++ b/caps/capabilities_test.go
@@ -35,10 +35,13 @@ var _ = Suite(&CapabilitySuite{})
 
 func (s *CapabilitySuite) TestString(c *C) {
 	cap := &Capability{
-		Name:     "test-name",
+		ID: CapabilityID{
+			SnapName: "test-snap",
+			CapName:  "test-cap",
+		},
 		Label:    "test-label",
 		TypeName: "test-type",
 		Attrs:    nil,
 	}
-	c.Assert(cap.String(), Equals, "test-name")
+	c.Assert(cap.String(), Equals, "test-snap.test-cap")
 }

--- a/caps/repo.go
+++ b/caps/repo.go
@@ -29,8 +29,8 @@ import (
 type Repository struct {
 	// Protects the internals from concurrent access.
 	m sync.Mutex
-	// Map of capabilities, indexed by Capability.Name
-	caps map[string]*Capability
+	// Map of capabilities, indexed by Capability.CapabilityID
+	caps map[CapabilityID]*Capability
 	// A slice of types that are recognized and accepted
 	types []Type
 }
@@ -38,7 +38,7 @@ type Repository struct {
 // NewRepository creates an empty capability repository
 func NewRepository() *Repository {
 	return &Repository{
-		caps:  make(map[string]*Capability),
+		caps:  make(map[CapabilityID]*Capability),
 		types: make([]Type, 0),
 	}
 }
@@ -52,23 +52,26 @@ func (r *Repository) Add(cap *Capability) error {
 	defer r.m.Unlock()
 
 	// Reject capabilities with invalid names
-	if err := ValidateName(cap.Name); err != nil {
+	if err := ValidateName(cap.ID.SnapName); err != nil {
+		return err
+	}
+	if err := ValidateName(cap.ID.CapName); err != nil {
 		return err
 	}
 	// Reject capabilities with duplicate names
-	if _, ok := r.caps[cap.Name]; ok {
-		return fmt.Errorf("cannot add capability %q: name already exists", cap.Name)
+	if _, ok := r.caps[cap.ID]; ok {
+		return fmt.Errorf("cannot add capability %q: name already exists", cap.ID)
 	}
 	// Reject capabilities with unknown types
 	t := r.getType(cap.TypeName)
 	if t == nil {
-		return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.Name, cap.TypeName)
+		return fmt.Errorf("cannot add capability %q: type %q is unknown", cap.ID, cap.TypeName)
 	}
 	// Reject capabilities that don't pass type-specific sanitization
 	if err := t.Sanitize(cap); err != nil {
 		return err
 	}
-	r.caps[cap.Name] = cap
+	r.caps[cap.ID] = cap
 	return nil
 }
 
@@ -102,11 +105,11 @@ func (r *Repository) Type(name string) Type {
 
 // Capability finds and returns the Capability with the given name or nil if it
 // is not found.
-func (r *Repository) Capability(name string) *Capability {
+func (r *Repository) Capability(id CapabilityID) *Capability {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	return r.caps[name]
+	return r.caps[id]
 }
 
 // AddType adds a capability type to the repository.
@@ -130,16 +133,16 @@ func (r *Repository) AddType(t Type) error {
 
 // Remove removes the capability with the provided name.
 // Removing a capability that doesn't exist returns a NotFoundError.
-func (r *Repository) Remove(name string) error {
+func (r *Repository) Remove(id CapabilityID) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	_, ok := r.caps[name]
+	_, ok := r.caps[id]
 	if ok {
-		delete(r.caps, name)
+		delete(r.caps, id)
 		return nil
 	}
-	return &NotFoundError{"remove", name}
+	return &NotFoundError{"remove", id.String()}
 }
 
 // Names returns all capability names in the repository in lexicographical order.
@@ -150,7 +153,7 @@ func (r *Repository) Names() []string {
 	keys := make([]string, len(r.caps))
 	i := 0
 	for key := range r.caps {
-		keys[i] = key
+		keys[i] = key.String()
 		i++
 	}
 	sort.Strings(keys)
@@ -172,9 +175,14 @@ func (r *Repository) TypeNames() []string {
 
 type byName []Capability
 
-func (c byName) Len() int           { return len(c) }
-func (c byName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
-func (c byName) Less(i, j int) bool { return c[i].Name < c[j].Name }
+func (c byName) Len() int      { return len(c) }
+func (c byName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byName) Less(i, j int) bool {
+	if c[i].ID.SnapName != c[j].ID.SnapName {
+		return c[i].ID.SnapName < c[j].ID.SnapName
+	}
+	return c[i].ID.CapName < c[j].ID.CapName
+}
 
 // All returns all capabilities ordered by name.
 func (r *Repository) All() []Capability {
@@ -192,11 +200,11 @@ func (r *Repository) All() []Capability {
 }
 
 // Caps returns a shallow copy of the map of capabilities.
-func (r *Repository) Caps() map[string]*Capability {
+func (r *Repository) Caps() map[CapabilityID]*Capability {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	caps := make(map[string]*Capability, len(r.caps))
+	caps := make(map[CapabilityID]*Capability, len(r.caps))
 	for k, v := range r.caps {
 		caps[k] = v
 	}

--- a/caps/repo_test.go
+++ b/caps/repo_test.go
@@ -225,3 +225,25 @@ func (s *RepositorySuite) TestCaps(c *C) {
 		CapabilityID{"snap", "c"}: &Capability{ID: CapabilityID{"snap", "c"}, Label: "label-c", TypeName: "type"},
 	})
 }
+
+func (s *RepositorySuite) TestGrantRevoke(c *C) {
+	provider := CapabilityID{"provider", "cap"}
+	consumer := CapabilityID{"consumer", "slot"}
+	r := s.emptyRepo
+	c.Assert(r.IsGranted(provider, consumer), Equals, false)
+	r.Grant(provider, consumer)
+	c.Assert(r.IsGranted(provider, consumer), Equals, true)
+	r.Revoke(provider, consumer)
+	c.Assert(r.IsGranted(provider, consumer), Equals, false)
+}
+
+func (s *RepositorySuite) TestRevokeGrant(c *C) {
+	provider := CapabilityID{"provider", "cap"}
+	consumer := CapabilityID{"consumer", "slot"}
+	r := s.emptyRepo
+	c.Assert(r.IsGranted(provider, consumer), Equals, false)
+	r.Revoke(provider, consumer)
+	c.Assert(r.IsGranted(provider, consumer), Equals, false)
+	r.Grant(provider, consumer)
+	c.Assert(r.IsGranted(provider, consumer), Equals, true)
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -144,8 +144,11 @@ func (cs *clientSuite) TestClientCapabilities(c *check.C) {
 		"type": "sync",
 		"result": {
 			"capabilities": {
-				"n": {
-					"name": "n",
+				"s.c": {
+					"id": {
+						"snap": "s",
+						"capability": "c"
+					},
 					"label": "l",
 					"type": "t",
 					"attrs": {"k": "v"}
@@ -155,9 +158,12 @@ func (cs *clientSuite) TestClientCapabilities(c *check.C) {
 	}`
 	caps, err := cs.cli.Capabilities()
 	c.Check(err, check.IsNil)
-	c.Check(caps, check.DeepEquals, map[string]client.Capability{
-		"n": client.Capability{
-			Name:  "n",
+	c.Check(caps, check.DeepEquals, map[client.CapabilityID]client.Capability{
+		client.CapabilityID{"s", "c"}: client.Capability{
+			ID: client.CapabilityID{
+				SnapName: "s",
+				CapName:  "c",
+			},
 			Label: "l",
 			Type:  "t",
 			Attrs: map[string]string{"k": "v"},
@@ -174,7 +180,10 @@ func (cs *clientSuite) TestClientAddCapability(c *check.C) {
 		}
 	}`
 	cap := &client.Capability{
-		Name:  "n",
+		ID: client.CapabilityID{
+			SnapName: "s",
+			CapName:  "c",
+		},
 		Label: "l",
 		Type:  "t",
 		Attrs: map[string]string{"k": "v"},
@@ -186,7 +195,10 @@ func (cs *clientSuite) TestClientAddCapability(c *check.C) {
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"name":  "n",
+		"id": map[string]interface{}{
+			"snap":       "s",
+			"capability": "c",
+		},
 		"label": "l",
 		"type":  "t",
 		"attrs": map[string]interface{}{
@@ -202,11 +214,11 @@ func (cs *clientSuite) TestClientRemoveCapabilityOk(c *check.C) {
 		"type": "sync",
 		"result": { }
 	}`
-	err := cs.cli.RemoveCapability("n")
+	err := cs.cli.RemoveCapability(client.CapabilityID{"s", "c"})
 	c.Check(err, check.IsNil)
 	c.Check(cs.req.Body, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "DELETE")
-	c.Check(cs.req.URL.Path, check.Equals, "/1.0/capabilities/n")
+	c.Check(cs.req.URL.Path, check.Equals, "/1.0/capabilities/s.c")
 }
 
 func (cs *clientSuite) TestClientRemoveCapabilityNotFound(c *check.C) {
@@ -215,12 +227,12 @@ func (cs *clientSuite) TestClientRemoveCapabilityNotFound(c *check.C) {
 		"status_code": 404,
 		"type": "error",
 		"result": {
-			"str": "can't remove capability \"n\", no such capability"
+			"str": "can't remove capability \"s.c\", no such capability"
 		}
 	}`
-	err := cs.cli.RemoveCapability("n")
-	c.Check(err, check.ErrorMatches, `.*can't remove capability \"n\", no such capability`)
+	err := cs.cli.RemoveCapability(client.CapabilityID{"s", "c"})
+	c.Check(err, check.ErrorMatches, `.*can't remove capability \"s.c\", no such capability`)
 	c.Check(cs.req.Body, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "DELETE")
-	c.Check(cs.req.URL.Path, check.Equals, "/1.0/capabilities/n")
+	c.Check(cs.req.URL.Path, check.Equals, "/1.0/capabilities/s.c")
 }

--- a/cmd/snap/cmd_add_cap.go
+++ b/cmd/snap/cmd_add_cap.go
@@ -61,7 +61,8 @@ func AttributePairSliceToMap(attrs []AttributePair) map[string]string {
 }
 
 type cmdAddCap struct {
-	Name  string          `long:"name" required:"true" description:"unique capability name"`
+	Snap  string          `long:"snap" required:"true" description:"snap name"`
+	Name  string          `long:"name" required:"true" description:"capability name"`
 	Label string          `long:"label" required:"true" description:"human-friendly label"`
 	Type  string          `long:"type" required:"true" description:"type of the capability to add"`
 	Attrs []AttributePair `short:"a" description:"key=value attributes"`
@@ -81,7 +82,10 @@ func init() {
 
 func (x *cmdAddCap) Execute(args []string) error {
 	cap := &client.Capability{
-		Name:  x.Name,
+		ID: client.CapabilityID{
+			SnapName: x.Snap,
+			CapName:  x.Name,
+		},
 		Label: x.Label,
 		Type:  x.Type,
 		Attrs: AttributePairSliceToMap(x.Attrs),

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -53,7 +53,7 @@ func (x *cmdListCaps) Execute(args []string) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 1, ' ', 0)
 	fmt.Fprintln(w, "Name\tLabel\tType")
 	for _, cap := range caps {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", cap.Name, cap.Label, cap.Type)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", cap.ID, cap.Label, cap.Type)
 	}
 	w.Flush()
 	return nil

--- a/cmd/snap/cmd_remove_cap.go
+++ b/cmd/snap/cmd_remove_cap.go
@@ -26,7 +26,8 @@ import (
 )
 
 type removeCapOptions struct {
-	Name string `positional-arg-name:"name" description:"unique capability name"`
+	Snap string `positional-arg-name:"snap" description:"snap name"`
+	Name string `positional-arg-name:"name" description:"capability name"`
 }
 
 type cmdRemoveCap struct {
@@ -46,5 +47,5 @@ func init() {
 }
 
 func (x *cmdRemoveCap) Execute(args []string) error {
-	return client.New().RemoveCapability(x.Name)
+	return client.New().RemoveCapability(client.CapabilityID{x.Snap, x.Name})
 }


### PR DESCRIPTION
NOTE: this depends on #338 -- please look at just 704e50c2d1ad5ce6ba22b1e958a809282b15cf9a

Granted capabilities are modeled by the capability repository. The
repository stores a two-level map[CapabilityID]map[CapabilityID]bool.
The final value is dummy so the whole type acts as a set of pairs
(provided, consumed) where both fields represent the CapabilityID of the
provided and consumed capability.

This arrangement allows for multiple consumers of any capability and has
efficient lookup mechanism.

