### PR TITLE
client: filter snaps by source

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -54,10 +54,14 @@ const (
 // Snaps returns the list of all snaps installed on the system and
 // available for install from the store for this system.
 func (client *Client) Snaps() (map[string]*Snap, error) {
+	return client.snapsFromPath("/2.0/snaps")
+}
+
+func (client *Client) snapsFromPath(path string) (map[string]*Snap, error) {
 	const errPrefix = "cannot list snaps"
 
 	var result map[string]json.RawMessage
-	if err := client.doSync("GET", "/2.0/snaps", nil, &result); err != nil {
+	if err := client.doSync("GET", path, nil, &result); err != nil {
 		return nil, fmt.Errorf("%s: %s", errPrefix, err)
 	}
 

--- a/client/packages.go
+++ b/client/packages.go
@@ -22,6 +22,8 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 )
 
 // Snap holds the data for a snap as obtained from snapd.
@@ -35,6 +37,11 @@ type Snap struct {
 	Status        string `json:"status"`
 	Type          string `json:"type"`
 	Version       string `json:"version"`
+}
+
+// SnapFilter is used to filter snaps by source, name and/or type
+type SnapFilter struct {
+	Sources []string
 }
 
 // Statuses and types a snap may have.
@@ -55,6 +62,20 @@ const (
 // available for install from the store for this system.
 func (client *Client) Snaps() (map[string]*Snap, error) {
 	return client.snapsFromPath("/2.0/snaps")
+}
+
+// FilterSnaps returns a list of snaps per Snaps() but filtered by source, name
+// and/or type
+func (client *Client) FilterSnaps(filter SnapFilter) (map[string]*Snap, error) {
+	u := url.URL{Path: "/2.0/snaps"}
+
+	if len(filter.Sources) > 0 {
+		q := u.Query()
+		q.Set("sources", strings.Join(filter.Sources, ","))
+		u.RawQuery = q.Encode()
+	}
+
+	return client.snapsFromPath(u.String())
 }
 
 func (client *Client) snapsFromPath(path string) (map[string]*Snap, error) {

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -21,6 +21,7 @@ package client_test
 
 import (
 	"fmt"
+	"net/url"
 
 	"gopkg.in/check.v1"
 
@@ -88,6 +89,26 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 			Version:       "1.0.18",
 		},
 	})
+}
+
+func (cs *clientSuite) TestClientFilterSnaps(c *check.C) {
+	filterTests := []struct {
+		filter client.SnapFilter
+		path   string
+	}{
+		{client.SnapFilter{}, "/2.0/snaps"},
+		{client.SnapFilter{Sources: []string{"local"}}, "/2.0/snaps?sources=local"},
+		{client.SnapFilter{Sources: []string{"store"}}, "/2.0/snaps?sources=store"},
+		{client.SnapFilter{Sources: []string{"local", "store"}}, "/2.0/snaps?sources=local,store"},
+	}
+
+	for _, tt := range filterTests {
+		_, _ = cs.cli.FilterSnaps(tt.filter)
+		// query string parameters will be URL encoded
+		path, err := url.QueryUnescape(cs.req.URL.Path)
+		c.Assert(err, check.IsNil)
+		c.Assert(path, check.Equals, tt.path)
+	}
 }
 
 const (


### PR DESCRIPTION
Corresponds with #349 though could arguably land on master independently due to [the published API](https://github.com/ubuntu-core/snappy/blob/master/docs/rest.md#parameters-fixme-is-that-the-right-word-for-these).