### PR TITLE
move to the new error response

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -121,13 +121,13 @@ type response struct {
 }
 
 // errorResult is the real value of response.Result when an error occurs.
-// Note that only the 'Str' field is unmarshaled from JSON representation.
+// Note that only the 'message' field is unmarshaled from JSON representation.
 type errorResult struct {
-	Str string `json:"str"`
+	Message string `json:"message"`
 }
 
 func (e *errorResult) Error() string {
-	return e.Str
+	return e.Message
 }
 
 // SysInfo holds system information
@@ -145,7 +145,7 @@ func (rsp *response) err() error {
 	}
 	var resultErr errorResult
 	err := json.Unmarshal(rsp.Result, &resultErr)
-	if err != nil || resultErr.Str == "" {
+	if err != nil || resultErr.Message == "" {
 		return fmt.Errorf("server error: %q", rsp.Status)
 	}
 	return &resultErr

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -215,7 +215,7 @@ func (cs *clientSuite) TestClientRemoveCapabilityNotFound(c *check.C) {
 		"status_code": 404,
 		"type": "error",
 		"result": {
-			"str": "can't remove capability \"n\", no such capability"
+			"message": "can't remove capability \"n\", no such capability"
 		}
 	}`
 	err := cs.cli.RemoveCapability("n")

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -143,7 +143,7 @@ var (
 func sysInfo(c *Command, r *http.Request) Response {
 	lock, err := lockfile.Lock(dirs.SnapLockFile, true)
 	if err != nil {
-		return InternalError(err, "Unable to acquire lock")
+		return InternalError("unable to acquire lock: %v", err)
 	}
 	defer lock.Unlock()
 
@@ -181,7 +181,7 @@ func getSnapInfo(c *Command, r *http.Request) Response {
 
 	lock, err := lockfile.Lock(dirs.SnapLockFile, true)
 	if err != nil {
-		return InternalError(err, "Unable to acquire lock")
+		return InternalError("unable to acquire lock: %v", err)
 	}
 	defer lock.Unlock()
 
@@ -193,17 +193,17 @@ func getSnapInfo(c *Command, r *http.Request) Response {
 
 	bag := lightweight.PartBagByName(name, origin)
 	if bag == nil && part == nil {
-		return NotFound
+		return NotFound("unable to find snap with name %q and origin %q", name, origin)
 	}
 
 	route := c.d.router.Get(c.Path)
 	if route == nil {
-		return InternalError(nil, "router can't find route for snap %s.%s", name, origin)
+		return InternalError("router can't find route for snap %s.%s", name, origin)
 	}
 
 	url, err := route.URL("name", name, "origin", origin)
 	if err != nil {
-		return InternalError(err, "route can't build URL for snap %s.%s: %v", name, origin, err)
+		return InternalError("route can't build URL for snap %s.%s: %v", name, origin, err)
 	}
 
 	result := webify(bag.Map(part), url.String())
@@ -245,12 +245,12 @@ func (ps byQN) Less(a, b int) bool {
 func getSnapsInfo(c *Command, r *http.Request) Response {
 	route := c.d.router.Get(snapCmd.Path)
 	if route == nil {
-		return InternalError(nil, "router can't find route for snaps")
+		return InternalError("router can't find route for snaps")
 	}
 
 	lock, err := lockfile.Lock(dirs.SnapLockFile, true)
 	if err != nil {
-		return InternalError(err, "Unable to acquire lock")
+		return InternalError("unable to acquire lock: %v", err)
 	}
 	defer lock.Unlock()
 
@@ -273,7 +273,7 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 
 		url, err := route.URL("name", name, "origin", origin)
 		if err != nil {
-			return InternalError(err, "can't get route to details for %s.%s: %v", name, origin, err)
+			return InternalError("can't get route to details for %s.%s: %v", name, origin, err)
 		}
 
 		fullname := name + "." + origin
@@ -318,14 +318,14 @@ type svcDesc struct {
 func snapService(c *Command, r *http.Request) Response {
 	route := c.d.router.Get(operationCmd.Path)
 	if route == nil {
-		return InternalError(nil, "router can't find route for operation")
+		return InternalError("router can't find route for operation")
 	}
 
 	vars := muxVars(r)
 	name := vars["name"]
 	origin := vars["origin"]
 	if name == "" || origin == "" {
-		return BadRequest(nil, "missing name or origin")
+		return BadRequest("missing name or origin")
 	}
 	svcName := vars["service"]
 	pkgName := name + "." + origin
@@ -336,7 +336,7 @@ func snapService(c *Command, r *http.Request) Response {
 		decoder := json.NewDecoder(r.Body)
 		var cmd map[string]string
 		if err := decoder.Decode(&cmd); err != nil {
-			return BadRequest(err, "can't decode request body into service command: %v", err)
+			return BadRequest("can't decode request body into service command: %v", err)
 		}
 
 		action = cmd["action"]
@@ -350,7 +350,7 @@ func snapService(c *Command, r *http.Request) Response {
 		lock, err = lockfile.Lock(dirs.SnapLockFile, true)
 
 		if err != nil {
-			return InternalError(err, "Unable to acquire lock")
+			return InternalError("unable to acquire lock: %v", err)
 		}
 
 		defer func() {
@@ -359,28 +359,28 @@ func snapService(c *Command, r *http.Request) Response {
 			}
 		}()
 	default:
-		return BadRequest(nil, "unknown action %s", action)
+		return BadRequest("unknown action %s", action)
 	}
 
 	bag := lightweight.PartBagByName(name, origin)
 	idx := bag.ActiveIndex()
 	if idx < 0 {
-		return NotFound
+		return NotFound("unable to find snap with name %q and origin %q", name, origin)
 	}
 
 	ipart, err := bag.Load(idx)
 	if err != nil {
-		return InternalError(err, "unable to load active snap: %v", err)
+		return InternalError("unable to load active snap: %v", err)
 	}
 
 	part, ok := ipart.(*snappy.SnapPart)
 	if !ok {
-		return InternalError(nil, "active snap is not a *snappy.SnapPart: %T", ipart)
+		return InternalError("active snap is not a *snappy.SnapPart: %T", ipart)
 	}
 	svcs := part.ServiceYamls()
 
 	if len(svcs) == 0 {
-		return NotFound(nil, "snap %q has no services", pkgName)
+		return NotFound("snap %q has no services", pkgName)
 	}
 
 	svcmap := make(map[string]*svcDesc, len(svcs))
@@ -389,13 +389,13 @@ func snapService(c *Command, r *http.Request) Response {
 	}
 
 	if svcName != "" && svcmap[svcName] == nil {
-		return NotFound(nil, "snap %q has no service %q", pkgName, svcName)
+		return NotFound("snap %q has no service %q", pkgName, svcName)
 	}
 
 	// note findServices takes the *bare* name
 	actor, err := findServices(name, svcName, &progress.NullProgress{})
 	if err != nil {
-		return InternalError(err, "no services for %q [%q] found: %v", pkgName, svcName, err)
+		return InternalError("no services for %q [%q] found: %v", pkgName, svcName, err)
 	}
 
 	f := func() interface{} {
@@ -457,39 +457,39 @@ func snapConfig(c *Command, r *http.Request) Response {
 	name := vars["name"]
 	origin := vars["origin"]
 	if name == "" || origin == "" {
-		return BadRequest(nil, "missing name or origin")
+		return BadRequest("missing name or origin")
 	}
 	pkgName := name + "." + origin
 
 	lock, err := lockfile.Lock(dirs.SnapLockFile, true)
 	if err != nil {
-		return InternalError(err, "Unable to acquire lock")
+		return InternalError("unable to acquire lock: %v", err)
 	}
 	defer lock.Unlock()
 
 	bag := lightweight.PartBagByName(name, origin)
 	if bag == nil {
-		return NotFound
+		return NotFound("no snap found with name %q and origin %q", name, origin)
 	}
 
 	idx := bag.ActiveIndex()
 	if idx < 0 {
-		return BadRequest
+		return BadRequest("unable to configure non-active snap")
 	}
 
 	part, err := bag.Load(idx)
 	if err != nil {
-		return InternalError(err, "unable to get load active snap: %v", err)
+		return InternalError("unable to load active snap: %v", err)
 	}
 
 	bs, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return BadRequest(err, "reading config request body gave %v", err)
+		return BadRequest("reading config request body gave %v", err)
 	}
 
 	config, err := part.Config(bs)
 	if err != nil {
-		return InternalError(err, "unable to retrieve config for %s: %v", pkgName, err)
+		return InternalError("unable to retrieve config for %s: %v", pkgName, err)
 	}
 
 	return SyncResponse(config)
@@ -503,13 +503,13 @@ type configSubtask struct {
 func getOpInfo(c *Command, r *http.Request) Response {
 	route := c.d.router.Get(c.Path)
 	if route == nil {
-		return InternalError(nil, "router can't find route for operation")
+		return InternalError("router can't find route for operation")
 	}
 
 	id := muxVars(r)["uuid"]
 	task := c.d.GetTask(id)
 	if task == nil {
-		return NotFound
+		return NotFound("unable to find task with id %q", id)
 	}
 
 	return SyncResponse(task.Map(route))
@@ -523,11 +523,11 @@ func deleteOp(c *Command, r *http.Request) Response {
 	case nil:
 		return SyncResponse("done")
 	case errTaskNotFound:
-		return NotFound
+		return NotFound("unable to find task %q", id)
 	case errTaskStillRunning:
-		return BadRequest
+		return BadRequest("unable to delete task %q: still running", id)
 	default:
-		return InternalError(err, "")
+		return InternalError("unable to delete task %q: %v", id, err)
 	}
 }
 
@@ -574,7 +574,7 @@ func (inst *snapInstruction) install() interface{} {
 	_, err := snappyInstall(inst.pkg, flags, inst)
 	if err != nil {
 		if inst.License != nil && snappy.IsLicenseNotAccepted(err) {
-			return error(inst.License)
+			return inst.License
 		}
 		return err
 	}
@@ -651,13 +651,13 @@ var pkgActionDispatch = pkgActionDispatchImpl
 func postSnap(c *Command, r *http.Request) Response {
 	route := c.d.router.Get(operationCmd.Path)
 	if route == nil {
-		return InternalError(nil, "router can't find route for operation")
+		return InternalError("router can't find route for operation")
 	}
 
 	decoder := json.NewDecoder(r.Body)
 	var inst snapInstruction
 	if err := decoder.Decode(&inst); err != nil {
-		return BadRequest(err, "can't decode request body into snap instruction: %v", err)
+		return BadRequest("can't decode request body into snap instruction: %v", err)
 	}
 
 	vars := muxVars(r)
@@ -665,7 +665,7 @@ func postSnap(c *Command, r *http.Request) Response {
 
 	f := pkgActionDispatch(&inst)
 	if f == nil {
-		return BadRequest(nil, "unknown action %s", inst.Action)
+		return BadRequest("unknown action %s", inst.Action)
 	}
 
 	return AsyncResponse(c.d.AddTask(func() interface{} {
@@ -689,7 +689,7 @@ var newSnap = newSnapImpl
 func sideloadSnap(c *Command, r *http.Request) Response {
 	route := c.d.router.Get(operationCmd.Path)
 	if route == nil {
-		return InternalError(nil, "router can't find route for operation")
+		return InternalError("router can't find route for operation")
 	}
 
 	body := r.Body
@@ -701,12 +701,12 @@ func sideloadSnap(c *Command, r *http.Request) Response {
 
 		_, params, err := mime.ParseMediaType(contentType)
 		if err != nil {
-			return BadRequest(err, "")
+			return BadRequest("unable to parse POST body: %v", err)
 		}
 
 		form, err := multipart.NewReader(r.Body, params["boundary"]).ReadForm(maxReadBuflen)
 		if err != nil {
-			return BadRequest(err, "")
+			return BadRequest("unable to read POST form: %v", err)
 		}
 
 		// if allow-unsigned is present in the form, unsigned is OK
@@ -719,7 +719,7 @@ func sideloadSnap(c *Command, r *http.Request) Response {
 			for i := range v {
 				body, err = v[i].Open()
 				if err != nil {
-					return BadRequest(err, "")
+					return BadRequest("unable to open POST form file: %v", err)
 				}
 				defer body.Close()
 
@@ -738,12 +738,12 @@ func sideloadSnap(c *Command, r *http.Request) Response {
 
 	tmpf, err := ioutil.TempFile("", "snapd-sideload-pkg-")
 	if err != nil {
-		return InternalError(err, "can't create tempfile: %v", err)
+		return InternalError("can't create tempfile: %v", err)
 	}
 
 	if _, err := io.Copy(tmpf, body); err != nil {
 		os.Remove(tmpf.Name())
-		return InternalError(err, "can't copy request into tempfile: %v", err)
+		return InternalError("can't copy request into tempfile: %v", err)
 	}
 
 	return AsyncResponse(c.d.AddTask(func() interface{} {
@@ -776,18 +776,18 @@ func getLogs(c *Command, r *http.Request) Response {
 
 	lock, err := lockfile.Lock(dirs.SnapLockFile, true)
 	if err != nil {
-		return InternalError(err, "Unable to acquire lock")
+		return InternalError("unable to acquire lock: %v", err)
 	}
 	defer lock.Unlock()
 
 	actor, err := findServices(name, svcName, &progress.NullProgress{})
 	if err != nil {
-		return NotFound(err, "no services found for %q: %v", name, err)
+		return NotFound("no services found for %q: %v", name, err)
 	}
 
 	rawlogs, err := actor.Logs()
 	if err != nil {
-		return InternalError(err, "unable to get logs for %q: %v", name, err)
+		return InternalError("unable to get logs for %q: %v", name, err)
 	}
 
 	logs := make([]map[string]interface{}, len(rawlogs))
@@ -806,23 +806,24 @@ func getLogs(c *Command, r *http.Request) Response {
 func iconGet(name, origin string) Response {
 	lock, err := lockfile.Lock(dirs.SnapLockFile, true)
 	if err != nil {
-		return InternalError(err, "Unable to acquire lock")
+		return InternalError("unable to acquire lock: %v", err)
 	}
 	defer lock.Unlock()
 
 	bag := lightweight.PartBagByName(name, origin)
 	if bag == nil || len(bag.Versions) == 0 {
-		return NotFound
+		return NotFound("unable to find snap with name %q and origin %q", name, origin)
 	}
 
 	part := bag.LoadBest()
 	if part == nil {
-		return NotFound
+		return NotFound("unable to load snap with name %q and origin %q", name, origin)
 	}
 
 	path := filepath.Clean(part.Icon())
 	if !strings.HasPrefix(path, dirs.SnapSnapsDir) {
-		return BadRequest
+		// XXX: how could this happen?
+		return BadRequest("requested icon is not in snap path")
 	}
 
 	return FileResponse(path)
@@ -846,18 +847,20 @@ func addCapability(c *Command, r *http.Request) Response {
 	decoder := json.NewDecoder(r.Body)
 	var newCap caps.Capability
 	if err := decoder.Decode(&newCap); err != nil || newCap.TypeName == "" {
-		return BadRequest(err, "can't decode request body into a capability")
+		return BadRequest("can't decode request body into a capability: %v", err)
 	}
+
 	// Re-construct the perfect type object knowing just the type name that is
 	// passed through the JSON representation.
 	newType := c.d.capRepo.Type(newCap.TypeName)
 	if newType == nil {
-		err := fmt.Errorf("unknown type name %q", newCap.TypeName)
-		return BadRequest(err, "can't add capability")
+		return BadRequest("cannot add capability: unknown type name %q", newCap.TypeName)
 	}
+
 	if err := c.d.capRepo.Add(&newCap); err != nil {
-		return BadRequest(err, "can't add capability")
+		return BadRequest("%v", err)
 	}
+
 	return &resp{
 		Type:   ResponseTypeSync,
 		Status: http.StatusCreated,
@@ -874,8 +877,8 @@ func deleteCapability(c *Command, r *http.Request) Response {
 	case nil:
 		return SyncResponse(nil)
 	case *caps.NotFoundError:
-		return NotFound(err, "can't remove capability")
+		return NotFound("can't find capability %q: %v", name, err)
 	default:
-		return InternalError(err, "")
+		return InternalError("can't remove capability %q: %v", name, err)
 	}
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -242,7 +242,7 @@ func (s *apiSuite) TestSnapInfoBadRoute(c *check.C) {
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, http.StatusInternalServerError)
-	c.Check(rsp.Result.(*errorResult).Msg, check.Matches, `route can't build URL .*`)
+	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `route can't build URL .*`)
 }
 
 func (s *apiSuite) TestListIncludesAll(c *check.C) {
@@ -1041,8 +1041,9 @@ func (s *apiSuite) TestInstallLicensedIntegration(c *check.C) {
 	task.tomb.Wait()
 	c.Check(task.State(), check.Equals, TaskFailed)
 	errRes := task.output.(errorResult)
-	c.Check(errRes.Str, check.Equals, "license agreement required")
-	c.Check(errRes.Obj, check.DeepEquals, &licenseData{
+	c.Check(errRes.Message, check.Equals, "license agreement required")
+	c.Check(errRes.Kind, check.Equals, errorKindLicenseRequired)
+	c.Check(errRes.Value, check.DeepEquals, &licenseData{
 		Intro:   "hi",
 		License: "yak yak",
 	})
@@ -1154,7 +1155,7 @@ func (s *apiSuite) TestAddCapabilitiesNameClash(c *check.C) {
 	// Verify (external)
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Result.(*errorResult).Msg, check.Matches, `can't add capability`)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `cannot add capability "name": name already exists`)
 	// Verify (internal)
 	c.Check(d.capRepo.All(), testutil.DeepContains, *cap)
 	c.Check(d.capRepo.All(), check.Not(testutil.DeepContains), *capClashing)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -92,12 +92,12 @@ func (c *Command) canAccess(r *http.Request) bool {
 
 func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !c.canAccess(r) {
-		Forbidden.ServeHTTP(w, r)
+		Forbidden("access denied").ServeHTTP(w, r)
 		return
 	}
 
 	var rspf ResponseFunc
-	var rsp Response = BadMethod
+	var rsp = BadMethod("method %q not allowed", r.Method)
 
 	switch r.Method {
 	case "GET":
@@ -178,7 +178,7 @@ func (d *Daemon) addRoutes() {
 
 	// also maybe add a /favicon.ico handler...
 
-	d.router.NotFoundHandler = NotFound
+	d.router.NotFoundHandler = NotFound("not found")
 }
 
 // Start the Daemon

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -144,8 +144,8 @@ func AsyncResponse(result map[string]interface{}) Response {
 	}
 }
 
-// ErrorResponse builds an "error" response from the given error status.
-func ErrorResponse(status int) ErrorResponseFunc {
+// makeErrorResponder builds an errorResponder from the given error status.
+func makeErrorResponder(status int) errorResponder {
 	r := &resp{
 		Type:   ResponseTypeError,
 		Status: status,
@@ -167,16 +167,16 @@ func (f FileResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, string(f))
 }
 
-// ErrorResponseFunc is a callable that produces an error Response.
+// errorResponder is a callable that produces an error Response.
 // e.g., InternalError("something broke: %v", err), etc.
-type ErrorResponseFunc func(string, ...interface{}) Response
+type errorResponder func(string, ...interface{}) Response
 
 // standard error responses
 var (
-	NotFound       = ErrorResponse(http.StatusNotFound)
-	BadRequest     = ErrorResponse(http.StatusBadRequest)
-	BadMethod      = ErrorResponse(http.StatusMethodNotAllowed)
-	InternalError  = ErrorResponse(http.StatusInternalServerError)
-	NotImplemented = ErrorResponse(http.StatusNotImplemented)
-	Forbidden      = ErrorResponse(http.StatusForbidden)
+	NotFound       = makeErrorResponder(http.StatusNotFound)
+	BadRequest     = makeErrorResponder(http.StatusBadRequest)
+	BadMethod      = makeErrorResponder(http.StatusMethodNotAllowed)
+	InternalError  = makeErrorResponder(http.StatusInternalServerError)
+	NotImplemented = makeErrorResponder(http.StatusNotImplemented)
+	Forbidden      = makeErrorResponder(http.StatusForbidden)
 )

--- a/daemon/task.go
+++ b/daemon/task.go
@@ -130,13 +130,21 @@ func RunTask(f func() interface{}) *Task {
 		out := f()
 		t.output = out
 
-		if err, ok := out.(error); ok {
-			// // TODO: make errors properly json-serializable, and avoid this hack (loses info!)
+		switch out := out.(type) {
+		case *licenseData:
 			t.output = errorResult{
-				Obj: err,
-				Str: err.Error(),
+				Message: out.Error(),
+				Kind:    errorKindLicenseRequired,
+				Value:   out,
 			}
-			return err
+
+			return error(out)
+		case error:
+			t.output = errorResult{
+				Message: out.Error(),
+			}
+
+			return out
 		}
 
 		return nil

--- a/daemon/task_test.go
+++ b/daemon/task_test.go
@@ -80,7 +80,6 @@ func (s *taskSuite) TestFails(c *check.C) {
 
 	c.Check(t.State(), check.Equals, TaskFailed)
 	c.Check(t.Output(), check.DeepEquals, errorResult{
-		Obj: err,
-		Str: err.Error(),
+		Message: err.Error(),
 	})
 }

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -106,12 +106,20 @@ wrong, in those cases, the following return value is used:
 
 HTTP code must be one of of 400, 401, 403, 404, 405, 409, 412 or 500.
 
+Error *results* will also be used in the output of `async` responses.
+
 If, in implementing a client, you find yourself keying off of
 `message` to alter the behaviour of your client to e.g. better inform
 the user of the error or otherwise adapt to the error condition,
 **STOP** and *talk to us*; this is where `kind` comes in. New entries
 for `kind` (and associated `value` metadata) will be added as needed
 by client implementations.
+
+#### Error kinds
+
+kind               | value description
+-------------------|--------------------
+`license-required` | see “A note on licenses”, below
 
 ### Timestamps
 
@@ -316,12 +324,13 @@ field would be
 
 ```javascript
 "output": {
-    "obj": {
+    "value": {
         "agreed": false,
         "intro": "licensed requires that you accept the following license before continuing",
         "license": "In order to use this software you must agree with us."
     },
-    "str": "License agreement required."
+    "kind": "license-required",
+    "message": "License agreement required."
 }
 ```
 

--- a/integration-tests/tests/snapd_test.go
+++ b/integration-tests/tests/snapd_test.go
@@ -212,7 +212,7 @@ func do404(c *check.C, resource string) {
 		resource+path,
 		"GET",
 		apiInteraction{
-			responsePattern: `{"result":{},"status":"Not Found","status_code":404,"type":"error"}`})
+			responsePattern: `{"result":{"message":"not found"},"status":"Not Found","status_code":404,"type":"error"}`})
 }
 
 func doMethodNotAllowed(c *check.C, resource, verb string) {
@@ -220,7 +220,7 @@ func doMethodNotAllowed(c *check.C, resource, verb string) {
 		resource,
 		verb,
 		apiInteraction{
-			responsePattern: `{"result":{},"status":"Method Not Allowed","status_code":405,"type":"error"}`})
+			responsePattern: `{"result":{"message":"method \S+ not allowed"},"status":"Method Not Allowed","status_code":405,"type":"error"}`})
 }
 
 // makeRequest makes a request to the API according to the provided options.


### PR DESCRIPTION
daemon, client, docs/rest.md, snapd integration tests: move to the new error response

This implements the error response we agreed in Gramado, both for the sync error result and the async failure output, with human-readable message and optional machine-readable kind and value fields.
