### PR TITLE
skills: tweak valid names and error messages

### DIFF
--- a/skills/core.go
+++ b/skills/core.go
@@ -43,7 +43,7 @@ type Slot struct {
 }
 
 // Regular expression describing correct identifiers.
-var validName = regexp.MustCompile("^[a-z](:?[a-z0-9-]*[a-z0-9])?$")
+var validName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 
 // ValidateName checks if a string can be used as a skill or slot name.
 func ValidateName(name string) error {

--- a/skills/core.go
+++ b/skills/core.go
@@ -49,7 +49,7 @@ var validName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 func ValidateName(name string) error {
 	valid := validName.MatchString(name)
 	if !valid {
-		return fmt.Errorf("%q is not a valid skill name", name)
+		return fmt.Errorf("invalid skill name: %q", name)
 	}
 	return nil
 }

--- a/skills/core.go
+++ b/skills/core.go
@@ -49,7 +49,7 @@ var validName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 func ValidateName(name string) error {
 	valid := validName.MatchString(name)
 	if !valid {
-		return fmt.Errorf("%q is not a valid skill or slot name", name)
+		return fmt.Errorf("%q is not a valid skill name", name)
 	}
 	return nil
 }

--- a/skills/core_test.go
+++ b/skills/core_test.go
@@ -48,6 +48,8 @@ func (s *CoreSuite) TestValidateName(c *C) {
 		"",
 		// dashes alone are not a name
 		"-", "--",
+		// double dashes in a name are not allowed
+		"a--a",
 		// name should not end with a dash
 		"a-",
 		// name cannot have any spaces in it

--- a/skills/core_test.go
+++ b/skills/core_test.go
@@ -61,6 +61,6 @@ func (s *CoreSuite) TestValidateName(c *C) {
 	}
 	for _, name := range invalidNames {
 		err := ValidateName(name)
-		c.Assert(err, ErrorMatches, `".*" is not a valid skill or slot name`)
+		c.Assert(err, ErrorMatches, `".*" is not a valid skill name`)
 	}
 }

--- a/skills/core_test.go
+++ b/skills/core_test.go
@@ -61,6 +61,6 @@ func (s *CoreSuite) TestValidateName(c *C) {
 	}
 	for _, name := range invalidNames {
 		err := ValidateName(name)
-		c.Assert(err, ErrorMatches, `".*" is not a valid skill name`)
+		c.Assert(err, ErrorMatches, `invalid skill name: ".*"`)
 	}
 }

--- a/skills/core_test.go
+++ b/skills/core_test.go
@@ -36,7 +36,7 @@ var _ = Suite(&CoreSuite{})
 func (s *CoreSuite) TestValidateName(c *C) {
 	validNames := []string{
 		"a", "aa", "aaa", "aaaa",
-		"a-a", "aa-a", "a-aa",
+		"a-a", "aa-a", "a-aa", "a-b-c",
 		"a0", "a-0", "a-0a",
 	}
 	for _, name := range validNames {


### PR DESCRIPTION
Valid names no longer include strings with double dashes, so for example "a--a" is no longer allowed.
The error message simply states "... is not a valid skill name" since it is shorter and looks nicer.