### PR TITLE
fix lp:1537005

### DIFF
--- a/snappy/snap_remote_repo.go
+++ b/snappy/snap_remote_repo.go
@@ -270,10 +270,11 @@ func (s *SnapUbuntuStoreRepository) All() ([]Part, error) {
 
 // Search searches the repository for the given searchTerm
 func (s *SnapUbuntuStoreRepository) Search(searchTerm string) (SharedNames, error) {
-	q := s.searchURI.Query()
+	u := *s.searchURI // make a copy, so we can mutate it
+	q := u.Query()
 	q.Set("q", searchTerm)
-	s.searchURI.RawQuery = q.Encode()
-	req, err := http.NewRequest("GET", s.searchURI.String(), nil)
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -470,6 +470,24 @@ func (s *SnapTestSuite) TestUbuntuStoreAll(c *C) {
 	c.Check(parts[0].Description(), Equals, "Returns for store credit only.")
 }
 
+func (s *SnapTestSuite) TestUbuntuStoreSearchDoesNotMutateSearchURI(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.RawQuery, Equals, "q=foo")
+		c.Check(storeSearchURI.RawQuery, Equals, "")
+		io.WriteString(w, MockSearchJSON)
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	var err error
+	storeSearchURI, err = url.Parse(mockServer.URL)
+	c.Assert(err, IsNil)
+	repo := NewUbuntuStoreSnapRepository()
+	c.Assert(repo, NotNil)
+
+	repo.Search("foo")
+}
+
 func (s *SnapTestSuite) TestUbuntuStoreRepositoryAliasSearch(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, MockAliasSearchJSON)


### PR DESCRIPTION
snap: make a copy of the search uri before mutating it

we were mutating the store's searchURI, which would be somewhat bad in an of itself because an `All` after a `Search` on the same repo would still be filtered, but it was actually just the global search uri, meaning it leaked into other repo instances.

Closes: LP#1537005
