### PR TITLE
asserts: make AssertionType into a real struct exposing the metadata Name and PrimaryKey

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -122,6 +122,6 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 func init() {
 	typeRegistry[AccountKeyType] = &assertionTypeRegistration{
 		assembler:  assembleAccountKey,
-		primaryKey: []string{"account-id", "public-key-id"},
+		primaryKey: AccountKeyType.PrimaryKey,
 	}
 }

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -120,8 +120,5 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 }
 
 func init() {
-	typeRegistry[AccountKeyType] = &assertionTypeRegistration{
-		assembler:  assembleAccountKey,
-		primaryKey: AccountKeyType.PrimaryKey,
-	}
+	typeRegistry[AccountKeyType.Name] = AccountKeyType
 }

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -118,7 +118,3 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 		pubKey:        pubk,
 	}, nil
 }
-
-func init() {
-	typeRegistry[AccountKeyType.Name] = AccountKeyType
-}

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -45,15 +45,11 @@ var (
 // ...
 )
 
+var typeRegistry = make(map[string]*AssertionType)
+
 // Type returns the AssertionType with name or nil
 func Type(name string) *AssertionType {
-	// XXX intermediate impl.
-	for k, _ := range typeRegistry {
-		if k.Name == name {
-			return k
-		}
-	}
-	return nil
+	return typeRegistry[name]
 }
 
 // Assertion represents an assertion through its general elements.
@@ -281,7 +277,7 @@ func writeHeader(buf *bytes.Buffer, headers map[string]string, name string) {
 }
 
 func assembleAndSign(assertType *AssertionType, headers map[string]string, body []byte, privKey PrivateKey) (Assertion, error) {
-	_, err := checkAssertType(assertType)
+	err := checkAssertType(assertType)
 	if err != nil {
 		return nil, err
 	}
@@ -374,15 +370,6 @@ func assembleAndSign(assertType *AssertionType, headers map[string]string, body 
 	}
 	return assert, nil
 }
