### PR TITLE
client: pass query as well as path in client internals

### DIFF
--- a/client/asserts.go
+++ b/client/asserts.go
@@ -30,7 +30,7 @@ import (
 // and its prerequisite in the database.
 func (client *Client) Assert(b []byte) error {
 	var rsp interface{}
-	if err := client.doSync("POST", "/2.0/assertions", bytes.NewReader(b), &rsp); err != nil {
+	if err := client.doSync("POST", "/2.0/assertions", nil, bytes.NewReader(b), &rsp); err != nil {
 		return fmt.Errorf("cannot assert: %v", err)
 	}
 

--- a/client/caps.go
+++ b/client/caps.go
@@ -48,7 +48,7 @@ type Capability struct {
 func (client *Client) Capabilities() (map[string]Capability, error) {
 	var resultOk map[string]map[string]Capability
 
-	if err := client.doSync("GET", "/2.0/capabilities", nil, &resultOk); err != nil {
+	if err := client.doSync("GET", "/2.0/capabilities", nil, nil, &resultOk); err != nil {
 		return nil, fmt.Errorf("cannot obtain capabilities: %s", err)
 	}
 
@@ -63,7 +63,7 @@ func (client *Client) AddCapability(c *Capability) error {
 	}
 
 	var rsp interface{}
-	if err := client.doSync("POST", "/2.0/capabilities", bytes.NewReader(b), &rsp); err != nil {
+	if err := client.doSync("POST", "/2.0/capabilities", nil, bytes.NewReader(b), &rsp); err != nil {
 		return fmt.Errorf("cannot add capability: %s", err)
 	}
 
@@ -73,7 +73,7 @@ func (client *Client) AddCapability(c *Capability) error {
 // RemoveCapability removes one capability from the system
 func (client *Client) RemoveCapability(name string) error {
 	var rsp interface{}
-	if err := client.doSync("DELETE", fmt.Sprintf("/2.0/capabilities/%s", name), nil, &rsp); err != nil {
+	if err := client.doSync("DELETE", fmt.Sprintf("/2.0/capabilities/%s", name), nil, nil, &rsp); err != nil {
 		return fmt.Errorf("cannot remove capability: %s", err)
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -55,12 +55,13 @@ func New() *Client {
 // raw performs a request and returns the resulting http.Response and
 // error you usually only need to call this directly if you expect the
 // response to not be JSON, otherwise you'd call Do(...) instead.
-func (client *Client) raw(method, opaque string, body io.Reader) (*http.Response, error) {
+func (client *Client) raw(method, path string, query url.Values, body io.Reader) (*http.Response, error) {
 	// fake a url to keep http.Client happy
 	u := url.URL{
-		Scheme: "http",
-		Host:   "localhost",
-		Opaque: opaque,
+		Scheme:   "http",
+		Host:     "localhost",
+		Path:     path,
+		RawQuery: query.Encode(),
 	}
 	req, err := http.NewRequest(method, u.String(), body)
 	if err != nil {
@@ -73,8 +74,8 @@ func (client *Client) raw(method, opaque string, body io.Reader) (*http.Response
 // do performs a request and decodes the resulting json into the given
 // value. It's low-level, for testing/experimenting only; you should
 // usually use a higher level interface that builds on this.
-func (client *Client) do(method, opaque string, body io.Reader, v interface{}) error {
-	rsp, err := client.raw(method, opaque, body)
+func (client *Client) do(method, path string, query url.Values, body io.Reader, v interface{}) error {
+	rsp, err := client.raw(method, path, query, body)
 	if err != nil {
 		return err
 	}
@@ -91,10 +92,10 @@ func (client *Client) do(method, opaque string, body io.Reader, v interface{}) e
 // doSync performs a request to the given path using the specified HTTP method.
 // It expects a "sync" response from the API and on success decodes the JSON
 // response payload into the given value.
-func (client *Client) doSync(method, opaque string, body io.Reader, v interface{}) error {
+func (client *Client) doSync(method, path string, query url.Values, body io.Reader, v interface{}) error {
 	var rsp response
 
-	if err := client.do(method, opaque, body, &rsp); err != nil {
+	if err := client.do(method, path, query, body, &rsp); err != nil {
 		return fmt.Errorf("failed to communicate with server: %s", err)
 	}
 	if err := rsp.err(); err != nil {
@@ -155,7 +156,7 @@ func (rsp *response) err() error {
 func (client *Client) SysInfo() (*SysInfo, error) {
 	var sysInfo SysInfo
 
-	if err := client.doSync("GET", "/2.0/system-info", nil, &sysInfo); err != nil {
+	if err := client.doSync("GET", "/2.0/system-info", nil, nil, &sysInfo); err != nil {
 		return nil, fmt.Errorf("bad sysinfo result: %v", err)
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -55,12 +55,12 @@ func New() *Client {
 // raw performs a request and returns the resulting http.Response and
 // error you usually only need to call this directly if you expect the
 // response to not be JSON, otherwise you'd call Do(...) instead.
-func (client *Client) raw(method, path string, body io.Reader) (*http.Response, error) {
+func (client *Client) raw(method, opaque string, body io.Reader) (*http.Response, error) {
 	// fake a url to keep http.Client happy
 	u := url.URL{
 		Scheme: "http",
 		Host:   "localhost",
-		Path:   path,
+		Opaque: opaque,
 	}
 	req, err := http.NewRequest(method, u.String(), body)
 	if err != nil {
@@ -73,8 +73,8 @@ func (client *Client) raw(method, path string, body io.Reader) (*http.Response, 
 // do performs a request and decodes the resulting json into the given
 // value. It's low-level, for testing/experimenting only; you should
 // usually use a higher level interface that builds on this.
-func (client *Client) do(method, path string, body io.Reader, v interface{}) error {
-	rsp, err := client.raw(method, path, body)
+func (client *Client) do(method, opaque string, body io.Reader, v interface{}) error {
+	rsp, err := client.raw(method, opaque, body)
 	if err != nil {
 		return err
 	}
@@ -91,10 +91,10 @@ func (client *Client) do(method, path string, body io.Reader, v interface{}) err
 // doSync performs a request to the given path using the specified HTTP method.
 // It expects a "sync" response from the API and on success decodes the JSON
 // response payload into the given value.
-func (client *Client) doSync(method, path string, body io.Reader, v interface{}) error {
+func (client *Client) doSync(method, opaque string, body io.Reader, v interface{}) error {
 	var rsp response
 
-	if err := client.do(method, path, body, &rsp); err != nil {
+	if err := client.do(method, opaque, body, &rsp); err != nil {
 		return fmt.Errorf("failed to communicate with server: %s", err)
 	}
 	if err := rsp.err(); err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,14 +22,20 @@ package client_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"gopkg.in/check.v1"
 
 	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/dirs"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -54,6 +60,8 @@ func (cs *clientSuite) SetUpTest(c *check.C) {
 	cs.req = nil
 	cs.header = nil
 	cs.status = http.StatusOK
+
+	dirs.SetRootDir(c.MkDir())
 }
 
 func (cs *clientSuite) Do(req *http.Request) (*http.Response, error) {
@@ -68,7 +76,7 @@ func (cs *clientSuite) Do(req *http.Request) (*http.Response, error) {
 
 func (cs *clientSuite) TestClientDoReportsErrors(c *check.C) {
 	cs.err = errors.New("ouchie")
-	err := cs.cli.Do("GET", "/", nil, nil)
+	err := cs.cli.Do("GET", "/", nil, nil, nil)
 	c.Check(err, check.Equals, cs.err)
 }
 
@@ -76,7 +84,7 @@ func (cs *clientSuite) TestClientWorks(c *check.C) {
 	var v []int
 	cs.rsp = `[1,2]`
 	reqBody := ioutil.NopCloser(strings.NewReader(""))
-	err := cs.cli.Do("GET", "/this", reqBody, &v)
+	err := cs.cli.Do("GET", "/this", nil, reqBody, &v)
 	c.Check(err, check.IsNil)
 	c.Check(v, check.DeepEquals, []int{1, 2})
 	c.Assert(cs.req, check.NotNil)
@@ -102,6 +110,33 @@ func (cs *clientSuite) TestClientSysInfo(c *check.C) {
 		APICompatibility: "42",
 		Store:            "store",
 	})
+}
+
+func (cs *clientSuite) TestClientIntegration(c *check.C) {
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapdSocket), 0755), check.IsNil)
+	l, err := net.Listen("unix", dirs.SnapdSocket)
+	if err != nil {
+		c.Fatalf("unable to listen on %q: %v", dirs.SnapdSocket, err)
+	}
+
+	f := func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/2.0/system-info")
+		c.Check(r.URL.RawQuery, check.Equals, "")
+
+		fmt.Fprintln(w, `{"type":"sync", "result":{"store":"X"}}`)
+	}
+
+	srv := &httptest.Server{
+		Listener: l,
+		Config:   &http.Server{Handler: http.HandlerFunc(f)},
+	}
+	srv.Start()
+	defer srv.Close()
+
+	cli := client.New()
+	si, err := cli.SysInfo()
+	c.Check(err, check.IsNil)
+	c.Check(si.Store, check.Equals, "X")
 }
 
 func (cs *clientSuite) TestClientReportsOpError(c *check.C) {

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -21,6 +21,7 @@ package client
 
 import (
 	"io"
+	"net/url"
 )
 
 // SetDoer sets the client's doer to the given one
@@ -29,6 +30,6 @@ func (client *Client) SetDoer(d doer) {
 }
 
 // Do does do.
-func (client *Client) Do(method, path string, body io.Reader, v interface{}) error {
-	return client.do(method, path, body, v)
+func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) error {
+	return client.do(method, path, query, body, v)
 }

--- a/client/icons.go
+++ b/client/icons.go
@@ -36,7 +36,7 @@ type Icon struct {
 func (c *Client) Icon(pkgID string) (*Icon, error) {
 	const errPrefix = "cannot retrieve icon"
 
-	response, err := c.raw("GET", fmt.Sprintf("/2.0/icons/%s/icon", pkgID), nil)
+	response, err := c.raw("GET", fmt.Sprintf("/2.0/icons/%s/icon", pkgID), nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed to communicate with server: %s", errPrefix, err)
 	}

--- a/client/packages.go
+++ b/client/packages.go
@@ -62,14 +62,13 @@ const (
 // Snaps returns the list of all snaps installed on the system and
 // available for install from the store for this system.
 func (client *Client) Snaps() (map[string]*Snap, error) {
-	return client.snapsFromPath("/2.0/snaps")
+	return client.snapsFromPath("/2.0/snaps", nil)
 }
 
 // FilterSnaps returns a list of snaps per Snaps() but filtered by source, name
 // and/or type
 func (client *Client) FilterSnaps(filter SnapFilter) (map[string]*Snap, error) {
-	u := url.URL{Path: "/2.0/snaps"}
-	q := u.Query()
+	q := url.Values{}
 
 	if len(filter.Sources) > 0 {
 		q.Set("sources", strings.Join(filter.Sources, ","))
@@ -79,16 +78,14 @@ func (client *Client) FilterSnaps(filter SnapFilter) (map[string]*Snap, error) {
 		q.Set("types", strings.Join(filter.Types, ","))
 	}
 
-	u.RawQuery = q.Encode()
-
-	return client.snapsFromPath(u.String())
+	return client.snapsFromPath("/2.0/snaps", q)
 }
 
-func (client *Client) snapsFromPath(path string) (map[string]*Snap, error) {
+func (client *Client) snapsFromPath(path string, query url.Values) (map[string]*Snap, error) {
 	const errPrefix = "cannot list snaps"
 
 	var result map[string]json.RawMessage
-	if err := client.doSync("GET", path, nil, &result); err != nil {
+	if err := client.doSync("GET", path, query, nil, &result); err != nil {
 		return nil, fmt.Errorf("%s: %s", errPrefix, err)
 	}
 
@@ -111,7 +108,7 @@ func (client *Client) Snap(name string) (*Snap, error) {
 	var pkg *Snap
 
 	path := fmt.Sprintf("/2.0/snaps/%s", name)
-	if err := client.doSync("GET", path, nil, &pkg); err != nil {
+	if err := client.doSync("GET", path, nil, nil, &pkg); err != nil {
 		return nil, fmt.Errorf("cannot retrieve snap %q: %s", name, err)
 	}
 

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -21,7 +21,6 @@ package client_test
 
 import (
 	"fmt"
-	"net/url"
 
 	"gopkg.in/check.v1"
 
@@ -95,22 +94,21 @@ func (cs *clientSuite) TestClientFilterSnaps(c *check.C) {
 	filterTests := []struct {
 		filter client.SnapFilter
 		path   string
+		query  string
 	}{
-		{client.SnapFilter{}, "/2.0/snaps"},
-		{client.SnapFilter{Sources: []string{"local"}}, "/2.0/snaps?sources=local"},
-		{client.SnapFilter{Sources: []string{"store"}}, "/2.0/snaps?sources=store"},
-		{client.SnapFilter{Sources: []string{"local", "store"}}, "/2.0/snaps?sources=local,store"},
-		{client.SnapFilter{Types: []string{"app"}}, "/2.0/snaps?types=app"},
-		{client.SnapFilter{Types: []string{"app", "framework"}}, "/2.0/snaps?types=app,framework"},
-		{client.SnapFilter{Sources: []string{"local"}, Types: []string{"app"}}, "/2.0/snaps?sources=local&types=app"},
+		{client.SnapFilter{}, "/2.0/snaps", ""},
+		{client.SnapFilter{Sources: []string{"local"}}, "/2.0/snaps", "sources=local"},
+		{client.SnapFilter{Sources: []string{"store"}}, "/2.0/snaps", "sources=store"},
+		{client.SnapFilter{Sources: []string{"local", "store"}}, "/2.0/snaps", "sources=local%2Cstore"},
+		{client.SnapFilter{Types: []string{"app"}}, "/2.0/snaps", "types=app"},
+		{client.SnapFilter{Types: []string{"app", "framework"}}, "/2.0/snaps", "types=app%2Cframework"},
+		{client.SnapFilter{Sources: []string{"local"}, Types: []string{"app"}}, "/2.0/snaps", "sources=local&types=app"},
 	}
 
 	for _, tt := range filterTests {
 		_, _ = cs.cli.FilterSnaps(tt.filter)
-		// query string parameters will be URL encoded
-		path, err := url.QueryUnescape(cs.req.URL.Path)
-		c.Assert(err, check.IsNil)
-		c.Assert(path, check.Equals, tt.path)
+		c.Check(cs.req.URL.Path, check.Equals, tt.path, check.Commentf("%v", tt.filter))
+		c.Check(cs.req.URL.RawQuery, check.Equals, tt.query, check.Commentf("%v", tt.filter))
 	}
 }
 

--- a/client/services.go
+++ b/client/services.go
@@ -68,7 +68,7 @@ func (client *Client) Services(pkg string) (map[string]*Service, error) {
 	var services map[string]*Service
 
 	path := fmt.Sprintf("/2.0/snaps/%s/services", pkg)
-	if err := client.doSync("GET", path, nil, &services); err != nil {
+	if err := client.doSync("GET", path, nil, nil, &services); err != nil {
 		return nil, fmt.Errorf("cannot list services: %s", err)
 	}
 


### PR DESCRIPTION
we were using just path in the client internals, and this led to having the query escaped, which was patently wrong. This fixes that by explicitly passing a `url.Values` around in addition to the path itself.