### PR TITLE
snappy: refactor snapYaml to remove methods on snapYaml type

### DIFF
--- a/snappy/click.go
+++ b/snappy/click.go
@@ -290,7 +290,7 @@ func stripGlobalRootDirImpl(dir string) string {
 	return dir[len(dirs.GlobalRootDir):]
 }
 
-func (m *snapYaml) addPackageServices(baseDir string, inhibitHooks bool, inter interacter) error {
+func addPackageServices(m *snapYaml, baseDir string, inhibitHooks bool, inter interacter) error {
 	for _, app := range m.Apps {
 		if app.Daemon == "" {
 			continue
@@ -381,7 +381,7 @@ func (m *snapYaml) addPackageServices(baseDir string, inhibitHooks bool, inter i
 	return nil
 }
 
-func (m *snapYaml) removePackageServices(baseDir string, inter interacter) error {
+func removePackageServices(m *snapYaml, baseDir string, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	for _, app := range m.Apps {
 		if app.Daemon == "" {
@@ -428,7 +428,7 @@ func (m *snapYaml) removePackageServices(baseDir string, inter interacter) error
 	return nil
 }
 
-func (m *snapYaml) addPackageBinaries(baseDir string) error {
+func addPackageBinaries(m *snapYaml, baseDir string) error {
 	if err := os.MkdirAll(dirs.SnapBinariesDir, 0755); err != nil {
 		return err
 	}
@@ -460,7 +460,7 @@ func (m *snapYaml) addPackageBinaries(baseDir string) error {
 	return nil
 }
 
-func (m *snapYaml) removePackageBinaries(baseDir string) error {
+func removePackageBinaries(m *snapYaml, baseDir string) error {
 	for _, app := range m.Apps {
 		os.Remove(generateBinaryName(m, app))
 	}

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -748,7 +748,7 @@ func (s *SnapTestSuite) TestAddPackageServicesStripsGlobalRootdir(c *C) {
 	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	baseDir := filepath.Dir(filepath.Dir(yamlFile))
-	err = m.addPackageServices(baseDir, false, nil)
+	err = addPackageServices(m, baseDir, false, nil)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/etc/systemd/system/hello-app_svc1_1.10.service"))
@@ -777,7 +777,7 @@ apps:
 	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	baseDir := filepath.Dir(filepath.Dir(yamlFile))
-	err = m.addPackageServices(baseDir, false, nil)
+	err = addPackageServices(m, baseDir, false, nil)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/etc/dbus-1/system.d/foo_bar_1.conf"))
@@ -799,7 +799,7 @@ apps:
 	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	baseDir := filepath.Dir(filepath.Dir(yamlFile))
-	err = m.addPackageServices(baseDir, false, nil)
+	err = addPackageServices(m, baseDir, false, nil)
 	c.Assert(err, IsNil)
 
 	_, err = ioutil.ReadFile(filepath.Join(s.tempdir, "/etc/dbus-1/system.d/foo_bar_1.conf"))
@@ -817,7 +817,7 @@ func (s *SnapTestSuite) TestAddPackageBinariesStripsGlobalRootdir(c *C) {
 	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	baseDir := filepath.Dir(filepath.Dir(yamlFile))
-	err = m.addPackageBinaries(baseDir)
+	err = addPackageBinaries(m, baseDir)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/snaps/bin/hello-app.hello"))
@@ -1072,7 +1072,7 @@ apps:
 	m, err := parseSnapYamlFile(yamlFile)
 	c.Assert(err, IsNil)
 	inter := &MockProgressMeter{}
-	c.Check(m.removePackageServices(filepath.Dir(filepath.Dir(yamlFile)), inter), IsNil)
+	c.Check(removePackageServices(m, filepath.Dir(filepath.Dir(yamlFile)), inter), IsNil)
 	c.Assert(len(inter.notified) > 0, Equals, true)
 	c.Check(inter.notified[len(inter.notified)-1], Equals, "wat_wat_42.service refused to stop, killing.")
 	c.Assert(len(sysdLog) >= 3, Equals, true)

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -548,7 +548,7 @@ var loadAppArmorPolicy = func(fn string) ([]byte, error) {
 	return content, err
 }
 
-func (m *snapYaml) removeOneSecurityPolicy(name, baseDir string) error {
+func removeOneSecurityPolicy(m *snapYaml, name, baseDir string) error {
 	profileName, err := getSecurityProfile(m, filepath.Base(name), baseDir)
 	if err != nil {
 		return err
@@ -580,7 +580,7 @@ func removePolicy(m *snapYaml, baseDir string) error {
 		if app.Daemon == "" {
 			continue
 		}
-		if err := m.removeOneSecurityPolicy(app.Name, baseDir); err != nil {
+		if err := removeOneSecurityPolicy(m, app.Name, baseDir); err != nil {
 			return err
 		}
 	}
@@ -589,12 +589,12 @@ func removePolicy(m *snapYaml, baseDir string) error {
 		if app.Daemon != "" {
 			continue
 		}
-		if err := m.removeOneSecurityPolicy(app.Name, baseDir); err != nil {
+		if err := removeOneSecurityPolicy(m, app.Name, baseDir); err != nil {
 			return err
 		}
 	}
 
-	if err := m.removeOneSecurityPolicy("snappy-config", baseDir); err != nil {
+	if err := removeOneSecurityPolicy(m, "snappy-config", baseDir); err != nil {
 		return err
 	}
 

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -363,7 +363,7 @@ func (s *SnapFile) Install(inter progress.Meter, flags InstallFlags) (name strin
 
 // CanInstall checks whether the SnapPart passes a series of tests required for installation
 func (s *SnapFile) CanInstall(allowGadget bool, inter interacter) error {
-	if err := s.m.checkForPackageInstalled(s.Origin()); err != nil {
+	if err := checkForPackageInstalled(s.m, s.Origin()); err != nil {
 		return err
 	}
 
@@ -372,7 +372,7 @@ func (s *SnapFile) CanInstall(allowGadget bool, inter interacter) error {
 		return &ErrArchitectureNotSupported{s.m.Architectures}
 	}
 
-	if err := s.m.checkForFrameworks(); err != nil {
+	if err := checkForFrameworks(s.m); err != nil {
 		return err
 	}
 
@@ -390,7 +390,7 @@ func (s *SnapFile) CanInstall(allowGadget bool, inter interacter) error {
 	}
 
 	curr, _ := filepath.EvalSymlinks(filepath.Join(s.instdir, "..", "current"))
-	if err := s.m.checkLicenseAgreement(inter, s.deb, curr); err != nil {
+	if err := checkLicenseAgreement(s.m, inter, s.deb, curr); err != nil {
 		return err
 	}
 

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -226,13 +226,13 @@ func (s *SnapFile) Install(inter progress.Meter, flags InstallFlags) (name strin
 	}
 
 	// generate the mount unit for the squashfs
-	if err := s.m.addSquashfsMount(s.instdir, inhibitHooks, inter); err != nil {
+	if err := addSquashfsMount(s.m, s.instdir, inhibitHooks, inter); err != nil {
 		return "", err
 	}
 	// if anything goes wrong we ensure we stop
 	defer func() {
 		if err != nil {
-			if e := s.m.removeSquashfsMount(s.instdir, inter); e != nil {
+			if e := removeSquashfsMount(s.m, s.instdir, inter); e != nil {
 				logger.Noticef("Failed to remove mount unit for  %s: %s", fullName, e)
 			}
 		}

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -401,7 +401,7 @@ func (s *SnapPart) remove(inter interacter) (err error) {
 	}
 
 	// ensure mount unit stops
-	if err := s.m.removeSquashfsMount(s.basedir, inter); err != nil {
+	if err := removeSquashfsMount(s.m, s.basedir, inter); err != nil {
 		return err
 	}
 

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -279,11 +279,11 @@ func (s *SnapPart) activate(inhibitHooks bool, inter interacter) error {
 	}
 
 	// add the "binaries:" from the snap.yaml
-	if err := s.m.addPackageBinaries(s.basedir); err != nil {
+	if err := addPackageBinaries(s.m, s.basedir); err != nil {
 		return err
 	}
 	// add the "services:" from the snap.yaml
-	if err := s.m.addPackageServices(s.basedir, inhibitHooks, inter); err != nil {
+	if err := addPackageServices(s.m, s.basedir, inhibitHooks, inter); err != nil {
 		return err
 	}
 
@@ -331,11 +331,11 @@ func (s *SnapPart) deactivate(inhibitHooks bool, inter interacter) error {
 	}
 
 	// remove generated services, binaries, security policy
-	if err := s.m.removePackageBinaries(s.basedir); err != nil {
+	if err := removePackageBinaries(s.m, s.basedir); err != nil {
 		return err
 	}
 
-	if err := s.m.removePackageServices(s.basedir, inter); err != nil {
+	if err := removePackageServices(s.m, s.basedir, inter); err != nil {
 		return err
 	}
 

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -292,7 +292,7 @@ func (m *snapYaml) checkLicenseAgreement(ag agreer, d snap.File, currentActiveDi
 	return nil
 }
 
-func (m *snapYaml) addSquashfsMount(baseDir string, inhibitHooks bool, inter interacter) error {
+func addSquashfsMount(m *snapYaml, baseDir string, inhibitHooks bool, inter interacter) error {
 	squashfsPath := stripGlobalRootDir(squashfs.BlobPath(baseDir))
 	whereDir := stripGlobalRootDir(baseDir)
 
@@ -314,7 +314,7 @@ func (m *snapYaml) addSquashfsMount(baseDir string, inhibitHooks bool, inter int
 	return nil
 }
 
-func (m *snapYaml) removeSquashfsMount(baseDir string, inter interacter) error {
+func removeSquashfsMount(m *snapYaml, baseDir string, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	unit := systemd.MountUnitPath(stripGlobalRootDir(baseDir), "mount")
 	if helpers.FileExists(unit) {

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -218,7 +218,7 @@ func (m *snapYaml) qualifiedName(origin string) string {
 	return m.Name + "." + origin
 }
 
-func (m *snapYaml) checkForPackageInstalled(origin string) error {
+func checkForPackageInstalled(m *snapYaml, origin string) error {
 	part := ActiveSnapByName(m.Name)
 	if part == nil {
 		return nil
@@ -231,7 +231,7 @@ func (m *snapYaml) checkForPackageInstalled(origin string) error {
 	return nil
 }
 
-func (m *snapYaml) checkForFrameworks() error {
+func checkForFrameworks(m *snapYaml) error {
 	installed, err := ActiveSnapIterByType(BareName, snap.TypeFramework)
 	if err != nil {
 		return err
@@ -258,7 +258,7 @@ func (m *snapYaml) checkForFrameworks() error {
 // package, as deduced from the license agreement (which might involve asking
 // the user), or an error that explains the reason why installation should not
 // proceed.
-func (m *snapYaml) checkLicenseAgreement(ag agreer, d snap.File, currentActiveDir string) error {
+func checkLicenseAgreement(m *snapYaml, ag agreer, d snap.File, currentActiveDir string) error {
 	if m.LicenseAgreement != "explicit" {
 		return nil
 	}

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -128,13 +128,13 @@ func (s *SquashfsTestSuite) TestInstallViaSquashfsWorks(c *C) {
 }
 
 func (s *SquashfsTestSuite) TestAddSquashfsMount(c *C) {
-	m := snapYaml{
+	m := &snapYaml{
 		Name:          "foo.origin",
 		Version:       "1.0",
 		Architectures: []string{"all"},
 	}
 	inter := &MockProgressMeter{}
-	err := m.addSquashfsMount(filepath.Join(dirs.SnapSnapsDir, "foo.origin/1.0"), true, inter)
+	err := addSquashfsMount(m, filepath.Join(dirs.SnapSnapsDir, "foo.origin/1.0"), true, inter)
 	c.Assert(err, IsNil)
 
 	// ensure correct mount unit
@@ -151,9 +151,9 @@ Where=/snaps/foo.origin/1.0
 }
 
 func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
-	m := snapYaml{}
+	m := &snapYaml{}
 	inter := &MockProgressMeter{}
-	err := m.addSquashfsMount(filepath.Join(dirs.SnapSnapsDir, "foo.origin/1.0"), true, inter)
+	err := addSquashfsMount(m, filepath.Join(dirs.SnapSnapsDir, "foo.origin/1.0"), true, inter)
 	c.Assert(err, IsNil)
 
 	// ensure we have the files
@@ -161,7 +161,7 @@ func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
 	c.Assert(helpers.FileExists(p), Equals, true)
 
 	// now call remove and ensure they are gone
-	err = m.removeSquashfsMount(filepath.Join(dirs.SnapSnapsDir, "foo.origin/1.0"), inter)
+	err = removeSquashfsMount(m, filepath.Join(dirs.SnapSnapsDir, "foo.origin/1.0"), inter)
 	c.Assert(err, IsNil)
 	p = filepath.Join(dirs.SnapServicesDir, "snaps-foo.origin-1.0.mount")
 	c.Assert(helpers.FileExists(p), Equals, false)

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -1058,7 +1058,7 @@ func (s *SnapTestSuite) TestDetectsAlreadyInstalled(c *C) {
 
 	yaml, err := parseSnapYamlData([]byte(data), false)
 	c.Assert(err, IsNil)
-	c.Check(yaml.checkForPackageInstalled("otherns"), ErrorMatches, ".*is already installed with origin.*")
+	c.Check(checkForPackageInstalled(yaml, "otherns"), ErrorMatches, ".*is already installed with origin.*")
 }
 
 func (s *SnapTestSuite) TestIgnoresAlreadyInstalledSameOrigin(c *C) {
@@ -1071,7 +1071,7 @@ func (s *SnapTestSuite) TestIgnoresAlreadyInstalledSameOrigin(c *C) {
 
 	yaml, err := parseSnapYamlData([]byte(data), false)
 	c.Assert(err, IsNil)
-	c.Check(yaml.checkForPackageInstalled(testOrigin), IsNil)
+	c.Check(checkForPackageInstalled(yaml, testOrigin), IsNil)
 }
 
 func (s *SnapTestSuite) TestIgnoresAlreadyInstalledFrameworkSameOrigin(c *C) {
@@ -1082,7 +1082,7 @@ func (s *SnapTestSuite) TestIgnoresAlreadyInstalledFrameworkSameOrigin(c *C) {
 
 	yaml, err := parseSnapYamlData([]byte(data), false)
 	c.Assert(err, IsNil)
-	c.Check(yaml.checkForPackageInstalled(testOrigin), IsNil)
+	c.Check(checkForPackageInstalled(yaml, testOrigin), IsNil)
 }
 
 func (s *SnapTestSuite) TestDetectsAlreadyInstalledFramework(c *C) {
@@ -1093,7 +1093,7 @@ func (s *SnapTestSuite) TestDetectsAlreadyInstalledFramework(c *C) {
 
 	yaml, err := parseSnapYamlData([]byte(data), false)
 	c.Assert(err, IsNil)
-	c.Check(yaml.checkForPackageInstalled("otherns"), ErrorMatches, ".*is already installed with origin.*")
+	c.Check(checkForPackageInstalled(yaml, "otherns"), ErrorMatches, ".*is already installed with origin.*")
 }
 
 func (s *SnapTestSuite) TestUsesStoreMetaData(c *C) {
@@ -1127,7 +1127,7 @@ frameworks:
 `)
 	yaml, err := parseSnapYamlData(data, false)
 	c.Assert(err, IsNil)
-	err = yaml.checkForFrameworks()
+	err = checkForFrameworks(yaml)
 	c.Assert(err, ErrorMatches, `missing frameworks: missing, also-missing`)
 }
 


### PR DESCRIPTION
Tiny branch that removes the methods from the snapYaml type.