### PR TITLE
asserts: introduce Decoder to parse streams of assertions and Encoder to build them

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -22,6 +22,7 @@ package asserts
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strconv"
@@ -218,11 +219,135 @@ func Decode(serializedAssertion []byte) (Assertion, error) {
 		return nil, fmt.Errorf("parsing assertion headers: %v", err)
 	}
 
-	if len(signature) == 0 {
-		return nil, fmt.Errorf("empty assertion signature")
+	return Assemble(headers, body, content, signature)
+}
+
+// Decoder parses a stream of assertions bundled by separating them with double newlines.
+type Decoder struct {
+	rd   io.Reader
+	buf  []byte
+	rest []byte
+}
+
+// NewDecoder returns a Decoder to parse the stream of assertions from the reader.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{rd: r, buf: make([]byte, 1)}
+}
+
+func (dec *Decoder) readUntilNLNL() ([]byte, error) {
+	resBuf := new(bytes.Buffer)
+	resBuf.Write(dec.rest)
+	pos := 0
+	for {
+		b := resBuf.Bytes()
+		nlnlIdx := bytes.Index(b[pos:], nlnl)
+		if nlnlIdx == -1 {
+			pos = resBuf.Len() - 1
+			if pos < 0 {
+				pos = 0
+			}
+		} else {
+			nlnlIdx += pos
+			dec.rest = b[nlnlIdx+len(nlnl):]
+			return b[:nlnlIdx+len(nlnl)], nil
+		}
+
+		n, err := dec.rd.Read(dec.buf)
+		if err != nil {
+			if err != io.EOF {
+				return nil, err
+			}
+			if n == 0 {
+				break
+			}
+		}
+		resBuf.Write(dec.buf[:n])
+	}
+	return resBuf.Bytes(), io.EOF
+}
+
+func (dec *Decoder) readExactly(n int) ([]byte, error) {
+	res := make([]byte, n)
+	restSz := len(dec.rest)
+	if restSz >= n {
+		copy(res, dec.rest[:n])
+		dec.rest = dec.rest[n:]
+	} else {
+		copy(res, dec.rest)
+		dec.rest = nil
+		_, err := io.ReadFull(dec.rd, res[restSz:])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// Decode parses the next assertion from the stream.
+func (dec *Decoder) Decode() (Assertion, error) {
+	// read the headers and the nlnl separator after them
+	headAndSep, err := dec.readUntilNLNL()
+	if err != nil {
+		if err == io.EOF && len(headAndSep) != 0 {
+			return nil, io.ErrUnexpectedEOF
+		}
+		return nil, err
 	}
 
-	return Assemble(headers, body, content, signature)
+	head := headAndSep[:len(headAndSep)-len(nlnl)]
+
+	headers, err := parseHeaders(head)
+	if err != nil {
+		return nil, fmt.Errorf("parsing assertion headers: %v", err)
+	}
+
+	length, err := checkInteger(headers, "body-length", 0)
+	if err != nil {
+		return nil, fmt.Errorf("assertion: %v", err)
+	}
+
+	var body []byte
+	var sig []byte
+	if length > 0 {
+		// read the body if length != 0
+		body, err = dec.readExactly(length)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// try to read the end of body a.k.a content/signature separator
+	endOfBody, err := dec.readUntilNLNL()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	var content []byte
+	if bytes.Equal(endOfBody, nlnl) {
+		// we got the nlnl content/signature separator, read the signature now and the assertion/assertion nlnl separation
+		sig, err = dec.readUntilNLNL()
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		contentBuf := bytes.NewBuffer(make([]byte, 0, len(headAndSep)+len(body)))
+		contentBuf.Write(headAndSep)
+		contentBuf.Write(body)
+		content = contentBuf.Bytes()
+	} else {
+		// we got the signature directly which is a ok format only if body length == 0
+		if length > 0 {
+			return nil, fmt.Errorf("missing content/signature separator")
+		}
+		sig = endOfBody
+		content = head
+	}
+
+	// normalize sig ending newlines
+	if bytes.HasSuffix(sig, nlnl) {
+		sig = sig[:len(sig)-1]
+	}
+
+	return Assemble(headers, body, content, sig)
 }
 
 func checkRevision(headers map[string]string) (int, error) {
@@ -262,6 +387,10 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 	revision, err := checkRevision(headers)
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
+	}
+
+	if len(signature) == 0 {
+		return nil, fmt.Errorf("empty assertion signature")
 	}
 
 	assert, err := assertType.assembler(assertionBase{

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -241,22 +241,24 @@ type Decoder struct {
 	maxSigSize     int
 }
 
-func newDecoder(r io.Reader, bufSize, maxHeadersSize, maxBodySize, maxSigSize int) *Decoder {
-	return &Decoder{
-		rd:             r,
-		initialBufSize: bufSize,
-		b:              bufio.NewReaderSize(r, bufSize),
-		maxHeadersSize: maxHeadersSize,
-		maxBodySize:    maxBodySize,
-		maxSigSize:     maxSigSize,
-	}
+// initBuffer finishes a Decoder initialization by setting up the bufio.Reader,
+// it returns the *Decoder for convenience of notation.
+func (d *Decoder) initBuffer() *Decoder {
+	d.b = bufio.NewReaderSize(d.rd, d.initialBufSize)
+	return d
 }
 
 const defaultDecoderButSize = 4096
 
 // NewDecoder returns a Decoder to parse the stream of assertions from the reader.
 func NewDecoder(r io.Reader) *Decoder {
-	return newDecoder(r, defaultDecoderButSize, MaxHeadersSize, MaxBodySize, MaxSignatureSize)
+	return (&Decoder{
+		rd:             r,
+		initialBufSize: defaultDecoderButSize,
+		maxHeadersSize: MaxHeadersSize,
+		maxBodySize:    MaxBodySize,
+		maxSigSize:     MaxSignatureSize,
+	}).initBuffer()
 }
 
 func (d *Decoder) peek(size int) ([]byte, error) {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -569,7 +569,7 @@ func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{wr: w}
 }
 
-// Append emits an already encoded assertion into the stream with a proper required separator.
+// append emits an already encoded assertion into the stream with a proper required separator.
 func (enc *Encoder) append(encoded []byte) error {
 	sz := len(encoded)
 	if sz == 0 {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -305,7 +305,7 @@ func (d *Decoder) readUntil(delim []byte, maxSize int) ([]byte, error) {
 		last = size - len(delim) + 1
 		size *= 2
 		if size > maxSize {
-			return nil, fmt.Errorf("max size exceeded")
+			return nil, fmt.Errorf("maximum size exceeded while looking for delimiter %q", delim)
 		}
 	}
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -231,8 +231,6 @@ type Decoder struct {
 	err            error
 }
 
-const decoderBufSize = 16
-
 func newDecoder(r io.Reader, bufSize int) *Decoder {
 	return &Decoder{
 		rd:             r,

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -270,7 +270,7 @@ func (as *assertsSuite) TestDecoderBrokenBodySeparation(c *C) {
 func (as *assertsSuite) TestDecoderHeadTooBig(c *C) {
 	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 4, 4, 1024, 1024)
 	_, err := decoder.Decode()
-	c.Assert(err, ErrorMatches, "error reading assertion head: max size exceeded")
+	c.Assert(err, ErrorMatches, "error reading assertion headers: max size exceeded")
 }
 
 func (as *assertsSuite) TestDecoderBodyTooBig(c *C) {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -270,7 +270,7 @@ func (as *assertsSuite) TestDecoderBrokenBodySeparation(c *C) {
 func (as *assertsSuite) TestDecoderHeadTooBig(c *C) {
 	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 4, 4, 1024, 1024)
 	_, err := decoder.Decode()
-	c.Assert(err, ErrorMatches, "error reading assertion headers: max size exceeded")
+	c.Assert(err, ErrorMatches, `error reading assertion headers: maximum size exceeded while looking for delimiter "\\n\\n"`)
 }
 
 func (as *assertsSuite) TestDecoderBodyTooBig(c *C) {
@@ -282,7 +282,7 @@ func (as *assertsSuite) TestDecoderBodyTooBig(c *C) {
 func (as *assertsSuite) TestDecoderSignatureTooBig(c *C) {
 	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 4, 1024, 1024, 7)
 	_, err := decoder.Decode()
-	c.Assert(err, ErrorMatches, "error reading assertion signature: max size exceeded")
+	c.Assert(err, ErrorMatches, `error reading assertion signature: maximum size exceeded while looking for delimiter "\\n\\n"`)
 }
 
 func (as *assertsSuite) TestEncode(c *C) {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -221,7 +221,7 @@ func (as *assertsSuite) TestDecoderHappyWithSeparatorsVariations(c *C) {
 
 	for _, streamData := range streams {
 		stream := bytes.NewBufferString(streamData)
-		decoder := asserts.NewDecoderStressed(stream, 16)
+		decoder := asserts.NewDecoderStressed(stream, 16, 1024, 1024, 1024)
 		a, err := decoder.Decode()
 		c.Assert(err, IsNil, Commentf("stream: %q", streamData))
 
@@ -239,7 +239,7 @@ func (as *assertsSuite) TestDecoderUnexpectedEOF(c *C) {
 
 	for _, brk := range []int{1, fstHeadEnd / 2, fstHeadEnd, fstHeadEnd + 1, fstHeadEnd + 2, fstHeadEnd + 6} {
 		stream := bytes.NewBufferString(streamData[:brk])
-		decoder := asserts.NewDecoderStressed(stream, 16)
+		decoder := asserts.NewDecoderStressed(stream, 16, 1024, 1024, 1024)
 		_, err := decoder.Decode()
 		c.Check(err, Equals, io.ErrUnexpectedEOF, Commentf("brk: %d", brk))
 	}
@@ -265,6 +265,24 @@ func (as *assertsSuite) TestDecoderBrokenBodySeparation(c *C) {
 	decoder = asserts.NewDecoder(bytes.NewBufferString(streamData))
 	_, err = decoder.Decode()
 	c.Assert(err, ErrorMatches, "missing content/signature separator")
+}
+
+func (as *assertsSuite) TestDecoderHeadTooBig(c *C) {
+	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 4, 4, 1024, 1024)
+	_, err := decoder.Decode()
+	c.Assert(err, ErrorMatches, "error reading assertion head: max size exceeded")
+}
+
+func (as *assertsSuite) TestDecoderBodyTooBig(c *C) {
+	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 1024, 1024, 5, 1024)
+	_, err := decoder.Decode()
+	c.Assert(err, ErrorMatches, "assertion body length 8 exceeds maximum body size")
+}
+
+func (as *assertsSuite) TestDecoderSignatureTooBig(c *C) {
+	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 4, 1024, 1024, 7)
+	_, err := decoder.Decode()
+	c.Assert(err, ErrorMatches, "error reading assertion signature: max size exceeded")
 }
 
 func (as *assertsSuite) TestEncode(c *C) {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -181,9 +181,9 @@ func checkContent(c *C, a asserts.Assertion, encoded string) {
 func (as *assertsSuite) TestEncoderDecoderHappy(c *C) {
 	stream := new(bytes.Buffer)
 	enc := asserts.NewEncoder(stream)
-	enc.Append([]byte(exampleEmptyBody2NlNl))
-	enc.Append([]byte(exampleBodyAndExtraHeaders))
-	enc.Append([]byte(exampleEmptyBodyAllDefaults))
+	asserts.EncoderAppend(enc, []byte(exampleEmptyBody2NlNl))
+	asserts.EncoderAppend(enc, []byte(exampleBodyAndExtraHeaders))
+	asserts.EncoderAppend(enc, []byte(exampleEmptyBodyAllDefaults))
 
 	decoder := asserts.NewDecoder(stream)
 	a, err := decoder.Decode()
@@ -205,6 +205,13 @@ func (as *assertsSuite) TestEncoderDecoderHappy(c *C) {
 	c.Assert(err, Equals, io.EOF)
 }
 
+func (as *assertsSuite) TestDecodeEmptyStream(c *C) {
+	stream := new(bytes.Buffer)
+	decoder := asserts.NewDecoder(stream)
+	_, err := decoder.Decode()
+	c.Check(err, Equals, io.EOF)
+}
+
 func (as *assertsSuite) TestDecoderHappyWithSeparatorsVariations(c *C) {
 	streams := []string{
 		exampleBodyAndExtraHeaders,
@@ -214,7 +221,7 @@ func (as *assertsSuite) TestDecoderHappyWithSeparatorsVariations(c *C) {
 
 	for _, streamData := range streams {
 		stream := bytes.NewBufferString(streamData)
-		decoder := asserts.NewDecoderStressed(stream, 10)
+		decoder := asserts.NewDecoderStressed(stream, 16)
 		a, err := decoder.Decode()
 		c.Assert(err, IsNil, Commentf("stream: %q", streamData))
 
@@ -232,7 +239,7 @@ func (as *assertsSuite) TestDecoderUnexpectedEOF(c *C) {
 
 	for _, brk := range []int{1, fstHeadEnd / 2, fstHeadEnd, fstHeadEnd + 1, fstHeadEnd + 2, fstHeadEnd + 6} {
 		stream := bytes.NewBufferString(streamData[:brk])
-		decoder := asserts.NewDecoderStressed(stream, 10)
+		decoder := asserts.NewDecoderStressed(stream, 16)
 		_, err := decoder.Decode()
 		c.Check(err, Equals, io.ErrUnexpectedEOF, Commentf("brk: %d", brk))
 	}

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -42,13 +42,13 @@ func (as *assertsSuite) TestUnknown(c *C) {
 	c.Check(asserts.Type("unknown"), IsNil)
 }
 
-const emptyBodyAllDefaults = "type: test-only\n" +
+const exampleEmptyBodyAllDefaults = "type: test-only\n" +
 	"authority-id: auth-id1" +
 	"\n\n" +
 	"openpgp c2ln"
 
 func (as *assertsSuite) TestDecodeEmptyBodyAllDefaults(c *C) {
-	a, err := asserts.Decode([]byte(emptyBodyAllDefaults))
+	a, err := asserts.Decode([]byte(exampleEmptyBodyAllDefaults))
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.TestOnlyType)
 	_, ok := a.(*asserts.TestOnly)
@@ -59,7 +59,7 @@ func (as *assertsSuite) TestDecodeEmptyBodyAllDefaults(c *C) {
 	c.Check(a.AuthorityID(), Equals, "auth-id1")
 }
 
-const emptyBody2NlNl = "type: test-only\n" +
+const exampleEmptyBody2NlNl = "type: test-only\n" +
 	"authority-id: auth-id1\n" +
 	"revision: 0\n" +
 	"body-length: 0" +
@@ -68,14 +68,14 @@ const emptyBody2NlNl = "type: test-only\n" +
 	"openpgp c2ln\n"
 
 func (as *assertsSuite) TestDecodeEmptyBodyNormalize2NlNl(c *C) {
-	a, err := asserts.Decode([]byte(emptyBody2NlNl))
+	a, err := asserts.Decode([]byte(exampleEmptyBody2NlNl))
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.TestOnlyType)
 	c.Check(a.Revision(), Equals, 0)
 	c.Check(a.Body(), IsNil)
 }
 
-const bodyAndExtraHeaders = "type: test-only\n" +
+const exampleBodyAndExtraHeaders = "type: test-only\n" +
 	"authority-id: auth-id2\n" +
 	"primary-key1: key1\n" +
 	"primary-key2: key2\n" +
@@ -88,7 +88,7 @@ const bodyAndExtraHeaders = "type: test-only\n" +
 	"openpgp c2ln\n"
 
 func (as *assertsSuite) TestDecodeWithABodyAndExtraHeaders(c *C) {
-	a, err := asserts.Decode([]byte(bodyAndExtraHeaders))
+	a, err := asserts.Decode([]byte(exampleBodyAndExtraHeaders))
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.TestOnlyType)
 	c.Check(a.AuthorityID(), Equals, "auth-id2")
@@ -180,11 +180,11 @@ func checkContent(c *C, a asserts.Assertion, encoded string) {
 
 func (as *assertsSuite) TestDecoderHappy(c *C) {
 	stream := new(bytes.Buffer)
-	stream.WriteString(emptyBody2NlNl)
+	stream.WriteString(exampleEmptyBody2NlNl)
 	stream.WriteString("\n")
-	stream.WriteString(bodyAndExtraHeaders)
+	stream.WriteString(exampleBodyAndExtraHeaders)
 	stream.WriteString("\n")
-	stream.WriteString(emptyBodyAllDefaults)
+	stream.WriteString(exampleEmptyBodyAllDefaults)
 	stream.WriteString("\n\n")
 
 	decoder := asserts.NewDecoder(stream)
@@ -193,15 +193,15 @@ func (as *assertsSuite) TestDecoderHappy(c *C) {
 	c.Check(a.Type(), Equals, asserts.TestOnlyType)
 	_, ok := a.(*asserts.TestOnly)
 	c.Check(ok, Equals, true)
-	checkContent(c, a, emptyBody2NlNl)
+	checkContent(c, a, exampleEmptyBody2NlNl)
 
 	a, err = decoder.Decode()
 	c.Assert(err, IsNil)
-	checkContent(c, a, bodyAndExtraHeaders)
+	checkContent(c, a, exampleBodyAndExtraHeaders)
 
 	a, err = decoder.Decode()
 	c.Assert(err, IsNil)
-	checkContent(c, a, emptyBodyAllDefaults)
+	checkContent(c, a, exampleEmptyBodyAllDefaults)
 
 	a, err = decoder.Decode()
 	c.Assert(err, Equals, io.EOF)
@@ -209,9 +209,9 @@ func (as *assertsSuite) TestDecoderHappy(c *C) {
 
 func (as *assertsSuite) TestDecoderHappyWithSeparatorsVariations(c *C) {
 	streams := []string{
-		bodyAndExtraHeaders,
-		emptyBody2NlNl,
-		emptyBodyAllDefaults,
+		exampleBodyAndExtraHeaders,
+		exampleEmptyBody2NlNl,
+		exampleEmptyBodyAllDefaults,
 	}
 
 	for _, streamData := range streams {

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -37,7 +37,7 @@ var AssembleAndSignInTest = assembleAndSign
 // decodePrivateKey exposed for tests
 var DecodePrivateKeyInTest = decodePrivateKey
 
-// NewDecoderStressed makes a Decoder with a stressed setup with the given buffer size.
+// NewDecoderStressed makes a Decoder with a stressed setup with the given buffer and maximum sizes.
 func NewDecoderStressed(r io.Reader, bufSize, maxHeadSize, maxBodySize, maxSigSize int) *Decoder {
 	return newDecoder(r, bufSize, maxHeadSize, maxBodySize, maxSigSize)
 }

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -38,8 +38,8 @@ var AssembleAndSignInTest = assembleAndSign
 var DecodePrivateKeyInTest = decodePrivateKey
 
 // NewDecoderStressed makes a Decoder with a stressed setup with the given buffer size.
-func NewDecoderStressed(r io.Reader, bufSize int) *Decoder {
-	return newDecoder(r, bufSize)
+func NewDecoderStressed(r io.Reader, bufSize, maxHeadSize, maxBodySize, maxSigSize int) *Decoder {
+	return newDecoder(r, bufSize, maxHeadSize, maxBodySize, maxSigSize)
 }
 
 // Encoder.append exposed for tests

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -39,7 +39,12 @@ var DecodePrivateKeyInTest = decodePrivateKey
 
 // NewDecoderStressed makes a Decoder with a stressed setup with the given buffer size.
 func NewDecoderStressed(r io.Reader, bufSize int) *Decoder {
-	return &Decoder{rd: r, buf: make([]byte, bufSize)}
+	return newDecoder(r, bufSize)
+}
+
+// Encoder.append exposed for tests
+func EncoderAppend(enc *Encoder, encoded []byte) error {
+	return enc.append(encoded)
 }
 
 func BootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -38,8 +38,14 @@ var AssembleAndSignInTest = assembleAndSign
 var DecodePrivateKeyInTest = decodePrivateKey
 
 // NewDecoderStressed makes a Decoder with a stressed setup with the given buffer and maximum sizes.
-func NewDecoderStressed(r io.Reader, bufSize, maxHeadSize, maxBodySize, maxSigSize int) *Decoder {
-	return newDecoder(r, bufSize, maxHeadSize, maxBodySize, maxSigSize)
+func NewDecoderStressed(r io.Reader, bufSize, maxHeadersSize, maxBodySize, maxSigSize int) *Decoder {
+	return (&Decoder{
+		rd:             r,
+		initialBufSize: bufSize,
+		maxHeadersSize: maxHeadersSize,
+		maxBodySize:    maxBodySize,
+		maxSigSize:     maxSigSize,
+	}).initBuffer()
 }
 
 // Encoder.append exposed for tests

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"io"
 	"time"
 
 	"golang.org/x/crypto/openpgp/packet"
@@ -35,6 +36,11 @@ var AssembleAndSignInTest = assembleAndSign
 
 // decodePrivateKey exposed for tests
 var DecodePrivateKeyInTest = decodePrivateKey
+
+// NewDecoderStressed makes a Decoder with a stressed setup with the given buffer size.
+func NewDecoderStressed(r io.Reader, bufSize int) *Decoder {
+	return &Decoder{rd: r, buf: make([]byte, bufSize)}
+}
 
 func BootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
 	return &AccountKey{


### PR DESCRIPTION
This introduces decoders (created with NewDecoder(io.Reader)) that can handle streams of assertions bundled by ensuring double newlines ("\n\n") at the end of each.  Introduces Encoder/NewEncoder(io.Writer) as well.