### PR TITLE
cmd/snapd,daemon: filter snaps by source

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -262,46 +262,68 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 	}
 	defer lock.Unlock()
 
-	sources := make([]string, 1, 2)
-	sources[0] = "local"
-	// we're not worried if the remote repos error out
-	found, _ := newRemoteRepo().All()
-	if len(found) > 0 {
-		sources = append(sources, "store")
-	}
-
-	sort.Sort(byQN(found))
-
-	bags := lightweight.AllPartBags()
-
+	// map snap names to snap attributes
 	results := make(map[string]map[string]interface{})
-	for _, part := range found {
-		name := part.Name()
-		origin := part.Origin()
+	sources := make([]string, 0, 2)
+	query := r.URL.Query()
 
-		url, err := route.URL("name", name, "origin", origin)
-		if err != nil {
-			return InternalError("can't get route to details for %s.%s: %v", name, origin, err)
+	var includeStore, includeLocal bool
+	if len(query["sources"]) > 0 {
+		for _, v := range strings.Split(query["sources"][0], ",") {
+			if v == "store" {
+				includeStore = true
+			} else if v == "local" {
+				includeLocal = true
+			}
 		}
-
-		fullname := name + "." + origin
-		qn := snappy.QualifiedName(part)
-		results[fullname] = webify(bags[qn].Map(part), url.String())
-		delete(bags, qn)
+	} else {
+		includeStore = true
+		includeLocal = true
 	}
 
-	for _, v := range bags {
-		m := v.Map(nil)
-		name, _ := m["name"].(string)
-		origin, _ := m["origin"].(string)
+	var bags map[string]*lightweight.PartBag
 
-		resource := "no resource URL for this resource"
-		url, _ := route.URL("name", name, "origin", origin)
-		if url != nil {
-			resource = url.String()
+	if includeLocal {
+		sources = append(sources, "local")
+		bags = lightweight.AllPartBags()
+
+		for _, v := range bags {
+			m := v.Map(nil)
+			name, _ := m["name"].(string)
+			origin, _ := m["origin"].(string)
+
+			resource := "no resource URL for this resource"
+			url, _ := route.URL("name", name, "origin", origin)
+			if url != nil {
+				resource = url.String()
+			}
+
+			results[name+"."+origin] = webify(m, resource)
+		}
+	}
+
+	if includeStore {
+		// we're not worried if the remote repos error out
+		found, _ := newRemoteRepo().All()
+		if len(found) > 0 {
+			sources = append(sources, "store")
 		}
 
-		results[name+"."+origin] = webify(m, resource)
+		sort.Sort(byQN(found))
+
+		for _, part := range found {
+			name := part.Name()
+			origin := part.Origin()
+
+			url, err := route.URL("name", name, "origin", origin)
+			if err != nil {
+				return InternalError("can't get route to details for %s.%s: %v", name, origin, err)
+			}
+
+			fullname := name + "." + origin
+			qn := snappy.QualifiedName(part)
+			results[fullname] = webify(bags[qn].Map(part), url.String())
+		}
 	}
 
 	return SyncResponse(map[string]interface{}{

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -293,8 +293,8 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 			origin, _ := m["origin"].(string)
 
 			resource := "no resource URL for this resource"
-			url, _ := route.URL("name", name, "origin", origin)
-			if url != nil {
+			url, err := route.URL("name", name, "origin", origin)
+			if err == nil {
 				resource = url.String()
 			}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -262,7 +262,7 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 	}
 	defer lock.Unlock()
 
-	// map snap names to snap attributes
+	// TODO: Marshal incrementally leveraging json.RawMessage.
 	results := make(map[string]map[string]interface{})
 	sources := make([]string, 0, 2)
 	query := r.URL.Query()
@@ -303,7 +303,8 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 	}
 
 	if includeStore {
-		// we're not worried if the remote repos error out
+		// TODO: If there are no results (local or remote), report the error. If
+		//       there are results at all, inform that the result is partial.
 		found, _ := newRemoteRepo().All()
 		if len(found) > 0 {
 			sources = append(sources, "store")

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -413,6 +413,85 @@ func (s *apiSuite) TestSnapsInfoOnePerIntegration(c *check.C) {
 	}
 }
 
+func (s *apiSuite) TestSnapsInfoOnlyLocal(c *check.C) {
+	s.parts = []snappy.Part{&tP{name: "store", origin: "foo"}}
+	s.mkInstalled(c, "local", "foo", "v1", true, "")
+
+	req, err := http.NewRequest("GET", "/2.0/snaps?sources=local", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getSnapsInfo(snapsCmd, req).(*resp)
+
+	result := rsp.Result.(map[string]interface{})
+	c.Assert(result["sources"], check.DeepEquals, []string{"local"})
+
+	snaps := result["snaps"].(map[string]map[string]interface{})
+	c.Assert(snaps, check.HasLen, 1)
+	c.Assert(snaps["local.foo"], check.NotNil)
+}
+
+func (s *apiSuite) TestSnapsInfoOnlyStore(c *check.C) {
+	s.parts = []snappy.Part{&tP{name: "store", origin: "foo"}}
+	s.mkInstalled(c, "local", "foo", "v1", true, "")
+
+	req, err := http.NewRequest("GET", "/2.0/snaps?sources=store", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getSnapsInfo(snapsCmd, req).(*resp)
+
+	result := rsp.Result.(map[string]interface{})
+	c.Assert(result["sources"], check.DeepEquals, []string{"store"})
+
+	snaps := result["snaps"].(map[string]map[string]interface{})
+	c.Assert(snaps, check.HasLen, 1)
+	c.Assert(snaps["store.foo"], check.NotNil)
+}
+
+func (s *apiSuite) TestSnapsInfoLocalAndStore(c *check.C) {
+	s.parts = []snappy.Part{&tP{name: "remote", origin: "foo"}}
+	s.mkInstalled(c, "local", "foo", "v1", true, "")
+
+	req, err := http.NewRequest("GET", "/2.0/snaps?sources=local,store", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getSnapsInfo(snapsCmd, req).(*resp)
+
+	result := rsp.Result.(map[string]interface{})
+	c.Assert(result["sources"], check.DeepEquals, []string{"local", "store"})
+
+	snaps := result["snaps"].(map[string]map[string]interface{})
+	c.Assert(snaps, check.HasLen, 2)
+}
+
+func (s *apiSuite) TestSnapsInfoDefaultSources(c *check.C) {
+	s.parts = []snappy.Part{&tP{name: "remote", origin: "foo"}}
+	s.mkInstalled(c, "local", "foo", "v1", true, "")
+
+	req, err := http.NewRequest("GET", "/2.0/snaps", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getSnapsInfo(snapsCmd, req).(*resp)
+
+	result := rsp.Result.(map[string]interface{})
+	c.Assert(result["sources"], check.DeepEquals, []string{"local", "store"})
+}
+
+func (s *apiSuite) TestSnapsInfoUnknownSource(c *check.C) {
+	s.parts = []snappy.Part{&tP{name: "remote", origin: "foo"}}
+	s.mkInstalled(c, "local", "foo", "v1", true, "")
+
+	req, err := http.NewRequest("GET", "/2.0/snaps?sources=unknown", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getSnapsInfo(snapsCmd, req).(*resp)
+
+	result := rsp.Result.(map[string]interface{})
+	c.Assert(result["sources"], check.HasLen, 0)
+
+	snaps := result["snaps"].(map[string]map[string]interface{})
+	c.Assert(snaps, check.HasLen, 0)
+}
+
 func (s *apiSuite) TestDeleteOpNotFound(c *check.C) {
 	s.vars = map[string]string{"uuid": "42"}
 	rsp := deleteOp(operationCmd, nil).Self(nil, nil).(*resp)


### PR DESCRIPTION
Make the `/2.0/snaps` endpoint behave [as described](https://github.com/ubuntu-core/snappy/blob/master/docs/rest.md#parameters-fixme-is-that-the-right-word-for-these) in the presence of a `sources` query string parameter.