### PR TITLE
integration-tests: re-enable some failover tests

### DIFF
--- a/integration-tests/tests/failover_rclocal_crash_test.go
+++ b/integration-tests/tests/failover_rclocal_crash_test.go
@@ -21,23 +21,20 @@
 package tests
 
 import (
-//"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
+	"path/filepath"
 
-//"gopkg.in/check.v1"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
+
+	"gopkg.in/check.v1"
 )
-
-/*
-TODO: uncomment when bug https://bugs.launchpad.net/snappy/+bug/1476129 is fixed
-(fgimenez 20150728)
 
 func (s *failoverSuite) TestRCLocalCrash(c *check.C) {
 	breakSnap := func(snapPath string) error {
-		fullPath := filepath.Join(snapPath, "etc", "rc.local")
-  	cli.ExecCommand(c, "sudo", "chmod", "a+xw", targetFile)
-    cli.ExecCommandToFile(c, targetFile,
-		  "sudo", "echo", "#!bin/sh\nprintf c > /proc/sysrq-trigger")
+		targetFile := filepath.Join(snapPath, "etc", "rc.local")
+		cli.ExecCommand(c, "sudo", "chmod", "a+xw", targetFile)
+		cli.ExecCommandToFile(c, targetFile,
+			"sudo", "echo", "#!bin/sh\nprintf c > /proc/sysrq-trigger")
 		return nil
 	}
 	s.testUpdateToBrokenVersion(c, "ubuntu-core.canonical", breakSnap)
 }
-*/

--- a/integration-tests/tests/failover_test.go
+++ b/integration-tests/tests/failover_test.go
@@ -38,8 +38,6 @@ type failoverSuite struct {
 // This is the logic common to all the failover tests. Each of them has to call this method
 // with the snap that will be updated and the function that changes it to fail.
 func (s *failoverSuite) testUpdateToBrokenVersion(c *check.C, snap string, changeFunc updates.ChangeFakeUpdateSnap) {
-	c.Skip("KNOWN BUG FIXME: https://bugs.launchpad.net/snappy/+bug/1534029")
-
 	snapName := strings.Split(snap, ".")[0]
 	currentVersion := common.GetCurrentVersion(c, snapName)
 


### PR DESCRIPTION
Tiny branch that re-enables some more of the failover tests.