### PR TITLE
skills: provide different security snippets for skill and slot side

### DIFF
--- a/skills/core.go
+++ b/skills/core.go
@@ -53,13 +53,23 @@ type Type interface {
 	// Sanitize checks if a skill is correct, altering if necessary.
 	Sanitize(skill *Skill) error
 
-	// SecuritySnippet returns the configuration snippet that should be used by
-	// the given security system to enable this skill to be consumed.
+	// SkillSecuritySnippet returns the configuration snippet needed by the
+	// given security system to allow a snap to offer a skill of this type.
+	//
 	// An empty snippet is returned when the skill doesn't require anything
-	// from the security system to work, in addition to the default configuration.
-	// ErrUnknownSecurity is returned when the skill cannot deal with the
-	// requested security system.
-	SecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error)
+	// from the security system to work, in addition to the default
+	// configuration.  ErrUnknownSecurity is returned when the skill cannot
+	// deal with the requested security system.
+	SkillSecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error)
+
+	// SlotSecuritySnippet returns the configuration snippet needed by the
+	// given security system to allow a snap to use a skill of this type.
+	//
+	// An empty snippet is returned when the skill doesn't require anything
+	// from the security system to work, in addition to the default
+	// configuration.  ErrUnknownSecurity is returned when the skill cannot
+	// deal with the requested security system.
+	SlotSecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // SecuritySystem is a name of a security system.


### PR DESCRIPTION
Security snippets allow snaps to gain the permission needed to interact
with a skill. So far only the consumer (use) side of the security was
taken care of. This patch replaces the Type.SecuritySnippet() with two
methods: Type.SkillSecuritySnippet() and Type.SlotSecuritySnippet().

A snap that offers a skill will be granted additional permissions
expressed by SkillSecuritySnippet(). A snap that uses a skill will be
granted additional permissions expressed by SlotSecuritySnippet().

For a practical example, a snap that offers GPIOs as bool-files might
gain access to /sys/class/gpio/{export,unexport} while a snap that uses
those skills will only gain access to /sys/class/gpio/gpio$number/value.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>