### PR TITLE
asserts: introduce a memory backed assertion backstore

### DIFF
--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -66,8 +66,19 @@ func assembleTestOnly(assert assertionBase) (Assertion, error) {
 
 var TestOnlyType = &AssertionType{"test-only", []string{"primary-key"}, assembleTestOnly}
 
+type TestOnly2 struct {
+	assertionBase
+}
+
+func assembleTestOnly2(assert assertionBase) (Assertion, error) {
+	return &TestOnly2{assert}, nil
+}
+
+var TestOnly2Type = &AssertionType{"test-only-2", []string{"pk1", "pk2"}, assembleTestOnly2}
+
 func init() {
 	typeRegistry[TestOnlyType.Name] = TestOnlyType
+	typeRegistry[TestOnly2Type.Name] = TestOnly2Type
 }
 
 // AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests

--- a/asserts/membackstore.go
+++ b/asserts/membackstore.go
@@ -1,0 +1,152 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"fmt"
+	"sync"
+)
+
+type memoryBackstore struct {
+	top memBSLevel
+	mu  sync.RWMutex
+}
+
+type memBSLevel map[string]interface{}
+
+func (lev memBSLevel) put(key []string, assert Assertion) error {
+	key0 := key[0]
+	if len(key) > 1 {
+		down, ok := lev[key0].(memBSLevel)
+		if !ok {
+			down = make(memBSLevel)
+			lev[key0] = down
+		}
+		return down.put(key[1:], assert)
+	}
+	cur, ok := lev[key0].(Assertion)
+	if ok {
+		rev := assert.Revision()
+		curRev := cur.Revision()
+		if curRev >= rev {
+			return fmt.Errorf("assertion added must have more recent revision than current one (adding %d, currently %d)", rev, curRev)
+		}
+	}
+	lev[key0] = assert
+	return nil
+}
+
+func (lev memBSLevel) get(key []string) (Assertion, error) {
+	key0 := key[0]
+	if len(key) > 1 {
+		down, ok := lev[key0].(memBSLevel)
+		if !ok {
+			return nil, ErrNotFound
+		}
+		return down.get(key[1:])
+	}
+
+	cur, ok := lev[key0].(Assertion)
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cur, nil
+}
+
+func (lev memBSLevel) search(hint []string, found func(Assertion)) {
+	hint0 := hint[0]
+	if len(hint) > 1 {
+		if hint0 == "" {
+			for _, down := range lev {
+				down.(memBSLevel).search(hint[1:], found)
+			}
+			return
+		}
+		down, ok := lev[hint0].(memBSLevel)
+		if ok {
+			down.search(hint[1:], found)
+		}
+		return
+	}
+
+	if hint0 == "" {
+		for _, a := range lev {
+			found(a.(Assertion))
+		}
+		return
+	}
+
+	cur, ok := lev[hint0].(Assertion)
+	if ok {
+		found(cur)
+	}
+}
+
+// NewMemoryBackstore creates a memory backed assertions backstore.
+func NewMemoryBackstore() Backstore {
+	return &memoryBackstore{
+		top: make(memBSLevel),
+	}
+}
+
+func (mbs *memoryBackstore) Put(assertType *AssertionType, assert Assertion) error {
+	mbs.mu.Lock()
+	defer mbs.mu.Unlock()
+
+	internalKey := make([]string, 1+len(assertType.PrimaryKey))
+	internalKey[0] = assertType.Name
+	for i, name := range assertType.PrimaryKey {
+		internalKey[1+i] = assert.Header(name)
+	}
+
+	err := mbs.top.put(internalKey, assert)
+	return err
+}
+
+func (mbs *memoryBackstore) Get(assertType *AssertionType, key []string) (Assertion, error) {
+	mbs.mu.RLock()
+	defer mbs.mu.RUnlock()
+
+	internalKey := make([]string, 1+len(assertType.PrimaryKey))
+	internalKey[0] = assertType.Name
+	copy(internalKey[1:], key)
+
+	return mbs.top.get(internalKey)
+}
+
+func (mbs *memoryBackstore) Search(assertType *AssertionType, headers map[string]string, foundCb func(Assertion)) error {
+	mbs.mu.RLock()
+	defer mbs.mu.RUnlock()
+
+	hint := make([]string, 1+len(assertType.PrimaryKey))
+	hint[0] = assertType.Name
+	for i, name := range assertType.PrimaryKey {
+		hint[1+i] = headers[name]
+	}
+
+	candCb := func(a Assertion) {
+		if searchMatch(a, headers) {
+			foundCb(a)
+		}
+	}
+
+	mbs.top.search(hint, candCb)
+	return nil
+}

