### PR TITLE
snappy,systemd: use Type field in systemd.ServiceDescription

### DIFF
--- a/docs/meta.md
+++ b/docs/meta.md
@@ -35,7 +35,7 @@ The following keys are optional:
 
 * `apps`: the map of apps (binaries and services) that a snap provides
     * `command`: (required) the command to start the service
-    * `daemon`: (optional) [simple|forking|oneshot]
+    * `daemon`: (optional) [simple|forking|oneshot|dbus]
     * `stop`: (optional) the command to stop the service
     * `stop-timeout`: (optional) the time in seconds to wait for the
                       service to stop

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -248,7 +248,7 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 			IsFramework:    m.Type == snap.TypeFramework,
 			IsNetworked:    app.Ports != nil && len(app.Ports.External) > 0,
 			BusName:        app.BusName,
-			Forking:        app.Forking,
+			Type:           app.Daemon,
 			UdevAppName:    udevPartName,
 			Socket:         app.Socket,
 			SocketFileName: socketFileName,

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -849,10 +849,10 @@ TimeoutStopSec=30
 [Install]
 WantedBy=multi-user.target
 `
-	expectedServiceAppWrapper     = fmt.Sprintf(expectedServiceWrapperFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target", ".canonical", "canonical", "\n", arch.UbuntuArchitecture())
-	expectedNetAppWrapper         = fmt.Sprintf(expectedServiceWrapperFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target\nAfter=snappy-wait4network.service\nRequires=snappy-wait4network.service", ".canonical", "canonical", "\n", arch.UbuntuArchitecture())
-	expectedServiceFmkWrapper     = fmt.Sprintf(expectedServiceWrapperFmt, "Before=ubuntu-snappy.frameworks.target\nAfter=ubuntu-snappy.frameworks-pre.target\nRequires=ubuntu-snappy.frameworks-pre.target", "", "", "BusName=foo.bar.baz\nType=dbus", arch.UbuntuArchitecture())
-	expectedSocketUsingWrapper    = fmt.Sprintf(expectedServiceWrapperFmt, "After=ubuntu-snappy.frameworks.target xkcd-webserver_xkcd-webserver_0.3.4.socket\nRequires=ubuntu-snappy.frameworks.target xkcd-webserver_xkcd-webserver_0.3.4.socket", ".canonical", "canonical", "\n", arch.UbuntuArchitecture())
+	expectedServiceAppWrapper     = fmt.Sprintf(expectedServiceWrapperFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target", ".canonical", "canonical", "Type=simple\n", arch.UbuntuArchitecture())
+	expectedNetAppWrapper         = fmt.Sprintf(expectedServiceWrapperFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target\nAfter=snappy-wait4network.service\nRequires=snappy-wait4network.service", ".canonical", "canonical", "Type=simple\n", arch.UbuntuArchitecture())
+	expectedServiceFmkWrapper     = fmt.Sprintf(expectedServiceWrapperFmt, "Before=ubuntu-snappy.frameworks.target\nAfter=ubuntu-snappy.frameworks-pre.target\nRequires=ubuntu-snappy.frameworks-pre.target", "", "", "Type=dbus\nBusName=foo.bar.baz", arch.UbuntuArchitecture())
+	expectedSocketUsingWrapper    = fmt.Sprintf(expectedServiceWrapperFmt, "After=ubuntu-snappy.frameworks.target xkcd-webserver_xkcd-webserver_0.3.4.socket\nRequires=ubuntu-snappy.frameworks.target xkcd-webserver_xkcd-webserver_0.3.4.socket", ".canonical", "canonical", "Type=simple\n", arch.UbuntuArchitecture())
 	expectedTypeForkingFmkWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target", ".canonical", "canonical", "Type=forking\n", arch.UbuntuArchitecture())
 )
 
@@ -864,7 +864,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceTypeForking(c *C) {
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
-		Forking:     true,
+		Daemon:      "forking",
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
@@ -884,6 +884,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapper(c *C) {
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
+		Daemon:      "simple",
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
@@ -904,6 +905,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceAppWrapperWithExternalPort(
 		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
 		Ports:       &Ports{External: map[string]Port{"foo": Port{}}},
+		Daemon:      "simple",
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
@@ -924,6 +926,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceFmkWrapper(c *C) {
 		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
 		BusName:     "foo.bar.baz",
+		Daemon:      "dbus",
 	}
 	pkgPath := "/snaps/xkcd-webserver/0.3.4/"
 	aaProfile := "xkcd-webserver_xkcd-webserver_0.3.4"
@@ -942,6 +945,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceRestart(c *C) {
 	service := &AppYaml{
 		Name:        "xkcd-webserver",
 		RestartCond: systemd.RestartOnAbort,
+		Daemon:      "simple",
 	}
 	pkgPath := "/snaps/xkcd-webserver/0.3.4/"
 	aaProfile := "xkcd-webserver_xkcd-webserver_0.3.4"
@@ -962,6 +966,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWrapperWhitelist(c *C) {
 		PostStop:    "bin/foo post-stop",
 		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver\nExec=foo",
+		Daemon:      "simple",
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
@@ -1107,6 +1112,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapSocket(c *C) {
 		SocketMode:   "0660",
 		SocketUser:   "root",
 		SocketGroup:  "adm",
+		Daemon:       "simple",
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"
@@ -1141,6 +1147,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapServiceWithSockte(c *C) {
 		StopTimeout: timeout.DefaultTimeout,
 		Description: "A fun webserver",
 		Socket:      true,
+		Daemon:      "simple",
 	}
 	pkgPath := "/snaps/xkcd-webserver.canonical/0.3.4/"
 	aaProfile := "xkcd-webserver.canonical_xkcd-webserver_0.3.4"

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -68,7 +68,6 @@ type AppYaml struct {
 	PostStop    string          `yaml:"poststop,omitempty"`
 	StopTimeout timeout.Timeout `yaml:"stop-timeout,omitempty"`
 	BusName     string          `yaml:"bus-name,omitempty"`
-	Forking     bool            `yaml:"forking,omitempty"`
 
 	// set to yes if we need to create a systemd socket for this service
 	Socket       bool   `yaml:"socket,omitempty" json:"socket,omitempty"`

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -163,12 +163,12 @@ type ServiceDescription struct {
 	PostStop        string
 	StopTimeout     time.Duration
 	Restart         RestartCondition
+	Type            string
 	AaProfile       string
 	IsFramework     bool
 	IsNetworked     bool
 	BusName         string
 	UdevAppName     string
-	Forking         bool
 	Socket          bool
 	SocketFileName  string
 	ListenStream    string
@@ -365,9 +365,8 @@ Environment="SNAP_APP={{.AppTriple}}" {{.EnvVars}}
 {{if .Stop}}ExecStop=/usr/bin/ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.FullPathStop}}{{end}}
 {{if .PostStop}}ExecStopPost=/usr/bin/ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.FullPathPostStop}}{{end}}
 {{if .StopTimeout}}TimeoutStopSec={{.StopTimeout.Seconds}}{{end}}
-{{if .BusName}}BusName={{.BusName}}
-Type=dbus{{else}}{{if .Forking}}Type=forking{{end}}
-{{end}}
+Type={{.Type}}
+{{if .BusName}}BusName={{.BusName}}{{end}}
 
 [Install]
 WantedBy={{.ServiceSystemdTarget}}
@@ -400,6 +399,7 @@ WantedBy={{.ServiceSystemdTarget}}
 		EnvVars              string
 		SocketFileName       string
 		Restart              string
+		Type                 string
 	}{
 		*desc,
 		filepath.Join(desc.AppPath, desc.Start),
@@ -413,6 +413,7 @@ WantedBy={{.ServiceSystemdTarget}}
 		"",
 		desc.SocketFileName,
 		restartCond,
+		desc.Type,
 	}
 	allVars := helpers.GetBasicSnapEnvVars(wrapperData)
 	allVars = append(allVars, helpers.GetUserSnapEnvVars(wrapperData)...)

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -232,13 +232,13 @@ WantedBy=multi-user.target
 `
 
 var (
-	expectedAppService  = fmt.Sprintf(expectedServiceFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target", ".mvo", "mvo", "\n", arch.UbuntuArchitecture())
-	expectedFmkService  = fmt.Sprintf(expectedServiceFmt, "Before=ubuntu-snappy.frameworks.target\nAfter=ubuntu-snappy.frameworks-pre.target\nRequires=ubuntu-snappy.frameworks-pre.target", "", "", "\n", arch.UbuntuArchitecture())
-	expectedDbusService = fmt.Sprintf(expectedServiceFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target", ".mvo", "mvo", "BusName=foo.bar.baz\nType=dbus", arch.UbuntuArchitecture())
+	expectedAppService  = fmt.Sprintf(expectedServiceFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target", ".mvo", "mvo", "Type=simple\n", arch.UbuntuArchitecture())
+	expectedFmkService  = fmt.Sprintf(expectedServiceFmt, "Before=ubuntu-snappy.frameworks.target\nAfter=ubuntu-snappy.frameworks-pre.target\nRequires=ubuntu-snappy.frameworks-pre.target", "", "", "Type=simple\n", arch.UbuntuArchitecture())
+	expectedDbusService = fmt.Sprintf(expectedServiceFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target", ".mvo", "mvo", "Type=dbus\nBusName=foo.bar.baz", arch.UbuntuArchitecture())
 
 	// things that need network
-	expectedNetAppService = fmt.Sprintf(expectedServiceFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target\nAfter=snappy-wait4network.service\nRequires=snappy-wait4network.service", ".mvo", "mvo", "\n", arch.UbuntuArchitecture())
-	expectedNetFmkService = fmt.Sprintf(expectedServiceFmt, "Before=ubuntu-snappy.frameworks.target\nAfter=ubuntu-snappy.frameworks-pre.target\nRequires=ubuntu-snappy.frameworks-pre.target\nAfter=snappy-wait4network.service\nRequires=snappy-wait4network.service", "", "", "\n", arch.UbuntuArchitecture())
+	expectedNetAppService = fmt.Sprintf(expectedServiceFmt, "After=ubuntu-snappy.frameworks.target\nRequires=ubuntu-snappy.frameworks.target\nAfter=snappy-wait4network.service\nRequires=snappy-wait4network.service", ".mvo", "mvo", "Type=simple\n", arch.UbuntuArchitecture())
+	expectedNetFmkService = fmt.Sprintf(expectedServiceFmt, "Before=ubuntu-snappy.frameworks.target\nAfter=ubuntu-snappy.frameworks-pre.target\nRequires=ubuntu-snappy.frameworks-pre.target\nAfter=snappy-wait4network.service\nRequires=snappy-wait4network.service", "", "", "Type=simple\n", arch.UbuntuArchitecture())
 )
 
 func (s *SystemdTestSuite) TestGenAppServiceFile(c *C) {
@@ -255,6 +255,7 @@ func (s *SystemdTestSuite) TestGenAppServiceFile(c *C) {
 		StopTimeout: time.Duration(10 * time.Second),
 		AaProfile:   "aa-profile",
 		UdevAppName: "app.mvo",
+		Type:        "simple",
 	}
 
 	c.Check(New("", nil).GenServiceFile(desc), Equals, expectedAppService)
@@ -286,6 +287,7 @@ func (s *SystemdTestSuite) TestGenNetAppServiceFile(c *C) {
 		AaProfile:   "aa-profile",
 		IsNetworked: true,
 		UdevAppName: "app.mvo",
+		Type:        "simple",
 	}
 
 	c.Check(New("", nil).GenServiceFile(desc), Equals, expectedNetAppService)
@@ -306,6 +308,7 @@ func (s *SystemdTestSuite) TestGenFmkServiceFile(c *C) {
 		AaProfile:   "aa-profile",
 		IsFramework: true,
 		UdevAppName: "app",
+		Type:        "simple",
 	}
 
 	c.Check(New("", nil).GenServiceFile(desc), Equals, expectedFmkService)
@@ -327,6 +330,7 @@ func (s *SystemdTestSuite) TestGenNetFmkServiceFile(c *C) {
 		IsNetworked: true,
 		IsFramework: true,
 		UdevAppName: "app",
+		Type:        "simple",
 	}
 
 	c.Check(New("", nil).GenServiceFile(desc), Equals, expectedNetFmkService)
@@ -347,6 +351,7 @@ func (s *SystemdTestSuite) TestGenServiceFileWithBusName(c *C) {
 		AaProfile:   "aa-profile",
 		BusName:     "foo.bar.baz",
 		UdevAppName: "app.mvo",
+		Type:        "dbus",
 	}
 
 	generated := New("", nil).GenServiceFile(desc)


### PR DESCRIPTION
Instead of the package.yaml "forking" key we have a explicit daemon
value in snap.yaml now. Use this in the systemd package.