### PR TITLE
Feature/snap yaml

### DIFF
--- a/cmd/snappy/cmd_policygen.go
+++ b/cmd/snappy/cmd_policygen.go
@@ -33,7 +33,7 @@ type cmdPolicygen struct {
 	Compare       bool `long:"compare"`
 	Force         bool `short:"f" long:"force"`
 	Positional    struct {
-		PackageYaml string `positional-arg-name:"package.yaml path"`
+		SnapYaml string `positional-arg-name:"snap.yaml path"`
 	} `positional-args:"yes"`
 }
 
@@ -46,7 +46,7 @@ func init() {
 		logger.Panicf("Unable to install: %v", err)
 	}
 	addOptionDescription(arg, "force", i18n.G("Force policy generation."))
-	addOptionDescription(arg, "package.yaml path", i18n.G("The path to the package.yaml used to generate the apparmor policy."))
+	addOptionDescription(arg, "snap.yaml path", i18n.G("The path to the snap.yaml used to generate the apparmor policy."))
 }
 
 func (x *cmdPolicygen) Execute(args []string) error {
@@ -58,9 +58,9 @@ func (x *cmdPolicygen) doPolicygen() error {
 		return snappy.RegenerateAllPolicy(x.Force)
 	}
 
-	fn := x.Positional.PackageYaml
+	fn := x.Positional.SnapYaml
 	if fn == "" {
-		return fmt.Errorf(i18n.G("must supply path to package.yaml"))
+		return fmt.Errorf(i18n.G("must supply path to snap.yaml"))
 	}
 	if _, err := os.Stat(fn); err != nil {
 		return fmt.Errorf("policygen: no such file: %s", fn)

--- a/coreconfig/config.go
+++ b/coreconfig/config.go
@@ -167,7 +167,7 @@ func newSystemConfig() (*systemConfig, error) {
 var yamlMarshal = yaml.Marshal
 
 // Get is a special configuration case for the system, for which
-// there is no such entry in a package.yaml to satisfy the snappy config interface.
+// there is no such entry in a snap.yaml to satisfy the snappy config interface.
 // This implements getting the current configuration for ubuntu-core.
 func Get() (rawConfig string, err error) {
 	config, err := newSystemConfig()

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -311,7 +311,7 @@ var findServices = snappy.FindServices
 
 type svcDesc struct {
 	Op     string                       `json:"op"`
-	Spec   *snappy.ServiceYaml          `json:"spec"`
+	Spec   *snappy.AppYaml              `json:"spec"`
 	Status *snappy.PackageServiceStatus `json:"status"`
 }
 
@@ -377,7 +377,7 @@ func snapService(c *Command, r *http.Request) Response {
 	if !ok {
 		return InternalError(nil, "active snap is not a *snappy.SnapPart: %T", ipart)
 	}
-	svcs := part.ServiceYamls()
+	svcs := part.Apps()
 
 	if len(svcs) == 0 {
 		return NotFound(nil, "snap %q has no services", pkgName)
@@ -385,7 +385,10 @@ func snapService(c *Command, r *http.Request) Response {
 
 	svcmap := make(map[string]*svcDesc, len(svcs))
 	for i := range svcs {
-		svcmap[svcs[i].Name] = &svcDesc{Spec: &svcs[i], Op: action}
+		if svcs[i].Daemon == "" {
+			continue
+		}
+		svcmap[svcs[i].Name] = &svcDesc{Spec: svcs[i], Op: action}
 	}
 
 	if svcName != "" && svcmap[svcName] == nil {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -111,7 +111,7 @@ func (s *apiSuite) mkInstalled(c *check.C, name, origin, version string, active 
 name: %s
 version: %s
 %s`, name, version, extraYaml)
-	c.Check(ioutil.WriteFile(filepath.Join(metadir, "package.yaml"), []byte(content), 0644), check.IsNil)
+	c.Check(ioutil.WriteFile(filepath.Join(metadir, "snap.yaml"), []byte(content), 0644), check.IsNil)
 	c.Check(ioutil.WriteFile(filepath.Join(metadir, "hashes.yaml"), []byte(nil), 0644), check.IsNil)
 
 	if active {
@@ -130,7 +130,7 @@ gadget: {store: {id: %q}}
 	m := filepath.Join(d, "1", "meta")
 	c.Assert(os.MkdirAll(m, 0755), check.IsNil)
 	c.Assert(os.Symlink("1", filepath.Join(d, "current")), check.IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(m, "package.yaml"), content, 0644), check.IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(m, "snap.yaml"), content, 0644), check.IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(m, "hashes.yaml"), []byte(nil), 0644), check.IsNil)
 }
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -739,7 +739,10 @@ func (s *apiSuite) TestSnapServiceGet(c *check.C) {
 	req, err := http.NewRequest("GET", "/2.0/snaps/foo.bar/services", nil)
 	c.Assert(err, check.IsNil)
 
-	s.mkInstalled(c, "foo", "bar", "v1", true, "services: [{name: svc}]")
+	s.mkInstalled(c, "foo", "bar", "v1", true, `apps:
+ svc:
+  daemon: forking
+`)
 	s.vars = map[string]string{"name": "foo", "origin": "bar"} // NB: no service specified
 
 	rsp := snapService(snapSvcsCmd, req).(*resp)
@@ -750,7 +753,7 @@ func (s *apiSuite) TestSnapServiceGet(c *check.C) {
 	m := rsp.Result.(map[string]*svcDesc)
 	c.Assert(m["svc"], check.FitsTypeOf, new(svcDesc))
 	c.Check(m["svc"].Op, check.Equals, "status")
-	c.Check(m["svc"].Spec, check.DeepEquals, &snappy.ServiceYaml{Name: "svc", StopTimeout: timeout.DefaultTimeout})
+	c.Check(m["svc"].Spec, check.DeepEquals, &snappy.AppYaml{Name: "svc", Daemon: "forking", StopTimeout: timeout.DefaultTimeout})
 	c.Check(m["svc"].Status, check.DeepEquals, &snappy.PackageServiceStatus{ServiceName: "svc"})
 }
 
@@ -763,7 +766,11 @@ func (s *apiSuite) TestSnapServicePut(c *check.C) {
 	req, err := http.NewRequest("PUT", "/2.0/snaps/foo.bar/services", buf)
 	c.Assert(err, check.IsNil)
 
-	s.mkInstalled(c, "foo", "bar", "v1", true, "services: [{name: svc}]")
+	s.mkInstalled(c, "foo", "bar", "v1", true, `apps:
+ svc:
+  command: svc
+  daemon: forking
+`)
 	s.vars = map[string]string{"name": "foo", "origin": "bar"} // NB: no service specified
 
 	rsp := snapService(snapSvcsCmd, req).(*resp)
@@ -843,10 +850,10 @@ func (s *apiSuite) TestServiceLogs(c *check.C) {
 
 func (s *apiSuite) TestAppIconGet(c *check.C) {
 	// have an active foo.bar in the system
-	s.mkInstalled(c, "foo", "bar", "v1", true, "icon: icon.ick")
+	s.mkInstalled(c, "foo", "bar", "v1", true, "")
 
-	// have an icon for it in the snap itself
-	iconfile := filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "icon.ick")
+	// have an icon for it in the package itself
+	iconfile := filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "icon.ick")
 	c.Check(ioutil.WriteFile(iconfile, []byte("ick"), 0644), check.IsNil)
 
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
@@ -862,10 +869,10 @@ func (s *apiSuite) TestAppIconGet(c *check.C) {
 
 func (s *apiSuite) TestAppIconGetInactive(c *check.C) {
 	// have an *in*active foo.bar in the system
-	s.mkInstalled(c, "foo", "bar", "v1", false, "icon: icon.ick")
+	s.mkInstalled(c, "foo", "bar", "v1", false, "")
 
-	// have an icon for it in the snap itself
-	iconfile := filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "icon.ick")
+	// have an icon for it in the package itself
+	iconfile := filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "icon.ick")
 	c.Check(ioutil.WriteFile(iconfile, []byte("ick"), 0644), check.IsNil)
 
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
@@ -881,7 +888,11 @@ func (s *apiSuite) TestAppIconGetInactive(c *check.C) {
 
 func (s *apiSuite) TestAppIconGetNoIcon(c *check.C) {
 	// have an *in*active foo.bar in the system
-	s.mkInstalled(c, "foo", "bar", "v1", true, "") // NOTE: no icon in the yaml
+	s.mkInstalled(c, "foo", "bar", "v1", true, "")
+
+	// NO ICON!
+	err := os.RemoveAll(filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "icon.svg"))
+	c.Assert(err, check.IsNil)
 
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
 	req, err := http.NewRequest("GET", "/2.0/icons/foo.bar/icon", nil)

--- a/daemon/snappy_part_iface_test.go
+++ b/daemon/snappy_part_iface_test.go
@@ -53,7 +53,7 @@ type tP struct {
 	frameworks    []string
 	frameworksErr error
 
-	svcYamls []snappy.ServiceYaml
+	svcYamls map[string]*snappy.AppYaml
 }
 
 func (p *tP) Name() string         { return p.name }
@@ -85,4 +85,4 @@ func (p *tP) SetActive(bool, progress.Meter) error { return p.setActiveErr }
 func (p *tP) Frameworks() ([]string, error)        { return p.frameworks, p.frameworksErr }
 
 // for ServiceYamler interface:
-func (p *tP) ServiceYamls() []snappy.ServiceYaml { return p.svcYamls }
+func (p *tP) Apps() map[string]*snappy.AppYaml { return p.svcYamls }

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -66,7 +66,7 @@ frameworks from framework policies.
 ## Usage
 ### framework yaml
 
-For frameworks, meta/package.yaml might contain something like:
+For frameworks, meta/snap.yaml might contain something like:
 
     name: foo
     version: 1.1.234
@@ -147,7 +147,7 @@ might contain something like:
 
 ### App yaml
 
-For apps wanting to use a particular framework, meta/package.yaml simply
+For apps wanting to use a particular framework, meta/snap.yaml simply
 references the security policy provided by the framework. Eg, if a service in
 the `norf` app wants to access the `bar` service provided by the `foo`
 framework in the above framework yaml example, it might use:
@@ -218,7 +218,7 @@ The command line experience is:
     apps: hello-world
 
 A convenience afforded to frameworks is that commands don't require that the
-package name be appended. Eg, using the above `package.yaml`, use:
+package name be appended. Eg, using the above `snap.yaml`, use:
 
     $ baz --version
     1.1.235

--- a/docs/gadget.md
+++ b/docs/gadget.md
@@ -72,7 +72,7 @@ counterpart will use this information to brand the system accordingly.
 #### dtb
 
 The default dtb (device tree blob) can be overridden by a key entry point in
-the `package.yaml` for the `gadget`.
+the `snap.yaml` for the `gadget`.
 
 If a dtb is specified during provisioning, it will be selected as the dtb to
 use for the system. If using an AB partition layout, when an update for the
@@ -117,7 +117,7 @@ is doing.
 
 ## Structure and layout
 
-The `package.yaml` is structured as:
+The `snap.yaml` is structured as:
 
 
 	name: package-string # mandatory
@@ -189,7 +189,7 @@ Rules about packages in the config:
   `gadget` snap is also installed and can not be (re)configured after the
   install.
 
-The `gadget` part of the `package.yaml` is not a configuration per se and treated
+The `gadget` part of the `snap.yaml` is not a configuration per se and treated
 separately.
 
 Rules about `software`:

--- a/docs/meta.md
+++ b/docs/meta.md
@@ -5,13 +5,7 @@ are located under the `meta/` directory.
 
 The following files are supported:
 
-## readme.md
-
-The `readme.md` file contains a description of the snap. The snappy
-tools will automatically extract the heading as the short summary for
-the snap and the first paragraph as the description in the store.
-
-## package.yaml
+## snap.yaml
 
 This file describes the snap package and is the most important file
 for a snap package. The following keys are mandatory:
@@ -21,8 +15,9 @@ for a snap package. The following keys are mandatory:
 
 The following keys are optional:
 
-* `icon`: a SVG icon for the snap that is displayed in the store
-* `explicit-license-agreement`: set to `Y` if the user needs to accept a
+* `summary`: A short summary
+* `description`: A long description
+* `license-agreement`: set to `explicit` if the user needs to accept a
   special `meta/license.txt` before the snap can be installed
 * `license-version`: a string that, when it changes and
   `explicit-license-agreement` is `Y`, prompts the user to accept the

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,7 +20,7 @@ origin from the store if applicable -- only snaps of `type: app` (the
 default) use an origin to compose the `APP_ID`), the
 service/binary name and package version. The `APP_ID` takes the form of
 `<pkgname>.<origin>_<appname>_<version>`. For example, if this is in
-`package.yaml`:
+`snap.yaml`:
 
     name: foo
     version: 0.1
@@ -58,20 +58,20 @@ areas, whitelist syscall filtering via seccomp and device cgroups provides for
 strong application confinement and isolation (see below for future work).
 
 ### AppArmor
-Upon snap package install, `package.yaml` is examined and AppArmor profiles are
+Upon snap package install, `snap.yaml` is examined and AppArmor profiles are
 generated for each service and binary to have names based on the `APP_ID`.
 As mentioned, AppArmor profiles are template based and may be extended through
 policy groups, which are expressed in the yaml as `caps`.
 
 ### Seccomp
-Upon snap package install, `package.yaml` is examined and seccomp filters are
+Upon snap package install, `snap.yaml` is examined and seccomp filters are
 generated for each service and binary. Like with AppArmor, seccomp filters are
 template based and may be extended through filter groups, which are expressed
 in the yaml as `caps`.
 
 ## Defining snap policy
 
-The `package.yaml` need not specify anything for default confinement. Several
+The `snap.yaml` need not specify anything for default confinement. Several
 options are available to modify the confinement:
 
 * `caps`: (optional) list of (easy to understand, human readable) additional

--- a/integration-tests/data/snaps/wrong-yaml/meta/readme.md
+++ b/integration-tests/data/snaps/wrong-yaml/meta/readme.md
@@ -1,3 +1,3 @@
 Wrong metadata snap
 
-A snap with an invalid meta/package.yaml
+A snap with an invalid meta/snap.yaml

--- a/integration-tests/manual-tests.md
+++ b/integration-tests/manual-tests.md
@@ -1,12 +1,12 @@
 # Test gadget snap with pre-installed snaps
 
 1. Branch snappy-systems
-2. Modify the `package.yaml` to add a snap, e.g.:
+2. Modify the `snap.yaml` to add a snap, e.g.:
 
     ```diff
-    === modified file 'generic-amd64/meta/package.yaml'
-    --- generic-amd64/meta/package.yaml	2015-07-03 12:50:03 +0000
-    +++ generic-amd64/meta/package.yaml	2015-11-09 16:26:12 +0000
+    === modified file 'generic-amd64/meta/snap.yaml'
+    --- generic-amd64/meta/snap.yaml	2015-07-03 12:50:03 +0000
+    +++ generic-amd64/meta/snap.yaml	2015-11-09 16:26:12 +0000
     @@ -7,6 +7,8 @@
      config:
          ubuntu-core:
@@ -47,12 +47,12 @@
 # Test gadget snap with modules
 
 1. Branch snappy-systems
-2. Modify the `package.yaml` to add a module, e.g.:
+2. Modify the `snap.yaml` to add a module, e.g.:
 
     ```diff
-    === modified file 'generic-amd64/meta/package.yaml'
-    --- generic-amd64/meta/package.yaml	2015-07-03 12:50:03 +0000
-    +++ generic-amd64/meta/package.yaml	2015-11-12 10:14:30 +0000
+    === modified file 'generic-amd64/meta/snap.yaml'
+    --- generic-amd64/meta/snap.yaml	2015-07-03 12:50:03 +0000
+    +++ generic-amd64/meta/snap.yaml	2015-11-12 10:14:30 +0000
     @@ -7,6 +7,7 @@
      config:
          ubuntu-core:

--- a/integration-tests/testutils/store/store_test.go
+++ b/integration-tests/testutils/store/store_test.go
@@ -140,7 +140,7 @@ func (s *storeTestSuite) makeTestSnap(c *C, packageYamlContent string) string {
 	tmpdir := c.MkDir()
 	os.MkdirAll(filepath.Join(tmpdir, "meta"), 0755)
 
-	packageYaml := filepath.Join(tmpdir, "meta", "package.yaml")
+	packageYaml := filepath.Join(tmpdir, "meta", "snap.yaml")
 	err := ioutil.WriteFile(packageYaml, []byte(packageYamlContent), 0644)
 	c.Assert(err, IsNil)
 

--- a/integration-tests/testutils/store/store_test.go
+++ b/integration-tests/testutils/store/store_test.go
@@ -141,11 +141,7 @@ func (s *storeTestSuite) makeTestSnap(c *C, packageYamlContent string) string {
 	os.MkdirAll(filepath.Join(tmpdir, "meta"), 0755)
 
 	packageYaml := filepath.Join(tmpdir, "meta", "package.yaml")
-	ioutil.WriteFile(packageYaml, []byte(packageYamlContent), 0644)
-	readmeMd := filepath.Join(tmpdir, "meta", "readme.md")
-
-	content := "Random\nExample"
-	err := ioutil.WriteFile(readmeMd, []byte(content), 0644)
+	err := ioutil.WriteFile(packageYaml, []byte(packageYamlContent), 0644)
 	c.Assert(err, IsNil)
 
 	targetDir := s.store.blobDir

--- a/integration-tests/testutils/updates/updates.go
+++ b/integration-tests/testutils/updates/updates.go
@@ -84,7 +84,7 @@ func makeFakeUpdateForSnap(c *check.C, snap, targetDir string, changeFunc Change
 	copySnap(c, snap, fakeUpdateDir)
 
 	// fake new version
-	cli.ExecCommand(c, "sudo", "sed", "-i", `s/version:\(.*\)/version:\1+fake1/`, filepath.Join(fakeUpdateDir, "meta/package.yaml"))
+	cli.ExecCommand(c, "sudo", "sed", "-i", `s/version:\(.*\)/version:\1+fake1/`, filepath.Join(fakeUpdateDir, "meta/snap.yaml"))
 
 	if err := changeFunc(fakeUpdateDir); err != nil {
 		return err

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-01-19 12:57+0100\n"
+        "POT-Creation-Date: 2016-01-21 11:38+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -355,7 +355,7 @@ msgstr  ""
 msgid   "The package to rollback "
 msgstr  ""
 
-msgid   "The path to the package.yaml used to generate the apparmor policy."
+msgid   "The path to the snap.yaml used to generate the apparmor policy."
 msgstr  ""
 
 msgid   "The type of shell you want"
@@ -442,7 +442,7 @@ msgstr  ""
 msgid   "installed: %s\n"
 msgstr  ""
 
-msgid   "must supply path to package.yaml"
+msgid   "must supply path to snap.yaml"
 msgstr  ""
 
 msgid   "package name is required"

--- a/snap/lightweight/lightweight.go
+++ b/snap/lightweight/lightweight.go
@@ -171,7 +171,7 @@ func find(name string, origin string) map[string]*PartBag {
 			// the parts.
 			if typ == snap.TypeFramework && helpers.FileExists(filepath.Join(dirs.SnapSnapsDir, name)) {
 				// FIMXE: way too simplistic
-				if content, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, name, versions[0], "meta", "package.yaml")); err == nil {
+				if content, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, name, versions[0], "meta", "snap.yaml")); err == nil {
 					if bytes.Contains(content, []byte("\ntype: gadget\n")) {
 						typ = snap.TypeGadget
 						inst = dirs.SnapSnapsDir
@@ -254,7 +254,7 @@ type concreteSnap struct {
 }
 
 func (c *concreteSnap) IsInstalled(version string) bool {
-	return helpers.FileExists(filepath.Join(c.instdir, c.self.QualifiedName(), version, "meta", "package.yaml"))
+	return helpers.FileExists(filepath.Join(c.instdir, c.self.QualifiedName(), version, "meta", "snap.yaml"))
 }
 
 func (c *concreteSnap) ActiveIndex() int {
@@ -298,7 +298,7 @@ func (c *concreteSnap) ActiveIndex() int {
 }
 
 func (c *concreteSnap) Load(version string) (snappy.Part, error) {
-	yamlPath := filepath.Join(c.instdir, c.self.QualifiedName(), version, "meta", "package.yaml")
+	yamlPath := filepath.Join(c.instdir, c.self.QualifiedName(), version, "meta", "snap.yaml")
 	if !helpers.FileExists(yamlPath) {
 		return removed.New(c.self.Name, c.self.Origin, version, c.self.Type), nil
 	}

--- a/snap/lightweight/lightweight_test.go
+++ b/snap/lightweight/lightweight_test.go
@@ -73,7 +73,7 @@ func (s *lightweightSuite) MkInstalled(c *check.C, _type snap.Type, appdir, name
 	apath := filepath.Join(appdir, qn, version, "meta")
 	yaml := fmt.Sprintf("name: %s\nversion: %s\ntype: %s\n", name, version, _type)
 	c.Check(os.MkdirAll(apath, 0755), check.IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(apath, "package.yaml"), []byte(yaml), 0644), check.IsNil)
+	c.Check(ioutil.WriteFile(filepath.Join(apath, "snap.yaml"), []byte(yaml), 0644), check.IsNil)
 	c.Check(ioutil.WriteFile(filepath.Join(apath, "icon.png"), nil, 0644), check.IsNil)
 
 	if active {
@@ -276,8 +276,8 @@ func (s *lightweightSuite) TestMapInactiveGadgetNoPart(c *check.C) {
 
 func (s *lightweightSuite) TestLoadBadApp(c *check.C) {
 	s.MkRemoved(c, "quux.blah", "1")
-	// an unparsable package.yaml:
-	c.Check(os.MkdirAll(filepath.Join(dirs.SnapSnapsDir, "quux.blah", "1", "meta", "package.yaml"), 0755), check.IsNil)
+	// an unparsable snap.yaml:
+	c.Check(os.MkdirAll(filepath.Join(dirs.SnapSnapsDir, "quux.blah", "1", "meta", "snap.yaml"), 0755), check.IsNil)
 
 	bag := PartBagByName("quux", "blah")
 	c.Assert(bag, check.NotNil)

--- a/snap/lightweight/lightweight_test.go
+++ b/snap/lightweight/lightweight_test.go
@@ -71,10 +71,10 @@ func (s *lightweightSuite) MkInstalled(c *check.C, _type snap.Type, appdir, name
 	s.MkRemoved(c, qn, version)
 
 	apath := filepath.Join(appdir, qn, version, "meta")
-	yaml := fmt.Sprintf("name: %s\nversion: %s\nicon: icon.png\ntype: %s\n", name, version, _type)
+	yaml := fmt.Sprintf("name: %s\nversion: %s\ntype: %s\n", name, version, _type)
 	c.Check(os.MkdirAll(apath, 0755), check.IsNil)
 	c.Check(ioutil.WriteFile(filepath.Join(apath, "package.yaml"), []byte(yaml), 0644), check.IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(apath, "hashes.yaml"), nil, 0644), check.IsNil)
+	c.Check(ioutil.WriteFile(filepath.Join(apath, "icon.png"), nil, 0644), check.IsNil)
 
 	if active {
 		c.Check(os.Symlink(version, filepath.Join(appdir, qn, "current")), check.IsNil)
@@ -103,7 +103,7 @@ func (s *lightweightSuite) TestMapFmkNoPart(c *check.C) {
 		"origin":             "sideload",
 		"status":             "active",
 		"version":            "120",
-		"icon":               filepath.Join(s.d, "snaps", "fmk", "120", "icon.png"),
+		"icon":               filepath.Join(s.d, "snaps", "fmk", "120", "meta/icon.png"),
 		"type":               "framework",
 		"vendor":             "",
 		"download_size":      int64(-1),
@@ -174,7 +174,7 @@ func (s *lightweightSuite) TestMapAppNoPart(c *check.C) {
 		"origin":        "bar",
 		"status":        "active",
 		"version":       "1.0",
-		"icon":          filepath.Join(s.d, "snaps", "foo.bar", "1.0", "icon.png"),
+		"icon":          filepath.Join(s.d, "snaps", "foo.bar", "1.0", "meta/icon.png"),
 		"type":          "app",
 		"vendor":        "",
 		"download_size": int64(-1),
@@ -202,7 +202,7 @@ func (s *lightweightSuite) TestMapAppWithPart(c *check.C) {
 		"origin":           "bar",
 		"status":           "active",
 		"version":          "1.0",
-		"icon":             filepath.Join(s.d, "snaps", "foo.bar", "1.0", "icon.png"),
+		"icon":             filepath.Join(s.d, "snaps", "foo.bar", "1.0", "meta/icon.png"),
 		"type":             "app",
 		"vendor":           "",
 		"download_size":    int64(42),
@@ -266,7 +266,7 @@ func (s *lightweightSuite) TestMapInactiveGadgetNoPart(c *check.C) {
 		"origin":        "sideload", // best guess
 		"status":        "installed",
 		"version":       "3",
-		"icon":          filepath.Join(s.d, "snaps", "a-gadget", "3", "icon.png"),
+		"icon":          filepath.Join(s.d, "snaps", "a-gadget", "3", "meta/icon.png"),
 		"type":          "gadget",
 		"vendor":        "",
 		"download_size": int64(-1),

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -127,7 +127,7 @@ const (
 
 // Info returns information like name, type etc about the package
 func (s *Snap) Info() (*snap.Info, error) {
-	packageYaml, err := s.ReadFile("meta/package.yaml")
+	packageYaml, err := s.ReadFile("meta/snap.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("info failed for %s: %s", s.path, err)
 	}

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -48,8 +48,8 @@ func makeSnap(c *C, manifest, data string) *Snap {
 	tmp := c.MkDir()
 	err := os.MkdirAll(filepath.Join(tmp, "meta"), 0755)
 
-	// our regular package yaml
-	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "package.yaml"), []byte(manifest), 0644)
+	// our regular snap.yaml
+	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte(manifest), 0644)
 	c.Assert(err, IsNil)
 
 	// some data
@@ -86,7 +86,7 @@ func (s *SquashfsTestSuite) TestHashFile(c *C) {
 func (s *SquashfsTestSuite) TestReadFile(c *C) {
 	snap := makeSnap(c, "name: foo", "")
 
-	content, err := snap.ReadFile("meta/package.yaml")
+	content, err := snap.ReadFile("meta/snap.yaml")
 	c.Assert(err, IsNil)
 	c.Assert(string(content), Equals, "name: foo")
 }
@@ -105,7 +105,7 @@ func (s *SquashfsTestSuite) TestUnpackGlob(c *C) {
 	c.Assert(string(content), Equals, data)
 
 	// ensure glob was honored
-	c.Assert(helpers.FileExists(filepath.Join(outputDir, "meta/package.yaml")), Equals, false)
+	c.Assert(helpers.FileExists(filepath.Join(outputDir, "meta/snap.yaml")), Equals, false)
 }
 
 func (s *SquashfsTestSuite) TestBuild(c *C) {

--- a/snappy/build.go
+++ b/snappy/build.go
@@ -277,14 +277,10 @@ func prepare(sourceDir, targetDir, buildDir string) (snapName string, err error)
 		return "", err
 	}
 
-	if m.ExplicitLicenseAgreement {
+	if m.LicenseAgreement == "explicit" {
 		if err := licenseChecker(sourceDir); err != nil {
 			return "", err
 		}
-	}
-
-	if err := m.checkForNameClashes(); err != nil {
-		return "", err
 	}
 
 	if err := copyToBuildDir(sourceDir, buildDir); err != nil {

--- a/snappy/build.go
+++ b/snappy/build.go
@@ -138,36 +138,6 @@ func debArchitecture(m *packageYaml) string {
 	}
 }
 
-func parseReadme(readme string) (title, description string, err error) {
-	file, err := os.Open(readme)
-	if err != nil {
-		return "", "", err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		if title == "" {
-			title = scanner.Text()
-			continue
-		}
-
-		if description != "" && scanner.Text() == "" {
-			break
-		}
-		description += scanner.Text()
-	}
-	if title == "" {
-		return "", "", ErrReadmeInvalid
-	}
-
-	if strings.TrimSpace(description) == "" {
-		description = "no description"
-	}
-
-	return title, description, nil
-}
-
 // the du(1) command, useful to override for testing
 var duCmd = "du"
 

--- a/snappy/build.go
+++ b/snappy/build.go
@@ -242,7 +242,7 @@ var licenseChecker = checkLicenseExists
 
 func prepare(sourceDir, targetDir, buildDir string) (snapName string, err error) {
 	// ensure we have valid content
-	m, err := parsePackageYamlFile(filepath.Join(sourceDir, "meta", "package.yaml"))
+	m, err := parsePackageYamlFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
 	if err != nil {
 		return "", err
 	}

--- a/snappy/build.go
+++ b/snappy/build.go
@@ -127,7 +127,7 @@ func shouldExclude(basedir string, file string) bool {
 }
 
 // small helper that return the architecture or "multi" if its multiple arches
-func debArchitecture(m *packageYaml) string {
+func debArchitecture(m *snapYaml) string {
 	switch len(m.Architectures) {
 	case 0:
 		return "unknown"

--- a/snappy/build.go
+++ b/snappy/build.go
@@ -242,7 +242,7 @@ var licenseChecker = checkLicenseExists
 
 func prepare(sourceDir, targetDir, buildDir string) (snapName string, err error) {
 	// ensure we have valid content
-	m, err := parsePackageYamlFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
+	m, err := parseSnapYamlFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
 	if err != nil {
 		return "", err
 	}

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -83,13 +83,6 @@ func makeExampleSnapSourceDir(c *C, packageYaml string) string {
 	err = ioutil.WriteFile(filepath.Join(metaDir, "package.yaml"), []byte(packageYaml), 0644)
 	c.Assert(err, IsNil)
 
-	// meta/readme.md
-	readme := `some title
-
-some description`
-	err = ioutil.WriteFile(filepath.Join(metaDir, "readme.md"), []byte(readme), 0644)
-	c.Assert(err, IsNil)
-
 	const helloBinContent = `#!/bin/sh
 printf "hello world"
 `
@@ -291,7 +284,6 @@ integration:
 	c.Assert(err, IsNil)
 	for _, needle := range []string{
 		"meta/package.yaml",
-		"meta/readme.md",
 		"bin/hello-world",
 		"symlink -> bin/hello-world",
 	} {
@@ -323,7 +315,6 @@ integration:
 	c.Assert(err, IsNil)
 	for _, needle := range []string{
 		"meta/package.yaml",
-		"meta/readme.md",
 		"bin/hello-world",
 		"symlink -> bin/hello-world",
 	} {

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -132,11 +132,11 @@ func (s *BuildTestSuite) TestBuildNoManifestFails(c *C) {
 func (s *BuildTestSuite) TestBuildManifestRequiresMissingLicense(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, `name: hello
 version: 1.0.1
-architecture: ["i386", "amd64"]
+architectures: ["i386", "amd64"]
 integration:
  app:
   apparmor-profile: meta/hello.apparmor
-explicit-license-agreement: Y
+license-agreement: explicit
 `)
 	_, err := BuildSquashfsSnap(sourceDir, "")
 	c.Assert(err, NotNil) // XXX maybe make the error more explicit
@@ -145,11 +145,11 @@ explicit-license-agreement: Y
 func (s *BuildTestSuite) TestBuildManifestRequiresBlankLicense(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, `name: hello
 version: 1.0.1
-architecture: ["i386", "amd64"]
+architectures: ["i386", "amd64"]
 integration:
  app:
   apparmor-profile: meta/hello.apparmor
-explicit-license-agreement: Y
+license-agreement: explicit
 `)
 	lic := filepath.Join(sourceDir, "meta", "license.txt")
 	ioutil.WriteFile(lic, []byte("\n"), 0755)
@@ -252,18 +252,6 @@ func (s *BuildTestSuite) TestExcludeDynamicWeirdRegexps(c *C) {
 	c.Check(shouldExcludeDynamic(basedir, "*hello"), Equals, true)
 }
 
-func (s *BuildTestSuite) TestBuildChecksForClashes(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, `name: hello
-version: 1.0.1
-services:
- - name: foo
-binaries:
- - name: foo
-`)
-	_, err := BuildSquashfsSnap(sourceDir, "")
-	c.Assert(err, ErrorMatches, ".*binary and service both called foo.*")
-}
-
 func (s *BuildTestSuite) TestDebArchitecture(c *C) {
 	c.Check(debArchitecture(&packageYaml{Architectures: []string{"foo"}}), Equals, "foo")
 	c.Check(debArchitecture(&packageYaml{Architectures: []string{"foo", "bar"}}), Equals, "multi")
@@ -284,7 +272,7 @@ version: 1.0.1
 func (s *BuildTestSuite) TestBuildSquashfsSimple(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, `name: hello
 version: 1.0.1
-architecture: ["i386", "amd64"]
+architectures: ["i386", "amd64"]
 integration:
  app:
   apparmor-profile: meta/hello.apparmor
@@ -315,7 +303,7 @@ integration:
 func (s *BuildTestSuite) TestBuildSimpleOutputDir(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, `name: hello
 version: 1.0.1
-architecture: ["i386", "amd64"]
+architectures: ["i386", "amd64"]
 integration:
  app:
   apparmor-profile: meta/hello.apparmor

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -73,14 +73,14 @@ echo 17 some-dir`
 	duCmd = duCmdPath
 }
 
-func makeExampleSnapSourceDir(c *C, packageYaml string) string {
+func makeExampleSnapSourceDir(c *C, snapYamlContent string) string {
 	tempdir := c.MkDir()
 
 	// use meta/snap.yaml
 	metaDir := filepath.Join(tempdir, "meta")
 	err := os.Mkdir(metaDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(packageYaml), 0644)
+	err = ioutil.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(snapYamlContent), 0644)
 	c.Assert(err, IsNil)
 
 	const helloBinContent = `#!/bin/sh

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -76,11 +76,11 @@ echo 17 some-dir`
 func makeExampleSnapSourceDir(c *C, packageYaml string) string {
 	tempdir := c.MkDir()
 
-	// use meta/package.yaml
+	// use meta/snap.yaml
 	metaDir := filepath.Join(tempdir, "meta")
 	err := os.Mkdir(metaDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(metaDir, "package.yaml"), []byte(packageYaml), 0644)
+	err = ioutil.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(packageYaml), 0644)
 	c.Assert(err, IsNil)
 
 	const helloBinContent = `#!/bin/sh
@@ -117,7 +117,7 @@ printf "hello world"
 
 func (s *BuildTestSuite) TestBuildNoManifestFails(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "")
-	c.Assert(os.Remove(filepath.Join(sourceDir, "meta", "package.yaml")), IsNil)
+	c.Assert(os.Remove(filepath.Join(sourceDir, "meta", "snap.yaml")), IsNil)
 	_, err := BuildSquashfsSnap(sourceDir, "")
 	c.Assert(err, NotNil) // XXX maybe make the error more explicit
 }
@@ -283,7 +283,7 @@ integration:
 	output, err := exec.Command("unsquashfs", "-ll", "hello_1.0.1_multi.snap").CombinedOutput()
 	c.Assert(err, IsNil)
 	for _, needle := range []string{
-		"meta/package.yaml",
+		"meta/snap.yaml",
 		"bin/hello-world",
 		"symlink -> bin/hello-world",
 	} {
@@ -314,7 +314,7 @@ integration:
 	output, err := exec.Command("unsquashfs", "-ll", resultSnap).CombinedOutput()
 	c.Assert(err, IsNil)
 	for _, needle := range []string{
-		"meta/package.yaml",
+		"meta/snap.yaml",
 		"bin/hello-world",
 		"symlink -> bin/hello-world",
 	} {

--- a/snappy/build_test.go
+++ b/snappy/build_test.go
@@ -246,9 +246,9 @@ func (s *BuildTestSuite) TestExcludeDynamicWeirdRegexps(c *C) {
 }
 
 func (s *BuildTestSuite) TestDebArchitecture(c *C) {
-	c.Check(debArchitecture(&packageYaml{Architectures: []string{"foo"}}), Equals, "foo")
-	c.Check(debArchitecture(&packageYaml{Architectures: []string{"foo", "bar"}}), Equals, "multi")
-	c.Check(debArchitecture(&packageYaml{Architectures: nil}), Equals, "unknown")
+	c.Check(debArchitecture(&snapYaml{Architectures: []string{"foo"}}), Equals, "foo")
+	c.Check(debArchitecture(&snapYaml{Architectures: []string{"foo", "bar"}}), Equals, "multi")
+	c.Check(debArchitecture(&snapYaml{Architectures: nil}), Equals, "unknown")
 }
 
 func (s *BuildTestSuite) TestBuildFailsForUnknownType(c *C) {

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -63,7 +63,7 @@ func binPathForBinary(pkgPath string, app *AppYaml) string {
 	return filepath.Join(pkgPath, app.Command)
 }
 
-func verifyBinariesYaml(app *AppYaml) error {
+func verifyAppYaml(app *AppYaml) error {
 	return verifyStructStringsAgainstWhitelist(*app, servicesBinariesStringsWhitelist)
 }
 
@@ -109,7 +109,7 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 	// it's fine for this to error out; we might be in a framework or sth
 	origin := originFromBasedir(pkgPath)
 
-	if err := verifyBinariesYaml(app); err != nil {
+	if err := verifyAppYaml(app); err != nil {
 		return "", err
 	}
 
@@ -201,12 +201,8 @@ func verifyStructStringsAgainstWhitelist(s interface{}, whitelist *regexp.Regexp
 	return nil
 }
 
-func verifyServiceYaml(app *AppYaml) error {
-	return verifyStructStringsAgainstWhitelist(*app, servicesBinariesStringsWhitelist)
-}
-
 func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m *packageYaml) (string, error) {
-	if err := verifyServiceYaml(app); err != nil {
+	if err := verifyAppYaml(app); err != nil {
 		return "", err
 	}
 
@@ -245,7 +241,7 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 		}), nil
 }
 func generateSnapSocketFile(app *AppYaml, baseDir string, aaProfile string, m *packageYaml) (string, error) {
-	if err := verifyServiceYaml(app); err != nil {
+	if err := verifyAppYaml(app); err != nil {
 		return "", err
 	}
 

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -68,7 +68,15 @@ func verifyBinariesYaml(app *AppYaml) error {
 }
 
 func verifyUsesYaml(uses *usesYaml) error {
-	return verifyStructStringsAgainstWhitelist(*uses, servicesBinariesStringsWhitelist)
+	if err := verifyStructStringsAgainstWhitelist(*uses, servicesBinariesStringsWhitelist); err != nil {
+		return err
+	}
+
+	if uses.Type != "migration-skill" {
+		return fmt.Errorf("can not use skill %q, only migration-skill supported", uses.Type)
+	}
+
+	return nil
 }
 
 // Doesn't need to handle complications like internal quotes, just needs to

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -67,6 +67,10 @@ func verifyBinariesYaml(app *AppYaml) error {
 	return verifyStructStringsAgainstWhitelist(*app, servicesBinariesStringsWhitelist)
 }
 
+func verifyUsesYaml(uses *usesYaml) error {
+	return verifyStructStringsAgainstWhitelist(*uses, servicesBinariesStringsWhitelist)
+}
+
 // Doesn't need to handle complications like internal quotes, just needs to
 // wrap right side of an env variable declaration with quotes for the shell.
 func quoteEnvVar(envVar string) string {

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -44,7 +44,7 @@ import (
 var killWait = 5 * time.Second
 
 // servicesBinariesStringsWhitelist is the whitelist of legal chars
-// in the "binaries" and "services" section of the package.yaml
+// in the "binaries" and "services" section of the snap.yaml
 var servicesBinariesStringsWhitelist = regexp.MustCompile(`^[A-Za-z0-9/. _#:-]*$`)
 
 // generate the name

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -48,7 +48,7 @@ var killWait = 5 * time.Second
 var servicesBinariesStringsWhitelist = regexp.MustCompile(`^[A-Za-z0-9/. _#:-]*$`)
 
 // generate the name
-func generateBinaryName(m *packageYaml, app AppYaml) string {
+func generateBinaryName(m *packageYaml, app *AppYaml) string {
 	var binName string
 	if m.Type == snap.TypeFramework {
 		binName = filepath.Base(app.Name)
@@ -59,12 +59,12 @@ func generateBinaryName(m *packageYaml, app AppYaml) string {
 	return filepath.Join(dirs.SnapBinariesDir, binName)
 }
 
-func binPathForBinary(pkgPath string, app AppYaml) string {
+func binPathForBinary(pkgPath string, app *AppYaml) string {
 	return filepath.Join(pkgPath, app.Command)
 }
 
-func verifyBinariesYaml(app AppYaml) error {
-	return verifyStructStringsAgainstWhitelist(app, servicesBinariesStringsWhitelist)
+func verifyBinariesYaml(app *AppYaml) error {
+	return verifyStructStringsAgainstWhitelist(*app, servicesBinariesStringsWhitelist)
 }
 
 // Doesn't need to handle complications like internal quotes, just needs to
@@ -73,7 +73,7 @@ func quoteEnvVar(envVar string) string {
 	return "export " + strings.Replace(envVar, "=", "=\"", 1) + "\""
 }
 
-func generateSnapBinaryWrapper(app AppYaml, pkgPath, aaProfile string, m *packageYaml) (string, error) {
+func generateSnapBinaryWrapper(app *AppYaml, pkgPath, aaProfile string, m *packageYaml) (string, error) {
 	wrapperTemplate := `#!/bin/sh
 set -e
 
@@ -154,7 +154,6 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 // verifyStructStringsAgainstWhitelist takes a struct and ensures that
 // the given whitelist regexp matches all string fields of the struct
 func verifyStructStringsAgainstWhitelist(s interface{}, whitelist *regexp.Regexp) error {
-
 	// check all members of the services struct against our whitelist
 	t := reflect.TypeOf(s)
 	v := reflect.ValueOf(s)
@@ -190,11 +189,11 @@ func verifyStructStringsAgainstWhitelist(s interface{}, whitelist *regexp.Regexp
 	return nil
 }
 
-func verifyServiceYaml(app AppYaml) error {
-	return verifyStructStringsAgainstWhitelist(app, servicesBinariesStringsWhitelist)
+func verifyServiceYaml(app *AppYaml) error {
+	return verifyStructStringsAgainstWhitelist(*app, servicesBinariesStringsWhitelist)
 }
 
-func generateSnapServicesFile(app AppYaml, baseDir string, aaProfile string, m *packageYaml) (string, error) {
+func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m *packageYaml) (string, error) {
 	if err := verifyServiceYaml(app); err != nil {
 		return "", err
 	}
@@ -233,7 +232,7 @@ func generateSnapServicesFile(app AppYaml, baseDir string, aaProfile string, m *
 			Restart:        app.RestartCond,
 		}), nil
 }
-func generateSnapSocketFile(app AppYaml, baseDir string, aaProfile string, m *packageYaml) (string, error) {
+func generateSnapSocketFile(app *AppYaml, baseDir string, aaProfile string, m *packageYaml) (string, error) {
 	if err := verifyServiceYaml(app); err != nil {
 		return "", err
 	}
@@ -256,15 +255,15 @@ func generateSnapSocketFile(app AppYaml, baseDir string, aaProfile string, m *pa
 		}), nil
 }
 
-func generateServiceFileName(m *packageYaml, app AppYaml) string {
+func generateServiceFileName(m *packageYaml, app *AppYaml) string {
 	return filepath.Join(dirs.SnapServicesDir, fmt.Sprintf("%s_%s_%s.service", m.Name, app.Name, m.Version))
 }
 
-func generateSocketFileName(m *packageYaml, app AppYaml) string {
+func generateSocketFileName(m *packageYaml, app *AppYaml) string {
 	return filepath.Join(dirs.SnapServicesDir, fmt.Sprintf("%s_%s_%s.socket", m.Name, app.Name, m.Version))
 }
 
-func generateBusPolicyFileName(m *packageYaml, app AppYaml) string {
+func generateBusPolicyFileName(m *packageYaml, app *AppYaml) string {
 	return filepath.Join(dirs.SnapBusPolicyDir, fmt.Sprintf("%s_%s_%s.conf", m.Name, app.Name, m.Version))
 }
 

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -48,7 +48,7 @@ var killWait = 5 * time.Second
 var servicesBinariesStringsWhitelist = regexp.MustCompile(`^[A-Za-z0-9/. _#:-]*$`)
 
 // generate the name
-func generateBinaryName(m *packageYaml, app *AppYaml) string {
+func generateBinaryName(m *snapYaml, app *AppYaml) string {
 	var binName string
 	if m.Type == snap.TypeFramework {
 		binName = filepath.Base(app.Name)
@@ -85,7 +85,7 @@ func quoteEnvVar(envVar string) string {
 	return "export " + strings.Replace(envVar, "=", "=\"", 1) + "\""
 }
 
-func generateSnapBinaryWrapper(app *AppYaml, pkgPath, aaProfile string, m *packageYaml) (string, error) {
+func generateSnapBinaryWrapper(app *AppYaml, pkgPath, aaProfile string, m *snapYaml) (string, error) {
 	wrapperTemplate := `#!/bin/sh
 set -e
 
@@ -201,7 +201,7 @@ func verifyStructStringsAgainstWhitelist(s interface{}, whitelist *regexp.Regexp
 	return nil
 }
 
-func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m *packageYaml) (string, error) {
+func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m *snapYaml) (string, error) {
 	if err := verifyAppYaml(app); err != nil {
 		return "", err
 	}
@@ -240,7 +240,7 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 			Restart:        app.RestartCond,
 		}), nil
 }
-func generateSnapSocketFile(app *AppYaml, baseDir string, aaProfile string, m *packageYaml) (string, error) {
+func generateSnapSocketFile(app *AppYaml, baseDir string, aaProfile string, m *snapYaml) (string, error) {
 	if err := verifyAppYaml(app); err != nil {
 		return "", err
 	}
@@ -263,15 +263,15 @@ func generateSnapSocketFile(app *AppYaml, baseDir string, aaProfile string, m *p
 		}), nil
 }
 
-func generateServiceFileName(m *packageYaml, app *AppYaml) string {
+func generateServiceFileName(m *snapYaml, app *AppYaml) string {
 	return filepath.Join(dirs.SnapServicesDir, fmt.Sprintf("%s_%s_%s.service", m.Name, app.Name, m.Version))
 }
 
-func generateSocketFileName(m *packageYaml, app *AppYaml) string {
+func generateSocketFileName(m *snapYaml, app *AppYaml) string {
 	return filepath.Join(dirs.SnapServicesDir, fmt.Sprintf("%s_%s_%s.socket", m.Name, app.Name, m.Version))
 }
 
-func generateBusPolicyFileName(m *packageYaml, app *AppYaml) string {
+func generateBusPolicyFileName(m *snapYaml, app *AppYaml) string {
 	return filepath.Join(dirs.SnapBusPolicyDir, fmt.Sprintf("%s_%s_%s.conf", m.Name, app.Name, m.Version))
 }
 
@@ -288,7 +288,7 @@ func stripGlobalRootDirImpl(dir string) string {
 	return dir[len(dirs.GlobalRootDir):]
 }
 
-func (m *packageYaml) addPackageServices(baseDir string, inhibitHooks bool, inter interacter) error {
+func (m *snapYaml) addPackageServices(baseDir string, inhibitHooks bool, inter interacter) error {
 	for _, app := range m.Apps {
 		if app.Daemon == "" {
 			continue
@@ -379,7 +379,7 @@ func (m *packageYaml) addPackageServices(baseDir string, inhibitHooks bool, inte
 	return nil
 }
 
-func (m *packageYaml) removePackageServices(baseDir string, inter interacter) error {
+func (m *snapYaml) removePackageServices(baseDir string, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	for _, app := range m.Apps {
 		if app.Daemon == "" {
@@ -426,7 +426,7 @@ func (m *packageYaml) removePackageServices(baseDir string, inter interacter) er
 	return nil
 }
 
-func (m *packageYaml) addPackageBinaries(baseDir string) error {
+func (m *snapYaml) addPackageBinaries(baseDir string) error {
 	if err := os.MkdirAll(dirs.SnapBinariesDir, 0755); err != nil {
 		return err
 	}
@@ -458,7 +458,7 @@ func (m *packageYaml) addPackageBinaries(baseDir string) error {
 	return nil
 }
 
-func (m *packageYaml) removePackageBinaries(baseDir string) error {
+func (m *snapYaml) removePackageBinaries(baseDir string) error {
 	for _, app := range m.Apps {
 		os.Remove(generateBinaryName(m, app))
 	}

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -72,7 +72,7 @@ func (s *SnapTestSuite) TestLocalSnapInstallMissingAccepterFails(c *C) {
 	pkg := makeTestSnapPackage(c, `
 name: foo
 version: 1.0
-explicit-license-agreement: Y`)
+license-agreement: explicit`)
 	_, err := installClick(pkg, 0, nil, testOrigin)
 	c.Check(err, Equals, ErrLicenseNotAccepted)
 	c.Check(IsLicenseNotAccepted(err), Equals, true)
@@ -84,7 +84,7 @@ func (s *SnapTestSuite) TestLocalSnapInstallNegAccepterFails(c *C) {
 	pkg := makeTestSnapPackage(c, `
 name: foo
 version: 1.0
-explicit-license-agreement: Y`)
+license-agreement: explicit`)
 	_, err := installClick(pkg, 0, &MockProgressMeter{y: false}, testOrigin)
 	c.Check(err, Equals, ErrLicenseNotAccepted)
 	c.Check(IsLicenseNotAccepted(err), Equals, true)
@@ -99,7 +99,7 @@ func (s *SnapTestSuite) TestLocalSnapInstallNoLicenseFails(c *C) {
 	pkg := makeTestSnapPackageFull(c, `
 name: foo
 version: 1.0
-explicit-license-agreement: Y`, false)
+license-agreement: explicit`, false)
 	_, err := installClick(pkg, 0, &MockProgressMeter{y: true}, testOrigin)
 	c.Check(err, Equals, ErrLicenseNotProvided)
 	c.Check(IsLicenseNotAccepted(err), Equals, false)
@@ -111,7 +111,7 @@ func (s *SnapTestSuite) TestLocalSnapInstallPosAccepterWorks(c *C) {
 	pkg := makeTestSnapPackage(c, `
 name: foo
 version: 1.0
-explicit-license-agreement: Y`)
+license-agreement: explicit`)
 	_, err := installClick(pkg, 0, &MockProgressMeter{y: true}, testOrigin)
 	c.Check(err, Equals, nil)
 	c.Check(IsLicenseNotAccepted(err), Equals, false)
@@ -122,7 +122,7 @@ func (s *SnapTestSuite) TestLocalSnapInstallAccepterReasonable(c *C) {
 	pkg := makeTestSnapPackage(c, `
 name: foobar
 version: 1.0
-explicit-license-agreement: Y`)
+license-agreement: explicit`)
 	ag := &MockProgressMeter{y: true}
 	_, err := installClick(pkg, 0, ag, testOrigin)
 	c.Assert(err, Equals, nil)
@@ -136,7 +136,7 @@ explicit-license-agreement: Y`)
 func (s *SnapTestSuite) TestPreviouslyAcceptedLicense(c *C) {
 	ag := &MockProgressMeter{y: true}
 	yaml := `name: foox
-explicit-license-agreement: Y
+license-agreement: explicit
 license-version: 2
 `
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, yaml+"version: 1")
@@ -171,7 +171,7 @@ version: 1.0
 	c.Assert(err, IsNil)
 	c.Assert(part.activate(true, ag), IsNil)
 
-	pkg := makeTestSnapPackage(c, yaml+"version: 2\nexplicit-license-agreement: Y\n")
+	pkg := makeTestSnapPackage(c, yaml+"version: 2\nlicense-agreement: explicit\n")
 	_, err = installClick(pkg, 0, ag, testOrigin)
 	c.Check(IsLicenseNotAccepted(err), Equals, false)
 	c.Assert(err, Equals, nil)
@@ -183,7 +183,7 @@ version: 1.0
 func (s *SnapTestSuite) TestDifferentLicenseVersion(c *C) {
 	ag := &MockProgressMeter{y: true}
 	yaml := `name: foox
-explicit-license-agreement: Y
+license-agreement: explicit
 `
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, yaml+"license-version: 2\nversion: 1")
 	pkgdir := filepath.Dir(filepath.Dir(yamlFile))
@@ -302,7 +302,7 @@ func (s *SnapTestSuite) TestLocalGadgetSnapInstall(c *C) {
 	snapFile := makeTestSnapPackage(c, `name: foo
 version: 1.0
 type: gadget
-icon: foo.svg`)
+`)
 	_, err := installClick(snapFile, AllowGadget, nil, testOrigin)
 	c.Assert(err, IsNil)
 
@@ -315,7 +315,7 @@ func (s *SnapTestSuite) TestLocalGadgetSnapInstallVariants(c *C) {
 	snapFile := makeTestSnapPackage(c, `name: foo
 version: 1.0
 type: gadget
-icon: foo.svg`)
+`)
 	_, err := installClick(snapFile, AllowGadget, nil, testOrigin)
 	c.Assert(err, IsNil)
 	c.Assert(storeMinimalRemoteManifest("foo", "foo", testOrigin, "1.0", "", "remote-channel"), IsNil)
@@ -328,7 +328,7 @@ icon: foo.svg`)
 	snapFile = makeTestSnapPackage(c, `name: foo
 version: 2.0
 type: gadget
-icon: foo.svg`)
+`)
 	_, err = installClick(snapFile, 0, nil, testOrigin)
 	c.Check(err, IsNil)
 	c.Assert(storeMinimalRemoteManifest("foo", "foo", testOrigin, "2.0", "", "remote-channel"), IsNil)
@@ -347,7 +347,7 @@ icon: foo.svg`)
 	snapFile = makeTestSnapPackage(c, `name: foo-fork
 version: 2.0
 type: gadget
-icon: foo.svg`)
+`)
 	_, err = installClick(snapFile, 0, nil, testOrigin)
 	c.Check(err, Equals, ErrGadgetPackageInstall)
 
@@ -358,7 +358,6 @@ icon: foo.svg`)
 
 func (s *SnapTestSuite) TestClickSetActive(c *C) {
 	packageYaml := `name: foo
-icon: foo.svg
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
@@ -398,7 +397,6 @@ func (s *SnapTestSuite) TestClickCopyData(c *C) {
 	c.Assert(err, IsNil)
 
 	packageYaml := `name: foo
-icon: foo.svg
 `
 	canaryData := []byte("ni ni ni")
 
@@ -432,7 +430,6 @@ func (s *SnapTestSuite) TestClickCopyDataNoUserHomes(c *C) {
 	dirs.SnapDataHomeGlob = filepath.Join(s.tempdir, "no-such-home", "*", "snaps")
 
 	packageYaml := `name: foo
-icon: foo.svg
 `
 	appDir := "foo." + testOrigin
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
@@ -482,7 +479,7 @@ ubuntu-core-launcher pastebinit.mvo pastebinit.mvo_pastebinit_1.4.0.0.1 /snaps/p
 `
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
-	binary := AppYaml{Name: "pastebinit", Command: "bin/pastebinit"}
+	binary := &AppYaml{Name: "pastebinit", Command: "bin/pastebinit"}
 	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
 	aaProfile := "pastebinit.mvo_pastebinit_1.4.0.0.1"
 	m := packageYaml{Name: "pastebinit",
@@ -496,7 +493,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperFmk(c *C) {
-	binary := AppYaml{Name: "echo", Command: "bin/echo"}
+	binary := &AppYaml{Name: "echo", Command: "bin/echo"}
 	pkgPath := "/snaps/fmk/1.4.0.0.1/"
 	aaProfile := "fmk_echo_1.4.0.0.1"
 	m := packageYaml{Name: "fmk",
@@ -515,7 +512,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperFmk(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
-	binary := AppYaml{Name: "bin/pastebinit\nSomething nasty"}
+	binary := &AppYaml{Name: "bin/pastebinit\nSomething nasty"}
 	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
 	aaProfile := "pastebinit.mvo_pastebinit_1.4.0.0.1"
 	m := packageYaml{Name: "pastebinit",
@@ -526,13 +523,13 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyBinPathForBinaryNoExec(c *C) {
-	binary := AppYaml{Name: "pastebinit", Command: "bin/pastebinit"}
+	binary := &AppYaml{Name: "pastebinit", Command: "bin/pastebinit"}
 	pkgPath := "/snaps/pastebinit.mvo/1.0/"
 	c.Assert(binPathForBinary(pkgPath, binary), Equals, "/snaps/pastebinit.mvo/1.0/bin/pastebinit")
 }
 
 func (s *SnapTestSuite) TestSnappyBinPathForBinaryWithExec(c *C) {
-	binary := AppYaml{
+	binary := &AppYaml{
 		Name:    "pastebinit",
 		Command: "bin/random-pastebin",
 	}
@@ -542,9 +539,9 @@ func (s *SnapTestSuite) TestSnappyBinPathForBinaryWithExec(c *C) {
 
 func (s *SnapTestSuite) TestSnappyHandleBinariesOnUpgrade(c *C) {
 	packageYaml := `name: foo
-icon: foo.svg
-binaries:
- - name: bin/bar
+apps:
+ bar:
+  command: bin/bar
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")
@@ -570,10 +567,10 @@ binaries:
 
 func (s *SnapTestSuite) TestSnappyHandleServicesOnInstall(c *C) {
 	packageYaml := `name: foo
-icon: foo.svg
-services:
- - name: service
-   start: bin/hello
+apps:
+ service:
+   command: bin/hello
+   daemon: forking
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")
@@ -608,14 +605,15 @@ version: `
 	c.Assert(err, IsNil)
 
 	packageYaml := `name: foo
-icon: foo.svg
 frameworks:
  - fmk
-services:
- - name: svc1
-   start: bin/hello
- - name: svc2
-   start: bin/bye
+apps:
+ svc1:
+   command: bin/hello
+   daemon: forking
+ svc2:
+   command: bin/bye
+   daemon: forking
 version: `
 	snapFile := makeTestSnapPackage(c, packageYaml+"1.0")
 	_, err = installClick(snapFile, AllowUnauthenticated, inter, testOrigin)
@@ -728,10 +726,10 @@ func (s *SnapTestSuite) TestSnappyHandleServicesOnInstallInhibit(c *C) {
 	}
 
 	packageYaml := `name: foo
-icon: foo.svg
-services:
- - name: service
-   start: bin/hello
+apps:
+ service:
+   command: bin/hello
+   daemon: forking
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
 	_, err := installClick(snapFile, InhibitHooks, nil, testOrigin)
@@ -771,9 +769,10 @@ func (s *SnapTestSuite) TestAddPackageServicesBusPolicyFramework(c *C) {
 	yaml := `name: foo
 version: 1
 type: framework
-services:
-  - name: bar
+apps:
+  bar:
     bus-name: foo.bar.baz
+    daemon: forking
 `
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, yaml)
 	c.Assert(err, IsNil)
@@ -792,9 +791,10 @@ func (s *SnapTestSuite) TestAddPackageServicesBusPolicyNoFramework(c *C) {
 	yaml := `name: foo
 version: 1
 type: app
-services:
-  - name: bar
+apps:
+  bar:
     bus-name: foo.bar.baz
+    daemon: forking
 `
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, yaml)
 	c.Assert(err, IsNil)
@@ -859,7 +859,7 @@ WantedBy=multi-user.target
 )
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceTypeForking(c *C) {
-	service := AppYaml{
+	service := &AppYaml{
 		Name:        "xkcd-webserver",
 		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
@@ -879,7 +879,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceTypeForking(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapper(c *C) {
-	service := AppYaml{
+	service := &AppYaml{
 		Name:        "xkcd-webserver",
 		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
@@ -898,7 +898,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapper(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapperWithExternalPort(c *C) {
-	service := AppYaml{
+	service := &AppYaml{
 		Name:        "xkcd-webserver",
 		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
@@ -918,7 +918,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapperWithExternalPort(
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceFmkWrapper(c *C) {
-	service := AppYaml{
+	service := &AppYaml{
 		Name:        "xkcd-webserver",
 		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
@@ -941,7 +941,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceFmkWrapper(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceRestart(c *C) {
-	service := AppYaml{
+	service := &AppYaml{
 		Name:        "xkcd-webserver",
 		RestartCond: systemd.RestartOnAbort,
 	}
@@ -958,7 +958,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceRestart(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWrapperWhitelist(c *C) {
-	service := AppYaml{Name: "xkcd-webserver",
+	service := &AppYaml{Name: "xkcd-webserver",
 		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
@@ -975,34 +975,34 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWrapperWhitelist(c *C) {
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistSimple(c *C) {
-	c.Assert(verifyServiceYaml(AppYaml{Name: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(AppYaml{Description: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(AppYaml{Command: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(AppYaml{Stop: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(AppYaml{PostStop: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(&AppYaml{Name: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(&AppYaml{Description: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(&AppYaml{Command: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(&AppYaml{Stop: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(&AppYaml{PostStop: "foo"}), IsNil)
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistIllegal(c *C) {
-	c.Assert(verifyServiceYaml(AppYaml{Name: "x\n"}), NotNil)
-	c.Assert(verifyServiceYaml(AppYaml{Description: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(AppYaml{Command: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(AppYaml{Stop: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(AppYaml{PostStop: "foo\n"}), NotNil)
+	c.Assert(verifyServiceYaml(&AppYaml{Name: "x\n"}), NotNil)
+	c.Assert(verifyServiceYaml(&AppYaml{Description: "foo\n"}), NotNil)
+	c.Assert(verifyServiceYaml(&AppYaml{Command: "foo\n"}), NotNil)
+	c.Assert(verifyServiceYaml(&AppYaml{Stop: "foo\n"}), NotNil)
+	c.Assert(verifyServiceYaml(&AppYaml{PostStop: "foo\n"}), NotNil)
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistError(c *C) {
-	err := verifyServiceYaml(AppYaml{Name: "x\n"})
+	err := verifyServiceYaml(&AppYaml{Name: "x\n"})
 	c.Assert(err.Error(), Equals, "services description field 'Name' contains illegal 'x\n' (legal: '^[A-Za-z0-9/. _#:-]*$')")
 }
 
 func (s *SnapTestSuite) TestBinariesWhitelistSimple(c *C) {
-	c.Assert(verifyBinariesYaml(AppYaml{Name: "foo"}), IsNil)
-	c.Assert(verifyBinariesYaml(AppYaml{Command: "foo"}), IsNil)
-	c.Assert(verifyBinariesYaml(AppYaml{
+	c.Assert(verifyBinariesYaml(&AppYaml{Name: "foo"}), IsNil)
+	c.Assert(verifyBinariesYaml(&AppYaml{Command: "foo"}), IsNil)
+	c.Assert(verifyBinariesYaml(&AppYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityTemplate: "foo"},
 	}), IsNil)
-	c.Assert(verifyBinariesYaml(AppYaml{
+	c.Assert(verifyBinariesYaml(&AppYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityPolicy: &SecurityPolicyDefinition{
 				AppArmor: "foo"},
@@ -1011,44 +1011,19 @@ func (s *SnapTestSuite) TestBinariesWhitelistSimple(c *C) {
 }
 
 func (s *SnapTestSuite) TestBinariesWhitelistIllegal(c *C) {
-	c.Assert(verifyBinariesYaml(AppYaml{Name: "test!me"}), NotNil)
-	c.Assert(verifyBinariesYaml(AppYaml{Name: "x\n"}), NotNil)
-	c.Assert(verifyBinariesYaml(AppYaml{Command: "x\n"}), NotNil)
-	c.Assert(verifyBinariesYaml(AppYaml{
+	c.Assert(verifyBinariesYaml(&AppYaml{Name: "test!me"}), NotNil)
+	c.Assert(verifyBinariesYaml(&AppYaml{Name: "x\n"}), NotNil)
+	c.Assert(verifyBinariesYaml(&AppYaml{Command: "x\n"}), NotNil)
+	c.Assert(verifyBinariesYaml(&AppYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityTemplate: "x\n"},
 	}), NotNil)
-	c.Assert(verifyBinariesYaml(AppYaml{
+	c.Assert(verifyBinariesYaml(&AppYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityPolicy: &SecurityPolicyDefinition{
 				AppArmor: "x\n"},
 		},
 	}), NotNil)
-}
-
-func (s *SnapTestSuite) TestInstallChecksForClashes(c *C) {
-	// creating the thing by hand (as build refuses to)...
-	tmpdir := c.MkDir()
-	os.MkdirAll(filepath.Join(tmpdir, "meta"), 0755)
-	yaml := []byte(`name: hello
-version: 1.0.1
-services:
- - name: foo
-binaries:
- - name: foo
-`)
-	yamlFile := filepath.Join(tmpdir, "meta", "package.yaml")
-	c.Assert(ioutil.WriteFile(yamlFile, yaml, 0644), IsNil)
-	readmeMd := filepath.Join(tmpdir, "meta", "readme.md")
-	c.Assert(ioutil.WriteFile(readmeMd, []byte("blah\nx"), 0644), IsNil)
-	m, err := parsePackageYamlData(yaml, false)
-	c.Assert(err, IsNil)
-	snapName := fmt.Sprintf("%s_%s_all.snap", m.Name, m.Version)
-	d := squashfs.New(snapName)
-	c.Assert(d.Build(tmpdir), IsNil)
-
-	_, err = installClick(snapName, 0, nil, testOrigin)
-	c.Assert(err, ErrorMatches, ".*binary and service both called foo.*")
 }
 
 func (s *SnapTestSuite) TestInstallChecksFrameworks(c *C) {
@@ -1073,10 +1048,11 @@ func (s *SnapTestSuite) TestRemovePackageServiceKills(c *C) {
 	}
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, `name: wat
 version: 42
-icon: meta/wat.ico
-services:
- - name: wat
+apps:
+ wat:
+   command: wat
    stop-timeout: 25
+   daemon: forking
 `)
 	c.Assert(err, IsNil)
 	m, err := parsePackageYamlFile(yamlFile)
@@ -1104,7 +1080,7 @@ func (s *SnapTestSuite) TestCopySnapDataDirectoryError(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapSocket(c *C) {
-	service := AppYaml{Name: "xkcd-webserver",
+	service := &AppYaml{Name: "xkcd-webserver",
 		Command:      "bin/foo start",
 		Description:  "meep",
 		Socket:       true,
@@ -1138,7 +1114,7 @@ WantedBy=sockets.target
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWithSockte(c *C) {
-	service := AppYaml{
+	service := &AppYaml{
 		Name:        "xkcd-webserver",
 		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
@@ -1158,7 +1134,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWithSockte(c *C) {
 }
 
 func (s *SnapTestSuite) TestGenerateSnapSocketFile(c *C) {
-	srv := AppYaml{}
+	srv := &AppYaml{}
 	baseDir := "/base/dir"
 	aaProfile := "pkg_app_1.0"
 	m := &packageYaml{}
@@ -1178,9 +1154,9 @@ func (s *SnapTestSuite) TestGenerateSnapSocketFile(c *C) {
 
 func (s *SnapTestSuite) TestSnappyHandleBinariesOnInstall(c *C) {
 	packageYaml := `name: foo
-icon: foo.svg
-binaries:
- - name: bin/bar
+apps:
+ bar:
+  command: bin/bar
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -482,7 +482,7 @@ ubuntu-core-launcher pastebinit.mvo pastebinit.mvo_pastebinit_1.4.0.0.1 /snaps/p
 `
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
-	binary := Binary{Name: "pastebinit", Exec: "bin/pastebinit"}
+	binary := AppYaml{Name: "pastebinit", Command: "bin/pastebinit"}
 	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
 	aaProfile := "pastebinit.mvo_pastebinit_1.4.0.0.1"
 	m := packageYaml{Name: "pastebinit",
@@ -496,7 +496,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperFmk(c *C) {
-	binary := Binary{Name: "echo", Exec: "bin/echo"}
+	binary := AppYaml{Name: "echo", Command: "bin/echo"}
 	pkgPath := "/snaps/fmk/1.4.0.0.1/"
 	aaProfile := "fmk_echo_1.4.0.0.1"
 	m := packageYaml{Name: "fmk",
@@ -515,7 +515,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperFmk(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
-	binary := Binary{Name: "bin/pastebinit\nSomething nasty"}
+	binary := AppYaml{Name: "bin/pastebinit\nSomething nasty"}
 	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
 	aaProfile := "pastebinit.mvo_pastebinit_1.4.0.0.1"
 	m := packageYaml{Name: "pastebinit",
@@ -526,15 +526,15 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyBinPathForBinaryNoExec(c *C) {
-	binary := Binary{Name: "pastebinit", Exec: "bin/pastebinit"}
+	binary := AppYaml{Name: "pastebinit", Command: "bin/pastebinit"}
 	pkgPath := "/snaps/pastebinit.mvo/1.0/"
 	c.Assert(binPathForBinary(pkgPath, binary), Equals, "/snaps/pastebinit.mvo/1.0/bin/pastebinit")
 }
 
 func (s *SnapTestSuite) TestSnappyBinPathForBinaryWithExec(c *C) {
-	binary := Binary{
-		Name: "pastebinit",
-		Exec: "bin/random-pastebin",
+	binary := AppYaml{
+		Name:    "pastebinit",
+		Command: "bin/random-pastebin",
 	}
 	pkgPath := "/snaps/pastebinit.mvo/1.1/"
 	c.Assert(binPathForBinary(pkgPath, binary), Equals, "/snaps/pastebinit.mvo/1.1/bin/random-pastebin")
@@ -859,9 +859,9 @@ WantedBy=multi-user.target
 )
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceTypeForking(c *C) {
-	service := ServiceYaml{
+	service := AppYaml{
 		Name:        "xkcd-webserver",
-		Start:       "bin/foo start",
+		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
@@ -879,9 +879,9 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceTypeForking(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapper(c *C) {
-	service := ServiceYaml{
+	service := AppYaml{
 		Name:        "xkcd-webserver",
-		Start:       "bin/foo start",
+		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
@@ -898,9 +898,9 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapper(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapperWithExternalPort(c *C) {
-	service := ServiceYaml{
+	service := AppYaml{
 		Name:        "xkcd-webserver",
-		Start:       "bin/foo start",
+		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
@@ -918,9 +918,9 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapperWithExternalPort(
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceFmkWrapper(c *C) {
-	service := ServiceYaml{
+	service := AppYaml{
 		Name:        "xkcd-webserver",
-		Start:       "bin/foo start",
+		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
@@ -941,7 +941,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceFmkWrapper(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceRestart(c *C) {
-	service := ServiceYaml{
+	service := AppYaml{
 		Name:        "xkcd-webserver",
 		RestartCond: systemd.RestartOnAbort,
 	}
@@ -958,8 +958,8 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceRestart(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWrapperWhitelist(c *C) {
-	service := ServiceYaml{Name: "xkcd-webserver",
-		Start:       "bin/foo start",
+	service := AppYaml{Name: "xkcd-webserver",
+		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
@@ -975,34 +975,34 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWrapperWhitelist(c *C) {
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistSimple(c *C) {
-	c.Assert(verifyServiceYaml(ServiceYaml{Name: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(ServiceYaml{Description: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(ServiceYaml{Start: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(ServiceYaml{Stop: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(ServiceYaml{PostStop: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(AppYaml{Name: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(AppYaml{Description: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(AppYaml{Command: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(AppYaml{Stop: "foo"}), IsNil)
+	c.Assert(verifyServiceYaml(AppYaml{PostStop: "foo"}), IsNil)
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistIllegal(c *C) {
-	c.Assert(verifyServiceYaml(ServiceYaml{Name: "x\n"}), NotNil)
-	c.Assert(verifyServiceYaml(ServiceYaml{Description: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(ServiceYaml{Start: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(ServiceYaml{Stop: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(ServiceYaml{PostStop: "foo\n"}), NotNil)
+	c.Assert(verifyServiceYaml(AppYaml{Name: "x\n"}), NotNil)
+	c.Assert(verifyServiceYaml(AppYaml{Description: "foo\n"}), NotNil)
+	c.Assert(verifyServiceYaml(AppYaml{Command: "foo\n"}), NotNil)
+	c.Assert(verifyServiceYaml(AppYaml{Stop: "foo\n"}), NotNil)
+	c.Assert(verifyServiceYaml(AppYaml{PostStop: "foo\n"}), NotNil)
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistError(c *C) {
-	err := verifyServiceYaml(ServiceYaml{Name: "x\n"})
+	err := verifyServiceYaml(AppYaml{Name: "x\n"})
 	c.Assert(err.Error(), Equals, "services description field 'Name' contains illegal 'x\n' (legal: '^[A-Za-z0-9/. _#:-]*$')")
 }
 
 func (s *SnapTestSuite) TestBinariesWhitelistSimple(c *C) {
-	c.Assert(verifyBinariesYaml(Binary{Name: "foo"}), IsNil)
-	c.Assert(verifyBinariesYaml(Binary{Exec: "foo"}), IsNil)
-	c.Assert(verifyBinariesYaml(Binary{
+	c.Assert(verifyBinariesYaml(AppYaml{Name: "foo"}), IsNil)
+	c.Assert(verifyBinariesYaml(AppYaml{Command: "foo"}), IsNil)
+	c.Assert(verifyBinariesYaml(AppYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityTemplate: "foo"},
 	}), IsNil)
-	c.Assert(verifyBinariesYaml(Binary{
+	c.Assert(verifyBinariesYaml(AppYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityPolicy: &SecurityPolicyDefinition{
 				AppArmor: "foo"},
@@ -1011,14 +1011,14 @@ func (s *SnapTestSuite) TestBinariesWhitelistSimple(c *C) {
 }
 
 func (s *SnapTestSuite) TestBinariesWhitelistIllegal(c *C) {
-	c.Assert(verifyBinariesYaml(Binary{Name: "test!me"}), NotNil)
-	c.Assert(verifyBinariesYaml(Binary{Name: "x\n"}), NotNil)
-	c.Assert(verifyBinariesYaml(Binary{Exec: "x\n"}), NotNil)
-	c.Assert(verifyBinariesYaml(Binary{
+	c.Assert(verifyBinariesYaml(AppYaml{Name: "test!me"}), NotNil)
+	c.Assert(verifyBinariesYaml(AppYaml{Name: "x\n"}), NotNil)
+	c.Assert(verifyBinariesYaml(AppYaml{Command: "x\n"}), NotNil)
+	c.Assert(verifyBinariesYaml(AppYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityTemplate: "x\n"},
 	}), NotNil)
-	c.Assert(verifyBinariesYaml(Binary{
+	c.Assert(verifyBinariesYaml(AppYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityPolicy: &SecurityPolicyDefinition{
 				AppArmor: "x\n"},
@@ -1104,8 +1104,8 @@ func (s *SnapTestSuite) TestCopySnapDataDirectoryError(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapSocket(c *C) {
-	service := ServiceYaml{Name: "xkcd-webserver",
-		Start:        "bin/foo start",
+	service := AppYaml{Name: "xkcd-webserver",
+		Command:      "bin/foo start",
 		Description:  "meep",
 		Socket:       true,
 		ListenStream: "/var/run/docker.sock",
@@ -1138,9 +1138,9 @@ WantedBy=sockets.target
 }
 
 func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWithSockte(c *C) {
-	service := ServiceYaml{
+	service := AppYaml{
 		Name:        "xkcd-webserver",
-		Start:       "bin/foo start",
+		Command:     "bin/foo start",
 		Stop:        "bin/foo stop",
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
@@ -1158,7 +1158,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWithSockte(c *C) {
 }
 
 func (s *SnapTestSuite) TestGenerateSnapSocketFile(c *C) {
-	srv := ServiceYaml{}
+	srv := AppYaml{}
 	baseDir := "/base/dir"
 	aaProfile := "pkg_app_1.0"
 	m := &packageYaml{}

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -249,8 +249,6 @@ type: framework
 
 	yamlFile := filepath.Join(tmpdir, "meta", "package.yaml")
 	c.Assert(ioutil.WriteFile(yamlFile, yaml, 0644), IsNil)
-	readmeMd := filepath.Join(tmpdir, "meta", "readme.md")
-	c.Assert(ioutil.WriteFile(readmeMd, []byte("blah\nx"), 0644), IsNil)
 	m, err := parsePackageYamlData(yaml, false)
 	c.Assert(err, IsNil)
 	snapName := fmt.Sprintf("%s_%s_all.snap", m.Name, m.Version)

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -973,29 +973,29 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWrapperWhitelist(c *C) {
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistSimple(c *C) {
-	c.Assert(verifyServiceYaml(&AppYaml{Name: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(&AppYaml{Description: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(&AppYaml{Command: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(&AppYaml{Stop: "foo"}), IsNil)
-	c.Assert(verifyServiceYaml(&AppYaml{PostStop: "foo"}), IsNil)
+	c.Assert(verifyAppYaml(&AppYaml{Name: "foo"}), IsNil)
+	c.Assert(verifyAppYaml(&AppYaml{Description: "foo"}), IsNil)
+	c.Assert(verifyAppYaml(&AppYaml{Command: "foo"}), IsNil)
+	c.Assert(verifyAppYaml(&AppYaml{Stop: "foo"}), IsNil)
+	c.Assert(verifyAppYaml(&AppYaml{PostStop: "foo"}), IsNil)
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistIllegal(c *C) {
-	c.Assert(verifyServiceYaml(&AppYaml{Name: "x\n"}), NotNil)
-	c.Assert(verifyServiceYaml(&AppYaml{Description: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(&AppYaml{Command: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(&AppYaml{Stop: "foo\n"}), NotNil)
-	c.Assert(verifyServiceYaml(&AppYaml{PostStop: "foo\n"}), NotNil)
+	c.Assert(verifyAppYaml(&AppYaml{Name: "x\n"}), NotNil)
+	c.Assert(verifyAppYaml(&AppYaml{Description: "foo\n"}), NotNil)
+	c.Assert(verifyAppYaml(&AppYaml{Command: "foo\n"}), NotNil)
+	c.Assert(verifyAppYaml(&AppYaml{Stop: "foo\n"}), NotNil)
+	c.Assert(verifyAppYaml(&AppYaml{PostStop: "foo\n"}), NotNil)
 }
 
 func (s *SnapTestSuite) TestServiceWhitelistError(c *C) {
-	err := verifyServiceYaml(&AppYaml{Name: "x\n"})
+	err := verifyAppYaml(&AppYaml{Name: "x\n"})
 	c.Assert(err.Error(), Equals, `services description field 'Name' contains illegal "x\n" (legal: '^[A-Za-z0-9/. _#:-]*$')`)
 }
 
 func (s *SnapTestSuite) TestBinariesWhitelistSimple(c *C) {
-	c.Assert(verifyBinariesYaml(&AppYaml{Name: "foo"}), IsNil)
-	c.Assert(verifyBinariesYaml(&AppYaml{Command: "foo"}), IsNil)
+	c.Assert(verifyAppYaml(&AppYaml{Name: "foo"}), IsNil)
+	c.Assert(verifyAppYaml(&AppYaml{Command: "foo"}), IsNil)
 }
 
 func (s *SnapTestSuite) TestUsesWhitelistSimple(c *C) {
@@ -1014,9 +1014,9 @@ func (s *SnapTestSuite) TestUsesWhitelistSimple(c *C) {
 }
 
 func (s *SnapTestSuite) TestBinariesWhitelistIllegal(c *C) {
-	c.Assert(verifyBinariesYaml(&AppYaml{Name: "test!me"}), NotNil)
-	c.Assert(verifyBinariesYaml(&AppYaml{Name: "x\n"}), NotNil)
-	c.Assert(verifyBinariesYaml(&AppYaml{Command: "x\n"}), NotNil)
+	c.Assert(verifyAppYaml(&AppYaml{Name: "test!me"}), NotNil)
+	c.Assert(verifyAppYaml(&AppYaml{Name: "x\n"}), NotNil)
+	c.Assert(verifyAppYaml(&AppYaml{Command: "x\n"}), NotNil)
 }
 
 func (s *SnapTestSuite) TestWrongType(c *C) {

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -355,13 +355,13 @@ type: gadget
 }
 
 func (s *SnapTestSuite) TestClickSetActive(c *C) {
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 `
-	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
+	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
 	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 
@@ -394,11 +394,11 @@ func (s *SnapTestSuite) TestClickCopyData(c *C) {
 	err := os.MkdirAll(homeData, 0755)
 	c.Assert(err, IsNil)
 
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 `
 	canaryData := []byte("ni ni ni")
 
-	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	canaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "1.0", "canary.txt")
@@ -407,7 +407,7 @@ func (s *SnapTestSuite) TestClickCopyData(c *C) {
 	err = ioutil.WriteFile(filepath.Join(homeData, "canary.home"), canaryData, 0644)
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
+	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
 	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	newCanaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "2.0", "canary.txt")
@@ -427,17 +427,17 @@ func (s *SnapTestSuite) TestClickCopyDataNoUserHomes(c *C) {
 	// this home dir path does not exist
 	dirs.SnapDataHomeGlob = filepath.Join(s.tempdir, "no-such-home", "*", "snaps")
 
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 `
 	appDir := "foo." + testOrigin
-	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	canaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "1.0", "canary.txt")
 	err = ioutil.WriteFile(canaryDataFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
+	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
 	_, err = installClick(snapFile, AllowUnauthenticated, nil, testOrigin)
 	c.Assert(err, IsNil)
 	_, err = os.Stat(filepath.Join(dirs.SnapDataDir, appDir, "2.0", "canary.txt"))
@@ -536,12 +536,12 @@ func (s *SnapTestSuite) TestSnappyBinPathForBinaryWithExec(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyHandleBinariesOnUpgrade(c *C) {
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 apps:
  bar:
   command: bin/bar
 `
-	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")
 	c.Assert(err, IsNil)
 
@@ -554,7 +554,7 @@ apps:
 	c.Assert(strings.Contains(string(content), oldSnapBin), Equals, true)
 
 	// and that it gets updated on upgrade
-	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
+	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
 	_, err = installClick(snapFile, AllowUnauthenticated, nil, "mvo")
 	c.Assert(err, IsNil)
 	newSnapBin := filepath.Join(dirs.SnapSnapsDir[len(dirs.GlobalRootDir):], "foo.mvo", "2.0", "bin", "bar")
@@ -564,13 +564,13 @@ apps:
 }
 
 func (s *SnapTestSuite) TestSnappyHandleServicesOnInstall(c *C) {
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 apps:
  service:
    command: bin/hello
    daemon: forking
 `
-	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")
 	c.Assert(err, IsNil)
 
@@ -602,7 +602,7 @@ version: `
 	_, err := installClick(fmkFile, AllowUnauthenticated, inter, "")
 	c.Assert(err, IsNil)
 
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 frameworks:
  - fmk
 apps:
@@ -613,7 +613,7 @@ apps:
    command: bin/bye
    daemon: forking
 version: `
-	snapFile := makeTestSnapPackage(c, packageYaml+"1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"1.0")
 	_, err = installClick(snapFile, AllowUnauthenticated, inter, testOrigin)
 	c.Assert(err, IsNil)
 
@@ -723,13 +723,13 @@ func (s *SnapTestSuite) TestSnappyHandleServicesOnInstallInhibit(c *C) {
 		return []byte("ActiveState=inactive\n"), nil
 	}
 
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 apps:
  service:
    command: bin/hello
    daemon: forking
 `
-	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err := installClick(snapFile, InhibitHooks, nil, testOrigin)
 	c.Assert(err, IsNil)
 
@@ -1041,12 +1041,12 @@ func (s *SnapTestSuite) TestUsesWhitelistIllegal(c *C) {
 }
 
 func (s *SnapTestSuite) TestInstallChecksFrameworks(c *C) {
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 version: 0.1
 frameworks:
   - missing
 `
-	snapFile := makeTestSnapPackage(c, packageYaml)
+	snapFile := makeTestSnapPackage(c, snapYamlContent)
 	_, err := installClick(snapFile, 0, nil, testOrigin)
 	c.Assert(err, ErrorMatches, `.*missing framework.*`)
 }
@@ -1167,12 +1167,12 @@ func (s *SnapTestSuite) TestGenerateSnapSocketFile(c *C) {
 }
 
 func (s *SnapTestSuite) TestSnappyHandleBinariesOnInstall(c *C) {
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 apps:
  bar:
   command: bin/bar
 `
-	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err := installClick(snapFile, AllowUnauthenticated, nil, "mvo")
 	c.Assert(err, IsNil)
 

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -217,7 +217,7 @@ func (s *SnapTestSuite) TestSnapRemove(c *C) {
 	_, err = os.Stat(instDir)
 	c.Assert(err, IsNil)
 
-	yamlPath := filepath.Join(instDir, "meta", "package.yaml")
+	yamlPath := filepath.Join(instDir, "meta", "snap.yaml")
 	part, err := NewInstalledSnapPart(yamlPath, testOrigin)
 	c.Assert(err, IsNil)
 	err = part.remove(&MockProgressMeter{})
@@ -247,7 +247,7 @@ version: 1.0.1
 type: framework
 `)
 
-	yamlFile := filepath.Join(tmpdir, "meta", "package.yaml")
+	yamlFile := filepath.Join(tmpdir, "meta", "snap.yaml")
 	c.Assert(ioutil.WriteFile(yamlFile, yaml, 0644), IsNil)
 	m, err := parsePackageYamlData(yaml, false)
 	c.Assert(err, IsNil)
@@ -289,7 +289,7 @@ func (s *SnapTestSuite) TestSnapRemovePackagePolicy(c *C) {
 
 	s.buildFramework(c)
 	appdir := filepath.Join(s.tempdir, "snaps", "hello", "1.0.1")
-	yamlPath := filepath.Join(appdir, "meta", "package.yaml")
+	yamlPath := filepath.Join(appdir, "meta", "snap.yaml")
 	part, err := NewInstalledSnapPart(yamlPath, testOrigin)
 	c.Assert(err, IsNil)
 	err = part.remove(&MockProgressMeter{})
@@ -583,7 +583,7 @@ apps:
 
 	// and that it gets removed on remove
 	snapDir := filepath.Join(dirs.SnapSnapsDir, "foo.mvo", "1.0")
-	yamlPath := filepath.Join(snapDir, "meta", "package.yaml")
+	yamlPath := filepath.Join(snapDir, "meta", "snap.yaml")
 	part, err := NewInstalledSnapPart(yamlPath, testOrigin)
 	c.Assert(err, IsNil)
 	err = part.remove(&progress.NullProgress{})
@@ -640,7 +640,7 @@ func (s *SnapTestSuite) TestSnappyHandleDependentServicesOnInstall(c *C) {
 	c.Check(cmdlog, DeepEquals, []string{"stop", "show", "stop", "show", "start", "start"})
 
 	// check it got set active
-	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, "fmk", "current", "meta", "package.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, "fmk", "current", "meta", "snap.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(content), "version: 2"), Equals, true)
 
@@ -671,7 +671,7 @@ func (s *SnapTestSuite) TestSnappyHandleDependentServicesOnInstallFailingToStop(
 	c.Check(cmdlog, DeepEquals, []string{"stop", "show", "stop", "start"})
 
 	// check it got rolled back
-	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, "fmk", "current", "meta", "package.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, "fmk", "current", "meta", "snap.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(content), "version: 1"), Equals, true)
 
@@ -704,7 +704,7 @@ func (s *SnapTestSuite) TestSnappyHandleDependentServicesOnInstallFailingToStart
 	})
 
 	// check it got rolled back
-	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, "fmk", "current", "meta", "package.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, "fmk", "current", "meta", "snap.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(content), "version: 1"), Equals, true)
 
@@ -1167,7 +1167,7 @@ apps:
 
 	// and that it gets removed on remove
 	snapDir := filepath.Join(dirs.SnapSnapsDir, "foo.mvo", "1.0")
-	yamlPath := filepath.Join(snapDir, "meta", "package.yaml")
+	yamlPath := filepath.Join(snapDir, "meta", "snap.yaml")
 	part, err := NewInstalledSnapPart(yamlPath, testOrigin)
 	c.Assert(err, IsNil)
 	err = part.remove(&MockProgressMeter{})

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -996,11 +996,14 @@ func (s *SnapTestSuite) TestServiceWhitelistError(c *C) {
 func (s *SnapTestSuite) TestBinariesWhitelistSimple(c *C) {
 	c.Assert(verifyBinariesYaml(&AppYaml{Name: "foo"}), IsNil)
 	c.Assert(verifyBinariesYaml(&AppYaml{Command: "foo"}), IsNil)
-	c.Assert(verifyBinariesYaml(&AppYaml{
+}
+
+func (s *SnapTestSuite) TestUsesWhitelistSimple(c *C) {
+	c.Assert(verifyUsesYaml(&usesYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityTemplate: "foo"},
 	}), IsNil)
-	c.Assert(verifyBinariesYaml(&AppYaml{
+	c.Assert(verifyUsesYaml(&usesYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityPolicy: &SecurityPolicyDefinition{
 				AppArmor: "foo"},
@@ -1012,11 +1015,14 @@ func (s *SnapTestSuite) TestBinariesWhitelistIllegal(c *C) {
 	c.Assert(verifyBinariesYaml(&AppYaml{Name: "test!me"}), NotNil)
 	c.Assert(verifyBinariesYaml(&AppYaml{Name: "x\n"}), NotNil)
 	c.Assert(verifyBinariesYaml(&AppYaml{Command: "x\n"}), NotNil)
-	c.Assert(verifyBinariesYaml(&AppYaml{
+}
+
+func (s *SnapTestSuite) TestUsesWhitelistIllegal(c *C) {
+	c.Assert(verifyUsesYaml(&usesYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityTemplate: "x\n"},
 	}), NotNil)
-	c.Assert(verifyBinariesYaml(&AppYaml{
+	c.Assert(verifyUsesYaml(&usesYaml{
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityPolicy: &SecurityPolicyDefinition{
 				AppArmor: "x\n"},

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -249,7 +249,7 @@ type: framework
 
 	yamlFile := filepath.Join(tmpdir, "meta", "snap.yaml")
 	c.Assert(ioutil.WriteFile(yamlFile, yaml, 0644), IsNil)
-	m, err := parsePackageYamlData(yaml, false)
+	m, err := parseSnapYamlData(yaml, false)
 	c.Assert(err, IsNil)
 	snapName := fmt.Sprintf("%s_%s_all.snap", m.Name, m.Version)
 	d := squashfs.New(snapName)

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -480,7 +480,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 	binary := &AppYaml{Name: "pastebinit", Command: "bin/pastebinit"}
 	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
 	aaProfile := "pastebinit.mvo_pastebinit_1.4.0.0.1"
-	m := packageYaml{Name: "pastebinit",
+	m := snapYaml{Name: "pastebinit",
 		Version: "1.4.0.0.1"}
 
 	expected := fmt.Sprintf(expectedWrapper, arch.UbuntuArchitecture())
@@ -494,7 +494,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperFmk(c *C) {
 	binary := &AppYaml{Name: "echo", Command: "bin/echo"}
 	pkgPath := "/snaps/fmk/1.4.0.0.1/"
 	aaProfile := "fmk_echo_1.4.0.0.1"
-	m := packageYaml{Name: "fmk",
+	m := snapYaml{Name: "fmk",
 		Version: "1.4.0.0.1",
 		Type:    "framework"}
 
@@ -513,7 +513,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
 	binary := &AppYaml{Name: "bin/pastebinit\nSomething nasty"}
 	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
 	aaProfile := "pastebinit.mvo_pastebinit_1.4.0.0.1"
-	m := packageYaml{Name: "pastebinit",
+	m := snapYaml{Name: "pastebinit",
 		Version: "1.4.0.0.1"}
 
 	_, err := generateSnapBinaryWrapper(binary, pkgPath, aaProfile, &m)
@@ -868,7 +868,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceTypeForking(c *C) {
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
-	m := packageYaml{Name: "xkcd-webserver",
+	m := snapYaml{Name: "xkcd-webserver",
 		Version: "0.3.4"}
 
 	generatedWrapper, err := generateSnapServicesFile(service, pkgPath, aaProfile, &m)
@@ -887,7 +887,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapper(c *C) {
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
-	m := packageYaml{Name: "xkcd-webserver",
+	m := snapYaml{Name: "xkcd-webserver",
 		Version: "0.3.4"}
 
 	generatedWrapper, err := generateSnapServicesFile(service, pkgPath, aaProfile, &m)
@@ -907,7 +907,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapperWithExternalPort(
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
-	m := packageYaml{Name: "xkcd-webserver",
+	m := snapYaml{Name: "xkcd-webserver",
 		Version: "0.3.4"}
 
 	generatedWrapper, err := generateSnapServicesFile(service, pkgPath, aaProfile, &m)
@@ -927,7 +927,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceFmkWrapper(c *C) {
 	}
 	pkgPath := "/snaps/xkcd-webserver/0.3.4/"
 	aaProfile := "xkcd-webserver_xkcd-webserver_0.3.4"
-	m := packageYaml{
+	m := snapYaml{
 		Name:    "xkcd-webserver",
 		Version: "0.3.4",
 		Type:    snap.TypeFramework,
@@ -945,7 +945,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceRestart(c *C) {
 	}
 	pkgPath := "/snaps/xkcd-webserver/0.3.4/"
 	aaProfile := "xkcd-webserver_xkcd-webserver_0.3.4"
-	m := packageYaml{
+	m := snapYaml{
 		Name:    "xkcd-webserver",
 		Version: "0.3.4",
 	}
@@ -965,7 +965,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWrapperWhitelist(c *C) {
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
-	m := packageYaml{Name: "xkcd-webserver",
+	m := snapYaml{Name: "xkcd-webserver",
 		Version: "0.3.4"}
 
 	_, err := generateSnapServicesFile(service, pkgPath, aaProfile, &m)
@@ -1105,7 +1105,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapSocket(c *C) {
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
-	m := packageYaml{
+	m := snapYaml{
 		Name:    "xkcd-webserver",
 		Version: "0.3.4"}
 
@@ -1139,7 +1139,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWithSockte(c *C) {
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
-	m := packageYaml{Name: "xkcd-webserver",
+	m := snapYaml{Name: "xkcd-webserver",
 		Version: "0.3.4"}
 
 	generatedWrapper, err := generateSnapServicesFile(service, pkgPath, aaProfile, &m)
@@ -1151,7 +1151,7 @@ func (s *SnapTestSuite) TestGenerateSnapSocketFile(c *C) {
 	srv := &AppYaml{}
 	baseDir := "/base/dir"
 	aaProfile := "pkg_app_1.0"
-	m := &packageYaml{}
+	m := &snapYaml{}
 
 	// no socket mode means 0660
 	content, err := generateSnapSocketFile(srv, baseDir, aaProfile, m)

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -745,7 +745,7 @@ func (s *SnapTestSuite) TestAddPackageServicesStripsGlobalRootdir(c *C) {
 
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, "")
 	c.Assert(err, IsNil)
-	m, err := parsePackageYamlFile(yamlFile)
+	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	baseDir := filepath.Dir(filepath.Dir(yamlFile))
 	err = m.addPackageServices(baseDir, false, nil)
@@ -774,7 +774,7 @@ apps:
 `
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, yaml)
 	c.Assert(err, IsNil)
-	m, err := parsePackageYamlFile(yamlFile)
+	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	baseDir := filepath.Dir(filepath.Dir(yamlFile))
 	err = m.addPackageServices(baseDir, false, nil)
@@ -796,7 +796,7 @@ apps:
 `
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, yaml)
 	c.Assert(err, IsNil)
-	m, err := parsePackageYamlFile(yamlFile)
+	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	baseDir := filepath.Dir(filepath.Dir(yamlFile))
 	err = m.addPackageServices(baseDir, false, nil)
@@ -814,7 +814,7 @@ func (s *SnapTestSuite) TestAddPackageBinariesStripsGlobalRootdir(c *C) {
 
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, "")
 	c.Assert(err, IsNil)
-	m, err := parsePackageYamlFile(yamlFile)
+	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	baseDir := filepath.Dir(filepath.Dir(yamlFile))
 	err = m.addPackageBinaries(baseDir)
@@ -1069,7 +1069,7 @@ apps:
    daemon: forking
 `)
 	c.Assert(err, IsNil)
-	m, err := parsePackageYamlFile(yamlFile)
+	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	inter := &MockProgressMeter{}
 	c.Check(m.removePackageServices(filepath.Dir(filepath.Dir(yamlFile)), inter), IsNil)

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -57,14 +57,14 @@ func init() {
 func makeInstalledMockSnap(tempdir, packageYamlContent string) (yamlFile string, err error) {
 	const packageHello = `name: hello-app
 version: 1.10
-icon: meta/hello.svg
-binaries:
- - name: bin/hello
-services:
- - name: svc1
-   start: bin/hello
+apps:
+ hello:
+  command: bin/hello
+ svc1:
+   command: bin/hello
    stop: bin/goodbye
    poststop: bin/missya
+   daemon: forking
 `
 	if packageYamlContent == "" {
 		packageYamlContent = packageHello
@@ -206,7 +206,6 @@ echo "hello"`
 		packageYamlContent = `
 name: foo
 version: 1.0
-icon: foo.svg
 `
 	}
 	ioutil.WriteFile(packageYaml, []byte(packageYamlContent), 0644)
@@ -245,7 +244,6 @@ func makeTwoTestSnaps(c *C, snapType snap.Type, extra ...string) {
 	inter := &MockProgressMeter{}
 
 	packageYaml := `name: foo
-icon: foo.svg
 `
 	if len(extra) > 0 {
 		packageYaml += strings.Join(extra, "\n") + "\n"

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -70,7 +70,7 @@ apps:
 		packageYamlContent = packageHello
 	}
 
-	var m packageYaml
+	var m snapYaml
 	if err := yaml.Unmarshal([]byte(packageYamlContent), &m); err != nil {
 		return "", err
 	}

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -80,7 +80,7 @@ apps:
 	if err := os.MkdirAll(metaDir, 0775); err != nil {
 		return "", err
 	}
-	yamlFile = filepath.Join(metaDir, "package.yaml")
+	yamlFile = filepath.Join(metaDir, "snap.yaml")
 	if err := ioutil.WriteFile(yamlFile, []byte(packageYamlContent), 0644); err != nil {
 		return "", err
 	}
@@ -173,7 +173,7 @@ connect
 }
 
 // makeTestSnapPackage creates a real snap package that can be installed on
-// disk using packageYaml as its meta/package.yaml
+// disk using packageYaml as its meta/snap.yaml
 func makeTestSnapPackage(c *C, packageYamlContent string) (snapFile string) {
 	return makeTestSnapPackageFull(c, packageYamlContent, true)
 }
@@ -196,7 +196,7 @@ echo "hello"`
 	ioutil.WriteFile(exampleBinary, []byte(content), 0755)
 	// meta
 	os.MkdirAll(filepath.Join(tmpdir, "meta"), 0755)
-	packageYaml := filepath.Join(tmpdir, "meta", "package.yaml")
+	packageYaml := filepath.Join(tmpdir, "meta", "snap.yaml")
 	if packageYamlContent == "" {
 		packageYamlContent = `
 name: foo

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -85,11 +85,6 @@ apps:
 		return "", err
 	}
 
-	readmeMd := filepath.Join(metaDir, "readme.md")
-	if err := ioutil.WriteFile(readmeMd, []byte("Hello\nApp"), 0644); err != nil {
-		return "", err
-	}
-
 	if err := addMockDefaultApparmorProfile("hello-app_hello_1.10"); err != nil {
 		return "", err
 	}
@@ -209,10 +204,6 @@ version: 1.0
 `
 	}
 	ioutil.WriteFile(packageYaml, []byte(packageYamlContent), 0644)
-	readmeMd := filepath.Join(tmpdir, "meta", "readme.md")
-	content = "Random\nExample"
-	err := ioutil.WriteFile(readmeMd, []byte(content), 0644)
-	c.Assert(err, IsNil)
 	if makeLicense {
 		license := filepath.Join(tmpdir, "meta", "license.txt")
 		content = "WTFPL"
@@ -222,12 +213,12 @@ version: 1.0
 	for _, filenameAndContent := range files {
 		filename := filenameAndContent[0]
 		content := filenameAndContent[1]
-		err = ioutil.WriteFile(filepath.Join(tmpdir, filename), []byte(content), 0644)
+		err := ioutil.WriteFile(filepath.Join(tmpdir, filename), []byte(content), 0644)
 		c.Assert(err, IsNil)
 	}
 
 	// build it
-	err = helpers.ChDir(tmpdir, func() error {
+	err := helpers.ChDir(tmpdir, func() error {
 		var err error
 		snapFile, err = snapBuilderFunc(tmpdir, "")
 		c.Assert(err, IsNil)

--- a/snappy/config.go
+++ b/snappy/config.go
@@ -56,7 +56,7 @@ func snapConfig(snapDir, origin, rawConfig string) (newConfig string, err error)
 		return "", ErrConfigNotFound
 	}
 
-	part, err := NewInstalledSnapPart(filepath.Join(snapDir, "meta", "package.yaml"), origin)
+	part, err := NewInstalledSnapPart(filepath.Join(snapDir, "meta", "snap.yaml"), origin)
 	if err != nil {
 		return "", ErrPackageNotFound
 	}

--- a/snappy/datadir.go
+++ b/snappy/datadir.go
@@ -73,7 +73,7 @@ func data1(spec, basedir string) []SnapDataDir {
 	// have written?”
 	// To which I can only say: DataDirs finds all the data dirs on the
 	// system, not just those of packages that are installed. If you've
-	// removed a package its package.yaml is gone, its data is still there,
+	// removed a package its snap.yaml is gone, its data is still there,
 	// and you want us to be able to clean that up.
 	for _, dir := range dirs {
 		version := filepath.Base(dir)

--- a/snappy/errors.go
+++ b/snappy/errors.go
@@ -88,7 +88,7 @@ var (
 	// ErrInvalidCredentials is returned on login error
 	ErrInvalidCredentials = errors.New("invalid credentials")
 
-	// ErrInvalidFrameworkSpecInYaml is returned if a package.yaml
+	// ErrInvalidFrameworkSpecInYaml is returned if a snap.yaml
 	// has both frameworks and framework entries.
 	ErrInvalidFrameworkSpecInYaml = errors.New("yaml can't have both \"frameworks\" and (deprecated) \"framework\" keys")
 
@@ -106,10 +106,10 @@ var (
 	// ErrLicenseBlank is returned when the package specifies that
 	// accepting license is required, but the license file was empty or
 	// blank
-	ErrLicenseBlank = errors.New("package.yaml requires accepting a license, but license file was blank")
+	ErrLicenseBlank = errors.New("snap.yaml requires accepting a license, but license file was blank")
 	// ErrLicenseNotProvided is returned when the package specifies that
 	// accepting a license is required, but no license file is provided
-	ErrLicenseNotProvided = errors.New("package.yaml requires license, but no license was provided")
+	ErrLicenseNotProvided = errors.New("snap.yaml requires license, but no license was provided")
 
 	// ErrNotFirstBoot is an error that indicates that the first boot has already
 	// run

--- a/snappy/errors.go
+++ b/snappy/errors.go
@@ -59,10 +59,6 @@ var (
 	// that is already in the hwaccess list
 	ErrHWAccessAlreadyAdded = errors.New("device is already in hw-access list")
 
-	// ErrReadmeInvalid is returned if the package contains a invalid
-	// meta/readme.md
-	ErrReadmeInvalid = errors.New("meta/readme.md invalid")
-
 	// ErrAuthenticationNeeds2fa is returned if the authentication
 	// needs 2factor
 	ErrAuthenticationNeeds2fa = errors.New("authentication needs second factor")

--- a/snappy/errors.go
+++ b/snappy/errors.go
@@ -216,7 +216,7 @@ type ErrStructIllegalContent struct {
 }
 
 func (e *ErrStructIllegalContent) Error() string {
-	return fmt.Sprintf("services description field '%s' contains illegal '%s' (legal: '%s')", e.Field, e.Content, e.Whitelist)
+	return fmt.Sprintf("services description field '%s' contains illegal %q (legal: '%s')", e.Field, e.Content, e.Whitelist)
 }
 
 // ErrGarbageCollectImpossible is alerting about some of the assumptions of the

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -57,7 +57,7 @@ type FirstBootTestSuite struct {
 	globs        []string
 	ethdir       string
 	ifup         string
-	m            *packageYaml
+	m            *snapYaml
 	e            error
 	partMap      map[string]Part
 	partMapErr   error
@@ -110,7 +110,7 @@ func (s *FirstBootTestSuite) TearDownTest(c *C) {
 	newPartMap = newPartMapImpl
 }
 
-func (s *FirstBootTestSuite) getGadget() (*packageYaml, error) {
+func (s *FirstBootTestSuite) getGadget() (*snapYaml, error) {
 	return s.m, s.e
 }
 
@@ -127,7 +127,7 @@ func (s *FirstBootTestSuite) newFakeApp() *fakePart {
 }
 
 func (s *FirstBootTestSuite) TestFirstBootConfigure(c *C) {
-	s.m = &packageYaml{Config: s.gadgetConfig}
+	s.m = &snapYaml{Config: s.gadgetConfig}
 	fakeMyApp := s.newFakeApp()
 
 	c.Assert(FirstBoot(), IsNil)
@@ -147,7 +147,7 @@ func (s *FirstBootTestSuite) TestSoftwareActivate(c *C) {
 	c.Assert(part.IsActive(), Equals, false)
 	name := part.Name()
 
-	s.m = &packageYaml{Gadget: Gadget{Software: Software{BuiltIn: []string{name}}}}
+	s.m = &snapYaml{Gadget: Gadget{Software: Software{BuiltIn: []string{name}}}}
 
 	repo := NewMetaLocalRepository()
 	all, err := repo.All()
@@ -205,7 +205,7 @@ func (s *FirstBootTestSuite) TestEnableFirstEtherSomeEth(c *C) {
 }
 
 func (s *FirstBootTestSuite) TestEnableFirstEtherGadgetNoIfup(c *C) {
-	s.m = &packageYaml{Gadget: Gadget{SkipIfupProvisioning: true}}
+	s.m = &snapYaml{Gadget: Gadget{SkipIfupProvisioning: true}}
 	dir := c.MkDir()
 	_, err := os.Create(filepath.Join(dir, "eth42"))
 	c.Assert(err, IsNil)
@@ -266,7 +266,7 @@ func (s *FirstBootTestSuite) TestSystemSnapsEnablesOS(c *C) {
 }
 
 func (s *FirstBootTestSuite) TestSystemSnapsEnablesKernel(c *C) {
-	s.m = &packageYaml{Gadget: Gadget{Hardware: Hardware{Bootloader: "grub"}}}
+	s.m = &snapYaml{Gadget: Gadget{Hardware: Hardware{Bootloader: "grub"}}}
 
 	s.ensureSystemSnapIsEnabledOnFirstBoot(c, mockKernelYaml, true)
 }

--- a/snappy/gadget.go
+++ b/snappy/gadget.go
@@ -18,7 +18,7 @@
  */
 
 // TODO this should be it's own package, but depends on splitting out
-// package.yaml's
+// snap.yaml's
 
 package snappy
 
@@ -36,7 +36,7 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-// Gadget represents the structure inside the package.yaml for the gadget component
+// Gadget represents the structure inside the snap.yaml for the gadget component
 // of a gadget package type.
 type Gadget struct {
 	Store                Store    `yaml:"store,omitempty"`

--- a/snappy/gadget.go
+++ b/snappy/gadget.go
@@ -131,7 +131,7 @@ func (hw *HardwareAssign) generateUdevRuleContent() (string, error) {
 // logic for a gadget package in every other function
 var getGadget = getGadgetImpl
 
-func getGadgetImpl() (*packageYaml, error) {
+func getGadgetImpl() (*snapYaml, error) {
 	gadgets, _ := ActiveSnapsByType(snap.TypeGadget)
 	if len(gadgets) == 1 {
 		return gadgets[0].(*SnapPart).m, nil
@@ -189,7 +189,7 @@ func IsBuiltInSoftware(name string) bool {
 	return false
 }
 
-func cleanupGadgetHardwareUdevRules(m *packageYaml) error {
+func cleanupGadgetHardwareUdevRules(m *snapYaml) error {
 	oldFiles, err := filepath.Glob(filepath.Join(dirs.SnapUdevRulesDir, fmt.Sprintf("80-snappy_%s_*.rules", m.Name)))
 	if err != nil {
 		return err
@@ -211,7 +211,7 @@ func cleanupGadgetHardwareUdevRules(m *packageYaml) error {
 	return nil
 }
 
-func writeGadgetHardwareUdevRules(m *packageYaml) error {
+func writeGadgetHardwareUdevRules(m *snapYaml) error {
 	os.MkdirAll(dirs.SnapUdevRulesDir, 0755)
 
 	// cleanup
@@ -267,7 +267,7 @@ const apparmorAdditionalContent = `{
 // default apparmor will not allow access to /dev. We grant access here
 // and the ubuntu-core-launcher is then used to generate a confinement
 // based on the devices cgroup.
-func writeApparmorAdditionalFile(m *packageYaml) error {
+func writeApparmorAdditionalFile(m *snapYaml) error {
 	if err := os.MkdirAll(dirs.SnapAppArmorDir, 0755); err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func writeApparmorAdditionalFile(m *packageYaml) error {
 	return nil
 }
 
-func installGadgetHardwareUdevRules(m *packageYaml) error {
+func installGadgetHardwareUdevRules(m *snapYaml) error {
 	if err := writeGadgetHardwareUdevRules(m); err != nil {
 		return err
 	}

--- a/snappy/gadget_test.go
+++ b/snappy/gadget_test.go
@@ -67,7 +67,7 @@ func (s *GadgetSuite) TestStoreID(c *C) {
 }
 
 func (s *GadgetSuite) TestWriteApparmorAdditionalFile(c *C) {
-	m, err := parsePackageYamlData(hardwareYaml, false)
+	m, err := parseSnapYamlData(hardwareYaml, false)
 	c.Assert(err, IsNil)
 
 	err = writeApparmorAdditionalFile(m)
@@ -79,7 +79,7 @@ func (s *GadgetSuite) TestWriteApparmorAdditionalFile(c *C) {
 }
 
 func (s *GadgetSuite) TestCleanupGadgetHardwareRules(c *C) {
-	m, err := parsePackageYamlData(hardwareYaml, false)
+	m, err := parseSnapYamlData(hardwareYaml, false)
 	c.Assert(err, IsNil)
 
 	err = writeApparmorAdditionalFile(m)

--- a/snappy/gadget_test.go
+++ b/snappy/gadget_test.go
@@ -18,7 +18,7 @@
  */
 
 // TODO this should be it's own package, but depends on splitting out
-// package.yaml's
+// snap.yaml's
 
 package snappy
 

--- a/snappy/gadget_test.go
+++ b/snappy/gadget_test.go
@@ -42,8 +42,8 @@ var (
 )
 
 func (s *GadgetSuite) SetUpTest(c *C) {
-	getGadget = func() (*packageYaml, error) {
-		return &packageYaml{
+	getGadget = func() (*snapYaml, error) {
+		return &snapYaml{
 			Gadget: Gadget{
 				Software: Software{[]string{"makeuppackage", "anotherpackage"}},
 				Store:    Store{"ninjablocks"},

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -109,17 +109,17 @@ func (s *SnapTestSuite) installThree(c *C, flags InstallFlags) {
 	err := os.MkdirAll(homeData, 0755)
 	c.Assert(err, IsNil)
 
-	packageYaml := `name: foo
+	snapYamlContent := `name: foo
 `
-	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
+	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err = Install(snapFile, flags, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, packageYaml+"version: 2.0")
+	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
 	_, err = Install(snapFile, flags, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, packageYaml+"version: 3.0")
+	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 3.0")
 	_, err = Install(snapFile, flags, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 }

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -79,9 +79,8 @@ func (s *SnapTestSuite) TestInstallInstallLicense(c *C) {
 	snapFile := makeTestSnapPackage(c, `
 name: foo
 version: 1.0
-icon: foo.svg
 vendor: Foo Bar <foo@example.com>
-explicit-license-agreement: Y
+license-agreement: explicit
 `)
 	ag := &MockProgressMeter{y: true}
 	name, err := Install(snapFile, AllowUnauthenticated|DoInstallGC, ag)
@@ -94,9 +93,8 @@ func (s *SnapTestSuite) TestInstallInstallLicenseNo(c *C) {
 	snapFile := makeTestSnapPackage(c, `
 name: foo
 version: 1.0
-icon: foo.svg
 vendor: Foo Bar <foo@example.com>
-explicit-license-agreement: Y
+license-agreement: explicit
 `)
 	ag := &MockProgressMeter{y: false}
 	_, err := Install(snapFile, AllowUnauthenticated|DoInstallGC, ag)
@@ -112,7 +110,6 @@ func (s *SnapTestSuite) installThree(c *C, flags InstallFlags) {
 	c.Assert(err, IsNil)
 
 	packageYaml := `name: foo
-icon: foo.svg
 `
 	snapFile := makeTestSnapPackage(c, packageYaml+"version: 1.0")
 	_, err = Install(snapFile, flags, &progress.NullProgress{})

--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -35,9 +35,9 @@ import (
 // SystemConfig is a config map holding configs for multiple packages
 type SystemConfig map[string]interface{}
 
-// ServiceYamler implements snappy packages that offer services
-type ServiceYamler interface {
-	ServiceYamls() []ServiceYaml
+// AppYamler implements snappy packages that offer services
+type AppYamler interface {
+	AppYamls() []AppYaml
 }
 
 // Configuration allows requesting a gadget snappy package type's config

--- a/snappy/parts_test.go
+++ b/snappy/parts_test.go
@@ -34,14 +34,14 @@ import (
 func (s *SnapTestSuite) TestActiveSnapByType(c *C) {
 	yamlPath, err := makeInstalledMockSnap(s.tempdir, `name: app1
 version: 1.10
-icon: meta/hello.svg`)
+`)
 	c.Assert(err, IsNil)
 	makeSnapActive(yamlPath)
 
 	yamlPath, err = makeInstalledMockSnap(s.tempdir, `name: framework1
 version: 1.0
 type: framework
-icon: meta/hello.svg`)
+`)
 	c.Assert(err, IsNil)
 	makeSnapActive(yamlPath)
 

--- a/snappy/purge.go
+++ b/snappy/purge.go
@@ -54,7 +54,7 @@ func Purge(partSpec string, flags PurgeFlags, meter progress.Meter) error {
 	// .snap being installed for multiple users, or the .snap using both the
 	// snap data path as well as the user data path. They all need to be purged.
 	for _, datadir := range datadirs {
-		yamlPath := filepath.Join(dirs.SnapSnapsDir, datadir.QualifiedName(), datadir.Version, "meta", "package.yaml")
+		yamlPath := filepath.Join(dirs.SnapSnapsDir, datadir.QualifiedName(), datadir.Version, "meta", "snap.yaml")
 		part, err := NewInstalledSnapPart(yamlPath, datadir.Origin)
 		if err != nil {
 			// no such part installed

--- a/snappy/purge_test.go
+++ b/snappy/purge_test.go
@@ -80,9 +80,6 @@ func (s *purgeSuite) mkpkg(c *C, args ...string) (dataDirs []string, part *SnapP
 	yaml := "version: 1.0\nname: hello-app\nversion: " + version + "\n" + extra
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, yaml)
 	c.Assert(err, IsNil)
-	pkgdir := filepath.Dir(filepath.Dir(yamlFile))
-	c.Assert(os.MkdirAll(filepath.Join(pkgdir, ".click", "info"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(pkgdir, ".click", "info", app+".manifest"), []byte(`{"name": "`+app+`"}`), 0644), IsNil)
 
 	dataDir := filepath.Join(dirs.SnapDataDir, app, version)
 	c.Assert(os.MkdirAll(dataDir, 0755), IsNil)
@@ -150,7 +147,11 @@ func (s *purgeSuite) TestPurgeActiveExplicitOK(c *C) {
 
 func (s *purgeSuite) TestPurgeActiveRestartServices(c *C) {
 	inter := &MockProgressMeter{}
-	ddirs, part := s.mkpkg(c, "v1", "services:\n - name: svc")
+	ddirs, part := s.mkpkg(c, "v1", `apps:
+ svc:
+  command: foo
+  daemon: forking
+`)
 	c.Assert(part.activate(true, inter), IsNil)
 	for _, ddir := range ddirs {
 		canary := filepath.Join(ddir, "canary")

--- a/snappy/rollback_test.go
+++ b/snappy/rollback_test.go
@@ -50,8 +50,10 @@ func (s *SnapTestSuite) TestRollbackFindVersion(c *C) {
 }
 
 func (s *SnapTestSuite) TestRollbackService(c *C) {
-	makeTwoTestSnaps(c, snap.TypeApp, `services:
- - name: svc1
+	makeTwoTestSnaps(c, snap.TypeApp, `apps:
+ svc1:
+  command: something
+  daemon: forking
 `)
 	pkg := ActiveSnapByName("foo")
 	c.Assert(pkg, NotNil)

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -741,7 +741,7 @@ func findSkillForApp(m *packageYaml, app *AppYaml) (*usesYaml, error) {
 
 	skill, ok := m.Uses[app.UsesRef[0]]
 	if !ok {
-		return nil, fmt.Errorf("can not find skill %s", skill)
+		return nil, fmt.Errorf("can not find skill %q", app.UsesRef[0])
 	}
 	return skill, nil
 }

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -848,7 +848,7 @@ func compareSinglePolicyToCurrent(oldPolicyFn, newPolicy string) error {
 // CompareGeneratePolicyFromFile is used to simulate security policy
 // generation and returns if the policy would have changed
 func CompareGeneratePolicyFromFile(fn string) error {
-	m, err := parsePackageYamlFileWithVersion(fn)
+	m, err := parseSnapYamlFileWithVersion(fn)
 	if err != nil {
 		return err
 	}
@@ -890,7 +890,7 @@ func CompareGeneratePolicyFromFile(fn string) error {
 }
 
 // FIXME: refactor so that we don't need this
-func parsePackageYamlFileWithVersion(fn string) (*snapYaml, error) {
+func parseSnapYamlFileWithVersion(fn string) (*snapYaml, error) {
 	m, err := parseSnapYamlFile(fn)
 
 	// FIXME: duplicated code from snapp.go:NewSnapPartFromYaml,
@@ -910,7 +910,7 @@ func parsePackageYamlFileWithVersion(fn string) (*snapYaml, error) {
 // from the specified manifest file name
 func GeneratePolicyFromFile(fn string, force bool) error {
 	// FIXME: force not used yet
-	m, err := parsePackageYamlFileWithVersion(fn)
+	m, err := parseSnapYamlFileWithVersion(fn)
 	if err != nil {
 		return err
 	}

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -323,7 +323,7 @@ func getSecurityProfile(m *packageYaml, appName, baseDir string) (string, error)
 		return fmt.Sprintf("%s_%s_%s", m.Name, cleanedName, m.Version), nil
 	}
 
-	origin, err := originFromYamlPath(filepath.Join(baseDir, "meta", "package.yaml"))
+	origin, err := originFromYamlPath(filepath.Join(baseDir, "meta", "snap.yaml"))
 
 	return fmt.Sprintf("%s.%s_%s_%s", m.Name, origin, cleanedName, m.Version), err
 }
@@ -656,7 +656,7 @@ func (sd *SecurityDefinitions) generatePolicyForServiceBinaryResult(m *packageYa
 	// add the hw-override parts and merge with the other overrides
 	origin := ""
 	if m.Type != snap.TypeFramework && m.Type != snap.TypeGadget {
-		origin, err = originFromYamlPath(filepath.Join(baseDir, "meta", "package.yaml"))
+		origin, err = originFromYamlPath(filepath.Join(baseDir, "meta", "snap.yaml"))
 		if err != nil {
 			return nil, err
 		}
@@ -781,7 +781,7 @@ func regeneratePolicyForSnap(snapname string) error {
 		}
 		if appID.Version != appliedVersion {
 			// FIXME: dirs.SnapSnapsDir is too simple, gadget
-			fn := filepath.Join(dirs.SnapSnapsDir, appID.Pkgname, appID.Version, "meta", "package.yaml")
+			fn := filepath.Join(dirs.SnapSnapsDir, appID.Pkgname, appID.Version, "meta", "snap.yaml")
 			if !helpers.FileExists(fn) {
 				continue
 			}
@@ -920,7 +920,7 @@ func RegenerateAllPolicy(force bool) error {
 			continue
 		}
 		basedir := part.basedir
-		yFn := filepath.Join(basedir, "meta", "package.yaml")
+		yFn := filepath.Join(basedir, "meta", "snap.yaml")
 
 		// FIXME: use ErrPolicyNeedsRegenerating here to check if
 		//        re-generation is needed

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -317,7 +317,7 @@ func findWhitespacePrefix(t string, s string) string {
 	return subs[1]
 }
 
-func getSecurityProfile(m *packageYaml, appName, baseDir string) (string, error) {
+func getSecurityProfile(m *snapYaml, appName, baseDir string) (string, error) {
 	cleanedName := strings.Replace(appName, "/", "-", -1)
 	if m.Type == snap.TypeFramework || m.Type == snap.TypeGadget {
 		return fmt.Sprintf("%s_%s_%s", m.Name, cleanedName, m.Version), nil
@@ -445,7 +445,7 @@ func mergeAppArmorTemplateAdditionalContent(appArmorTemplate, aaPolicy string, o
 	return aaPolicy, nil
 }
 
-func getAppArmorTemplatedPolicy(m *packageYaml, appID *securityAppID, template string, caps []string, overrides *SecurityOverrideDefinition) (string, error) {
+func getAppArmorTemplatedPolicy(m *snapYaml, appID *securityAppID, template string, caps []string, overrides *SecurityOverrideDefinition) (string, error) {
 	t, err := securityPolicyTypeAppArmor.findTemplate(template)
 	if err != nil {
 		return "", err
@@ -477,7 +477,7 @@ func getAppArmorTemplatedPolicy(m *packageYaml, appID *securityAppID, template s
 	return mergeAppArmorTemplateAdditionalContent(t, aaPolicy, overrides)
 }
 
-func getSeccompTemplatedPolicy(m *packageYaml, appID *securityAppID, templateName string, caps []string, overrides *SecurityOverrideDefinition) (string, error) {
+func getSeccompTemplatedPolicy(m *snapYaml, appID *securityAppID, templateName string, caps []string, overrides *SecurityOverrideDefinition) (string, error) {
 	t, err := securityPolicyTypeSeccomp.findTemplate(templateName)
 	if err != nil {
 		return "", err
@@ -503,7 +503,7 @@ func getSeccompTemplatedPolicy(m *packageYaml, appID *securityAppID, templateNam
 
 var finalCurtain = regexp.MustCompile(`}\s*$`)
 
-func getAppArmorCustomPolicy(m *packageYaml, appID *securityAppID, fn string, overrides *SecurityOverrideDefinition) (string, error) {
+func getAppArmorCustomPolicy(m *snapYaml, appID *securityAppID, fn string, overrides *SecurityOverrideDefinition) (string, error) {
 	custom, err := ioutil.ReadFile(fn)
 	if err != nil {
 		return "", err
@@ -524,7 +524,7 @@ func getAppArmorCustomPolicy(m *packageYaml, appID *securityAppID, fn string, ov
 	return mergeAppArmorTemplateAdditionalContent("", aaPolicy, overrides)
 }
 
-func getSeccompCustomPolicy(m *packageYaml, appID *securityAppID, fn string) (string, error) {
+func getSeccompCustomPolicy(m *snapYaml, appID *securityAppID, fn string) (string, error) {
 	custom, err := ioutil.ReadFile(fn)
 	if err != nil {
 		return "", err
@@ -548,7 +548,7 @@ var loadAppArmorPolicy = func(fn string) ([]byte, error) {
 	return content, err
 }
 
-func (m *packageYaml) removeOneSecurityPolicy(name, baseDir string) error {
+func (m *snapYaml) removeOneSecurityPolicy(name, baseDir string) error {
 	profileName, err := getSecurityProfile(m, filepath.Base(name), baseDir)
 	if err != nil {
 		return err
@@ -575,7 +575,7 @@ func (m *packageYaml) removeOneSecurityPolicy(name, baseDir string) error {
 	return nil
 }
 
-func removePolicy(m *packageYaml, baseDir string) error {
+func removePolicy(m *snapYaml, baseDir string) error {
 	for _, app := range m.Apps {
 		if app.Daemon == "" {
 			continue
@@ -636,7 +636,7 @@ func (sd *SecurityDefinitions) warnDeprecatedKeys() {
 	}
 }
 
-func (sd *SecurityDefinitions) generatePolicyForServiceBinaryResult(m *packageYaml, name string, baseDir string) (*securityPolicyResult, error) {
+func (sd *SecurityDefinitions) generatePolicyForServiceBinaryResult(m *snapYaml, name string, baseDir string) (*securityPolicyResult, error) {
 	res := &securityPolicyResult{}
 	appID, err := getSecurityProfile(m, name, baseDir)
 	if err != nil {
@@ -698,7 +698,7 @@ func (sd *SecurityDefinitions) generatePolicyForServiceBinaryResult(m *packageYa
 	return res, nil
 }
 
-func (sd *SecurityDefinitions) generatePolicyForServiceBinary(m *packageYaml, name string, baseDir string) error {
+func (sd *SecurityDefinitions) generatePolicyForServiceBinary(m *snapYaml, name string, baseDir string) error {
 	p, err := sd.generatePolicyForServiceBinaryResult(m, name, baseDir)
 	if err != nil {
 		return err
@@ -731,7 +731,7 @@ func hasConfig(baseDir string) bool {
 	return helpers.FileExists(filepath.Join(baseDir, "meta", "hooks", "config"))
 }
 
-func findSkillForApp(m *packageYaml, app *AppYaml) (*usesYaml, error) {
+func findSkillForApp(m *snapYaml, app *AppYaml) (*usesYaml, error) {
 	if len(app.UsesRef) == 0 {
 		return nil, nil
 	}
@@ -746,7 +746,7 @@ func findSkillForApp(m *packageYaml, app *AppYaml) (*usesYaml, error) {
 	return skill, nil
 }
 
-func generatePolicy(m *packageYaml, baseDir string) error {
+func generatePolicy(m *snapYaml, baseDir string) error {
 	var foundError error
 
 	// generate default security config for snappy-config
@@ -890,7 +890,7 @@ func CompareGeneratePolicyFromFile(fn string) error {
 }
 
 // FIXME: refactor so that we don't need this
-func parsePackageYamlFileWithVersion(fn string) (*packageYaml, error) {
+func parsePackageYamlFileWithVersion(fn string) (*snapYaml, error) {
 	m, err := parseSnapYamlFile(fn)
 
 	// FIXME: duplicated code from snapp.go:NewSnapPartFromYaml,

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -891,7 +891,7 @@ func CompareGeneratePolicyFromFile(fn string) error {
 
 // FIXME: refactor so that we don't need this
 func parsePackageYamlFileWithVersion(fn string) (*packageYaml, error) {
-	m, err := parsePackageYamlFile(fn)
+	m, err := parseSnapYamlFile(fn)
 
 	// FIXME: duplicated code from snapp.go:NewSnapPartFromYaml,
 	//        version is overriden by sideloaded versions

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -601,12 +601,12 @@ var mockSecurityPackageYaml = `
 name: hello-world
 vendor: someone
 version: 1.0
-binaries:
- - name: binary1
+apps:
+ binary1:
    caps: []
-services:
- - name: service1
+ service1:
    caps: []
+   daemon: forking
 `
 
 func (a *SecurityTestSuite) TestSecurityGeneratePolicyFromFileSimple(c *C) {
@@ -813,8 +813,8 @@ var mockSecurityDeprecatedPackageYaml = `
 name: hello-world
 vendor: someone
 version: 1.0
-binaries:
- - name: binary1
+apps:
+ binary1:
    caps: []
 `
 

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -825,7 +825,7 @@ apps:
    uses: [binary1]
 uses:
  binary1:
-   type: migration-service
+   type: migration-skill
    caps: []
 `
 

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -37,7 +37,7 @@ import (
 type SecurityTestSuite struct {
 	tempDir               string
 	buildDir              string
-	m                     *packageYaml
+	m                     *snapYaml
 	scFilterGenCall       []string
 	scFilterGenCallReturn []byte
 
@@ -54,7 +54,7 @@ func (a *SecurityTestSuite) SetUpTest(c *C) {
 	// set global sandbox
 	dirs.SetRootDir(c.MkDir())
 
-	a.m = &packageYaml{
+	a.m = &snapYaml{
 		Name:    "foo",
 		Version: "1.0",
 	}
@@ -122,7 +122,7 @@ func makeMockSeccompCap(c *C, capname string, content []byte) {
 }
 
 func (a *SecurityTestSuite) TestSnappyGetSecurityProfile(c *C) {
-	m := packageYaml{
+	m := snapYaml{
 		Name:    "foo",
 		Version: "1.0",
 	}
@@ -133,7 +133,7 @@ func (a *SecurityTestSuite) TestSnappyGetSecurityProfile(c *C) {
 }
 
 func (a *SecurityTestSuite) TestSnappyGetSecurityProfileInvalid(c *C) {
-	m := packageYaml{
+	m := snapYaml{
 		Name:    "foo",
 		Version: "1.0",
 	}
@@ -143,7 +143,7 @@ func (a *SecurityTestSuite) TestSnappyGetSecurityProfileInvalid(c *C) {
 }
 
 func (a *SecurityTestSuite) TestSnappyGetSecurityProfileFramework(c *C) {
-	m := packageYaml{
+	m := snapYaml{
 		Name:    "foo",
 		Version: "1.0",
 		Type:    snap.TypeFramework,
@@ -350,7 +350,7 @@ func (a *SecurityTestSuite) TestSecurityGenAppArmorTemplatePolicy(c *C) {
 	makeMockApparmorTemplate(c, "mock-template", mockApparmorTemplate)
 	makeMockApparmorCap(c, "cap1", []byte(`capito`))
 
-	m := &packageYaml{
+	m := &snapYaml{
 		Name:    "foo",
 		Version: "1.0",
 	}
@@ -400,7 +400,7 @@ func (a *SecurityTestSuite) TestSecurityGenSeccompTemplatedPolicy(c *C) {
 	makeMockSeccompTemplate(c, "mock-template", mockSeccompTemplate)
 	makeMockSeccompCap(c, "cap1", []byte("#cap1\ncapino\n"))
 
-	m := &packageYaml{
+	m := &snapYaml{
 		Name:    "foo",
 		Version: "1.0",
 	}
@@ -462,7 +462,7 @@ profile "foo_bar_1.0" (attach_disconnected) {
 `
 
 func (a *SecurityTestSuite) TestSecurityGetApparmorCustomPolicy(c *C) {
-	m := &packageYaml{
+	m := &snapYaml{
 		Name:    "foo",
 		Version: "1.0",
 	}
@@ -482,7 +482,7 @@ func (a *SecurityTestSuite) TestSecurityGetApparmorCustomPolicy(c *C) {
 
 func (a *SecurityTestSuite) TestSecurityGetSeccompCustomPolicy(c *C) {
 	// yes, getSeccompCustomPolicy does not care for packageYaml or appid
-	m := &packageYaml{}
+	m := &snapYaml{}
 	appid := &securityAppID{}
 
 	customPolicy := filepath.Join(c.MkDir(), "foo")
@@ -572,7 +572,7 @@ sc-network-client
 
 	// empty SecurityDefinition means "network-client" cap
 	sd := &SecurityDefinitions{}
-	m := &packageYaml{
+	m := &snapYaml{
 		Name:    "pkg",
 		Version: "1.0",
 	}
@@ -799,7 +799,7 @@ func makeCustomAppArmorPolicy(c *C) string {
 }
 
 func (a *SecurityTestSuite) TestSecurityGenerateCustomPolicyAdditionalIsConsidered(c *C) {
-	m := &packageYaml{
+	m := &snapYaml{
 		Name:    "foo",
 		Version: "1.0",
 	}
@@ -971,7 +971,7 @@ func (a *SecurityTestSuite) TestSecurityGeneratePolicyForServiceBinaryFramework(
 	makeMockSecurityEnv(c)
 
 	sd := &SecurityDefinitions{}
-	m := &packageYaml{
+	m := &snapYaml{
 		Name:    "framework-name",
 		Type:    "framework",
 		Version: "1.0",
@@ -993,7 +993,7 @@ func (a *SecurityTestSuite) TestSecurityGeneratePolicyForServiceBinaryErrors(c *
 	makeMockSecurityEnv(c)
 
 	sd := &SecurityDefinitions{}
-	m := &packageYaml{
+	m := &snapYaml{
 		Name:    "app",
 		Version: "1.0",
 	}
@@ -1036,7 +1036,7 @@ version: 123456789
 
 func (a *SecurityTestSuite) TestFindSkillForAppEmpty(c *C) {
 	app := &AppYaml{}
-	m := &packageYaml{}
+	m := &snapYaml{}
 	skill, err := findSkillForApp(m, app)
 	c.Check(err, IsNil)
 	c.Check(skill, IsNil)
@@ -1046,7 +1046,7 @@ func (a *SecurityTestSuite) TestFindSkillForAppTooMany(c *C) {
 	app := &AppYaml{
 		UsesRef: []string{"one", "two"},
 	}
-	m := &packageYaml{}
+	m := &snapYaml{}
 	skill, err := findSkillForApp(m, app)
 	c.Check(skill, IsNil)
 	c.Check(err, ErrorMatches, "only a single skill is supported, 2 found")
@@ -1056,7 +1056,7 @@ func (a *SecurityTestSuite) TestFindSkillForAppNotFound(c *C) {
 	app := &AppYaml{
 		UsesRef: []string{"not-there"},
 	}
-	m := &packageYaml{}
+	m := &snapYaml{}
 	skill, err := findSkillForApp(m, app)
 	c.Check(skill, IsNil)
 	c.Check(err, ErrorMatches, `can not find skill "not-there"`)
@@ -1066,7 +1066,7 @@ func (a *SecurityTestSuite) TestFindSkillFinds(c *C) {
 	app := &AppYaml{
 		UsesRef: []string{"skill"},
 	}
-	m := &packageYaml{
+	m := &snapYaml{
 		Uses: map[string]*usesYaml{
 			"skill": &usesYaml{Type: "some-type"},
 		},

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -1031,4 +1031,47 @@ version: 123456789
 	m, err := parsePackageYamlFileWithVersion(y)
 	c.Assert(err, IsNil)
 	c.Assert(m.Version, Equals, testVersion)
+
+}
+
+func (a *SecurityTestSuite) TestFindSkillForAppEmpty(c *C) {
+	app := &AppYaml{}
+	m := &packageYaml{}
+	skill, err := findSkillForApp(m, app)
+	c.Check(err, IsNil)
+	c.Check(skill, IsNil)
+}
+
+func (a *SecurityTestSuite) TestFindSkillForAppTooMany(c *C) {
+	app := &AppYaml{
+		UsesRef: []string{"one", "two"},
+	}
+	m := &packageYaml{}
+	skill, err := findSkillForApp(m, app)
+	c.Check(skill, IsNil)
+	c.Check(err, ErrorMatches, "only a single skill is supported, 2 found")
+}
+
+func (a *SecurityTestSuite) TestFindSkillForAppNotFound(c *C) {
+	app := &AppYaml{
+		UsesRef: []string{"not-there"},
+	}
+	m := &packageYaml{}
+	skill, err := findSkillForApp(m, app)
+	c.Check(skill, IsNil)
+	c.Check(err, ErrorMatches, `can not find skill "not-there"`)
+}
+
+func (a *SecurityTestSuite) TestFindSkillFinds(c *C) {
+	app := &AppYaml{
+		UsesRef: []string{"skill"},
+	}
+	m := &packageYaml{
+		Uses: map[string]*usesYaml{
+			"skill": &usesYaml{Type: "some-type"},
+		},
+	}
+	skill, err := findSkillForApp(m, app)
+	c.Check(err, IsNil)
+	c.Check(skill.Type, Equals, "some-type")
 }

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -603,10 +603,17 @@ vendor: someone
 version: 1.0
 apps:
  binary1:
-   caps: []
+   uses: [binary1]
  service1:
-   caps: []
+   uses: [service1]
    daemon: forking
+uses:
+ binary1:
+  type: migration-skill
+  caps: []
+ service1:
+  type: migration-skill
+  caps: []
 `
 
 func (a *SecurityTestSuite) TestSecurityGeneratePolicyFromFileSimple(c *C) {
@@ -815,6 +822,10 @@ vendor: someone
 version: 1.0
 apps:
  binary1:
+   uses: [binary1]
+uses:
+ binary1:
+   type: migration-service
    caps: []
 `
 

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -481,7 +481,7 @@ func (a *SecurityTestSuite) TestSecurityGetApparmorCustomPolicy(c *C) {
 }
 
 func (a *SecurityTestSuite) TestSecurityGetSeccompCustomPolicy(c *C) {
-	// yes, getSeccompCustomPolicy does not care for packageYaml or appid
+	// yes, getSeccompCustomPolicy does not care for snapYaml or appid
 	m := &snapYaml{}
 	appid := &securityAppID{}
 
@@ -597,7 +597,7 @@ sc-network-client`)
 
 }
 
-var mockSecurityPackageYaml = `
+var mockSecuritySnapYaml = `
 name: hello-world
 vendor: someone
 version: 1.0
@@ -627,11 +627,11 @@ read
 write
 `))
 
-	mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityPackageYaml)
+	mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecuritySnapYaml)
 	c.Assert(err, IsNil)
 
 	// the acutal thing that gets tested
-	err = GeneratePolicyFromFile(mockPackageYamlFn, false)
+	err = GeneratePolicyFromFile(mockSnapYamlFn, false)
 	c.Assert(err, IsNil)
 
 	// ensure the apparmor policy got loaded
@@ -663,15 +663,15 @@ read
 write
 `))
 
-	mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityPackageYaml)
+	mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecuritySnapYaml)
 	c.Assert(err, IsNil)
-	configHook := filepath.Join(filepath.Dir(mockPackageYamlFn), "hooks", "config")
+	configHook := filepath.Join(filepath.Dir(mockSnapYamlFn), "hooks", "config")
 	os.MkdirAll(filepath.Dir(configHook), 0755)
 	err = ioutil.WriteFile(configHook, []byte("true"), 0755)
 	c.Assert(err, IsNil)
 
 	// generate config
-	err = GeneratePolicyFromFile(mockPackageYamlFn, false)
+	err = GeneratePolicyFromFile(mockSnapYamlFn, false)
 	c.Assert(err, IsNil)
 
 	// and for snappy-config
@@ -692,14 +692,14 @@ deny kexec
 read
 write
 `))
-	mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityPackageYaml)
+	mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecuritySnapYaml)
 	c.Assert(err, IsNil)
 
-	err = GeneratePolicyFromFile(mockPackageYamlFn, false)
+	err = GeneratePolicyFromFile(mockSnapYamlFn, false)
 	c.Assert(err, IsNil)
 
 	// nothing changed, compare is happy
-	err = CompareGeneratePolicyFromFile(mockPackageYamlFn)
+	err = CompareGeneratePolicyFromFile(mockSnapYamlFn)
 	c.Assert(err, IsNil)
 
 	// now change the templates
@@ -707,7 +707,7 @@ write
 ###POLICYGROUPS###
 `))
 	// ...and ensure that the difference is found
-	err = CompareGeneratePolicyFromFile(mockPackageYamlFn)
+	err = CompareGeneratePolicyFromFile(mockSnapYamlFn)
 	c.Assert(err, ErrorMatches, "policy differs.*")
 }
 
@@ -723,9 +723,9 @@ deny kexec
 read
 write
 `))
-	mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityPackageYaml)
+	mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecuritySnapYaml)
 	c.Assert(err, IsNil)
-	err = GeneratePolicyFromFile(mockPackageYamlFn, false)
+	err = GeneratePolicyFromFile(mockSnapYamlFn, false)
 	c.Assert(err, IsNil)
 
 	// ensure that AddHWAccess does the right thing
@@ -760,10 +760,10 @@ deny kexec
 read
 write
 `))
-	mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityPackageYaml)
+	mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecuritySnapYaml)
 	c.Assert(err, IsNil)
 
-	err = GeneratePolicyFromFile(mockPackageYamlFn, false)
+	err = GeneratePolicyFromFile(mockSnapYamlFn, false)
 	c.Assert(err, IsNil)
 
 	// now change the templates
@@ -816,7 +816,7 @@ func (a *SecurityTestSuite) TestSecurityGenerateCustomPolicyAdditionalIsConsider
 	c.Assert(content, Matches, `(?ms).*^# No abstractions specified$`)
 }
 
-var mockSecurityDeprecatedPackageYaml = `
+var mockSecurityDeprecatedSnapYaml = `
 name: hello-world
 vendor: someone
 version: 1.0
@@ -829,21 +829,21 @@ uses:
    caps: []
 `
 
-var mockSecurityDeprecatedPackageYamlApparmor1 = `
+var mockSecurityDeprecatedSnapYamlApparmor1 = `
    security-override:
     apparmor:
      read-path: [foo]
 `
-var mockSecurityDeprecatedPackageYamlApparmor2 = `
+var mockSecurityDeprecatedSnapYamlApparmor2 = `
    security-override:
     apparmor: {}
 `
-var mockSecurityDeprecatedPackageYamlSeccomp1 = `
+var mockSecurityDeprecatedSnapYamlSeccomp1 = `
    security-override:
     seccomp: {}
 `
 
-var mockSecurityDeprecatedPackageYamlSeccomp2 = `
+var mockSecurityDeprecatedSnapYamlSeccomp2 = `
    security-override:
     seccomp:
      syscalls: [1]
@@ -869,10 +869,10 @@ func (a *SecurityTestSuite) TestSecurityWarnsNot(c *C) {
 	ml := &mockLogger{}
 	logger.SetLogger(ml)
 
-	mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityDeprecatedPackageYaml)
+	mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityDeprecatedSnapYaml)
 	c.Assert(err, IsNil)
 
-	err = GeneratePolicyFromFile(mockPackageYamlFn, false)
+	err = GeneratePolicyFromFile(mockSnapYamlFn, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(ml.notice, DeepEquals, []string(nil))
@@ -882,15 +882,15 @@ func (a *SecurityTestSuite) TestSecurityWarnsOnDeprecatedApparmor(c *C) {
 	makeMockApparmorTemplate(c, "default", []byte(``))
 	makeMockSeccompTemplate(c, "default", []byte(``))
 
-	for _, s := range []string{mockSecurityDeprecatedPackageYamlApparmor1, mockSecurityDeprecatedPackageYamlApparmor2} {
+	for _, s := range []string{mockSecurityDeprecatedSnapYamlApparmor1, mockSecurityDeprecatedSnapYamlApparmor2} {
 
 		ml := &mockLogger{}
 		logger.SetLogger(ml)
 
-		mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityDeprecatedPackageYaml+s)
+		mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityDeprecatedSnapYaml+s)
 		c.Assert(err, IsNil)
 
-		err = GeneratePolicyFromFile(mockPackageYamlFn, false)
+		err = GeneratePolicyFromFile(mockSnapYamlFn, false)
 		c.Assert(err, IsNil)
 
 		c.Assert(ml.notice, DeepEquals, []string{"The security-override.apparmor key is no longer supported, please use use security-override directly"})
@@ -901,15 +901,15 @@ func (a *SecurityTestSuite) TestSecurityWarnsOnDeprecatedSeccomp(c *C) {
 	makeMockApparmorTemplate(c, "default", []byte(``))
 	makeMockSeccompTemplate(c, "default", []byte(``))
 
-	for _, s := range []string{mockSecurityDeprecatedPackageYamlSeccomp1, mockSecurityDeprecatedPackageYamlSeccomp2} {
+	for _, s := range []string{mockSecurityDeprecatedSnapYamlSeccomp1, mockSecurityDeprecatedSnapYamlSeccomp2} {
 
 		ml := &mockLogger{}
 		logger.SetLogger(ml)
 
-		mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityDeprecatedPackageYaml+s)
+		mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityDeprecatedSnapYaml+s)
 		c.Assert(err, IsNil)
 
-		err = GeneratePolicyFromFile(mockPackageYamlFn, false)
+		err = GeneratePolicyFromFile(mockSnapYamlFn, false)
 		c.Assert(err, IsNil)
 
 		c.Assert(ml.notice, DeepEquals, []string{"The security-override.seccomp key is no longer supported, please use use security-override directly"})
@@ -917,16 +917,16 @@ func (a *SecurityTestSuite) TestSecurityWarnsOnDeprecatedSeccomp(c *C) {
 }
 
 func makeInstalledMockSnapSideloaded(c *C) string {
-	mockPackageYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecurityPackageYaml)
+	mockSnapYamlFn, err := makeInstalledMockSnap(dirs.GlobalRootDir, mockSecuritySnapYaml)
 	c.Assert(err, IsNil)
 	// pretend its sideloaded
-	basePath := regexp.MustCompile(`(.*)/hello-world.` + testOrigin).FindString(mockPackageYamlFn)
+	basePath := regexp.MustCompile(`(.*)/hello-world.` + testOrigin).FindString(mockSnapYamlFn)
 	oldPath := filepath.Join(basePath, "1.0")
 	newPath := filepath.Join(basePath, "IsSideloadVer")
 	err = os.Rename(oldPath, newPath)
-	mockPackageYamlFn = filepath.Join(basePath, "IsSideloadVer", "meta", "snap.yaml")
+	mockSnapYamlFn = filepath.Join(basePath, "IsSideloadVer", "meta", "snap.yaml")
 
-	return mockPackageYamlFn
+	return mockSnapYamlFn
 }
 
 func (a *SecurityTestSuite) TestSecurityGeneratePolicyFromFileSideload(c *C) {
@@ -934,10 +934,10 @@ func (a *SecurityTestSuite) TestSecurityGeneratePolicyFromFileSideload(c *C) {
 	makeMockApparmorTemplate(c, "default", []byte(``))
 	makeMockSeccompTemplate(c, "default", []byte(``))
 
-	mockPackageYamlFn := makeInstalledMockSnapSideloaded(c)
+	mockSnapYamlFn := makeInstalledMockSnapSideloaded(c)
 
 	// the acutal thing that gets tested
-	err := GeneratePolicyFromFile(mockPackageYamlFn, false)
+	err := GeneratePolicyFromFile(mockSnapYamlFn, false)
 	c.Assert(err, IsNil)
 
 	// ensure the apparmor policy got loaded
@@ -957,13 +957,13 @@ func (a *SecurityTestSuite) TestSecurityCompareGeneratePolicyFromFileSideload(c 
 	makeMockApparmorTemplate(c, "default", []byte(``))
 	makeMockSeccompTemplate(c, "default", []byte(``))
 
-	mockPackageYamlFn := makeInstalledMockSnapSideloaded(c)
+	mockSnapYamlFn := makeInstalledMockSnapSideloaded(c)
 	// generate policy
-	err := GeneratePolicyFromFile(mockPackageYamlFn, false)
+	err := GeneratePolicyFromFile(mockSnapYamlFn, false)
 	c.Assert(err, IsNil)
 
 	// nothing changed, ensure compare is happy even for sideloaded pkgs
-	err = CompareGeneratePolicyFromFile(mockPackageYamlFn)
+	err = CompareGeneratePolicyFromFile(mockSnapYamlFn)
 	c.Assert(err, IsNil)
 }
 
@@ -1003,7 +1003,7 @@ func (a *SecurityTestSuite) TestSecurityGeneratePolicyForServiceBinaryErrors(c *
 	c.Assert(err, ErrorMatches, "invalid package on system")
 }
 
-func (a *SecurityTestSuite) TestParsePackageYamlWithVersion(c *C) {
+func (a *SecurityTestSuite) TestParseSnapYamlWithVersion(c *C) {
 	testVersion := "1.0"
 	dir := filepath.Join(a.tempDir, "foo", testVersion, "meta")
 	os.MkdirAll(dir, 0755)
@@ -1012,12 +1012,12 @@ func (a *SecurityTestSuite) TestParsePackageYamlWithVersion(c *C) {
 name: foo
 version: 123456789
 `), 0644)
-	m, err := parsePackageYamlFileWithVersion(y)
+	m, err := parseSnapYamlFileWithVersion(y)
 	c.Assert(err, IsNil)
 	c.Assert(m.Version, Equals, testVersion)
 }
 
-func (a *SecurityTestSuite) TestParsePackageYamlWithVersionSymlink(c *C) {
+func (a *SecurityTestSuite) TestParseSnapYamlWithVersionSymlink(c *C) {
 	testVersion := "1.0"
 	verDir := filepath.Join(a.tempDir, "foo", testVersion)
 	symDir := filepath.Join(a.tempDir, "foo", "current")
@@ -1028,7 +1028,7 @@ func (a *SecurityTestSuite) TestParsePackageYamlWithVersionSymlink(c *C) {
 name: foo
 version: 123456789
 `), 0644)
-	m, err := parsePackageYamlFileWithVersion(y)
+	m, err := parseSnapYamlFileWithVersion(y)
 	c.Assert(err, IsNil)
 	c.Assert(m.Version, Equals, testVersion)
 

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -913,7 +913,7 @@ func makeInstalledMockSnapSideloaded(c *C) string {
 	oldPath := filepath.Join(basePath, "1.0")
 	newPath := filepath.Join(basePath, "IsSideloadVer")
 	err = os.Rename(oldPath, newPath)
-	mockPackageYamlFn = filepath.Join(basePath, "IsSideloadVer", "meta", "package.yaml")
+	mockPackageYamlFn = filepath.Join(basePath, "IsSideloadVer", "meta", "snap.yaml")
 
 	return mockPackageYamlFn
 }
@@ -996,7 +996,7 @@ func (a *SecurityTestSuite) TestParsePackageYamlWithVersion(c *C) {
 	testVersion := "1.0"
 	dir := filepath.Join(a.tempDir, "foo", testVersion, "meta")
 	os.MkdirAll(dir, 0755)
-	y := filepath.Join(dir, "package.yaml")
+	y := filepath.Join(dir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`
 name: foo
 version: 123456789
@@ -1012,7 +1012,7 @@ func (a *SecurityTestSuite) TestParsePackageYamlWithVersionSymlink(c *C) {
 	symDir := filepath.Join(a.tempDir, "foo", "current")
 	os.MkdirAll(filepath.Join(verDir, "meta"), 0755)
 	os.Symlink(verDir, symDir)
-	y := filepath.Join(symDir, "meta", "package.yaml")
+	y := filepath.Join(symDir, "meta", "snap.yaml")
 	ioutil.WriteFile(y, []byte(`
 name: foo
 version: 123456789

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -126,7 +126,7 @@ func (a *SecurityTestSuite) TestSnappyGetSecurityProfile(c *C) {
 		Name:    "foo",
 		Version: "1.0",
 	}
-	b := Binary{Name: "bin/app"}
+	b := AppYaml{Name: "bin/app"}
 	ap, err := getSecurityProfile(&m, b.Name, "/snaps/foo.mvo/1.0/")
 	c.Assert(err, IsNil)
 	c.Check(ap, Equals, "foo.mvo_bin-app_1.0")
@@ -137,7 +137,7 @@ func (a *SecurityTestSuite) TestSnappyGetSecurityProfileInvalid(c *C) {
 		Name:    "foo",
 		Version: "1.0",
 	}
-	b := Binary{Name: "bin/app"}
+	b := AppYaml{Name: "bin/app"}
 	_, err := getSecurityProfile(&m, b.Name, "/snaps/foo/1.0/")
 	c.Assert(err, Equals, ErrInvalidPart)
 }
@@ -148,7 +148,7 @@ func (a *SecurityTestSuite) TestSnappyGetSecurityProfileFramework(c *C) {
 		Version: "1.0",
 		Type:    snap.TypeFramework,
 	}
-	b := Binary{Name: "bin/app"}
+	b := AppYaml{Name: "bin/app"}
 	ap, err := getSecurityProfile(&m, b.Name, "/snaps/foo.mvo/1.0/")
 	c.Assert(err, IsNil)
 	c.Check(ap, Equals, "foo_bin-app_1.0")

--- a/snappy/service.go
+++ b/snappy/service.go
@@ -46,7 +46,7 @@ type ServiceActor interface {
 
 type svcT struct {
 	m   *packageYaml
-	svc *ServiceYaml
+	svc *AppYaml
 }
 
 type serviceActor struct {
@@ -86,14 +86,14 @@ func FindServices(snapName string, serviceName string, pb progress.Meter) (Servi
 		}
 		foundSnap = true
 
-		yamls := snap.ServiceYamls()
-		for i := range yamls {
-			if serviceName != "" && serviceName != yamls[i].Name {
+		yamls := snap.Apps()
+		for name, app := range yamls {
+			if serviceName != "" && serviceName != name {
 				continue
 			}
 			s := &svcT{
 				m:   snap.m,
-				svc: &yamls[i],
+				svc: &app,
 			}
 			svcs = append(svcs, s)
 		}

--- a/snappy/service.go
+++ b/snappy/service.go
@@ -45,7 +45,7 @@ type ServiceActor interface {
 }
 
 type svcT struct {
-	m   *packageYaml
+	m   *snapYaml
 	svc *AppYaml
 }
 

--- a/snappy/service.go
+++ b/snappy/service.go
@@ -93,7 +93,7 @@ func FindServices(snapName string, serviceName string, pb progress.Meter) (Servi
 			}
 			s := &svcT{
 				m:   snap.m,
-				svc: &app,
+				svc: app,
 			}
 			svcs = append(svcs, s)
 		}
@@ -119,7 +119,7 @@ func (actor *serviceActor) Status() ([]string, error) {
 	// TODO: make this a [i.String() for i in actor.ServiceStatus()]
 	var stati []string
 	for _, svc := range actor.svcs {
-		svcname := filepath.Base(generateServiceFileName(svc.m, *svc.svc))
+		svcname := filepath.Base(generateServiceFileName(svc.m, svc.svc))
 		status, err := actor.sysd.Status(svcname)
 		if err != nil {
 			return nil, err
@@ -143,7 +143,7 @@ type PackageServiceStatus struct {
 func (actor *serviceActor) ServiceStatus() ([]*PackageServiceStatus, error) {
 	var stati []*PackageServiceStatus
 	for _, svc := range actor.svcs {
-		svcname := filepath.Base(generateServiceFileName(svc.m, *svc.svc))
+		svcname := filepath.Base(generateServiceFileName(svc.m, svc.svc))
 		status, err := actor.sysd.ServiceStatus(svcname)
 		if err != nil {
 			return nil, err
@@ -162,7 +162,7 @@ func (actor *serviceActor) ServiceStatus() ([]*PackageServiceStatus, error) {
 // Start all the found services.
 func (actor *serviceActor) Start() error {
 	for _, svc := range actor.svcs {
-		svcname := filepath.Base(generateServiceFileName(svc.m, *svc.svc))
+		svcname := filepath.Base(generateServiceFileName(svc.m, svc.svc))
 		if err := actor.sysd.Start(svcname); err != nil {
 			// TRANSLATORS: the first %s is the package name, the second is the service name; the %v is the error
 			return fmt.Errorf(i18n.G("unable to start %s's service %s: %v"), svc.m.Name, svc.svc.Name, err)
@@ -175,7 +175,7 @@ func (actor *serviceActor) Start() error {
 // Stop all the found services.
 func (actor *serviceActor) Stop() error {
 	for _, svc := range actor.svcs {
-		svcname := filepath.Base(generateServiceFileName(svc.m, *svc.svc))
+		svcname := filepath.Base(generateServiceFileName(svc.m, svc.svc))
 		if err := actor.sysd.Stop(svcname, time.Duration(svc.svc.StopTimeout)); err != nil {
 			// TRANSLATORS: the first %s is the package name, the second is the service name; the %v is the error
 			return fmt.Errorf(i18n.G("unable to stop %s's service %s: %v"), svc.m.Name, svc.svc.Name, err)
@@ -198,7 +198,7 @@ func (actor *serviceActor) Restart() error {
 // Enable all the found services.
 func (actor *serviceActor) Enable() error {
 	for _, svc := range actor.svcs {
-		svcname := filepath.Base(generateServiceFileName(svc.m, *svc.svc))
+		svcname := filepath.Base(generateServiceFileName(svc.m, svc.svc))
 		if err := actor.sysd.Enable(svcname); err != nil {
 			// TRANSLATORS: the first %s is the package name, the second is the service name; the %v is the error
 			return fmt.Errorf(i18n.G("unable to enable %s's service %s: %v"), svc.m.Name, svc.svc.Name, err)
@@ -213,7 +213,7 @@ func (actor *serviceActor) Enable() error {
 // Disable all the found services.
 func (actor *serviceActor) Disable() error {
 	for _, svc := range actor.svcs {
-		svcname := filepath.Base(generateServiceFileName(svc.m, *svc.svc))
+		svcname := filepath.Base(generateServiceFileName(svc.m, svc.svc))
 		if err := actor.sysd.Disable(svcname); err != nil {
 			// TRANSLATORS: the first %s is the package name, the second is the service name; the %v is the error
 			return fmt.Errorf(i18n.G("unable to disable %s's service %s: %v"), svc.m.Name, svc.svc.Name, err)
@@ -230,7 +230,7 @@ func (actor *serviceActor) Logs() ([]systemd.Log, error) {
 	var svcnames []string
 
 	for _, svc := range actor.svcs {
-		svcname := filepath.Base(generateServiceFileName(svc.m, *svc.svc))
+		svcname := filepath.Base(generateServiceFileName(svc.m, svc.svc))
 		svcnames = append(svcnames, svcname)
 	}
 

--- a/snappy/service_test.go
+++ b/snappy/service_test.go
@@ -82,16 +82,18 @@ func (s *ServiceActorSuite) SetUpTest(c *C) {
 	systemd.JournalctlCmd = s.myJctl
 	_, err := makeInstalledMockSnap(dirs.GlobalRootDir, `name: hello-app
 version: 1.09
-services:
- - name: svc1
-   start: bin/hello
+apps:
+ svc1:
+   command: bin/hello
+   daemon: forking
 `)
 	c.Assert(err, IsNil)
 	f, err := makeInstalledMockSnap(dirs.GlobalRootDir, `name: hello-app
 version: 1.10
-services:
- - name: svc1
-   start: bin/hello
+apps:
+ svc1:
+   command: bin/hello
+   daemon: forking
 `)
 	c.Assert(err, IsNil)
 	c.Assert(makeSnapActive(f), IsNil)

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -316,7 +316,7 @@ func (s *SnapFile) Install(inter progress.Meter, flags InstallFlags) (name strin
 			if !dep.IsActive() {
 				continue
 			}
-			for _, svc := range dep.ServiceYamls() {
+			for _, svc := range dep.Apps() {
 				serviceName := filepath.Base(generateServiceFileName(dep.m, svc))
 				timeout := time.Duration(svc.StopTimeout)
 				if err = sysd.Stop(serviceName, timeout); err != nil {
@@ -362,10 +362,6 @@ func (s *SnapFile) CanInstall(allowGadget bool, inter interacter) error {
 	// verify we have a valid architecture
 	if !arch.IsSupportedArchitecture(s.m.Architectures) {
 		return &ErrArchitectureNotSupported{s.m.Architectures}
-	}
-
-	if err := s.m.checkForNameClashes(); err != nil {
-		return err
 	}
 
 	if err := s.m.checkForFrameworks(); err != nil {

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -58,7 +58,7 @@ func NewSnapFile(snapFile string, origin string, unsignedOk bool) (*SnapFile, er
 	_, err = d.MetaMember("hooks/config")
 	hasConfig := err == nil
 
-	m, err := parsePackageYamlData(yamlData, hasConfig)
+	m, err := parseSnapYamlData(yamlData, hasConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -36,7 +36,7 @@ import (
 
 // SnapFile is a local snap file that can get installed
 type SnapFile struct {
-	m   *packageYaml
+	m   *snapYaml
 	deb snap.File
 
 	origin  string

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -50,7 +50,7 @@ func NewSnapFile(snapFile string, origin string, unsignedOk bool) (*SnapFile, er
 		return nil, err
 	}
 
-	yamlData, err := d.MetaMember("package.yaml")
+	yamlData, err := d.MetaMember("snap.yaml")
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *SnapFile) Install(inter progress.Meter, flags InstallFlags) (name strin
 
 	var oldPart *SnapPart
 	if currentActiveDir, _ := filepath.EvalSymlinks(filepath.Join(s.instdir, "..", "current")); currentActiveDir != "" {
-		oldPart, err = NewInstalledSnapPart(filepath.Join(currentActiveDir, "meta", "package.yaml"), s.origin)
+		oldPart, err = NewInstalledSnapPart(filepath.Join(currentActiveDir, "meta", "snap.yaml"), s.origin)
 		if err != nil {
 			return "", err
 		}
@@ -276,7 +276,7 @@ func (s *SnapFile) Install(inter progress.Meter, flags InstallFlags) (name strin
 	}
 
 	if !inhibitHooks {
-		newPart, err := newSnapPartFromYaml(filepath.Join(s.instdir, "meta", "package.yaml"), s.origin, s.m)
+		newPart, err := newSnapPartFromYaml(filepath.Join(s.instdir, "meta", "snap.yaml"), s.origin, s.m)
 		if err != nil {
 			return "", err
 		}

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -510,18 +510,19 @@ func (s *SnapPart) CanInstall(allowGadget bool, inter interacter) error {
 // templates impacts the snap, and updates the policy if needed
 func (s *SnapPart) RequestSecurityPolicyUpdate(policies, templates map[string]bool) error {
 	var foundError error
-	for _, svc := range s.Apps() {
-		if svc.NeedsAppArmorUpdate(policies, templates) {
-			err := svc.generatePolicyForServiceBinary(s.m, svc.Name, s.basedir)
-			if err != nil {
-				logger.Noticef("Failed to regenerate policy for %s: %v", svc.Name, err)
-				foundError = err
-			}
-		}
-	}
 	for name, app := range s.Apps() {
-		if app.NeedsAppArmorUpdate(policies, templates) {
-			err := app.generatePolicyForServiceBinary(s.m, name, s.basedir)
+		skill, err := findSkillForApp(s.m, app)
+		if err != nil {
+			logger.Noticef("Failed to find skill for %s: %v", name, err)
+			foundError = err
+			continue
+		}
+		if skill == nil {
+			continue
+		}
+
+		if skill.NeedsAppArmorUpdate(policies, templates) {
+			err := skill.generatePolicyForServiceBinary(s.m, name, s.basedir)
 			if err != nil {
 				logger.Noticef("Failed to regenerate policy for %s: %v", name, err)
 				foundError = err

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -51,7 +51,7 @@ type SnapPart struct {
 
 // NewInstalledSnapPart returns a new SnapPart from the given yamlPath
 func NewInstalledSnapPart(yamlPath, origin string) (*SnapPart, error) {
-	m, err := parsePackageYamlFile(yamlPath)
+	m, err := parseSnapYamlFile(yamlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -40,12 +40,11 @@ import (
 
 // SnapPart represents a generic snap type
 type SnapPart struct {
-	m           *packageYaml
-	remoteM     *remote.Snap
-	origin      string
-	hash        string
-	isActive    bool
-	description string
+	m        *packageYaml
+	remoteM  *remote.Snap
+	origin   string
+	hash     string
+	isActive bool
 
 	basedir string
 }
@@ -89,11 +88,6 @@ func newSnapPartFromYaml(yamlPath, origin string, m *packageYaml) (*SnapPart, er
 		part.isActive = true
 	}
 
-	// get the *title* from readme.md and use that as the *description*.
-	if description, _, err := parseReadme(filepath.Join(part.basedir, "meta", "readme.md")); err == nil {
-		part.description = description
-	}
-
 	remoteManifestPath := RemoteManifestPath(part)
 	if helpers.FileExists(remoteManifestPath) {
 		content, err := ioutil.ReadFile(remoteManifestPath)
@@ -135,13 +129,13 @@ func (s *SnapPart) Version() string {
 	return s.m.Version
 }
 
-// Description returns the description
+// Description returns the summary description
 func (s *SnapPart) Description() string {
 	if r := s.remoteM; r != nil {
 		return r.Description
 	}
 
-	return s.description
+	return s.m.Summary
 }
 
 // Origin returns the origin

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -64,7 +64,7 @@ func NewInstalledSnapPart(yamlPath, origin string) (*SnapPart, error) {
 	return part, nil
 }
 
-// newSnapPartFromYaml returns a new SnapPart from the given *packageYaml at yamlPath
+// newSnapPartFromYaml returns a new SnapPart from the given *snapYaml at yamlPath
 func newSnapPartFromYaml(yamlPath, origin string, m *snapYaml) (*SnapPart, error) {
 	part := &SnapPart{
 		basedir: filepath.Dir(filepath.Dir(yamlPath)),

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -174,7 +174,12 @@ func (s *SnapPart) Channel() string {
 
 // Icon returns the path to the icon
 func (s *SnapPart) Icon() string {
-	return filepath.Join(s.basedir, "meta", "icon.png")
+	found, _ := filepath.Glob(filepath.Join(s.basedir, "meta", "icon.*"))
+	if len(found) == 0 {
+		return ""
+	}
+
+	return found[0]
 }
 
 // IsActive returns true if the snap is active
@@ -219,7 +224,7 @@ func (s *SnapPart) Date() time.Time {
 }
 
 // Apps return a list of AppsYamls the package declares
-func (s *SnapPart) Apps() map[string]AppYaml {
+func (s *SnapPart) Apps() map[string]*AppYaml {
 	return s.m.Apps
 }
 

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -254,7 +254,7 @@ func (s *SnapPart) activate(inhibitHooks bool, inter interacter) error {
 	// there is already an active part
 	if currentActiveDir != "" {
 		// TODO: support switching origins
-		oldYaml := filepath.Join(currentActiveDir, "meta", "package.yaml")
+		oldYaml := filepath.Join(currentActiveDir, "meta", "snap.yaml")
 		oldPart, err := NewInstalledSnapPart(oldYaml, s.origin)
 		if err != nil {
 			return err
@@ -270,7 +270,7 @@ func (s *SnapPart) activate(inhibitHooks bool, inter interacter) error {
 		}
 	}
 
-	// generate the security policy from the package.yaml
+	// generate the security policy from the snap.yaml
 	// Note that this must happen before binaries/services are
 	// generated because serices may get started
 	appsDir := filepath.Join(dirs.SnapSnapsDir, QualifiedName(s), s.Version())
@@ -278,11 +278,11 @@ func (s *SnapPart) activate(inhibitHooks bool, inter interacter) error {
 		return err
 	}
 
-	// add the "binaries:" from the package.yaml
+	// add the "binaries:" from the snap.yaml
 	if err := s.m.addPackageBinaries(s.basedir); err != nil {
 		return err
 	}
-	// add the "services:" from the package.yaml
+	// add the "services:" from the snap.yaml
 	if err := s.m.addPackageServices(s.basedir, inhibitHooks, inter); err != nil {
 		return err
 	}

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -40,7 +40,7 @@ import (
 
 // SnapPart represents a generic snap type
 type SnapPart struct {
-	m        *packageYaml
+	m        *snapYaml
 	remoteM  *remote.Snap
 	origin   string
 	hash     string
@@ -65,7 +65,7 @@ func NewInstalledSnapPart(yamlPath, origin string) (*SnapPart, error) {
 }
 
 // newSnapPartFromYaml returns a new SnapPart from the given *packageYaml at yamlPath
-func newSnapPartFromYaml(yamlPath, origin string, m *packageYaml) (*SnapPart, error) {
+func newSnapPartFromYaml(yamlPath, origin string, m *snapYaml) (*SnapPart, error) {
 	part := &SnapPart{
 		basedir: filepath.Dir(filepath.Dir(yamlPath)),
 		origin:  origin,

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -174,11 +174,7 @@ func (s *SnapPart) Channel() string {
 
 // Icon returns the path to the icon
 func (s *SnapPart) Icon() string {
-	if s.m.Icon == "" {
-		return ""
-	}
-
-	return filepath.Join(s.basedir, s.m.Icon)
+	return filepath.Join(s.basedir, "meta", "icon.png")
 }
 
 // IsActive returns true if the snap is active
@@ -222,14 +218,9 @@ func (s *SnapPart) Date() time.Time {
 	return st.ModTime()
 }
 
-// ServiceYamls return a list of ServiceYamls the package declares
-func (s *SnapPart) ServiceYamls() []ServiceYaml {
-	return s.m.ServiceYamls
-}
-
-// Binaries return a list of BinaryDescription the package declares
-func (s *SnapPart) Binaries() []Binary {
-	return s.m.Binaries
+// Apps return a list of AppsYamls the package declares
+func (s *SnapPart) Apps() map[string]AppYaml {
+	return s.m.Apps
 }
 
 // GadgetConfig return a list of packages to configure
@@ -520,7 +511,7 @@ func (s *SnapPart) CanInstall(allowGadget bool, inter interacter) error {
 // templates impacts the snap, and updates the policy if needed
 func (s *SnapPart) RequestSecurityPolicyUpdate(policies, templates map[string]bool) error {
 	var foundError error
-	for _, svc := range s.ServiceYamls() {
+	for _, svc := range s.Apps() {
 		if svc.NeedsAppArmorUpdate(policies, templates) {
 			err := svc.generatePolicyForServiceBinary(s.m, svc.Name, s.basedir)
 			if err != nil {
@@ -529,11 +520,11 @@ func (s *SnapPart) RequestSecurityPolicyUpdate(policies, templates map[string]bo
 			}
 		}
 	}
-	for _, bin := range s.Binaries() {
-		if bin.NeedsAppArmorUpdate(policies, templates) {
-			err := bin.generatePolicyForServiceBinary(s.m, bin.Name, s.basedir)
+	for name, app := range s.Apps() {
+		if app.NeedsAppArmorUpdate(policies, templates) {
+			err := app.generatePolicyForServiceBinary(s.m, name, s.basedir)
 			if err != nil {
-				logger.Noticef("Failed to regenerate policy for %s: %v", bin.Name, err)
+				logger.Noticef("Failed to regenerate policy for %s: %v", name, err)
 				foundError = err
 			}
 		}

--- a/snappy/snap_local_repo.go
+++ b/snappy/snap_local_repo.go
@@ -54,8 +54,8 @@ func (s *SnapLocalRepository) Details(name string, origin string) (versions []Pa
 	if origin == "" || origin == SideloadedOrigin {
 		origin = "*"
 	}
-	appParts, err := s.partsForGlobExpr(filepath.Join(s.path, name+"."+origin, "*", "meta", "package.yaml"))
-	fmkParts, err := s.partsForGlobExpr(filepath.Join(s.path, name, "*", "meta", "package.yaml"))
+	appParts, err := s.partsForGlobExpr(filepath.Join(s.path, name+"."+origin, "*", "meta", "snap.yaml"))
+	fmkParts, err := s.partsForGlobExpr(filepath.Join(s.path, name, "*", "meta", "snap.yaml"))
 
 	parts := append(appParts, fmkParts...)
 
@@ -73,7 +73,7 @@ func (s *SnapLocalRepository) Updates() (parts []Part, err error) {
 
 // Installed returns the installed snaps from this repository
 func (s *SnapLocalRepository) Installed() (parts []Part, err error) {
-	globExpr := filepath.Join(s.path, "*", "*", "meta", "package.yaml")
+	globExpr := filepath.Join(s.path, "*", "*", "meta", "snap.yaml")
 	return s.partsForGlobExpr(globExpr)
 }
 

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -167,10 +167,7 @@ func validatePackageYamlData(file string, yamlData []byte, m *packageYaml) error
 
 	// do all checks here
 	for _, app := range m.Apps {
-		if err := verifyBinariesYaml(app); err != nil {
-			return err
-		}
-		if err := verifyServiceYaml(app); err != nil {
+		if err := verifyAppYaml(app); err != nil {
 			return err
 		}
 	}

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -142,7 +142,7 @@ func parseSnapYamlFile(yamlPath string) (*snapYaml, error) {
 	return parseSnapYamlData(yamlData, hasConfig)
 }
 
-func validatePackageYamlData(file string, yamlData []byte, m *snapYaml) error {
+func validateSnapYamlData(file string, yamlData []byte, m *snapYaml) error {
 	// check mandatory fields
 	missing := []string{}
 	for _, name := range []string{"Name", "Version"} {
@@ -206,7 +206,7 @@ func parseSnapYamlData(yamlData []byte, hasConfig bool) (*snapYaml, error) {
 		}
 	}
 
-	if err := validatePackageYamlData("snap.yaml", yamlData, &m); err != nil {
+	if err := validateSnapYamlData("snap.yaml", yamlData, &m); err != nil {
 		return nil, err
 	}
 

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -139,7 +139,7 @@ func parsePackageYamlFile(yamlPath string) (*packageYaml, error) {
 	// legacy support sucks :-/
 	hasConfig := helpers.FileExists(filepath.Join(filepath.Dir(yamlPath), "hooks", "config"))
 
-	return parsePackageYamlData(yamlData, hasConfig)
+	return parseSnapYamlData(yamlData, hasConfig)
 }
 
 func validatePackageYamlData(file string, yamlData []byte, m *packageYaml) error {
@@ -182,7 +182,7 @@ func validatePackageYamlData(file string, yamlData []byte, m *packageYaml) error
 	return nil
 }
 
-func parsePackageYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error) {
+func parseSnapYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error) {
 	var m packageYaml
 	err := yaml.Unmarshal(yamlData, &m)
 	if err != nil {

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -98,7 +98,7 @@ var commasplitter = regexp.MustCompile(`\s*,\s*`).Split
 
 // TODO split into payloads per package type composing the common
 // elements for all snaps.
-type packageYaml struct {
+type snapYaml struct {
 	Name             string
 	Version          string
 	LicenseAgreement string `yaml:"license-agreement,omitempty"`
@@ -129,7 +129,7 @@ type packageYaml struct {
 	Dtbs   string `yaml:"dtbs,omitempty"`
 }
 
-func parseSnapYamlFile(yamlPath string) (*packageYaml, error) {
+func parseSnapYamlFile(yamlPath string) (*snapYaml, error) {
 
 	yamlData, err := ioutil.ReadFile(yamlPath)
 	if err != nil {
@@ -142,7 +142,7 @@ func parseSnapYamlFile(yamlPath string) (*packageYaml, error) {
 	return parseSnapYamlData(yamlData, hasConfig)
 }
 
-func validatePackageYamlData(file string, yamlData []byte, m *packageYaml) error {
+func validatePackageYamlData(file string, yamlData []byte, m *snapYaml) error {
 	// check mandatory fields
 	missing := []string{}
 	for _, name := range []string{"Name", "Version"} {
@@ -182,8 +182,8 @@ func validatePackageYamlData(file string, yamlData []byte, m *packageYaml) error
 	return nil
 }
 
-func parseSnapYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error) {
-	var m packageYaml
+func parseSnapYamlData(yamlData []byte, hasConfig bool) (*snapYaml, error) {
+	var m snapYaml
 	err := yaml.Unmarshal(yamlData, &m)
 	if err != nil {
 		return nil, &ErrInvalidYaml{File: "snap.yaml", Err: err, Yaml: yamlData}
@@ -213,14 +213,14 @@ func parseSnapYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error) {
 	return &m, nil
 }
 
-func (m *packageYaml) qualifiedName(origin string) string {
+func (m *snapYaml) qualifiedName(origin string) string {
 	if m.Type == snap.TypeFramework || m.Type == snap.TypeGadget {
 		return m.Name
 	}
 	return m.Name + "." + origin
 }
 
-func (m *packageYaml) checkForPackageInstalled(origin string) error {
+func (m *snapYaml) checkForPackageInstalled(origin string) error {
 	part := ActiveSnapByName(m.Name)
 	if part == nil {
 		return nil
@@ -233,7 +233,7 @@ func (m *packageYaml) checkForPackageInstalled(origin string) error {
 	return nil
 }
 
-func (m *packageYaml) checkForFrameworks() error {
+func (m *snapYaml) checkForFrameworks() error {
 	installed, err := ActiveSnapIterByType(BareName, snap.TypeFramework)
 	if err != nil {
 		return err
@@ -260,7 +260,7 @@ func (m *packageYaml) checkForFrameworks() error {
 // package, as deduced from the license agreement (which might involve asking
 // the user), or an error that explains the reason why installation should not
 // proceed.
-func (m *packageYaml) checkLicenseAgreement(ag agreer, d snap.File, currentActiveDir string) error {
+func (m *snapYaml) checkLicenseAgreement(ag agreer, d snap.File, currentActiveDir string) error {
 	if m.LicenseAgreement != "explicit" {
 		return nil
 	}
@@ -294,7 +294,7 @@ func (m *packageYaml) checkLicenseAgreement(ag agreer, d snap.File, currentActiv
 	return nil
 }
 
-func (m *packageYaml) addSquashfsMount(baseDir string, inhibitHooks bool, inter interacter) error {
+func (m *snapYaml) addSquashfsMount(baseDir string, inhibitHooks bool, inter interacter) error {
 	squashfsPath := stripGlobalRootDir(squashfs.BlobPath(baseDir))
 	whereDir := stripGlobalRootDir(baseDir)
 
@@ -316,7 +316,7 @@ func (m *packageYaml) addSquashfsMount(baseDir string, inhibitHooks bool, inter 
 	return nil
 }
 
-func (m *packageYaml) removeSquashfsMount(baseDir string, inter interacter) error {
+func (m *snapYaml) removeSquashfsMount(baseDir string, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	unit := systemd.MountUnitPath(stripGlobalRootDir(baseDir), "mount")
 	if helpers.FileExists(unit) {

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -200,6 +200,12 @@ func parsePackageYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error)
 		app.Name = name
 	}
 
+	for name, uses := range m.Uses {
+		if uses.Type == "" {
+			uses.Type = name
+		}
+	}
+
 	if err := validatePackageYamlData("snap.yaml", yamlData, &m); err != nil {
 		return nil, err
 	}

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -129,7 +129,7 @@ type packageYaml struct {
 	Dtbs   string `yaml:"dtbs,omitempty"`
 }
 
-func parsePackageYamlFile(yamlPath string) (*packageYaml, error) {
+func parseSnapYamlFile(yamlPath string) (*packageYaml, error) {
 
 	yamlData, err := ioutil.ReadFile(yamlPath)
 	if err != nil {
@@ -274,7 +274,7 @@ func (m *packageYaml) checkLicenseAgreement(ag agreer, d snap.File, currentActiv
 		return ErrLicenseNotProvided
 	}
 
-	oldM, err := parsePackageYamlFile(filepath.Join(currentActiveDir, "meta", "snap.yaml"))
+	oldM, err := parseSnapYamlFile(filepath.Join(currentActiveDir, "meta", "snap.yaml"))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -177,10 +177,6 @@ func parsePackageYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error)
 		return nil, &ErrInvalidYaml{File: "package.yaml", Err: err, Yaml: yamlData}
 	}
 
-	if err := validatePackageYamlData("package.yaml", yamlData, &m); err != nil {
-		return nil, err
-	}
-
 	if m.Architectures == nil {
 		m.Architectures = []string{"all"}
 	}
@@ -190,6 +186,10 @@ func parsePackageYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error)
 			app.StopTimeout = timeout.DefaultTimeout
 		}
 		app.Name = name
+	}
+
+	if err := validatePackageYamlData("package.yaml", yamlData, &m); err != nil {
+		return nil, err
 	}
 
 	return &m, nil

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -56,12 +56,14 @@ type Ports struct {
 
 // AppYaml represents an application (binary or service)
 type AppYaml struct {
-	Name     string `yaml:"name" json:"name,omitempty"`
-	Version  string
+	// name is partent key
+	Name string
+	// part of the yaml
+	Version  string   `yaml:"version"`
 	Command  string   `yaml:"command"`
 	Provides []string `yaml:"provides"`
 	Consumes []string `yaml:"consumes"`
-	Daemon   string
+	Daemon   string   `yaml:"daemon"`
 
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 
@@ -105,7 +107,7 @@ type packageYaml struct {
 	Frameworks []string `yaml:"frameworks,omitempty"`
 
 	// Apps can be both binary or service
-	Apps map[string]AppYaml `yaml:"apps,omitempty"`
+	Apps map[string]*AppYaml `yaml:"apps,omitempty"`
 
 	// FIXME: clarify those
 
@@ -183,10 +185,11 @@ func parsePackageYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error)
 		m.Architectures = []string{"all"}
 	}
 
-	for _, app := range m.Apps {
+	for name, app := range m.Apps {
 		if app.StopTimeout == 0 {
 			app.StopTimeout = timeout.DefaultTimeout
 		}
+		app.Name = name
 	}
 
 	return &m, nil

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -174,7 +174,7 @@ func parsePackageYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error)
 	var m packageYaml
 	err := yaml.Unmarshal(yamlData, &m)
 	if err != nil {
-		return nil, &ErrInvalidYaml{File: "package.yaml", Err: err, Yaml: yamlData}
+		return nil, &ErrInvalidYaml{File: "snap.yaml", Err: err, Yaml: yamlData}
 	}
 
 	if m.Architectures == nil {
@@ -188,7 +188,7 @@ func parsePackageYamlData(yamlData []byte, hasConfig bool) (*packageYaml, error)
 		app.Name = name
 	}
 
-	if err := validatePackageYamlData("package.yaml", yamlData, &m); err != nil {
+	if err := validatePackageYamlData("snap.yaml", yamlData, &m); err != nil {
 		return nil, err
 	}
 
@@ -256,7 +256,7 @@ func (m *packageYaml) checkLicenseAgreement(ag agreer, d snap.File, currentActiv
 		return ErrLicenseNotProvided
 	}
 
-	oldM, err := parsePackageYamlFile(filepath.Join(currentActiveDir, "meta", "package.yaml"))
+	oldM, err := parsePackageYamlFile(filepath.Join(currentActiveDir, "meta", "snap.yaml"))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -86,6 +86,11 @@ type AppYaml struct {
 	// must be a pointer so that it can be "nil" and omitempty works
 	Ports *Ports `yaml:"ports,omitempty" json:"ports,omitempty"`
 
+	UsesRef []string `yaml:"uses"`
+}
+
+type usesYaml struct {
+	Type                string `yaml:"type"`
 	SecurityDefinitions `yaml:",inline"`
 }
 
@@ -108,6 +113,9 @@ type packageYaml struct {
 
 	// Apps can be both binary or service
 	Apps map[string]*AppYaml `yaml:"apps,omitempty"`
+
+	// Uses maps the used "skills" to the apps
+	Uses map[string]*usesYaml `yaml:"uses,omitempty"`
 
 	// FIXME: clarify those
 
@@ -163,6 +171,13 @@ func validatePackageYamlData(file string, yamlData []byte, m *packageYaml) error
 			return err
 		}
 		if err := verifyServiceYaml(app); err != nil {
+			return err
+		}
+	}
+
+	// check for "uses"
+	for _, uses := range m.Uses {
+		if err := verifyUsesYaml(uses); err != nil {
 			return err
 		}
 	}

--- a/snappy/snap_yaml_test.go
+++ b/snappy/snap_yaml_test.go
@@ -35,7 +35,7 @@ uses:
  migration-skill:
   caps: []
 `)
-	sy, err := parsePackageYamlData(snapYaml, false)
+	sy, err := parseSnapYamlData(snapYaml, false)
 	c.Assert(err, IsNil)
 	sy.Uses["migration-skill"].Type = "migration-skill"
 }

--- a/snappy/snap_yaml_test.go
+++ b/snappy/snap_yaml_test.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snappy
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type snapYamlTestSuite struct {
+}
+
+var _ = Suite(&snapYamlTestSuite{})
+
+func (s *snapYamlTestSuite) TestParseYamlSetsTypeInUsesFromName(c *C) {
+	snapYaml := []byte(`name: foo
+version: 1.0
+uses:
+ migration-skill:
+  caps: []
+`)
+	sy, err := parsePackageYamlData(snapYaml, false)
+	c.Assert(err, IsNil)
+	sy.Uses["migration-skill"].Type = "migration-skill"
+}

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -126,7 +126,7 @@ func (s *SquashfsTestSuite) TestInstallViaSquashfsWorks(c *C) {
 }
 
 func (s *SquashfsTestSuite) TestAddSquashfsMount(c *C) {
-	m := packageYaml{
+	m := snapYaml{
 		Name:          "foo.origin",
 		Version:       "1.0",
 		Architectures: []string{"all"},
@@ -149,7 +149,7 @@ Where=/snaps/foo.origin/1.0
 }
 
 func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
-	m := packageYaml{}
+	m := snapYaml{}
 	inter := &MockProgressMeter{}
 	err := m.addSquashfsMount(filepath.Join(dirs.SnapSnapsDir, "foo.origin/1.0"), true, inter)
 	c.Assert(err, IsNil)
@@ -356,8 +356,8 @@ func (s *SquashfsTestSuite) TestInstallKernelRebootRequired(c *C) {
 	c.Assert(snap.NeedsReboot(), Equals, false)
 }
 
-func getFakeGrubGadget() (*packageYaml, error) {
-	return &packageYaml{
+func getFakeGrubGadget() (*snapYaml, error) {
+	return &snapYaml{
 		Gadget: Gadget{
 			Hardware: Hardware{
 				Bootloader: "grub",

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -177,7 +177,7 @@ func (s *SquashfsTestSuite) TestRemoveViaSquashfsWorks(c *C) {
 	c.Assert(helpers.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-app.origin_1.10.snap")), Equals, true)
 
 	// now remove and ensure its gone
-	installedPart, err := newSnapPartFromYaml(filepath.Join(part.instdir, "meta", "package.yaml"), part.origin, part.m)
+	installedPart, err := newSnapPartFromYaml(filepath.Join(part.instdir, "meta", "snap.yaml"), part.origin, part.m)
 	c.Assert(err, IsNil)
 	err = installedPart.Uninstall(&MockProgressMeter{})
 	c.Assert(err, IsNil)
@@ -278,7 +278,7 @@ func (s *SquashfsTestSuite) TestInstallKernelSnapRemovesKernelAssets(c *C) {
 	c.Assert(helpers.FileExists(kernelAssetsDir), Equals, true)
 
 	// ensure uninstall cleans the kernel assets
-	installedPart, err := newSnapPartFromYaml(filepath.Join(part.instdir, "meta", "package.yaml"), part.origin, part.m)
+	installedPart, err := newSnapPartFromYaml(filepath.Join(part.instdir, "meta", "snap.yaml"), part.origin, part.m)
 	c.Assert(err, IsNil)
 	installedPart.isActive = false
 	err = installedPart.Uninstall(pbar)

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -95,7 +95,6 @@ var _ = Suite(&SquashfsTestSuite{})
 
 const packageHello = `name: hello-app
 version: 1.10
-icon: meta/hello.svg
 `
 
 func (s *SquashfsTestSuite) TestMakeSnapMakesSquashfs(c *C) {

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -1241,7 +1241,7 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateService(c *C) {
 		UsesRef: []string{"svc"},
 	}
 	part := &SnapPart{
-		m: &packageYaml{
+		m: &snapYaml{
 			Name:    "part",
 			Apps:    map[string]*AppYaml{"svc": svc},
 			Version: "42",
@@ -1265,7 +1265,7 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateBinary(c *C) {
 		UsesRef: []string{"echo"},
 	}
 	part := &SnapPart{
-		m: &packageYaml{
+		m: &snapYaml{
 			Name:    "part",
 			Apps:    map[string]*AppYaml{"echo": bin},
 			Version: "42",
@@ -1292,7 +1292,7 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateNothing(c *C) {
 		UsesRef: []string{"echo"},
 	}
 	part := &SnapPart{
-		m: &packageYaml{
+		m: &snapYaml{
 			Apps: map[string]*AppYaml{
 				"svc":  svc,
 				"echo": bin,

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -825,7 +825,7 @@ func (s *SnapTestSuite) TestPackageYamlMultipleArchitecturesParsing(c *C) {
 version: 1.0
 architectures: [i386, armhf]
 `), 0644)
-	m, err := parsePackageYamlFile(y)
+	m, err := parseSnapYamlFile(y)
 	c.Assert(err, IsNil)
 	c.Assert(m.Architectures, DeepEquals, []string{"i386", "armhf"})
 }
@@ -836,7 +836,7 @@ func (s *SnapTestSuite) TestPackageYamlSingleArchitecturesParsing(c *C) {
 version: 1.0
 architectures: [i386]
 `), 0644)
-	m, err := parsePackageYamlFile(y)
+	m, err := parseSnapYamlFile(y)
 	c.Assert(err, IsNil)
 	c.Assert(m.Architectures, DeepEquals, []string{"i386"})
 }
@@ -846,7 +846,7 @@ func (s *SnapTestSuite) TestPackageYamlNoArchitecturesParsing(c *C) {
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
 `), 0644)
-	m, err := parsePackageYamlFile(y)
+	m, err := parseSnapYamlFile(y)
 	c.Assert(err, IsNil)
 	c.Assert(m.Architectures, DeepEquals, []string{"all"})
 }
@@ -879,7 +879,7 @@ func (s *SnapTestSuite) TestPackageYamlLicenseParsing(c *C) {
 name: foo
 version: 1.0
 license-agreement: explicit`), 0644)
-	m, err := parsePackageYamlFile(y)
+	m, err := parseSnapYamlFile(y)
 	c.Assert(err, IsNil)
 	c.Assert(m.LicenseAgreement, Equals, "explicit")
 }
@@ -1184,7 +1184,7 @@ func (s *SnapTestSuite) TestRemoveChecksFrameworks(c *C) {
 version: 1.0
 type: framework`)
 	c.Assert(err, IsNil)
-	yaml, err := parsePackageYamlFile(yamlFile)
+	yaml, err := parseSnapYamlFile(yamlFile)
 
 	_, err = makeInstalledMockSnap(s.tempdir, `name: foo
 version: 1.0

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -104,8 +104,8 @@ func (s *SnapTestSuite) makeInstalledMockSnap(yamls ...string) (yamlFile string,
 	return makeInstalledMockSnap(s.tempdir, yaml)
 }
 
-func makeSnapActive(packageYamlPath string) (err error) {
-	snapdir := filepath.Dir(filepath.Dir(packageYamlPath))
+func makeSnapActive(snapYamlPath string) (err error) {
+	snapdir := filepath.Dir(filepath.Dir(snapYamlPath))
 	parent := filepath.Dir(snapdir)
 	err = os.Symlink(snapdir, filepath.Join(parent, "current"))
 
@@ -819,7 +819,7 @@ apps:
 	c.Assert(snap.InstalledSize(), Not(Equals), -1)
 }
 
-func (s *SnapTestSuite) TestPackageYamlMultipleArchitecturesParsing(c *C) {
+func (s *SnapTestSuite) TestSnapYamlMultipleArchitecturesParsing(c *C) {
 	y := filepath.Join(s.tempdir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
@@ -830,7 +830,7 @@ architectures: [i386, armhf]
 	c.Assert(m.Architectures, DeepEquals, []string{"i386", "armhf"})
 }
 
-func (s *SnapTestSuite) TestPackageYamlSingleArchitecturesParsing(c *C) {
+func (s *SnapTestSuite) TestSnapYamlSingleArchitecturesParsing(c *C) {
 	y := filepath.Join(s.tempdir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
@@ -841,7 +841,7 @@ architectures: [i386]
 	c.Assert(m.Architectures, DeepEquals, []string{"i386"})
 }
 
-func (s *SnapTestSuite) TestPackageYamlNoArchitecturesParsing(c *C) {
+func (s *SnapTestSuite) TestSnapYamlNoArchitecturesParsing(c *C) {
 	y := filepath.Join(s.tempdir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
@@ -851,7 +851,7 @@ version: 1.0
 	c.Assert(m.Architectures, DeepEquals, []string{"all"})
 }
 
-func (s *SnapTestSuite) TestPackageYamlBadArchitectureParsing(c *C) {
+func (s *SnapTestSuite) TestSnapYamlBadArchitectureParsing(c *C) {
 	data := []byte(`name: fatbinary
 version: 1.0
 architectures:
@@ -862,7 +862,7 @@ architectures:
 	c.Assert(err, NotNil)
 }
 
-func (s *SnapTestSuite) TestPackageYamlWorseArchitectureParsing(c *C) {
+func (s *SnapTestSuite) TestSnapYamlWorseArchitectureParsing(c *C) {
 	data := []byte(`name: fatbinary
 version: 1.0
 architectures:
@@ -873,7 +873,7 @@ architectures:
 	c.Assert(err, NotNil)
 }
 
-func (s *SnapTestSuite) TestPackageYamlLicenseParsing(c *C) {
+func (s *SnapTestSuite) TestSnapYamlLicenseParsing(c *C) {
 	y := filepath.Join(s.tempdir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`
 name: foo
@@ -895,7 +895,7 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryGadgetStoreId(c *C) {
 	defer mockServer.Close()
 
 	// install custom gadget snap with store-id
-	packageYaml, err := makeInstalledMockSnap(s.tempdir, `name: gadget-test
+	snapYamlFn, err := makeInstalledMockSnap(s.tempdir, `name: gadget-test
 version: 1.0
 gadget:
   store:
@@ -903,7 +903,7 @@ gadget:
 type: gadget
 `)
 	c.Assert(err, IsNil)
-	makeSnapActive(packageYaml)
+	makeSnapActive(snapYamlFn)
 
 	storeDetailsURI, err = url.Parse(mockServer.URL)
 	c.Assert(err, IsNil)
@@ -929,9 +929,9 @@ type: gadget
 	c.Assert(err, IsNil)
 	makeSnapActive(gadgetYaml)
 
-	packageYaml, err := makeInstalledMockSnap(s.tempdir, "")
+	snapYamlFn, err := makeInstalledMockSnap(s.tempdir, "")
 	c.Assert(err, IsNil)
-	makeSnapActive(packageYaml)
+	makeSnapActive(snapYamlFn)
 
 	p := &MockProgressMeter{}
 
@@ -944,7 +944,7 @@ type: gadget
 	c.Check(parts[0].Uninstall(p), Equals, ErrPackageNotRemovable)
 }
 
-var securityBinaryPackageYaml = []byte(`name: test-snap
+var securityBinarySnapYaml = []byte(`name: test-snap
 version: 1.2.8
 apps:
  testme:
@@ -978,8 +978,8 @@ uses:
 
 `)
 
-func (s *SnapTestSuite) TestPackageYamlSecurityBinaryParsing(c *C) {
-	m, err := parseSnapYamlData(securityBinaryPackageYaml, false)
+func (s *SnapTestSuite) TestSnapYamlSecurityBinaryParsing(c *C) {
+	m, err := parseSnapYamlData(securityBinarySnapYaml, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(m.Apps["testme"].Name, Equals, "testme")
@@ -1000,7 +1000,7 @@ func (s *SnapTestSuite) TestPackageYamlSecurityBinaryParsing(c *C) {
 	c.Assert(m.Uses["testme-policy"].SecurityPolicy.AppArmor, Equals, "meta/testme-policy.profile")
 }
 
-var securityServicePackageYaml = []byte(`name: test-snap
+var securityServiceSnapYaml = []byte(`name: test-snap
 version: 1.2.8
 apps:
  testme-service:
@@ -1019,8 +1019,8 @@ uses:
    security-template: "foo_template"
 `)
 
-func (s *SnapTestSuite) TestPackageYamlSecurityServiceParsing(c *C) {
-	m, err := parseSnapYamlData(securityServicePackageYaml, false)
+func (s *SnapTestSuite) TestSnapYamlSecurityServiceParsing(c *C) {
+	m, err := parseSnapYamlData(securityServiceSnapYaml, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(m.Apps["testme-service"].Name, Equals, "testme-service")
@@ -1461,41 +1461,41 @@ func (s *SnapTestSuite) TestWriteHardwareUdevActivate(c *C) {
 }
 
 func (s *SnapTestSuite) TestQualifiedNameName(c *C) {
-	packageYaml, err := parseSnapYamlData([]byte(`name: foo
+	snapYaml, err := parseSnapYamlData([]byte(`name: foo
 version: 1.0
 `), false)
 	c.Assert(err, IsNil)
 
-	udevName := packageYaml.qualifiedName("mvo")
+	udevName := snapYaml.qualifiedName("mvo")
 	c.Assert(udevName, Equals, "foo.mvo")
 }
 
 func (s *SnapTestSuite) TestQualifiedNameNameFramework(c *C) {
-	packageYaml, err := parseSnapYamlData([]byte(`name: foo
+	snapYaml, err := parseSnapYamlData([]byte(`name: foo
 version: 1.0
 type: framework
 `), false)
 	c.Assert(err, IsNil)
 
-	udevName := packageYaml.qualifiedName("")
+	udevName := snapYaml.qualifiedName("")
 	c.Assert(udevName, Equals, "foo")
 }
 
-func (s *SnapTestSuite) TestParsePackageYamlDataChecksName(c *C) {
+func (s *SnapTestSuite) TestParseSnapYamlDataChecksName(c *C) {
 	_, err := parseSnapYamlData([]byte(`
 version: 1.0
 `), false)
 	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'name'.*")
 }
 
-func (s *SnapTestSuite) TestParsePackageYamlDataChecksVersion(c *C) {
+func (s *SnapTestSuite) TestParseSnapYamlDataChecksVersion(c *C) {
 	_, err := parseSnapYamlData([]byte(`
 name: foo
 `), false)
 	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'version'.*")
 }
 
-func (s *SnapTestSuite) TestParsePackageYamlDataChecksMultiple(c *C) {
+func (s *SnapTestSuite) TestParseSnapYamlDataChecksMultiple(c *C) {
 	_, err := parseSnapYamlData([]byte(`
 `), false)
 	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'name, version'.*")

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -858,7 +858,7 @@ architectures:
   armhf:
     no
 `)
-	_, err := parsePackageYamlData(data, false)
+	_, err := parseSnapYamlData(data, false)
 	c.Assert(err, NotNil)
 }
 
@@ -869,7 +869,7 @@ architectures:
   - armhf:
       sometimes
 `)
-	_, err := parsePackageYamlData(data, false)
+	_, err := parseSnapYamlData(data, false)
 	c.Assert(err, NotNil)
 }
 
@@ -979,7 +979,7 @@ uses:
 `)
 
 func (s *SnapTestSuite) TestPackageYamlSecurityBinaryParsing(c *C) {
-	m, err := parsePackageYamlData(securityBinaryPackageYaml, false)
+	m, err := parseSnapYamlData(securityBinaryPackageYaml, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(m.Apps["testme"].Name, Equals, "testme")
@@ -1020,7 +1020,7 @@ uses:
 `)
 
 func (s *SnapTestSuite) TestPackageYamlSecurityServiceParsing(c *C) {
-	m, err := parsePackageYamlData(securityServicePackageYaml, false)
+	m, err := parseSnapYamlData(securityServicePackageYaml, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(m.Apps["testme-service"].Name, Equals, "testme-service")
@@ -1038,7 +1038,7 @@ func (s *SnapTestSuite) TestDetectsAlreadyInstalled(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(makeSnapActive(yamlPath), IsNil)
 
-	yaml, err := parsePackageYamlData([]byte(data), false)
+	yaml, err := parseSnapYamlData([]byte(data), false)
 	c.Assert(err, IsNil)
 	c.Check(yaml.checkForPackageInstalled("otherns"), ErrorMatches, ".*is already installed with origin.*")
 }
@@ -1051,7 +1051,7 @@ func (s *SnapTestSuite) TestIgnoresAlreadyInstalledSameOrigin(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(makeSnapActive(yamlPath), IsNil)
 
-	yaml, err := parsePackageYamlData([]byte(data), false)
+	yaml, err := parseSnapYamlData([]byte(data), false)
 	c.Assert(err, IsNil)
 	c.Check(yaml.checkForPackageInstalled(testOrigin), IsNil)
 }
@@ -1062,7 +1062,7 @@ func (s *SnapTestSuite) TestIgnoresAlreadyInstalledFrameworkSameOrigin(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(makeSnapActive(yamlPath), IsNil)
 
-	yaml, err := parsePackageYamlData([]byte(data), false)
+	yaml, err := parseSnapYamlData([]byte(data), false)
 	c.Assert(err, IsNil)
 	c.Check(yaml.checkForPackageInstalled(testOrigin), IsNil)
 }
@@ -1073,7 +1073,7 @@ func (s *SnapTestSuite) TestDetectsAlreadyInstalledFramework(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(makeSnapActive(yamlPath), IsNil)
 
-	yaml, err := parsePackageYamlData([]byte(data), false)
+	yaml, err := parseSnapYamlData([]byte(data), false)
 	c.Assert(err, IsNil)
 	c.Check(yaml.checkForPackageInstalled("otherns"), ErrorMatches, ".*is already installed with origin.*")
 }
@@ -1107,7 +1107,7 @@ frameworks:
  - missing
  - also-missing
 `)
-	yaml, err := parsePackageYamlData(data, false)
+	yaml, err := parseSnapYamlData(data, false)
 	c.Assert(err, IsNil)
 	err = yaml.checkForFrameworks()
 	c.Assert(err, ErrorMatches, `missing frameworks: missing, also-missing`)
@@ -1121,7 +1121,7 @@ frameworks:
 `)
 	c.Assert(err, IsNil)
 
-	yaml, err := parsePackageYamlData([]byte(`name: fmk
+	yaml, err := parseSnapYamlData([]byte(`name: fmk
 version: 1.0
 type: framework`), false)
 	c.Assert(err, IsNil)
@@ -1173,7 +1173,7 @@ apps:
 	c.Assert(ioutil.WriteFile(filepath.Join(d2, dp, "fmk_foo"), []byte("x"), 0644), IsNil)
 
 	pb := &MockProgressMeter{}
-	m, err := parsePackageYamlData([]byte(yaml), false)
+	m, err := parseSnapYamlData([]byte(yaml), false)
 	part := &SnapPart{m: m, origin: testOrigin, basedir: d1}
 	c.Assert(part.RefreshDependentsSecurity(&SnapPart{basedir: d2}, pb), IsNil)
 	// TODO: verify it was updated
@@ -1314,7 +1314,7 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateNothing(c *C) {
 }
 
 func (s *SnapTestSuite) TestDetectIllegalYamlBinaries(c *C) {
-	_, err := parsePackageYamlData([]byte(`name: foo
+	_, err := parseSnapYamlData([]byte(`name: foo
 version: 1.0
 apps:
  tes!me:
@@ -1324,7 +1324,7 @@ apps:
 }
 
 func (s *SnapTestSuite) TestDetectIllegalYamlService(c *C) {
-	_, err := parsePackageYamlData([]byte(`name: foo
+	_, err := parseSnapYamlData([]byte(`name: foo
 version: 1.0
 apps:
  tes!me:
@@ -1365,7 +1365,7 @@ func (s *SnapTestSuite) TestStructFieldsSurvivesNoTag(c *C) {
 }
 
 func (s *SnapTestSuite) TestIllegalPackageNameWithOrigin(c *C) {
-	_, err := parsePackageYamlData([]byte(`name: foo.something
+	_, err := parseSnapYamlData([]byte(`name: foo.something
 version: 1.0
 `), false)
 
@@ -1395,7 +1395,7 @@ gadget:
 `)
 
 func (s *SnapTestSuite) TestParseHardwareYaml(c *C) {
-	m, err := parsePackageYamlData(hardwareYaml, false)
+	m, err := parseSnapYamlData(hardwareYaml, false)
 	c.Assert(err, IsNil)
 	c.Assert(m.Gadget.Hardware.Assign[0].PartID, Equals, "device-hive-iot-hal")
 	c.Assert(m.Gadget.Hardware.Assign[0].Rules[0].Kernel, Equals, "ttyUSB0")
@@ -1412,7 +1412,7 @@ SUBSYSTEM=="tty", SUBSYSTEMS=="usb-serial", DRIVER=="pl2303", ATTRS{idVendor}=="
 `
 
 func (s *SnapTestSuite) TestGenerateHardwareYamlData(c *C) {
-	m, err := parsePackageYamlData(hardwareYaml, false)
+	m, err := parseSnapYamlData(hardwareYaml, false)
 	c.Assert(err, IsNil)
 
 	output, err := m.Gadget.Hardware.Assign[0].generateUdevRuleContent()
@@ -1422,7 +1422,7 @@ func (s *SnapTestSuite) TestGenerateHardwareYamlData(c *C) {
 }
 
 func (s *SnapTestSuite) TestWriteHardwareUdevEtc(c *C) {
-	m, err := parsePackageYamlData(hardwareYaml, false)
+	m, err := parseSnapYamlData(hardwareYaml, false)
 	c.Assert(err, IsNil)
 
 	dirs.SnapUdevRulesDir = c.MkDir()
@@ -1432,7 +1432,7 @@ func (s *SnapTestSuite) TestWriteHardwareUdevEtc(c *C) {
 }
 
 func (s *SnapTestSuite) TestWriteHardwareUdevCleanup(c *C) {
-	m, err := parsePackageYamlData(hardwareYaml, false)
+	m, err := parseSnapYamlData(hardwareYaml, false)
 	c.Assert(err, IsNil)
 
 	dirs.SnapUdevRulesDir = c.MkDir()
@@ -1461,7 +1461,7 @@ func (s *SnapTestSuite) TestWriteHardwareUdevActivate(c *C) {
 }
 
 func (s *SnapTestSuite) TestQualifiedNameName(c *C) {
-	packageYaml, err := parsePackageYamlData([]byte(`name: foo
+	packageYaml, err := parseSnapYamlData([]byte(`name: foo
 version: 1.0
 `), false)
 	c.Assert(err, IsNil)
@@ -1471,7 +1471,7 @@ version: 1.0
 }
 
 func (s *SnapTestSuite) TestQualifiedNameNameFramework(c *C) {
-	packageYaml, err := parsePackageYamlData([]byte(`name: foo
+	packageYaml, err := parseSnapYamlData([]byte(`name: foo
 version: 1.0
 type: framework
 `), false)
@@ -1482,21 +1482,21 @@ type: framework
 }
 
 func (s *SnapTestSuite) TestParsePackageYamlDataChecksName(c *C) {
-	_, err := parsePackageYamlData([]byte(`
+	_, err := parseSnapYamlData([]byte(`
 version: 1.0
 `), false)
 	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'name'.*")
 }
 
 func (s *SnapTestSuite) TestParsePackageYamlDataChecksVersion(c *C) {
-	_, err := parsePackageYamlData([]byte(`
+	_, err := parseSnapYamlData([]byte(`
 name: foo
 `), false)
 	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'version'.*")
 }
 
 func (s *SnapTestSuite) TestParsePackageYamlDataChecksMultiple(c *C) {
-	_, err := parsePackageYamlData([]byte(`
+	_, err := parseSnapYamlData([]byte(`
 `), false)
 	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'name, version'.*")
 }

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -820,7 +820,7 @@ apps:
 }
 
 func (s *SnapTestSuite) TestPackageYamlMultipleArchitecturesParsing(c *C) {
-	y := filepath.Join(s.tempdir, "package.yaml")
+	y := filepath.Join(s.tempdir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
 architectures: [i386, armhf]
@@ -831,7 +831,7 @@ architectures: [i386, armhf]
 }
 
 func (s *SnapTestSuite) TestPackageYamlSingleArchitecturesParsing(c *C) {
-	y := filepath.Join(s.tempdir, "package.yaml")
+	y := filepath.Join(s.tempdir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
 architectures: [i386]
@@ -842,7 +842,7 @@ architectures: [i386]
 }
 
 func (s *SnapTestSuite) TestPackageYamlNoArchitecturesParsing(c *C) {
-	y := filepath.Join(s.tempdir, "package.yaml")
+	y := filepath.Join(s.tempdir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
 `), 0644)
@@ -874,7 +874,7 @@ architectures:
 }
 
 func (s *SnapTestSuite) TestPackageYamlLicenseParsing(c *C) {
-	y := filepath.Join(s.tempdir, "package.yaml")
+	y := filepath.Join(s.tempdir, "snap.yaml")
 	ioutil.WriteFile(y, []byte(`
 name: foo
 version: 1.0
@@ -1263,15 +1263,15 @@ apps:
 }
 
 func (s *SnapTestSuite) TestOriginFromPath(c *C) {
-	n, err := originFromYamlPath("/gadget/foo.bar/1.0/meta/package.yaml")
+	n, err := originFromYamlPath("/gadget/foo.bar/1.0/meta/snap.yaml")
 	c.Check(err, IsNil)
 	c.Check(n, Equals, "bar")
 
-	n, err = originFromYamlPath("/gadget/foo_bar/1.0/meta/package.yaml")
+	n, err = originFromYamlPath("/gadget/foo_bar/1.0/meta/snap.yaml")
 	c.Check(err, NotNil)
 	c.Check(n, Equals, "")
 
-	n, err = originFromYamlPath("/oo_bar/1.0/mpackage.yaml")
+	n, err = originFromYamlPath("/oo_bar/1.0/msnap.yaml")
 	c.Check(err, NotNil)
 	c.Check(n, Equals, "")
 }
@@ -1413,20 +1413,20 @@ func (s *SnapTestSuite) TestParsePackageYamlDataChecksName(c *C) {
 	_, err := parsePackageYamlData([]byte(`
 version: 1.0
 `), false)
-	c.Assert(err, ErrorMatches, "can not parse package.yaml: missing required fields 'name'.*")
+	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'name'.*")
 }
 
 func (s *SnapTestSuite) TestParsePackageYamlDataChecksVersion(c *C) {
 	_, err := parsePackageYamlData([]byte(`
 name: foo
 `), false)
-	c.Assert(err, ErrorMatches, "can not parse package.yaml: missing required fields 'version'.*")
+	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'version'.*")
 }
 
 func (s *SnapTestSuite) TestParsePackageYamlDataChecksMultiple(c *C) {
 	_, err := parsePackageYamlData([]byte(`
 `), false)
-	c.Assert(err, ErrorMatches, "can not parse package.yaml: missing required fields 'name, version'.*")
+	c.Assert(err, ErrorMatches, "can not parse snap.yaml: missing required fields 'name, version'.*")
 }
 
 func (s *SnapTestSuite) TestCpiURLDependsOnEnviron(c *C) {

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -131,8 +131,8 @@ func (s *SnapTestSuite) TestLocalSnapSimple(c *C) {
 	c.Check(snap.IsInstalled(), Equals, true)
 
 	apps := snap.Apps()
-	c.Assert(apps, HasLen, 1)
-	c.Assert(apps["hello-app"].Name, Equals, "svc1")
+	c.Assert(apps, HasLen, 2)
+	c.Assert(apps["svc1"].Name, Equals, "svc1")
 
 	// ensure we get valid Date()
 	st, err := os.Stat(snap.basedir)
@@ -677,7 +677,6 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryInstallRemoteSnap(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
 
-	c.Check(installed[0].Icon(), Matches, ".*/snaps/foo.bar/1.0/foo.svg")
 	c.Check(installed[0].Origin(), Equals, "bar")
 	c.Check(installed[0].Description(), Equals, "this is a description")
 
@@ -688,8 +687,10 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryInstallRemoteSnap(c *C) {
 func (s *SnapTestSuite) TestRemoteSnapUpgradeService(c *C) {
 	snapPackage := makeTestSnapPackage(c, `name: foo
 version: 1.0
-services:
- - name: svc
+apps:
+ svc:
+  command: svc
+  daemon: forking
 `)
 	snapR, err := os.Open(snapPackage)
 	c.Assert(err, IsNil)
@@ -733,7 +734,6 @@ services:
 func (s *SnapTestSuite) TestErrorOnUnsupportedArchitecture(c *C) {
 	const packageHello = `name: hello-app
 version: 1.10
-icon: meta/hello.svg
 architectures:
     - yadayada
     - blahblah
@@ -759,11 +759,12 @@ func (s *SnapTestSuite) TestRemoteSnapErrors(c *C) {
 func (s *SnapTestSuite) TestServicesWithPorts(c *C) {
 	const packageHello = `name: hello-app
 version: 1.10
-icon: meta/hello.svg
-binaries:
- - name: bin/hello
-services:
- - name: svc1
+apps:
+ hello:
+  command: bin/hello
+ svc1:
+   command: svc1
+   type: forking
    description: "Service #1"
    ports:
       external:
@@ -772,7 +773,9 @@ services:
         nothing:
           port: 8081/tcp
           negotiable: yes
- - name: svc2
+ svc2:
+   command: svc2
+   type: forking
    description: "Service #2"
 `
 
@@ -789,7 +792,7 @@ services:
 	c.Assert(snap.IsActive(), Equals, false)
 
 	apps := snap.Apps()
-	c.Assert(apps, HasLen, 2)
+	c.Assert(apps, HasLen, 3)
 
 	c.Assert(apps["svc1"].Name, Equals, "svc1")
 	c.Assert(apps["svc1"].Description, Equals, "Service #1")
@@ -799,7 +802,7 @@ services:
 	c.Assert(external1Ui.Port, Equals, "8080/tcp")
 	c.Assert(external1Ui.Negotiable, Equals, false)
 
-	external1Nothing, ok := apps["svc2"].Ports.External["nothing"]
+	external1Nothing, ok := apps["svc1"].Ports.External["nothing"]
 	c.Assert(ok, Equals, true)
 	c.Assert(external1Nothing.Port, Equals, "8081/tcp")
 	c.Assert(external1Nothing.Negotiable, Equals, true)
@@ -820,7 +823,7 @@ func (s *SnapTestSuite) TestPackageYamlMultipleArchitecturesParsing(c *C) {
 	y := filepath.Join(s.tempdir, "package.yaml")
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
-architecture: [i386, armhf]
+architectures: [i386, armhf]
 `), 0644)
 	m, err := parsePackageYamlFile(y)
 	c.Assert(err, IsNil)
@@ -831,7 +834,7 @@ func (s *SnapTestSuite) TestPackageYamlSingleArchitecturesParsing(c *C) {
 	y := filepath.Join(s.tempdir, "package.yaml")
 	ioutil.WriteFile(y, []byte(`name: fatbinary
 version: 1.0
-architecture: i386
+architectures: [i386]
 `), 0644)
 	m, err := parsePackageYamlFile(y)
 	c.Assert(err, IsNil)
@@ -851,7 +854,7 @@ version: 1.0
 func (s *SnapTestSuite) TestPackageYamlBadArchitectureParsing(c *C) {
 	data := []byte(`name: fatbinary
 version: 1.0
-architecture:
+architectures:
   armhf:
     no
 `)
@@ -862,7 +865,7 @@ architecture:
 func (s *SnapTestSuite) TestPackageYamlWorseArchitectureParsing(c *C) {
 	data := []byte(`name: fatbinary
 version: 1.0
-architecture:
+architectures:
   - armhf:
       sometimes
 `)
@@ -943,23 +946,22 @@ type: gadget
 
 var securityBinaryPackageYaml = []byte(`name: test-snap
 version: 1.2.8
-icon: meta/hello.svg
-binaries:
- - name: testme
-   exec: bin/testme
+apps:
+ testme:
+   command: bin/testme
    description: "testme client"
    caps:
      - "foo_group"
    security-template: "foo_template"
- - name: testme-override
-   exec: bin/testme-override
+ testme-override:
+   command: bin/testme-override
    security-override:
      read-paths:
          - "/foo"
      syscalls:
          - "bar"
- - name: testme-policy
-   exec: bin/testme-policy
+ testme-policy:
+   command: bin/testme-policy
    security-policy:
      apparmor: meta/testme-policy.profile
 `)
@@ -988,10 +990,10 @@ func (s *SnapTestSuite) TestPackageYamlSecurityBinaryParsing(c *C) {
 
 var securityServicePackageYaml = []byte(`name: test-snap
 version: 1.2.8
-icon: meta/hello.svg
-services:
- - name: testme-service
-   start: bin/testme-service.start
+apps:
+ testme-service:
+   command: bin/testme-service.start
+   daemon: forking
    stop: bin/testme-service.stop
    description: "testme service"
    caps:
@@ -1011,17 +1013,6 @@ func (s *SnapTestSuite) TestPackageYamlSecurityServiceParsing(c *C) {
 	c.Assert(m.Apps["testme-service"].SecurityCaps[0], Equals, "network-client")
 	c.Assert(m.Apps["testme-service"].SecurityCaps[1], Equals, "foo_group")
 	c.Assert(m.Apps["testme-service"].SecurityTemplate, Equals, "foo_template")
-}
-
-func (s *SnapTestSuite) TestPackageYamlFrameworkAndFrameworksFails(c *C) {
-	_, err := parsePackageYamlData([]byte(`name: foo
-version: 1.0
-frameworks:
- - one
- - two
-framework: three, four
-`), false)
-	c.Assert(err, Equals, ErrInvalidFrameworkSpecInYaml)
 }
 
 func (s *SnapTestSuite) TestDetectsAlreadyInstalled(c *C) {
@@ -1141,8 +1132,9 @@ func (s *SnapTestSuite) TestRefreshDependentsSecurity(c *C) {
 version: 1.0
 frameworks:
  - fmk
-binaries:
- - name: hello
+apps:
+ hello:
+   command: hello
    caps:
     - fmk_foo
 `)
@@ -1227,24 +1219,24 @@ func (s *SnapTestSuite) TestNeedsAppArmorUpdatePolicyAbsent(c *C) {
 
 func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateService(c *C) {
 	// if one of the services needs updating, it's updated and returned
-	svc := AppYaml{Name: "svc", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
-	part := &SnapPart{m: &packageYaml{Name: "part", Apps: map[string]AppYaml{"svc": svc}, Version: "42"}, origin: testOrigin, basedir: filepath.Join(dirs.SnapSnapsDir, "part."+testOrigin, "42")}
+	svc := &AppYaml{Name: "svc", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
+	part := &SnapPart{m: &packageYaml{Name: "part", Apps: map[string]*AppYaml{"svc": svc}, Version: "42"}, origin: testOrigin, basedir: filepath.Join(dirs.SnapSnapsDir, "part."+testOrigin, "42")}
 	err := part.RequestSecurityPolicyUpdate(nil, map[string]bool{"foo": true})
 	c.Assert(err, NotNil)
 }
 
 func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateBinary(c *C) {
 	// if one of the binaries needs updating, the part needs updating
-	bin := AppYaml{Name: "echo", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
-	part := &SnapPart{m: &packageYaml{Name: "part", Apps: map[string]AppYaml{"echo": bin}, Version: "42"}, origin: testOrigin, basedir: filepath.Join(dirs.SnapSnapsDir, "part."+testOrigin, "42")}
+	bin := &AppYaml{Name: "echo", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
+	part := &SnapPart{m: &packageYaml{Name: "part", Apps: map[string]*AppYaml{"echo": bin}, Version: "42"}, origin: testOrigin, basedir: filepath.Join(dirs.SnapSnapsDir, "part."+testOrigin, "42")}
 	err := part.RequestSecurityPolicyUpdate(nil, map[string]bool{"foo": true})
 	c.Check(err, NotNil) // XXX: we should do better than this
 }
 
 func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateNothing(c *C) {
-	svc := AppYaml{Name: "svc", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
-	bin := AppYaml{Name: "echo", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
-	part := &SnapPart{m: &packageYaml{Apps: map[string]AppYaml{"svc": svc, "echo": bin}, Version: "42"}, origin: testOrigin}
+	svc := &AppYaml{Name: "svc", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
+	bin := &AppYaml{Name: "echo", SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"}}
+	part := &SnapPart{m: &packageYaml{Apps: map[string]*AppYaml{"svc": svc, "echo": bin}, Version: "42"}, origin: testOrigin}
 	err := part.RequestSecurityPolicyUpdate(nil, nil)
 	c.Check(err, IsNil)
 }
@@ -1252,9 +1244,9 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateNothing(c *C) {
 func (s *SnapTestSuite) TestDetectIllegalYamlBinaries(c *C) {
 	_, err := parsePackageYamlData([]byte(`name: foo
 version: 1.0
-binaries:
- - name: tes!me
-   exec: something
+apps:
+ tes!me:
+   command : something
 `), false)
 	c.Assert(err, NotNil)
 }
@@ -1262,9 +1254,10 @@ binaries:
 func (s *SnapTestSuite) TestDetectIllegalYamlService(c *C) {
 	_, err := parsePackageYamlData([]byte(`name: foo
 version: 1.0
-services:
- - name: tes!me
-   start: something
+apps:
+ tes!me:
+   command: something
+   daemon: forking
 `), false)
 	c.Assert(err, NotNil)
 }
@@ -1398,7 +1391,6 @@ func (s *SnapTestSuite) TestWriteHardwareUdevActivate(c *C) {
 func (s *SnapTestSuite) TestQualifiedNameName(c *C) {
 	packageYaml, err := parsePackageYamlData([]byte(`name: foo
 version: 1.0
-icon: foo.svg
 `), false)
 	c.Assert(err, IsNil)
 
@@ -1409,7 +1401,6 @@ icon: foo.svg
 func (s *SnapTestSuite) TestQualifiedNameNameFramework(c *C) {
 	packageYaml, err := parsePackageYamlData([]byte(`name: foo
 version: 1.0
-icon: foo.svg
 type: framework
 `), false)
 	c.Assert(err, IsNil)
@@ -1461,7 +1452,10 @@ func (s *SnapTestSuite) TestIcon(c *C) {
 	snapYaml, err := s.makeInstalledMockSnap()
 	part, err := NewInstalledSnapPart(snapYaml, testOrigin)
 	c.Assert(err, IsNil)
-	c.Check(part.Icon(), Matches, filepath.Join(dirs.SnapSnapsDir, QualifiedName(part), part.Version(), "meta/hello.svg"))
+	err = ioutil.WriteFile(filepath.Join(part.basedir, "meta", "icon.png"), nil, 0644)
+	c.Assert(err, IsNil)
+
+	c.Check(part.Icon(), Matches, filepath.Join(dirs.SnapSnapsDir, QualifiedName(part), part.Version(), "meta/icon.png"))
 }
 
 func (s *SnapTestSuite) TestIconEmpty(c *C) {

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -1245,8 +1245,8 @@ func (s *SnapTestSuite) TestDetectIllegalYamlBinaries(c *C) {
 	_, err := parsePackageYamlData([]byte(`name: foo
 version: 1.0
 apps:
- tes!me:
-   command : something
+ testme:
+   command : some!thing
 `), false)
 	c.Assert(err, NotNil)
 }
@@ -1255,8 +1255,8 @@ func (s *SnapTestSuite) TestDetectIllegalYamlService(c *C) {
 	_, err := parsePackageYamlData([]byte(`name: foo
 version: 1.0
 apps:
- tes!me:
-   command: something
+ testme:
+   command: some!thing
    daemon: forking
 `), false)
 	c.Assert(err, NotNil)

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -1245,8 +1245,8 @@ func (s *SnapTestSuite) TestDetectIllegalYamlBinaries(c *C) {
 	_, err := parsePackageYamlData([]byte(`name: foo
 version: 1.0
 apps:
- testme:
-   command : some!thing
+ tes!me:
+   command: someething
 `), false)
 	c.Assert(err, NotNil)
 }
@@ -1255,8 +1255,8 @@ func (s *SnapTestSuite) TestDetectIllegalYamlService(c *C) {
 	_, err := parsePackageYamlData([]byte(`name: foo
 version: 1.0
 apps:
- testme:
-   command: some!thing
+ tes!me:
+   command: something
    daemon: forking
 `), false)
 	c.Assert(err, NotNil)


### PR DESCRIPTION
This branch uses meta/snap.yaml instead of package.yaml.

To make the transition easier it also uses the new "skills" system and provides a "migration-skill" that takes exactly the same arguments as the previous security system.