--- a/asserts/membackstore_test.go
+++ b/asserts/membackstore_test.go
@@ -1,0 +1,171 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/asserts"
+)
+
+type memBackstoreSuite struct {
+	bs asserts.Backstore
+	a  asserts.Assertion
+}
+
+var _ = Suite(&memBackstoreSuite{})
+
+func (mbss *memBackstoreSuite) SetUpTest(c *C) {
+	mbss.bs = asserts.NewMemoryBackstore()
+
+	encoded := "type: test-only\n" +
+		"authority-id: auth-id1\n" +
+		"primary-key: foo" +
+		"\n\n" +
+		"openpgp c2ln"
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	mbss.a = a
+}
+
+func (mbss *memBackstoreSuite) TestPutAndGet(c *C) {
+	err := mbss.bs.Put(asserts.TestOnlyType, mbss.a)
+	c.Assert(err, IsNil)
+
+	a, err := mbss.bs.Get(asserts.TestOnlyType, []string{"foo"})
+	c.Assert(err, IsNil)
+
+	c.Check(a, Equals, mbss.a)
+}
+
+func (mbss *memBackstoreSuite) TestGetNotFound(c *C) {
+	a, err := mbss.bs.Get(asserts.TestOnlyType, []string{"foo"})
+	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Check(a, IsNil)
+
+	err = mbss.bs.Put(asserts.TestOnlyType, mbss.a)
+	c.Assert(err, IsNil)
+
+	a, err = mbss.bs.Get(asserts.TestOnlyType, []string{"bar"})
+	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Check(a, IsNil)
+}
+
+func (mbss *memBackstoreSuite) TestPutNotNewer(c *C) {
+	err := mbss.bs.Put(asserts.TestOnlyType, mbss.a)
+	c.Assert(err, IsNil)
+
+	err = mbss.bs.Put(asserts.TestOnlyType, mbss.a)
+	c.Check(err, ErrorMatches, "assertion added must have more recent revision than current one.*")
+}
+
+func (mbss *memBackstoreSuite) TestSearch(c *C) {
+	encoded := "type: test-only\n" +
+		"authority-id: auth-id1\n" +
+		"primary-key: one\n" +
+		"other: other1" +
+		"\n\n" +
+		"openpgp c2ln"
+	a1, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+
+	encoded = "type: test-only\n" +
+		"authority-id: auth-id1\n" +
+		"primary-key: two\n" +
+		"other: other2" +
+		"\n\n" +
+		"openpgp c2ln"
+	a2, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+
+	err = mbss.bs.Put(asserts.TestOnlyType, a1)
+	c.Assert(err, IsNil)
+	err = mbss.bs.Put(asserts.TestOnlyType, a2)
+	c.Assert(err, IsNil)
+
+	found := map[string]asserts.Assertion{}
+	cb := func(a asserts.Assertion) {
+		found[a.Header("primary-key")] = a
+	}
+	err = mbss.bs.Search(asserts.TestOnlyType, nil, cb)
+	c.Assert(err, IsNil)
+	c.Check(found, HasLen, 2)
+
+	found = map[string]asserts.Assertion{}
+	err = mbss.bs.Search(asserts.TestOnlyType, map[string]string{
+		"primary-key": "one",
+	}, cb)
+	c.Assert(err, IsNil)
+	c.Check(found, DeepEquals, map[string]asserts.Assertion{
+		"one": a1,
+	})
+
+	found = map[string]asserts.Assertion{}
+	err = mbss.bs.Search(asserts.TestOnlyType, map[string]string{
+		"other": "other2",
+	}, cb)
+	c.Assert(err, IsNil)
+	c.Check(found, DeepEquals, map[string]asserts.Assertion{
+		"two": a2,
+	})
+
+	found = map[string]asserts.Assertion{}
+	err = mbss.bs.Search(asserts.TestOnlyType, map[string]string{
+		"primary-key": "two",
+		"other":       "other1",
+	}, cb)
+	c.Assert(err, IsNil)
+	c.Check(found, HasLen, 0)
+}
+
+func (mbss *memBackstoreSuite) TestSearch2Levels(c *C) {
+	encoded := "type: test-only-2\n" +
+		"authority-id: auth-id1\n" +
+		"pk1: a\n" +
+		"pk2: x" +
+		"\n\n" +
+		"openpgp c2ln"
+	aAX, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+
+	encoded = "type: test-only-2\n" +
+		"authority-id: auth-id1\n" +
+		"pk1: b\n" +
+		"pk2: x" +
+		"\n\n" +
+		"openpgp c2ln"
+	aBX, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+
+	err = mbss.bs.Put(asserts.TestOnly2Type, aAX)
+	c.Assert(err, IsNil)
+	err = mbss.bs.Put(asserts.TestOnly2Type, aBX)
+	c.Assert(err, IsNil)
+
+	found := map[string]asserts.Assertion{}
+	cb := func(a asserts.Assertion) {
+		found[a.Header("pk1")+":"+a.Header("pk2")] = a
+	}
+	err = mbss.bs.Search(asserts.TestOnly2Type, map[string]string{
+		"pk2": "x",
+	}, cb)
+	c.Assert(err, IsNil)
+	c.Check(found, HasLen, 2)
+}


### PR DESCRIPTION
asserts: introduce a memory backed assertion backstore

This introduces a memory backed assertion backstore. Useful for tests and to replace the ad hoc trustedKeys map[string][]*AccountKey in Database to work toward making search/find work across disk assertions and trusted keys etc.