### PR TITLE
integration-tests: Remove the target release and channel

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -101,9 +101,8 @@ Run the tests with:
 
 With the `--update` flag you can flash an old image, update to the latest and
 then run the whole suite on the updated system. The `release`, the `channel` and
-the `revision` flags specify the image that will be flashed, and the
-`target-release` and `target-channel` flags specify the values to be used in the
-update if they are different from the flashed values.
+the `revision` flags specify the image that will be flashed. There must be an
+update available for the flashed iamge.
 
 For example, to update from *rolling edge -1* to the latest and then run the
 integration tests:
@@ -111,18 +110,12 @@ integration tests:
     go run integration-tests/main.go --snappy-from-branch \
     --revision=-1 --update
 
-To update from *15.04 alpha* to *rolling edge* and then run the integration tests:
-
-    go run integration-tests/main.go --snappy-from-branch \
-    --release=15.04 --channel=alpha \
-    --update --target-release=rolling --target-channel=edge
-
 ### Testing a rollback
 
 With the `--rollback` flag you can flash an old image, update to the latest,
 rollback again to the old image and then run the whole suite on the rolled
-back system. You should use the `release`, `channel`, `revision`, `target-release`
-and `target-channel` flags as when testing an update.
+back system. You should use the `release`, `channel` and `revision` flags as
+when testing an update.
 
 For example, to test a rollback from latest *rolling edge* to *rolling edge -1*:
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -102,7 +102,7 @@ Run the tests with:
 With the `--update` flag you can flash an old image, update to the latest and
 then run the whole suite on the updated system. The `release`, the `channel` and
 the `revision` flags specify the image that will be flashed. There must be an
-update available for the flashed iamge.
+update available for the flashed image.
 
 For example, to update from *rolling edge -1* to the latest and then run the
 integration tests:

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -64,10 +64,6 @@ func main() {
 			"Revision of the image to be built (can be relative to the latest available revision in the given release and channel as in -1), defaults to the empty string")
 		update = flag.Bool("update", false,
 			"If this flag is used, the image will be updated before running the tests.")
-		targetRelease = flag.String("target-release", "",
-			"If the update flag is used, the image will be updated to this release before running the tests.")
-		targetChannel = flag.String("target-channel", "",
-			"If the update flag is used, the image will be updated to this channel before running the tests.")
 		rollback = flag.Bool("rollback", false,
 			"If this flag is used, the image will be updated and then rolled back before running the tests.")
 		outputDir     = flag.String("output-dir", defaultOutputDir, "Directory where test artifacts will be stored.")
@@ -91,8 +87,7 @@ func main() {
 	// TODO: pass the config as arguments to the test binaries.
 	// --elopio - 2015-07-15
 	cfg := config.NewConfig(
-		configFileName, *imgRelease, *imgChannel, *targetRelease, *targetChannel,
-		remoteTestbed, *update, *rollback)
+		configFileName, *imgRelease, *imgChannel, remoteTestbed, *update, *rollback)
 	cfg.Write()
 
 	rootPath := testutils.RootPath()

--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -71,13 +71,14 @@ func (s *SnappySuite) SetUpSuite(c *check.C) {
 
 	if !IsInRebootProcess() {
 		if Cfg.Update || Cfg.Rollback {
-			switchSystemImageConf(c, Cfg.TargetRelease, Cfg.TargetChannel, "0")
 			// Always use the installed snappy because we are updating from an old
 			// image, so we should not use the snappy from the branch.
 			output := cli.ExecCommand(c, "sudo", "/usr/bin/snappy", "update")
-			if output != "" {
-				RebootWithMark(c, "setupsuite-update")
-			}
+			expected := "(?ms)" +
+				".*" +
+				"^Reboot to use the new ubuntu-core\\.\n"
+			c.Assert(output, check.Matches, expected)
+			RebootWithMark(c, "setupsuite-update")
 		}
 	} else if CheckRebootMark("setupsuite-update") {
 		RemoveRebootMark(c)

--- a/integration-tests/testutils/config/config.go
+++ b/integration-tests/testutils/config/config.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -40,10 +40,9 @@ type Config struct {
 }
 
 // NewConfig is the Config constructor
-func NewConfig(fileName, release, channel, targetRelease, targetChannel string, remoteTestbed, update, rollback bool) *Config {
+func NewConfig(fileName, release, channel string, remoteTestbed, update, rollback bool) *Config {
 	return &Config{
 		FileName: fileName, Release: release, Channel: channel,
-		TargetRelease: targetRelease, TargetChannel: targetChannel,
 		RemoteTestbed: remoteTestbed, Update: update, Rollback: rollback,
 	}
 }

--- a/integration-tests/testutils/config/config_test.go
+++ b/integration-tests/testutils/config/config_test.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014, 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -47,7 +47,7 @@ func testConfigFileName(c *check.C) string {
 func testConfigStruct(fileName string) *Config {
 	return NewConfig(
 		fileName,
-		"testrelease", "testchannel", "testtargetrelease", "testtargetchannel",
+		"testrelease", "testchannel",
 		true, true, true)
 }
 func testConfigContents(fileName string) string {
@@ -55,8 +55,6 @@ func testConfigContents(fileName string) string {
 		fmt.Sprintf(`"FileName":"%s",`, fileName) +
 		`"Release":"testrelease",` +
 		`"Channel":"testchannel",` +
-		`"TargetRelease":"testtargetrelease",` +
-		`"TargetChannel":"testtargetchannel",` +
 		`"RemoteTestbed":true,` +
 		`"Update":true,` +
 		`"Rollback":true` +
@@ -101,8 +99,6 @@ func (s *ConfigSuite) TestReadConfigLocalTestBed(c *check.C) {
 		fmt.Sprintf(`"FileName":"%s",`, configFileName) +
 		`"Release":"testrelease",` +
 		`"Channel":"testchannel",` +
-		`"TargetRelease":"testtargetrelease",` +
-		`"TargetChannel":"testtargetchannel",` +
 		`"RemoteTestbed":false,` +
 		`"Update":true,` +
 		`"Rollback":true` +
@@ -112,10 +108,7 @@ func (s *ConfigSuite) TestReadConfigLocalTestBed(c *check.C) {
 
 	cfg, err := ReadConfig(configFileName)
 
-	testConfigStruct := NewConfig(
-		configFileName,
-		"testrelease", "testchannel", "testtargetrelease", "testtargetchannel",
-		false, true, true)
+	testConfigStruct := NewConfig(configFileName, "testrelease", "testchannel", false, true, true)
 
 	c.Assert(err, check.IsNil, check.Commentf("Error reading config: %v", err))
 	c.Assert(cfg, check.DeepEquals, testConfigStruct)


### PR DESCRIPTION
We never really used the target release and channel for testing updates,
and it is actually affecting the updates when there is an available
update on the same release and channel as the flashed image because it
changes the current version to 0.