### PR TITLE
asserts: uniform searching accross trusted (account keys) and main backstore

### DIFF
--- a/asserts/database.go
+++ b/asserts/database.go
@@ -193,7 +193,7 @@ func (db *Database) Sign(assertType *AssertionType, headers map[string]string, b
 	return assembleAndSign(assertType, headers, body, privKey)
 }
 
-// find account key exactly by account id and key id
+// findAccountKey finds an AccountKey exactly by account id and key id.
 func (db *Database) findAccountKey(authorityID, keyID string) (*AccountKey, error) {
 	key := []string{authorityID, keyID}
 	// consider trusted account keys then disk stored account keys

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -118,7 +118,7 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 	for _, accKey := range cfg.TrustedKeys {
 		err := trustedBackstore.Put(AccountKeyType, accKey)
 		if err != nil {
-			return nil, fmt.Errorf("error populating trusted accout keys with key for %q key id %q: %v", accKey.AccountID(), accKey.PublicKeyID(), err)
+			return nil, fmt.Errorf("error populating trusted account keys with key for %q key id %q: %v", accKey.AccountID(), accKey.PublicKeyID(), err)
 		}
 	}
 

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -227,7 +227,8 @@ func (db *Database) Check(assert Assertion) error {
 
 	now := time.Now()
 	if !accKey.isKeyValidAt(now) {
-		return fmt.Errorf("no valid known public key verifies assertion")
+		// XXX clearer error message
+		return fmt.Errorf("no currently valid known public key verifies assertion")
 	}
 
 	err = accKey.publicKey().verify(content, sig)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -271,7 +271,7 @@ func (db *Database) Add(assert Assertion) error {
 	// know more/better
 	_, err = db.trusted.Get(assertType, keyValues)
 	if err != ErrNotFound {
-		return fmt.Errorf("cannot add assertion of type %q with primary key clashing with a trusted assertion: %v", assertType.Name, keyValues)
+		return fmt.Errorf("cannot add %q assertion with primary key clashing with a trusted assertion: %v", assertType.Name, keyValues)
 	}
 
 	return db.bs.Put(assertType, assert)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -119,7 +119,7 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 	for _, accKey := range cfg.TrustedKeys {
 		err := trustedBackstore.Put(AccountKeyType, accKey)
 		if err != nil {
-			return nil, fmt.Errorf("error populating trusted account keys with key for %q key id %q: %v", accKey.AccountID(), accKey.PublicKeyID(), err)
+			return nil, fmt.Errorf("error loading for use trusted account key %q for %q: %v", accKey.PublicKeyID(), accKey.AuthorityID(), err)
 		}
 	}
 
@@ -221,7 +221,7 @@ func (db *Database) Check(assert Assertion) error {
 	// TODO: later may need to consider type of assert to find candidate keys
 	accKey, err := db.findAccountKey(assert.AuthorityID(), sig.KeyID())
 	if err == ErrNotFound {
-		return fmt.Errorf("no matching public key for signature by %q key id %q", assert.AuthorityID(), sig.KeyID())
+		return fmt.Errorf("no matching public key %q for signature by %q", sig.KeyID(), assert.AuthorityID())
 	}
 	if err != nil {
 		return fmt.Errorf("error finding matching public key for signature: %v", err)
@@ -229,7 +229,7 @@ func (db *Database) Check(assert Assertion) error {
 
 	now := time.Now()
 	if !accKey.isKeyValidAt(now) {
-		return fmt.Errorf("assertion is signed with expired public key by %q key id %q", assert.AuthorityID(), sig.KeyID())
+		return fmt.Errorf("assertion is signed with expired public key %q from %q", sig.KeyID(), assert.AuthorityID())
 	}
 
 	err = accKey.publicKey().verify(content, sig)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -199,12 +199,10 @@ func (db *Database) findAccountKey(authorityID, keyID string) (*AccountKey, erro
 	// consider trusted account keys then disk stored account keys
 	for _, bs := range db.backstores {
 		a, err := bs.Get(AccountKeyType, key)
-		switch err {
-		case nil:
+		if err == nil {
 			return a.(*AccountKey), nil
-		case ErrNotFound:
-			// nothing to do
-		default:
+		}
+		if err != ErrNotFound {
 			return nil, err
 		}
 	}
@@ -305,16 +303,13 @@ func (db *Database) Find(assertionType *AssertionType, headers map[string]string
 	}
 
 	var assert Assertion
-Got:
 	for _, bs := range db.backstores {
 		a, err := bs.Get(assertionType, keyValues)
-		switch err {
-		case nil:
+		if err == nil {
 			assert = a
-			break Got
-		case ErrNotFound:
-			// nothing to do
-		default:
+			break
+		}
+		if err != ErrNotFound {
 			return nil, err
 		}
 	}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -127,6 +127,9 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 		bs:         bs,
 		keypairMgr: keypairMgr,
 		trusted:    trustedBackstore,
+		// order here is relevant, Find* precedence and
+		// findAccountKey depend on it, trusted should win over the
+		// general backstore!
 		backstores: []Backstore{trustedBackstore, bs},
 	}, nil
 }

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -552,5 +552,5 @@ func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithTrus
 	c.Assert(err, IsNil)
 
 	err = safs.db.Add(tKey)
-	c.Check(err, ErrorMatches, `cannot add assertion of type "account-key" with primary key clashing with a trusted assertion: .*`)
+	c.Check(err, ErrorMatches, `cannot add "account-key" assertion with primary key clashing with a trusted assertion: .*`)
 }

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -183,7 +183,7 @@ func (chks *checkSuite) TestCheckNoPubKey(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(chks.a)
-	c.Assert(err, ErrorMatches, "no valid known public key verifies assertion")
+	c.Assert(err, ErrorMatches, `no matching public key for signature by "canonical" key id.*`)
 }
 
 func (chks *checkSuite) TestCheckForgery(c *C) {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -183,7 +183,7 @@ func (chks *checkSuite) TestCheckNoPubKey(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(chks.a)
-	c.Assert(err, ErrorMatches, `no matching public key for signature by "canonical" key id .*`)
+	c.Assert(err, ErrorMatches, `no matching public key "[a-f0-9]+" for signature by "canonical"`)
 }
 
 func (chks *checkSuite) TestCheckExpiredPubKey(c *C) {
@@ -198,7 +198,7 @@ func (chks *checkSuite) TestCheckExpiredPubKey(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(chks.a)
-	c.Assert(err, ErrorMatches, `assertion is signed with expired public key by "canonical" key id .*`)
+	c.Assert(err, ErrorMatches, `assertion is signed with expired public key "[a-f0-9]+" from "canonical"`)
 }
 
 func (chks *checkSuite) TestCheckForgery(c *C) {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -496,3 +496,38 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	c.Assert(res, HasLen, 0)
 	c.Check(err, Equals, asserts.ErrNotFound)
 }
+
+func (safs *signAddFindSuite) TestFindFindsTrustedAccountKeys(c *C) {
+	pk1 := asserts.OpenPGPPrivateKey(testPrivKey1)
+	pubKey1Encoded, err := asserts.EncodePublicKey(pk1.PublicKey())
+	c.Assert(err, IsNil)
+
+	now := time.Now().UTC()
+	headers := map[string]string{
+		"authority-id":           "canonical",
+		"account-id":             "acc-id1",
+		"public-key-id":          pk1.PublicKey().ID(),
+		"public-key-fingerprint": pk1.PublicKey().Fingerprint(),
+		"since":                  now.Format(time.RFC3339),
+		"until":                  now.AddDate(1, 0, 0).Format(time.RFC3339),
+	}
+	accKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, []byte(pubKey1Encoded), safs.signingKeyID)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(accKey)
+	c.Assert(err, IsNil)
+
+	// find the trusted key as well
+	tKey, err := safs.db.Find(asserts.AccountKeyType, map[string]string{
+		"account-id":    "canonical",
+		"public-key-id": safs.signingKeyID,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(tKey.(*asserts.AccountKey).AccountID(), Equals, "canonical")
+	c.Assert(tKey.(*asserts.AccountKey).PublicKeyID(), Equals, safs.signingKeyID)
+
+	// find trusted and untrusted
+	accKeys, err := safs.db.FindMany(asserts.AccountKeyType, nil)
+	c.Assert(err, IsNil)
+	c.Check(accKeys, HasLen, 2)
+}

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -186,6 +186,21 @@ func (chks *checkSuite) TestCheckNoPubKey(c *C) {
 	c.Assert(err, ErrorMatches, `no matching public key for signature by "canonical" key id.*`)
 }
 
+func (chks *checkSuite) TestCheckExpiredPubKey(c *C) {
+	trustedKey := testPrivKey0
+
+	cfg := &asserts.DatabaseConfig{
+		Backstore:      chks.bs,
+		KeypairManager: asserts.NewMemoryKeypairManager(),
+		TrustedKeys:    []*asserts.AccountKey{asserts.ExpiredAccountKeyForTest("canonical", &trustedKey.PublicKey)},
+	}
+	db, err := asserts.OpenDatabase(cfg)
+	c.Assert(err, IsNil)
+
+	err = db.Check(chks.a)
+	c.Assert(err, ErrorMatches, "no currently valid known public key verifies assertion")
+}
+
 func (chks *checkSuite) TestCheckForgery(c *C) {
 	trustedKey := testPrivKey0
 

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -36,7 +36,7 @@ var AssembleAndSignInTest = assembleAndSign
 // decodePrivateKey exposed for tests
 var DecodePrivateKeyInTest = decodePrivateKey
 
-func BootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
+func makeAccountKeyForTest(authorityID string, pubKey *packet.PublicKey, validYears int) *AccountKey {
 	openPGPPubKey := OpenPGPPublicKey(pubKey)
 	return &AccountKey{
 		assertionBase: assertionBase{
@@ -47,9 +47,17 @@ func BootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *A
 			},
 		},
 		since:  time.Time{},
-		until:  time.Time{}.UTC().AddDate(9999, 0, 0),
+		until:  time.Time{}.UTC().AddDate(validYears, 0, 0),
 		pubKey: openPGPPubKey,
 	}
+}
+
+func BootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
+	return makeAccountKeyForTest(authorityID, pubKey, 9999)
+}
+
+func ExpiredAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
+	return makeAccountKeyForTest(authorityID, pubKey, 1)
 }
 
 // define dummy assertion types to use in the tests

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -37,16 +37,18 @@ var AssembleAndSignInTest = assembleAndSign
 var DecodePrivateKeyInTest = decodePrivateKey
 
 func BootstrapAccountKeyForTest(authorityID string, pubKey *packet.PublicKey) *AccountKey {
+	openPGPPubKey := OpenPGPPublicKey(pubKey)
 	return &AccountKey{
 		assertionBase: assertionBase{
 			headers: map[string]string{
-				"authority-id": authorityID,
-				"account-id":   authorityID,
+				"authority-id":  authorityID,
+				"account-id":    authorityID,
+				"public-key-id": openPGPPubKey.ID(),
 			},
 		},
 		since:  time.Time{},
 		until:  time.Time{}.UTC().AddDate(9999, 0, 0),
-		pubKey: OpenPGPPublicKey(pubKey),
+		pubKey: openPGPPubKey,
 	}
 }
 


### PR DESCRIPTION
The main change here is to make the internals more uniform so that Find* will also find assertions (account keys) coming from the trusted ones we setup from the config.

In the process simplify how we find internally account keys to check assertions, since we switched to key id indexing of them there can be one or none really for a signature.

Make an explicit check for the policy that was already implicitly assumed, don't let assertions added to the main backstore clash with trusted assertions/account keys, we can change this policy later if we change our understanding but it's better to enforce it explicitly for now.