### PR TITLE
integration-tests: get name of OS snap from bootloader

### DIFF
--- a/integration-tests/tests/config_test.go
+++ b/integration-tests/tests/config_test.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -35,12 +35,14 @@ var _ = check.Suite(&configSuite{})
 
 type configSuite struct {
 	common.SnappySuite
+	osSnap     string
 	backConfig string
 }
 
 func (s *configSuite) SetUpTest(c *check.C) {
 	s.SnappySuite.SetUpTest(c)
-	s.backConfig = currentConfig(c)
+	s.osSnap = common.OSSnapName(c)
+	s.backConfig = currentConfig(c, s.osSnap)
 }
 
 func (s *configSuite) TearDownTest(c *check.C) {
@@ -80,7 +82,7 @@ func (s *configSuite) doTest(c *check.C, targetCfg string) {
 	err := s.setConfig(c, config)
 	c.Assert(err, check.IsNil, check.Commentf("Error setting config: %s", err))
 
-	actualConfig := currentConfig(c)
+	actualConfig := currentConfig(c, s.osSnap)
 
 	// we admit any characters after a new line, this is needed because the reuse
 	// of the config yaml string in the regex pattern, after setting a configuration
@@ -99,13 +101,13 @@ func (s *configSuite) setConfig(c *check.C, config string) (err error) {
 	}
 	_, err = configFile.Write([]byte(config))
 
-	cli.ExecCommand(c, "sudo", "snappy", "config", "ubuntu-core", configFile.Name())
+	cli.ExecCommand(c, "sudo", "snappy", "config", s.osSnap, configFile.Name())
 
 	return
 }
 
-func currentConfig(c *check.C) string {
-	return cli.ExecCommand(c, "sudo", "snappy", "config", "ubuntu-core")
+func currentConfig(c *check.C, osSnap string) string {
+	return cli.ExecCommand(c, "sudo", "snappy", "config", osSnap)
 }
 
 func configString(cfg string) string {

--- a/integration-tests/tests/config_test.go
+++ b/integration-tests/tests/config_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/partition"
 
 	"gopkg.in/check.v1"
 )
@@ -41,7 +42,7 @@ type configSuite struct {
 
 func (s *configSuite) SetUpTest(c *check.C) {
 	s.SnappySuite.SetUpTest(c)
-	s.osSnap = common.OSSnapName(c)
+	s.osSnap = partition.OSSnapName(c)
 	s.backConfig = currentConfig(c, s.osSnap)
 }
 

--- a/integration-tests/tests/list_test.go
+++ b/integration-tests/tests/list_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/partition"
 
 	"gopkg.in/check.v1"
 )
@@ -44,7 +45,7 @@ func (s *listSuite) TestListMustPrintCoreVersion(c *check.C) {
 	expected := "(?ms)" +
 		"Name +Date +Version +Developer *\n" +
 		".*" +
-		fmt.Sprintf("^%s +.* +%s +canonical *\n", common.OSSnapName(c), verRegexp) +
+		fmt.Sprintf("^%s +.* +%s +canonical *\n", partition.OSSnapName(c), verRegexp) +
 		".*"
 	c.Assert(listOutput, check.Matches, expected)
 }

--- a/integration-tests/tests/list_test.go
+++ b/integration-tests/tests/list_test.go
@@ -44,7 +44,7 @@ func (s *listSuite) TestListMustPrintCoreVersion(c *check.C) {
 	expected := "(?ms)" +
 		"Name +Date +Version +Developer *\n" +
 		".*" +
-		fmt.Sprintf("^ubuntu-core +.* +%s +canonical *\n", verRegexp) +
+		fmt.Sprintf("^%s +.* +%s +canonical *\n", common.OSSnapName(c), verRegexp) +
 		".*"
 	c.Assert(listOutput, check.Matches, expected)
 }

--- a/integration-tests/tests/rollback_test.go
+++ b/integration-tests/tests/rollback_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/partition"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/updates"
 
 	"gopkg.in/check.v1"
@@ -47,7 +48,7 @@ func (s *rollbackSuite) TestRollbackMustRebootToOtherVersion(c *check.C) {
 		currentVersion := common.GetCurrentUbuntuCoreVersion(c)
 		c.Assert(snappy.VersionCompare(currentVersion, common.GetSavedVersion(c)), check.Equals, -1,
 			check.Commentf("Rebooted to the wrong version: %s", currentVersion))
-		cli.ExecCommand(c, "sudo", "snappy", "rollback", common.OSSnapName(c),
+		cli.ExecCommand(c, "sudo", "snappy", "rollback", partition.OSSnapName(c),
 			common.GetSavedVersion(c))
 		common.RebootWithMark(c, c.TestName()+"-rollback")
 	} else if common.CheckRebootMark(c.TestName() + "-rollback") {

--- a/integration-tests/tests/rollback_test.go
+++ b/integration-tests/tests/rollback_test.go
@@ -47,7 +47,7 @@ func (s *rollbackSuite) TestRollbackMustRebootToOtherVersion(c *check.C) {
 		currentVersion := common.GetCurrentUbuntuCoreVersion(c)
 		c.Assert(snappy.VersionCompare(currentVersion, common.GetSavedVersion(c)), check.Equals, -1,
 			check.Commentf("Rebooted to the wrong version: %s", currentVersion))
-		cli.ExecCommand(c, "sudo", "snappy", "rollback", "ubuntu-core",
+		cli.ExecCommand(c, "sudo", "snappy", "rollback", common.OSSnapName(c),
 			common.GetSavedVersion(c))
 		common.RebootWithMark(c, c.TestName()+"-rollback")
 	} else if common.CheckRebootMark(c.TestName() + "-rollback") {

--- a/integration-tests/tests/update_os_test.go
+++ b/integration-tests/tests/update_os_test.go
@@ -21,6 +21,7 @@
 package tests
 
 import (
+	"fmt"
 	//	"io/ioutil"
 	//	"path"
 
@@ -69,9 +70,9 @@ func (s *updateOSSuite) assertBootDirContents(c *check.C) {
 func (s *updateOSSuite) TestUpdateToSameReleaseAndChannel(c *check.C) {
 	if common.BeforeReboot() {
 		updateOutput := updates.CallFakeOSUpdate(c)
-		expected := "(?ms)" +
-			".*" +
-			"^Reboot to use ubuntu-core version .*\\.\n"
+		expected := fmt.Sprintf("(?ms)"+
+			".*"+
+			"^Reboot to use %s version .*\\.\n", common.OSSnapName(c))
 		c.Assert(updateOutput, check.Matches, expected)
 		s.assertBootDirContents(c)
 		common.Reboot(c)

--- a/integration-tests/tests/update_os_test.go
+++ b/integration-tests/tests/update_os_test.go
@@ -70,9 +70,9 @@ func (s *updateOSSuite) assertBootDirContents(c *check.C) {
 func (s *updateOSSuite) TestUpdateToSameReleaseAndChannel(c *check.C) {
 	if common.BeforeReboot() {
 		updateOutput := updates.CallFakeOSUpdate(c)
-		expected := fmt.Sprintf("(?ms)"+
+		expected := "(?ms)"+
 			".*"+
-			"^Reboot to use %s version .*\\.\n", common.OSSnapName(c))
+			fmt.Sprintf("^Reboot to use %s version .*\\.\n", common.OSSnapName(c))
 		c.Assert(updateOutput, check.Matches, expected)
 		s.assertBootDirContents(c)
 		common.Reboot(c)

--- a/integration-tests/tests/update_os_test.go
+++ b/integration-tests/tests/update_os_test.go
@@ -70,9 +70,9 @@ func (s *updateOSSuite) assertBootDirContents(c *check.C) {
 func (s *updateOSSuite) TestUpdateToSameReleaseAndChannel(c *check.C) {
 	if common.BeforeReboot() {
 		updateOutput := updates.CallFakeOSUpdate(c)
-		expected := "(?ms)"+
-			".*"+
-			fmt.Sprintf("^Reboot to use %s version .*\\.\n", common.OSSnapName(c))
+		expected := "(?ms)" +
+			".*" +
+			fmt.Sprintf("^Reboot to use %s version .*\\.\n", partition.OSSnapName(c))
 		c.Assert(updateOutput, check.Matches, expected)
 		s.assertBootDirContents(c)
 		common.Reboot(c)

--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -82,7 +82,7 @@ func (s *SnappySuite) SetUpSuite(c *check.C) {
 		Cfg.Update = false
 		Cfg.Write()
 		if Cfg.Rollback {
-			cli.ExecCommand(c, "sudo", "snappy", "rollback", OSSnapName(c))
+			cli.ExecCommand(c, "sudo", "snappy", "rollback", partition.OSSnapName(c))
 			RebootWithMark(c, "setupsuite-rollback")
 		}
 	} else if CheckRebootMark("setupsuite-rollback") {
@@ -119,13 +119,6 @@ func (s *SnappySuite) SetUpTest(c *check.C) {
 	}
 }
 
-// OSSnapName returns the name of the OS snap.
-func OSSnapName(c *check.C) string {
-	snappyOS, err := partition.SnappyOS()
-	c.Assert(err, check.IsNil, check.Commentf("Error getting the name of the OS snap: %s", err))
-	return strings.Split(snappyOS, ".")[0]
-}
-
 // GetCurrentVersion returns the version of the installed and active package.
 func GetCurrentVersion(c *check.C, packageName string) string {
 	output := cli.ExecCommand(c, "snappy", "list")
@@ -142,7 +135,7 @@ func GetCurrentVersion(c *check.C, packageName string) string {
 // GetCurrentUbuntuCoreVersion returns the version number of the installed and
 // active ubuntu-core.
 func GetCurrentUbuntuCoreVersion(c *check.C) string {
-	return GetCurrentVersion(c, OSSnapName(c))
+	return GetCurrentVersion(c, partition.OSSnapName(c))
 }
 
 // Reboot requests a reboot using the test name as the mark.

--- a/integration-tests/testutils/partition/bootloader.go
+++ b/integration-tests/testutils/partition/bootloader.go
@@ -74,6 +74,12 @@ func Mode() (mode string, err error) {
 	return confValue("snappy_mode")
 }
 
+// SnappyOS returns the name of the OS snap.
+// This is a workaround for https://bugs.launchpad.net/snappy/+bug/1532245
+func SnappyOS() (string, error) {
+	return confValue("snappy_os")
+}
+
 func getConfValue(key string) (string, error) {
 	system, err := BootSystem()
 	if err != nil {

--- a/integration-tests/testutils/partition/bootloader.go
+++ b/integration-tests/testutils/partition/bootloader.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/mvo5/uboot-go/uenv"
+	"gopkg.in/check.v1"
 )
 
 const (
@@ -74,9 +75,16 @@ func Mode() (mode string, err error) {
 	return confValue("snappy_mode")
 }
 
-// SnappyOS returns the name of the OS snap.
+// OSSnapName returns the name of the OS snap.
+func OSSnapName(c *check.C) string {
+	snappyOS, err := snappyOS()
+	c.Assert(err, check.IsNil, check.Commentf("Error getting the name of the OS snap: %s", err))
+	return strings.Split(snappyOS, ".")[0]
+}
+
+// snappyOS returns the name of the OS snap in the form name.origin_version.snap
 // This is a workaround for https://bugs.launchpad.net/snappy/+bug/1532245
-func SnappyOS() (string, error) {
+func snappyOS() (string, error) {
 	return confValue("snappy_os")
 }
 

--- a/integration-tests/testutils/partition/bootloader_test.go
+++ b/integration-tests/testutils/partition/bootloader_test.go
@@ -134,6 +134,18 @@ func (s *bootloaderTestSuite) TestModeReturnsSnappyModeFromConf(c *check.C) {
 	c.Assert(mode, check.Equals, "test_mode", check.Commentf("Wrong mode"))
 }
 
+func (s *bootloaderTestSuite) TestSnappyOSReturnsSnapFromConf(c *check.C) {
+	s.fakeConf = map[string]string{
+		"snappy_os": "test-os-snap.origin_version.snap",
+	}
+
+	snappyOS, err := SnappyOS()
+
+	c.Assert(err, check.IsNil, check.Commentf("Unexpected error %v", err))
+	c.Assert(snappyOS, check.Equals, "test-os-snap.origin_version.snap",
+		check.Commentf("Wrong os snap"))
+}
+
 type confTestSuite struct {
 	backBootSystem  func() (string, error)
 	system          string

--- a/integration-tests/testutils/partition/bootloader_test.go
+++ b/integration-tests/testutils/partition/bootloader_test.go
@@ -134,15 +134,14 @@ func (s *bootloaderTestSuite) TestModeReturnsSnappyModeFromConf(c *check.C) {
 	c.Assert(mode, check.Equals, "test_mode", check.Commentf("Wrong mode"))
 }
 
-func (s *bootloaderTestSuite) TestSnappyOSReturnsSnapFromConf(c *check.C) {
+func (s *bootloaderTestSuite) TestOSSnapNameReturnsSnapFromConf(c *check.C) {
 	s.fakeConf = map[string]string{
 		"snappy_os": "test-os-snap.origin_version.snap",
 	}
 
-	snappyOS, err := SnappyOS()
+	osSnapName := OSSnapName(c)
 
-	c.Assert(err, check.IsNil, check.Commentf("Unexpected error %v", err))
-	c.Assert(snappyOS, check.Equals, "test-os-snap.origin_version.snap",
+	c.Assert(osSnapName, check.Equals, "test-os-snap",
 		check.Commentf("Wrong os snap"))
 }
 

--- a/integration-tests/testutils/updates/updates.go
+++ b/integration-tests/testutils/updates/updates.go
@@ -68,7 +68,7 @@ func CallFakeOSUpdate(c *check.C) string {
 	currentVersion := common.GetCurrentUbuntuCoreVersion(c)
 	common.SetSavedVersion(c, currentVersion)
 
-	return CallFakeUpdate(c, "ubuntu-core.canonical", NoOp)
+	return CallFakeUpdate(c, common.OSSnapName(c)+".canonical", NoOp)
 }
 
 func makeFakeUpdateForSnap(c *check.C, snap, targetDir string, changeFunc ChangeFakeUpdateSnap) error {

--- a/integration-tests/testutils/updates/updates.go
+++ b/integration-tests/testutils/updates/updates.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/common"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/partition"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/store"
 )
 
@@ -68,7 +69,7 @@ func CallFakeOSUpdate(c *check.C) string {
 	currentVersion := common.GetCurrentUbuntuCoreVersion(c)
 	common.SetSavedVersion(c, currentVersion)
 
-	return CallFakeUpdate(c, common.OSSnapName(c)+".canonical", NoOp)
+	return CallFakeUpdate(c, partition.OSSnapName(c)+".canonical", NoOp)
 }
 
 func makeFakeUpdateForSnap(c *check.C, snap, targetDir string, changeFunc ChangeFakeUpdateSnap) error {


### PR DESCRIPTION
First branch for getting the integration tests working in raspberry pi2.
Currently the os snap is called ubuntu-core in amd64-generic and ubuntu-core-armhf in rpi2. According to Matias, by the end of the next week the store will support the same name for multiple architectures, so we might go back to hardcode the value. Instead of that, I would prefer to get a nice way to query for the name of the os snap, which has a bug reported in https://bugs.launchpad.net/snappy/+bug/1534029 . But we'll see what happens first...