### PR TITLE
skills: add a name validation function

### DIFF
--- a/skills/core.go
+++ b/skills/core.go
@@ -43,7 +43,7 @@ type Slot struct {
 }
 
 // Regular expression describing correct identifiers.
-var validName = regexp.MustCompile("^[a-z]([a-z0-9-]+[a-z0-9])?$")
+var validName = regexp.MustCompile("^[a-z]([a-z0-9-]*[a-z0-9])?$")
 
 // ValidateName checks if a string can be used as a skill or slot name.
 func ValidateName(name string) error {

--- a/skills/core.go
+++ b/skills/core.go
@@ -43,7 +43,7 @@ type Slot struct {
 }
 
 // Regular expression describing correct identifiers.
-var validName = regexp.MustCompile("^[a-z]([a-z0-9-]*[a-z0-9])?$")
+var validName = regexp.MustCompile("^[a-z](:?[a-z0-9-]*[a-z0-9])?$")
 
 // ValidateName checks if a string can be used as a skill or slot name.
 func ValidateName(name string) error {

--- a/skills/core.go
+++ b/skills/core.go
@@ -19,6 +19,11 @@
 
 package skills
 
+import (
+	"fmt"
+	"regexp"
+)
+
 // Skill represents a capacity offered by a snap.
 type Skill struct {
 	Name  string
@@ -35,4 +40,16 @@ type Slot struct {
 	Type  string
 	Attrs map[string]interface{}
 	Apps  []string
+}
+
+// Regular expression describing correct identifiers.
+var validName = regexp.MustCompile("^[a-z]([a-z0-9-]+[a-z0-9])?$")
+
+// ValidateName checks if a string can be used as a skill or slot name.
+func ValidateName(name string) error {
+	valid := validName.MatchString(name)
+	if !valid {
+		return fmt.Errorf("%q is not a valid skill or slot name", name)
+	}
+	return nil
 }

--- a/skills/core_test.go
+++ b/skills/core_test.go
@@ -20,8 +20,14 @@
 package skills
 
 import (
+	"testing"
+
 	. "gopkg.in/check.v1"
 )
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
 
 type CoreSuite struct{}
 

--- a/skills/core_test.go
+++ b/skills/core_test.go
@@ -34,13 +34,31 @@ type CoreSuite struct{}
 var _ = Suite(&CoreSuite{})
 
 func (s *CoreSuite) TestValidateName(c *C) {
-	c.Assert(ValidateName("name with space"), ErrorMatches,
-		`"name with space" is not a valid skill or slot name`)
-	c.Assert(ValidateName("name-with-trailing-dash-"), ErrorMatches,
-		`"name-with-trailing-dash-" is not a valid skill or slot name`)
-	c.Assert(ValidateName("name-with-3-dashes"), IsNil)
-	c.Assert(ValidateName("name"), IsNil)
-	c.Assert(ValidateName("a"), IsNil)
-	c.Assert(ValidateName("ab"), IsNil)
-	c.Assert(ValidateName("abc"), IsNil)
+	validNames := []string{
+		"a", "aa", "aaa", "aaaa",
+		"a-a", "aa-a", "a-aa",
+		"a0", "a-0", "a-0a",
+	}
+	for _, name := range validNames {
+		err := ValidateName(name)
+		c.Assert(err, IsNil)
+	}
+	invalidNames := []string{
+		// name cannot be empty
+		"",
+		// dashes alone are not a name
+		"-", "--",
+		// name should not end with a dash
+		"a-",
+		// name cannot have any spaces in it
+		"a ", " a", "a a",
+		// a number alone is not a name
+		"0", "123",
+		// identifier must be plain ASCII
+		"日本語", "한글", "ру́сский язы́к",
+	}
+	for _, name := range invalidNames {
+		err := ValidateName(name)
+		c.Assert(err, ErrorMatches, `".*" is not a valid skill or slot name`)
+	}
 }

--- a/skills/core_test.go
+++ b/skills/core_test.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package skills
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type CoreSuite struct{}
+
+var _ = Suite(&CoreSuite{})
+
+func (s *CoreSuite) TestValidateName(c *C) {
+	c.Assert(ValidateName("name with space"), ErrorMatches,
+		`"name with space" is not a valid skill or slot name`)
+	c.Assert(ValidateName("name-with-trailing-dash-"), ErrorMatches,
+		`"name-with-trailing-dash-" is not a valid skill or slot name`)
+	c.Assert(ValidateName("name-with-3-dashes"), IsNil)
+	c.Assert(ValidateName("name"), IsNil)
+}

--- a/skills/core_test.go
+++ b/skills/core_test.go
@@ -40,4 +40,7 @@ func (s *CoreSuite) TestValidateName(c *C) {
 		`"name-with-trailing-dash-" is not a valid skill or slot name`)
 	c.Assert(ValidateName("name-with-3-dashes"), IsNil)
 	c.Assert(ValidateName("name"), IsNil)
+	c.Assert(ValidateName("a"), IsNil)
+	c.Assert(ValidateName("ab"), IsNil)
+	c.Assert(ValidateName("abc"), IsNil)
 }


### PR DESCRIPTION
All skill, slot and type names are constrained to simple ASCII identifiers, optionally with internal dashes.