-
-// registry for assertion types describing how to assemble them etc...
-
-type assertionTypeRegistration struct {
-	assembler  func(assert assertionBase) (Assertion, error)
-	primaryKey []string
-}
-
-var typeRegistry = make(map[*AssertionType]*assertionTypeRegistration)
 
 // Encode serializes an assertion.
 func Encode(assert Assertion) []byte {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -384,14 +384,6 @@ type assertionTypeRegistration struct {
 
 var typeRegistry = make(map[*AssertionType]*assertionTypeRegistration)
 
-func primaryKey(t *AssertionType) []string {
-	reg, ok := typeRegistry[t]
-	if !ok {
-		panic("unknown assertion type used as value")
-	}
-	return reg.primaryKey
-}
-
 // Encode serializes an assertion.
 func Encode(assert Assertion) []byte {
 	content, signature := assert.Signature()

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -256,7 +256,7 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 	}
 	assertType := Type(typ)
 	if assertType == nil {
-		return nil, fmt.Errorf("unknown assertion type: %v", typ)
+		return nil, fmt.Errorf("unknown assertion type: %q", typ)
 	}
 
 	revision, err := checkRevision(headers)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -254,17 +254,13 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 	if assertType == nil {
 		return nil, fmt.Errorf("unknown assertion type: %v", typ)
 	}
-	reg, err := checkAssertType(assertType)
-	if err != nil {
-		return nil, err
-	}
 
 	revision, err := checkRevision(headers)
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
 	}
 
-	assert, err := reg.assembler(assertionBase{
+	assert, err := assertType.assembler(assertionBase{
 		headers:   headers,
 		body:      body,
 		revision:  revision,
@@ -285,7 +281,7 @@ func writeHeader(buf *bytes.Buffer, headers map[string]string, name string) {
 }
 
 func assembleAndSign(assertType *AssertionType, headers map[string]string, body []byte, privKey PrivateKey) (Assertion, error) {
-	reg, err := checkAssertType(assertType)
+	_, err := checkAssertType(assertType)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +320,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]string, body 
 		"revision":     true,
 		"body-length":  true,
 	}
-	for _, primKey := range reg.primaryKey {
+	for _, primKey := range assertType.PrimaryKey {
 		if _, err := checkMandatory(finalHeaders, primKey); err != nil {
 			return nil, err
 		}
@@ -366,7 +362,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]string, body 
 	// be 'cat' friendly, add a ignored newline to the signature which is the last part of the encoded assertion
 	signature = append(signature, '\n')
 
-	assert, err := reg.assembler(assertionBase{
+	assert, err := assertType.assembler(assertionBase{
 		headers:   finalHeaders,
 		body:      finalBody,
 		revision:  revision,

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -31,7 +31,10 @@ import (
 
 // AssertionType describes a known assertion type with its name and metadata.
 type AssertionType struct {
-	Name       string
+	// Name of the type.
+	Name string
+	// PrimaryKey holds the names of the headers that constitute the
+	// unique primary key for this assertion type.
 	PrimaryKey []string
 	assembler  func(assert assertionBase) (Assertion, error)
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -36,6 +36,7 @@ type AssertionType struct {
 	// PrimaryKey holds the names of the headers that constitute the
 	// unique primary key for this assertion type.
 	PrimaryKey []string
+
 	assembler  func(assert assertionBase) (Assertion, error)
 }
 

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -31,14 +31,16 @@ import (
 
 // AssertionType describes a known assertion type with its name and metadata.
 type AssertionType struct {
-	Name string
+	Name       string
+	PrimaryKey []string
+	assembler  func(assert assertionBase) (Assertion, error)
 }
 
-// Understood assertions
+// Understood assertion types.
 var (
-	AccountKeyType   = &AssertionType{"account-key"}
-	SnapBuildType    = &AssertionType{"snap-build"}
-	SnapRevisionType = &AssertionType{"snap-revision"}
+	AccountKeyType   = &AssertionType{"account-key", []string{"account-id", "public-key-id"}, assembleAccountKey}
+	SnapBuildType    = &AssertionType{"snap-build", []string{"snap-id", "snap-digest"}, assembleSnapBuild}
+	SnapRevisionType = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}
 
 // ...
 )

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -45,7 +45,11 @@ var (
 // ...
 )
 
-var typeRegistry = make(map[string]*AssertionType)
+var typeRegistry = map[string]*AssertionType{
+	AccountKeyType.Name: AccountKeyType,
+	SnapBuildType.Name: SnapBuildType,
+	SnapRevisionType.Name: SnapRevisionType,
+}
 
 // Type returns the AssertionType with name or nil
 func Type(name string) *AssertionType {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -37,7 +37,7 @@ type AssertionType struct {
 	// unique primary key for this assertion type.
 	PrimaryKey []string
 
-	assembler  func(assert assertionBase) (Assertion, error)
+	assembler func(assert assertionBase) (Assertion, error)
 }
 
 // Understood assertion types.

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -83,7 +83,7 @@ type Assertion interface {
 
 // assertionBase is the concrete base to hold representation data for actual assertions.
 type assertionBase struct {
-	// XXX type *AssertionType
+	// TODO: worth having a type *AssertionType cache field now?
 	headers map[string]string
 	body    []byte
 	// parsed revision

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -46,8 +46,8 @@ var (
 )
 
 var typeRegistry = map[string]*AssertionType{
-	AccountKeyType.Name: AccountKeyType,
-	SnapBuildType.Name: SnapBuildType,
+	AccountKeyType.Name:   AccountKeyType,
+	SnapBuildType.Name:    SnapBuildType,
 	SnapRevisionType.Name: SnapRevisionType,
 }
 

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -283,6 +283,11 @@ func writeHeader(buf *bytes.Buffer, headers map[string]string, name string) {
 }
 
 func assembleAndSign(assertType *AssertionType, headers map[string]string, body []byte, privKey PrivateKey) (Assertion, error) {
+	reg, err := checkAssertType(assertType)
+	if err != nil {
+		return nil, err
+	}
+
 	finalHeaders := make(map[string]string, len(headers))
 	for name, value := range headers {
 		finalHeaders[name] = value
@@ -294,11 +299,6 @@ func assembleAndSign(assertType *AssertionType, headers map[string]string, body 
 	finalHeaders["body-length"] = strconv.Itoa(bodyLength)
 
 	if _, err := checkMandatory(finalHeaders, "authority-id"); err != nil {
-		return nil, err
-	}
-
-	reg, err := checkAssertType(assertType)
-	if err != nil {
 		return nil, err
 	}
 

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -152,7 +152,7 @@ func (as *assertsSuite) TestDecodeInvalid(c *C) {
 		{"authority-id: auth-id\n", "authority-id: \n", `assertion: "authority-id" header should not be empty`},
 		{"openpgp c2ln", "", "empty assertion signature"},
 		{"type: test-only\n", "", `assertion: "type" header is mandatory`},
-		{"type: test-only\n", "type: unknown\n", "unknown assertion type: unknown"},
+		{"type: test-only\n", "type: unknown\n", `unknown assertion type: "unknown"`},
 		{"revision: 0\n", "revision: Z\n", `assertion: "revision" header is not an integer: Z`},
 		{"revision: 0\n", "revision: -10\n", "assertion: revision should be positive: -10"},
 	}

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -38,7 +38,7 @@ func (as *assertsSuite) TestDecodeEmptyBodyAllDefaults(c *C) {
 		"openpgp c2ln"
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
-	c.Check(a.Type(), Equals, asserts.AssertionType("test-only"))
+	c.Check(a.Type(), Equals, asserts.TestOnlyType)
 	_, ok := a.(*asserts.TestOnly)
 	c.Check(ok, Equals, true)
 	c.Check(a.Revision(), Equals, 0)
@@ -57,7 +57,7 @@ func (as *assertsSuite) TestDecodeEmptyBodyNormalize2NlNl(c *C) {
 		"openpgp c2ln"
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
-	c.Check(a.Type(), Equals, asserts.AssertionType("test-only"))
+	c.Check(a.Type(), Equals, asserts.TestOnlyType)
 	c.Check(a.Revision(), Equals, 0)
 	c.Check(a.Body(), IsNil)
 }
@@ -76,7 +76,7 @@ func (as *assertsSuite) TestDecodeWithABodyAndExtraHeaders(c *C) {
 		"openpgp c2ln"
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
-	c.Check(a.Type(), Equals, asserts.AssertionType("test-only"))
+	c.Check(a.Type(), Equals, asserts.TestOnlyType)
 	c.Check(a.AuthorityID(), Equals, "auth-id2")
 	c.Check(a.Header("primary-key1"), Equals, "key1")
 	c.Check(a.Header("primary-key2"), Equals, "key2")
@@ -99,7 +99,7 @@ func (as *assertsSuite) TestDecodeGetSignatureBits(c *C) {
 		"openpgp c2ln"
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
-	c.Check(a.Type(), Equals, asserts.AssertionType("test-only"))
+	c.Check(a.Type(), Equals, asserts.TestOnlyType)
 	c.Check(a.AuthorityID(), Equals, "auth-id1")
 	cont, signature := a.Signature()
 	c.Check(signature, DeepEquals, []byte("openpgp c2ln"))
@@ -178,7 +178,7 @@ func (as *assertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
 	}
-	a, err := asserts.AssembleAndSignInTest(asserts.AssertionType("test-only"), headers, nil, asserts.OpenPGPPrivateKey(testPrivKey1))
+	a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 
 	_, err = asserts.Decode(asserts.Encode(a))
@@ -191,7 +191,7 @@ func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 		"primary-key":  "0",
 	}
 	body := []byte("THE-BODY")
-	a, err := asserts.AssembleAndSignInTest(asserts.AssertionType("test-only"), headers, body, asserts.OpenPGPPrivateKey(testPrivKey1))
+	a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, body, asserts.OpenPGPPrivateKey(testPrivKey1))
 	c.Assert(err, IsNil)
 	c.Check(a.Body(), DeepEquals, body)
 

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -31,6 +31,15 @@ type assertsSuite struct{}
 
 var _ = Suite(&assertsSuite{})
 
+func (as *assertsSuite) TestType(c *C) {
+	c.Check(asserts.Type("test-only"), Equals, asserts.TestOnlyType)
+}
+
+func (as *assertsSuite) TestUnknown(c *C) {
+	c.Check(asserts.Type(""), IsNil)
+	c.Check(asserts.Type("unknown"), IsNil)
+}
+
 func (as *assertsSuite) TestDecodeEmptyBodyAllDefaults(c *C) {
 	encoded := "type: test-only\n" +
 		"authority-id: auth-id1" +

--- a/asserts/checkers.go
+++ b/asserts/checkers.go
@@ -38,10 +38,11 @@ func checkMandatory(headers map[string]string, name string) (string, error) {
 	return value, nil
 }
 
-func checkAssertType(assertType AssertionType) (*assertionTypeRegistration, error) {
+func checkAssertType(assertType *AssertionType) (*assertionTypeRegistration, error) {
+	// XXX assertType is nil case
 	reg := typeRegistry[assertType]
 	if reg == nil {
-		return nil, fmt.Errorf("unknown assertion type: %v", assertType)
+		return nil, fmt.Errorf("unknown assertion type: %s", assertType.Name)
 	}
 	return reg, nil
 }

--- a/asserts/checkers.go
+++ b/asserts/checkers.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -38,13 +39,18 @@ func checkMandatory(headers map[string]string, name string) (string, error) {
 	return value, nil
 }
 
-func checkAssertType(assertType *AssertionType) (*assertionTypeRegistration, error) {
-	// XXX assertType is nil case
-	reg := typeRegistry[assertType]
-	if reg == nil {
-		return nil, fmt.Errorf("unknown assertion type: %s", assertType.Name)
+var errInvalidAssertionType = errors.New("invalid assertion type")
+
+func checkAssertType(assertType *AssertionType) error {
+	if assertType == nil {
+		return errInvalidAssertionType
 	}
-	return reg, nil
+	sanity := typeRegistry[assertType.Name]
+	// not the expected registered value
+	if sanity != assertType {
+		return errInvalidAssertionType
+	}
+	return nil
 }
 
 // use 'defl' default if missing

--- a/asserts/checkers.go
+++ b/asserts/checkers.go
@@ -20,7 +20,6 @@
 package asserts
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -39,18 +38,21 @@ func checkMandatory(headers map[string]string, name string) (string, error) {
 	return value, nil
 }
 
-var errInvalidAssertionType = errors.New("invalid assertion type")
-
 func checkAssertType(assertType *AssertionType) error {
 	if assertType == nil {
-		return errInvalidAssertionType
+		return fmt.Errorf("internal error: assertion type cannot be nil")
 	}
+	// sanity check against known canonical
 	sanity := typeRegistry[assertType.Name]
-	// not the expected registered value
-	if sanity != assertType {
-		return errInvalidAssertionType
+	switch sanity {
+	case assertType:
+		// fine, matches canonical
+		return nil
+	case nil:
+		return fmt.Errorf("internal error: unknown assertion type: %q", assertType.Name)
+	default:
+		return fmt.Errorf("internal error: unpredefined assertion type for name %q used (unexpected address %p)", assertType.Name, assertType)
 	}
-	return nil
 }
 
 // use 'defl' default if missing

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -277,7 +277,7 @@ func searchMatch(assert Assertion, expectedHeaders map[string]string) bool {
 // Provided headers must contain the primary key for the assertion type.
 // It returns ErrNotFound if the assertion cannot be found.
 func (db *Database) Find(assertionType *AssertionType, headers map[string]string) (Assertion, error) {
-	_, err := checkAssertType(assertionType)
+	err := checkAssertType(assertionType)
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func (db *Database) Find(assertionType *AssertionType, headers map[string]string
 // FindMany finds assertions based on arbitrary headers.
 // It returns ErrNotFound if no assertion can be found.
 func (db *Database) FindMany(assertionType *AssertionType, headers map[string]string) ([]Assertion, error) {
-	_, err := checkAssertType(assertionType)
+	err := checkAssertType(assertionType)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -199,7 +199,7 @@ func (db *Database) findAccountKeys(authorityID, keyID string) ([]*AccountKey, e
 		}
 	}
 	// consider stored account keys
-	a, err := db.bs.Get(AccountKeyType, primaryKey(AccountKeyType), []string{authorityID, keyID})
+	a, err := db.bs.Get(AccountKeyType, AccountKeyType.PrimaryKey, []string{authorityID, keyID})
 	switch err {
 	case nil:
 		res = append(res, a.(*AccountKey))

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -34,27 +34,27 @@ type Backstore interface {
 	// Put stores an assertion for the given primaryKeyHeaders forming a unique key.
 	// It is responsible for checking that assert is newer than a
 	// previously stored revision.
-	Put(assertType AssertionType, primaryKeyHeaders []string, assert Assertion) error
+	Put(assertType *AssertionType, primaryKeyHeaders []string, assert Assertion) error
 	// Get returns the assertion with the given unique key for the primaryKeyHeaders.
 	// If none is present it returns ErrNotFound.
-	Get(assertType AssertionType, primaryKeyHeaders, key []string) (Assertion, error)
+	Get(assertType *AssertionType, primaryKeyHeaders, key []string) (Assertion, error)
 	// Search returns assertions matching the given headers.
 	// It invokes foundCb for each found assertion.
 	// As hint the primaryKeyHeaders forming a unique key are also given.
-	Search(assertType AssertionType, primaryKeyHeaders []string, headers map[string]string, foundCb func(Assertion)) error
+	Search(assertType *AssertionType, primaryKeyHeaders []string, headers map[string]string, foundCb func(Assertion)) error
 }
 
 type nullBackstore struct{}
 
-func (nbs nullBackstore) Put(t AssertionType, pkh []string, a Assertion) error {
+func (nbs nullBackstore) Put(t *AssertionType, pkh []string, a Assertion) error {
 	return fmt.Errorf("cannot store assertions without setting a proper assertion backstore implementation")
 }
 
-func (nbs nullBackstore) Get(t AssertionType, pkh, k []string) (Assertion, error) {
+func (nbs nullBackstore) Get(t *AssertionType, pkh, k []string) (Assertion, error) {
 	return nil, ErrNotFound
 }
 
-func (nbs nullBackstore) Search(t AssertionType, pkh []string, h map[string]string, f func(Assertion)) error {
+func (nbs nullBackstore) Search(t *AssertionType, pkh []string, h map[string]string, f func(Assertion)) error {
 	return nil
 }
 
@@ -175,7 +175,7 @@ func (db *Database) PublicKey(authorityID string, keyID string) (PublicKey, erro
 
 // Sign assembles an assertion with the provided information and signs it
 // with the private key from `headers["authority-id"]` that has the provided key id.
-func (db *Database) Sign(assertType AssertionType, headers map[string]string, body []byte, keyID string) (Assertion, error) {
+func (db *Database) Sign(assertType *AssertionType, headers map[string]string, body []byte, keyID string) (Assertion, error) {
 	authorityID, err := checkMandatory(headers, "authority-id")
 	if err != nil {
 		return nil, err
@@ -279,7 +279,7 @@ func searchMatch(assert Assertion, expectedHeaders map[string]string) bool {
 // Find an assertion based on arbitrary headers.
 // Provided headers must contain the primary key for the assertion type.
 // It returns ErrNotFound if the assertion cannot be found.
-func (db *Database) Find(assertionType AssertionType, headers map[string]string) (Assertion, error) {
+func (db *Database) Find(assertionType *AssertionType, headers map[string]string) (Assertion, error) {
 	reg, err := checkAssertType(assertionType)
 	if err != nil {
 		return nil, err
@@ -304,7 +304,7 @@ func (db *Database) Find(assertionType AssertionType, headers map[string]string)
 
 // FindMany finds assertions based on arbitrary headers.
 // It returns ErrNotFound if no assertion can be found.
-func (db *Database) FindMany(assertionType AssertionType, headers map[string]string) ([]Assertion, error) {
+func (db *Database) FindMany(assertionType *AssertionType, headers map[string]string) ([]Assertion, error) {
 	reg, err := checkAssertType(assertionType)
 	if err != nil {
 		return nil, err

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -170,7 +170,7 @@ func (chks *checkSuite) SetUpTest(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
-	chks.a, err = asserts.AssembleAndSignInTest(asserts.AssertionType("test-only"), headers, nil, asserts.OpenPGPPrivateKey(testPrivKey0))
+	chks.a, err = asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, asserts.OpenPGPPrivateKey(testPrivKey0))
 	c.Assert(err, IsNil)
 }
 
@@ -263,7 +263,7 @@ func (safs *signAddFindSuite) TestSign(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
 	err = safs.db.Check(a1)
@@ -275,7 +275,7 @@ func (safs *signAddFindSuite) TestSignEmptyKeyID(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, "")
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, "")
 	c.Assert(err, ErrorMatches, "key id is empty")
 	c.Check(a1, IsNil)
 }
@@ -284,7 +284,7 @@ func (safs *signAddFindSuite) TestSignMissingAuthorityId(c *C) {
 	headers := map[string]string{
 		"primary-key": "a",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, ErrorMatches, `"authority-id" header is mandatory`)
 	c.Check(a1, IsNil)
 }
@@ -293,7 +293,7 @@ func (safs *signAddFindSuite) TestSignMissingPrimaryKey(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, ErrorMatches, `"primary-key" header is mandatory`)
 	c.Check(a1, IsNil)
 }
@@ -303,7 +303,7 @@ func (safs *signAddFindSuite) TestSignNoPrivateKey(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, "abcd")
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, "abcd")
 	c.Assert(err, ErrorMatches, "no matching key pair found")
 	c.Check(a1, IsNil)
 }
@@ -323,7 +323,7 @@ func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
 		"primary-key":  "a",
 		"revision":     "zzz",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, ErrorMatches, `"revision" header is not an integer: zzz`)
 	c.Check(a1, IsNil)
 }
@@ -334,7 +334,7 @@ func (safs *signAddFindSuite) TestSignAssemblerError(c *C) {
 		"primary-key":  "a",
 		"count":        "zzz",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, ErrorMatches, `cannot assemble assertion test-only: "count" header is not an integer: zzz`)
 	c.Check(a1, IsNil)
 }
@@ -344,13 +344,13 @@ func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
 	err = safs.db.Add(a1)
 	c.Assert(err, IsNil)
 
-	retrieved1, err := safs.db.Find(asserts.AssertionType("test-only"), map[string]string{
+	retrieved1, err := safs.db.Find(asserts.TestOnlyType, map[string]string{
 		"primary-key": "a",
 	})
 	c.Assert(err, IsNil)
@@ -358,13 +358,13 @@ func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 	c.Check(retrieved1.Revision(), Equals, 0)
 
 	headers["revision"] = "1"
-	a2, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	a2, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
 	err = safs.db.Add(a2)
 	c.Assert(err, IsNil)
 
-	retrieved2, err := safs.db.Find(asserts.AssertionType("test-only"), map[string]string{
+	retrieved2, err := safs.db.Find(asserts.TestOnlyType, map[string]string{
 		"primary-key": "a",
 	})
 	c.Assert(err, IsNil)
@@ -380,20 +380,20 @@ func (safs *signAddFindSuite) TestFindNotFound(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
 	err = safs.db.Add(a1)
 	c.Assert(err, IsNil)
 
-	retrieved1, err := safs.db.Find(asserts.AssertionType("test-only"), map[string]string{
+	retrieved1, err := safs.db.Find(asserts.TestOnlyType, map[string]string{
 		"primary-key": "b",
 	})
 	c.Assert(err, Equals, asserts.ErrNotFound)
 	c.Check(retrieved1, IsNil)
 
 	// checking also extra headers
-	retrieved1, err = safs.db.Find(asserts.AssertionType("test-only"), map[string]string{
+	retrieved1, err = safs.db.Find(asserts.TestOnlyType, map[string]string{
 		"primary-key":  "a",
 		"authority-id": "other-auth-id",
 	})
@@ -402,7 +402,7 @@ func (safs *signAddFindSuite) TestFindNotFound(c *C) {
 }
 
 func (safs *signAddFindSuite) TestFindPrimaryLeftOut(c *C) {
-	retrieved1, err := safs.db.Find(asserts.AssertionType("test-only"), map[string]string{})
+	retrieved1, err := safs.db.Find(asserts.TestOnlyType, map[string]string{})
 	c.Assert(err, ErrorMatches, "must provide primary key: primary-key")
 	c.Check(retrieved1, IsNil)
 }
@@ -413,7 +413,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 		"primary-key":  "a",
 		"other":        "other-x",
 	}
-	aa, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	aa, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 	err = safs.db.Add(aa)
 	c.Assert(err, IsNil)
@@ -423,7 +423,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 		"primary-key":  "b",
 		"other":        "other-y",
 	}
-	ab, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	ab, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 	err = safs.db.Add(ab)
 	c.Assert(err, IsNil)
@@ -433,12 +433,12 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 		"primary-key":  "c",
 		"other":        "other-x",
 	}
-	ac, err := safs.signingDB.Sign(asserts.AssertionType("test-only"), headers, nil, safs.signingKeyID)
+	ac, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 	err = safs.db.Add(ac)
 	c.Assert(err, IsNil)
 
-	res, err := safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{
+	res, err := safs.db.FindMany(asserts.TestOnlyType, map[string]string{
 		"other": "other-x",
 	})
 	c.Assert(err, IsNil)
@@ -447,25 +447,25 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	sort.Strings(primKeys)
 	c.Check(primKeys, DeepEquals, []string{"a", "c"})
 
-	res, err = safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{
+	res, err = safs.db.FindMany(asserts.TestOnlyType, map[string]string{
 		"other": "other-y",
 	})
 	c.Assert(err, IsNil)
 	c.Assert(res, HasLen, 1)
 	c.Check(res[0].Header("primary-key"), Equals, "b")
 
-	res, err = safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{})
+	res, err = safs.db.FindMany(asserts.TestOnlyType, map[string]string{})
 	c.Assert(err, IsNil)
 	c.Assert(res, HasLen, 3)
 
-	res, err = safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{
+	res, err = safs.db.FindMany(asserts.TestOnlyType, map[string]string{
 		"primary-key": "b",
 		"other":       "other-y",
 	})
 	c.Assert(err, IsNil)
 	c.Assert(res, HasLen, 1)
 
-	res, err = safs.db.FindMany(asserts.AssertionType("test-only"), map[string]string{
+	res, err = safs.db.FindMany(asserts.TestOnlyType, map[string]string{
 		"primary-key": "b",
 		"other":       "other-x",
 	})

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -312,7 +312,7 @@ func (safs *signAddFindSuite) TestSignUnknowType(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
 	}
-	a1, err := safs.signingDB.Sign(&asserts.AssertionType{"xyz"}, headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(&asserts.AssertionType{Name: "xyz", PrimaryKey: nil}, headers, nil, safs.signingKeyID)
 	c.Assert(err, ErrorMatches, `unknown assertion type: xyz`)
 	c.Check(a1, IsNil)
 }

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -312,7 +312,7 @@ func (safs *signAddFindSuite) TestSignUnknowType(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
 	}
-	a1, err := safs.signingDB.Sign(asserts.AssertionType("xyz"), headers, nil, safs.signingKeyID)
+	a1, err := safs.signingDB.Sign(&asserts.AssertionType{"xyz"}, headers, nil, safs.signingKeyID)
 	c.Assert(err, ErrorMatches, `unknown assertion type: xyz`)
 	c.Check(a1, IsNil)
 }

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -308,12 +308,21 @@ func (safs *signAddFindSuite) TestSignNoPrivateKey(c *C) {
 	c.Check(a1, IsNil)
 }
 
-func (safs *signAddFindSuite) TestSignUnknowType(c *C) {
+func (safs *signAddFindSuite) TestSignUnknownType(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
 	}
 	a1, err := safs.signingDB.Sign(&asserts.AssertionType{Name: "xyz", PrimaryKey: nil}, headers, nil, safs.signingKeyID)
-	c.Assert(err, ErrorMatches, "invalid assertion type")
+	c.Assert(err, ErrorMatches, `internal error: unknown assertion type: "xyz"`)
+	c.Check(a1, IsNil)
+}
+
+func (safs *signAddFindSuite) TestSignNonPredefinedType(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+	}
+	a1, err := safs.signingDB.Sign(&asserts.AssertionType{Name: "test-only", PrimaryKey: nil}, headers, nil, safs.signingKeyID)
+	c.Assert(err, ErrorMatches, `internal error: unpredefined assertion type for name "test-only" used.*`)
 	c.Check(a1, IsNil)
 }
 

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -313,7 +313,7 @@ func (safs *signAddFindSuite) TestSignUnknowType(c *C) {
 		"authority-id": "canonical",
 	}
 	a1, err := safs.signingDB.Sign(&asserts.AssertionType{Name: "xyz", PrimaryKey: nil}, headers, nil, safs.signingKeyID)
-	c.Assert(err, ErrorMatches, `unknown assertion type: xyz`)
+	c.Assert(err, ErrorMatches, "invalid assertion type")
 	c.Check(a1, IsNil)
 }
 

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -67,10 +67,7 @@ func assembleTestOnly(assert assertionBase) (Assertion, error) {
 var TestOnlyType = &AssertionType{"test-only", []string{"primary-key"}, assembleTestOnly}
 
 func init() {
-	typeRegistry[TestOnlyType] = &assertionTypeRegistration{
-		assembler:  assembleTestOnly,
-		primaryKey: TestOnlyType.PrimaryKey,
-	}
+	typeRegistry[TestOnlyType.Name] = TestOnlyType
 }
 
 // AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -64,7 +64,7 @@ func assembleTestOnly(assert assertionBase) (Assertion, error) {
 	return &TestOnly{assert}, nil
 }
 
-var TestOnlyType = AssertionType("test-only")
+var TestOnlyType = &AssertionType{"test-only"}
 
 func init() {
 	typeRegistry[TestOnlyType] = &assertionTypeRegistration{

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -64,8 +64,10 @@ func assembleTestOnly(assert assertionBase) (Assertion, error) {
 	return &TestOnly{assert}, nil
 }
 
+var TestOnlyType = AssertionType("test-only")
+
 func init() {
-	typeRegistry[AssertionType("test-only")] = &assertionTypeRegistration{
+	typeRegistry[TestOnlyType] = &assertionTypeRegistration{
 		assembler:  assembleTestOnly,
 		primaryKey: []string{"primary-key"},
 	}

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -64,12 +64,12 @@ func assembleTestOnly(assert assertionBase) (Assertion, error) {
 	return &TestOnly{assert}, nil
 }
 
-var TestOnlyType = &AssertionType{"test-only"}
+var TestOnlyType = &AssertionType{"test-only", []string{"primary-key"}, assembleTestOnly}
 
 func init() {
 	typeRegistry[TestOnlyType] = &assertionTypeRegistration{
 		assembler:  assembleTestOnly,
-		primaryKey: []string{"primary-key"},
+		primaryKey: TestOnlyType.PrimaryKey,
 	}
 }
 

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -48,8 +48,8 @@ func OpenFSBackstore(path string) (Backstore, error) {
 }
 
 // guarantees that result assertion is of the expected type (both in the AssertionType and go type sense)
-func (fsbs *filesystemBackstore) readAssertion(assertType AssertionType, diskPrimaryPath string) (Assertion, error) {
-	encoded, err := readEntry(fsbs.top, string(assertType), diskPrimaryPath)
+func (fsbs *filesystemBackstore) readAssertion(assertType *AssertionType, diskPrimaryPath string) (Assertion, error) {
+	encoded, err := readEntry(fsbs.top, assertType.Name, diskPrimaryPath)
 	if os.IsNotExist(err) {
 		return nil, ErrNotFound
 	}
@@ -61,7 +61,7 @@ func (fsbs *filesystemBackstore) readAssertion(assertType AssertionType, diskPri
 		return nil, fmt.Errorf("broken assertion storage, failed to decode assertion: %v", err)
 	}
 	if assert.Type() != assertType {
-		return nil, fmt.Errorf("assertion that is not of type %q under their storage tree", assertType)
+		return nil, fmt.Errorf("assertion that is not of type %q under their storage tree", assertType.Name)
 	}
 	// because of Decode() construction assert has also the expected go type
 	return assert, nil
@@ -76,7 +76,7 @@ func buildDiskPrimaryPath(primaryPath []string) string {
 	return filepath.Join(comps...)
 }
 
-func (fsbs *filesystemBackstore) Put(assertType AssertionType, primaryKeyHeaders []string, assert Assertion) error {
+func (fsbs *filesystemBackstore) Put(assertType *AssertionType, primaryKeyHeaders []string, assert Assertion) error {
 	primaryPath := make([]string, len(primaryKeyHeaders))
 	for i, k := range primaryKeyHeaders {
 		primaryPath[i] = assert.Header(k)
@@ -94,23 +94,23 @@ func (fsbs *filesystemBackstore) Put(assertType AssertionType, primaryKeyHeaders
 	} else if err != ErrNotFound {
 		return err
 	}
-	err = atomicWriteEntry(Encode(assert), false, fsbs.top, string(assertType), diskPrimaryPath)
+	err = atomicWriteEntry(Encode(assert), false, fsbs.top, assertType.Name, diskPrimaryPath)
 	if err != nil {
 		return fmt.Errorf("broken assertion storage, failed to write assertion: %v", err)
 	}
 	return nil
 }
 
-func (fsbs *filesystemBackstore) Get(assertType AssertionType, primaryKeyHeaders, key []string) (Assertion, error) {
+func (fsbs *filesystemBackstore) Get(assertType *AssertionType, primaryKeyHeaders, key []string) (Assertion, error) {
 	return fsbs.readAssertion(assertType, buildDiskPrimaryPath(key))
 }
 
-func (fsbs *filesystemBackstore) search(assertType AssertionType, diskPattern []string, foundCb func(Assertion)) error {
-	assertTypeTop := filepath.Join(fsbs.top, string(assertType))
+func (fsbs *filesystemBackstore) search(assertType *AssertionType, diskPattern []string, foundCb func(Assertion)) error {
+	assertTypeTop := filepath.Join(fsbs.top, assertType.Name)
 	candCb := func(diskPrimaryPath string) error {
 		a, err := fsbs.readAssertion(assertType, diskPrimaryPath)
 		if err == ErrNotFound {
-			return fmt.Errorf("broken assertion storage, disappearing entry: %s/%s", assertType, diskPrimaryPath)
+			return fmt.Errorf("broken assertion storage, disappearing entry: %s/%s", assertType.Name, diskPrimaryPath)
 		}
 		if err != nil {
 			return err
@@ -120,12 +120,12 @@ func (fsbs *filesystemBackstore) search(assertType AssertionType, diskPattern []
 	}
 	err := findWildcard(assertTypeTop, diskPattern, candCb)
 	if err != nil {
-		return fmt.Errorf("broken assertion storage, searching for %s: %v", assertType, err)
+		return fmt.Errorf("broken assertion storage, searching for %s: %v", assertType.Name, err)
 	}
 	return nil
 }
 
-func (fsbs *filesystemBackstore) Search(assertType AssertionType, primaryKeyHeaders []string, headers map[string]string, foundCb func(Assertion)) error {
+func (fsbs *filesystemBackstore) Search(assertType *AssertionType, primaryKeyHeaders []string, headers map[string]string, foundCb func(Assertion)) error {
 	diskPattern := make([]string, len(primaryKeyHeaders))
 	for i, k := range primaryKeyHeaders {
 		keyVal := headers[k]

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -192,12 +192,6 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 }
 
 func init() {
-	typeRegistry[SnapBuildType] = &assertionTypeRegistration{
-		assembler:  assembleSnapBuild,
-		primaryKey: SnapBuildType.PrimaryKey,
-	}
-	typeRegistry[SnapRevisionType] = &assertionTypeRegistration{
-		assembler:  assembleSnapRevision,
-		primaryKey: SnapRevisionType.PrimaryKey,
-	}
+	typeRegistry[SnapBuildType.Name] = SnapBuildType
+	typeRegistry[SnapRevisionType.Name] = SnapRevisionType
 }

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -194,10 +194,10 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 func init() {
 	typeRegistry[SnapBuildType] = &assertionTypeRegistration{
 		assembler:  assembleSnapBuild,
-		primaryKey: []string{"snap-id", "snap-digest"},
+		primaryKey: SnapBuildType.PrimaryKey,
 	}
 	typeRegistry[SnapRevisionType] = &assertionTypeRegistration{
 		assembler:  assembleSnapRevision,
-		primaryKey: []string{"snap-id", "snap-digest"},
+		primaryKey: SnapRevisionType.PrimaryKey,
 	}
 }

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -190,8 +190,3 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 		timestamp:     timestamp,
 	}, nil
 }
-
-func init() {
-	typeRegistry[SnapBuildType.Name] = SnapBuildType
-	typeRegistry[SnapRevisionType.Name] = SnapRevisionType
-}

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -70,7 +70,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
-	sdbs.probeAssert, err = asserts.AssembleAndSignInTest(asserts.AssertionType("test-only"), headers, nil, pk)
+	sdbs.probeAssert, err = asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, pk)
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
This makes AssertionType into a real struct with exposed metadata Name and PrimaryKey fields. There's now also a Type(name) function to go from name string to predefined AssertionType. 

These are useful to let users of the library have access to the primary key header names of an assertion and also check if a string is actually the valid name of a known assertion type.