### PR TITLE
snappy: add new overlord type responsible for Installed/Install/Uninstall/SetActive and stub it out

### DIFF
--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -34,21 +34,21 @@ type Overlord struct {
 // Install installs the given snap file to the system.
 //
 // It returns the local snap file or an error
-func (o *Overlord) Install(snapFilePath string, origin string, inter progress.Meter, flags InstallFlags) (*SnapPart, error) {
+func (o *Overlord) Install(snapFilePath string, origin string, flags InstallFlags, meter progress.Meter) (*SnapPart, error) {
 	return nil, ErrNotImplemented
 }
 
 // Uninstall removes the given local snap from the system.
 //
 // It returns an error on failure
-func (o *Overlord) Uninstall(sp *SnapPart, pb progress.Meter) error {
+func (o *Overlord) Uninstall(sp *SnapPart, meter progress.Meter) error {
 	return ErrNotImplemented
 }
 
 // SetActive sets the active state of the given snap
 //
 // It returns an error on failure
-func (o *Overlord) SetActive(sp *SnapPart, active bool, pb progress.Meter) error {
+func (o *Overlord) SetActive(sp *SnapPart, active bool, meter progress.Meter) error {
 	return ErrNotImplemented
 }
 

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -23,10 +23,32 @@ import (
 	"path/filepath"
 
 	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 // Overlord is responsible for the overall system state
 type Overlord struct {
+}
+
+// Install installs the given snap file to the systems.
+//
+// It returns the local snap file or an error
+func (o *Overlord) Install(snapFilePath string, origin string, inter progress.Meter, flags InstallFlags) (*SnapPart, error) {
+	return nil, ErrNotImplemented
+}
+
+// Uninstall remove the given local snap from the system
+//
+// It returns an error on failure
+func (o *Overlord) Uninstall(sp *SnapPart, pb progress.Meter) error {
+	return ErrNotImplemented
+}
+
+// SetActive sets the active state of the given snap
+//
+// It returns an error on failure
+func (o *Overlord) SetActive(sp *SnapPart, active bool, pb progress.Meter) error {
+	return ErrNotImplemented
 }
 
 // Installed returns the installed snaps from this repository

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -26,18 +26,18 @@ import (
 	"github.com/ubuntu-core/snappy/progress"
 )
 
-// Overlord is responsible for the overall system state
+// Overlord is responsible for the overall system state.
 type Overlord struct {
 }
 
-// Install installs the given snap file to the systems.
+// Install installs the given snap file to the system.
 //
 // It returns the local snap file or an error
 func (o *Overlord) Install(snapFilePath string, origin string, inter progress.Meter, flags InstallFlags) (*SnapPart, error) {
 	return nil, ErrNotImplemented
 }
 
-// Uninstall remove the given local snap from the system
+// Uninstall removes the given local snap from the system.
 //
 // It returns an error on failure
 func (o *Overlord) Uninstall(sp *SnapPart, pb progress.Meter) error {

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -20,6 +20,7 @@
 package snappy
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/ubuntu-core/snappy/dirs"
@@ -52,13 +53,15 @@ func (o *Overlord) SetActive(sp *SnapPart, active bool, pb progress.Meter) error
 }
 
 // Installed returns the installed snaps from this repository
-func (o *Overlord) Installed() (parts []*SnapPart) {
+func (o *Overlord) Installed() ([]*SnapPart, error) {
 	globExpr := filepath.Join(dirs.SnapSnapsDir, "*", "*", "meta", "package.yaml")
-	if newParts, err := o.partsForGlobExpr(globExpr); err == nil {
-		parts = append(parts, newParts...)
+	parts, err := o.partsForGlobExpr(globExpr)
+	if err != nil {
+		return nil, fmt.Errorf("Can not get the installed snaps: %s", err)
+
 	}
 
-	return parts
+	return parts, nil
 }
 
 func (o *Overlord) partsForGlobExpr(globExpr string) (parts []*SnapPart, err error) {

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snappy
+
+import (
+	"path/filepath"
+
+	"github.com/ubuntu-core/snappy/dirs"
+)
+
+// Overlord is responsible for the overall system state
+type Overlord struct {
+}
+
+// Installed returns the installed snaps from this repository
+func (o *Overlord) Installed() (parts []*SnapPart) {
+	globExpr := filepath.Join(dirs.SnapSnapsDir, "*", "*", "meta", "package.yaml")
+	if newParts, err := o.partsForGlobExpr(globExpr); err == nil {
+		parts = append(parts, newParts...)
+	}
+
+	return parts
+}
+
+func (o *Overlord) partsForGlobExpr(globExpr string) (parts []*SnapPart, err error) {
+	matches, err := filepath.Glob(globExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, yamlfile := range matches {
+		// skip "current" and similar symlinks
+		realpath, err := filepath.EvalSymlinks(yamlfile)
+		if err != nil {
+			return nil, err
+		}
+		if realpath != yamlfile {
+			continue
+		}
+
+		origin, _ := originFromYamlPath(realpath)
+		snap, err := NewInstalledSnapPart(realpath, origin)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, snap)
+	}
+
+	return parts, nil
+}

--- a/snappy/overlord_test.go
+++ b/snappy/overlord_test.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snappy
+
+import (
+	"github.com/ubuntu-core/snappy/dirs"
+
+	. "gopkg.in/check.v1"
+)
+
+type overlordTestSuite struct {
+}
+
+var _ = Suite(&overlordTestSuite{})
+
+func (o *overlordTestSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+var helloAppYaml = `name: hello-app
+version: 1.0
+`
+
+func (o *overlordTestSuite) TestInstalled(c *C) {
+	makeInstalledMockSnap(dirs.GlobalRootDir, helloAppYaml)
+
+	overlord := &Overlord{}
+	installed := overlord.Installed()
+	c.Assert(installed, HasLen, 1)
+	c.Assert(installed[0].Name(), Equals, "hello-app")
+}

--- a/snappy/overlord_test.go
+++ b/snappy/overlord_test.go
@@ -42,7 +42,8 @@ func (o *overlordTestSuite) TestInstalled(c *C) {
 	makeInstalledMockSnap(dirs.GlobalRootDir, helloAppYaml)
 
 	overlord := &Overlord{}
-	installed := overlord.Installed()
+	installed, err := overlord.Installed()
+	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
 	c.Assert(installed[0].Name(), Equals, "hello-app")
 }


### PR DESCRIPTION
This adds the new overlord type. It implements "Installed()" in there and stubs Install/Uninstall/SetActive. If this looks good I will do a followup that moves the functionality over. 

This is to split the big https://github.com/ubuntu-core/snappy/pull/334/ into smaller chunks and to make it easier to talk about the important parts like the API without all the distraction from the shuffling of code. Hope this is useful, I'm open for alternatives if its not.