### PR TITLE
Filter active packages in snapd API

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -133,6 +133,10 @@ string. For example, `"1234567891234567"` represents
 * Operation: sync
 * Return: list of URLs for packages this Ubuntu Core system can handle.
 
+#### Optional parameters
+
+* `active=1` will restrict the results to only active packages
+
 The result is a JSON object with a packages key; its value is itself a
 JSON object whose keys are qualified package names (e.g.,
 hello-world.canonical), and whose values describe that package.


### PR DESCRIPTION
There's maybe a better way of implementing this but I though I'd see what people think.

This PR will cause requests made to `/1.0/packages?active=1` to return only active packages. As a shortcut, remote package are simply ignored.