### PR TITLE
client,daemon,asserts: expose the ability to query assertions in the system db

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -83,6 +83,9 @@ type Assertion interface {
 	Signature() (content, signature []byte)
 }
 
+// MediaType is the media type for enconded assertions on the wire.
+const MediaType = "application/x.ubuntu.assertion"
+
 // assertionBase is the concrete base to hold representation data for actual assertions.
 type assertionBase struct {
 	// TODO: worth having a type *AssertionType cache field now?

--- a/client/asserts.go
+++ b/client/asserts.go
@@ -63,7 +63,7 @@ func (client *Client) Asserts(assertTypeName string, headers map[string]string) 
 		return nil, parseError(response)
 	}
 
-	sanityCount, err := strconv.Atoi(response.Header.Get("X-Assertions-Count"))
+	sanityCount, err := strconv.Atoi(response.Header.Get("X-Ubuntu-Assertions-Count"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid assertions count")
 	}

--- a/client/asserts.go
+++ b/client/asserts.go
@@ -43,7 +43,7 @@ func (client *Client) Assert(b []byte) error {
 	return nil
 }
 
-// Asserts queries assertions with assertTypeName and matching headers.
+// Asserts queries assertions with type assertTypeName and matching assertion headers.
 func (client *Client) Asserts(assertTypeName string, headers map[string]string) ([]asserts.Assertion, error) {
 	path := fmt.Sprintf("/2.0/assertions/%s", assertTypeName)
 	q := url.Values{}

--- a/client/asserts.go
+++ b/client/asserts.go
@@ -44,17 +44,16 @@ func (client *Client) Assert(b []byte) error {
 
 // Asserts queries assertions with assertTypeName and matching headers.
 func (client *Client) Asserts(assertTypeName string, headers map[string]string) ([]asserts.Assertion, error) {
-	u := url.URL{Path: fmt.Sprintf("/2.0/assertions/%s", assertTypeName)}
+	path := fmt.Sprintf("/2.0/assertions/%s", assertTypeName)
+	q := url.Values{}
 
 	if len(headers) > 0 {
-		q := u.Query()
 		for k, v := range headers {
 			q.Set(k, v)
 		}
-		u.RawQuery = q.Encode()
 	}
 
-	response, err := client.raw("GET", u.String(), nil)
+	response, err := client.raw("GET", path, q, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query assertions: %v", err)
 	}

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -87,6 +87,8 @@ func (cs *clientSuite) TestClientAssertsJSONError(c *C) {
 }
 
 func (cs *clientSuite) TestClientAsserts(c *C) {
+	cs.header = http.Header{}
+	cs.header.Add("X-Assertions-Count", "2")
 	cs.rsp = `type: snap-revision
 authority-id: store-id1
 snap-id: snap-id-1
@@ -122,8 +124,20 @@ openpgp ...
 }
 
 func (cs *clientSuite) TestClientAssertsNoAssertions(c *C) {
-	cs.status = http.StatusNotFound
+	cs.header = http.Header{}
+	cs.header.Add("X-Assertions-Count", "0")
+	cs.rsp = ""
+	cs.status = http.StatusOK
 	a, err := cs.cli.Asserts("snap-revision", nil)
 	c.Assert(err, IsNil)
 	c.Check(a, HasLen, 0)
+}
+
+func (cs *clientSuite) TestClientAssertsMissingAssertions(c *C) {
+	cs.header = http.Header{}
+	cs.header.Add("X-Assertions-Count", "4")
+	cs.rsp = ""
+	cs.status = http.StatusOK
+	_, err := cs.cli.Asserts("snap-build", nil)
+	c.Assert(err, ErrorMatches, "response did not have the expected number of assertions")
 }

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"io/ioutil"
+
+	. "gopkg.in/check.v1"
+)
+
+func (cs *clientSuite) TestClientAssert(c *C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": {}
+	}`
+	a := []byte("Assertion.")
+	err := cs.cli.Assert(a)
+	c.Assert(err, IsNil)
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, IsNil)
+	c.Check(body, DeepEquals, a)
+	c.Check(cs.req.Method, Equals, "POST")
+	c.Check(cs.req.URL.Path, Equals, "/2.0/assertions")
+}

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -88,7 +88,7 @@ func (cs *clientSuite) TestClientAssertsJSONError(c *C) {
 
 func (cs *clientSuite) TestClientAsserts(c *C) {
 	cs.header = http.Header{}
-	cs.header.Add("X-Assertions-Count", "2")
+	cs.header.Add("X-Ubuntu-Assertions-Count", "2")
 	cs.rsp = `type: snap-revision
 authority-id: store-id1
 snap-id: snap-id-1
@@ -125,7 +125,7 @@ openpgp ...
 
 func (cs *clientSuite) TestClientAssertsNoAssertions(c *C) {
 	cs.header = http.Header{}
-	cs.header.Add("X-Assertions-Count", "0")
+	cs.header.Add("X-Ubuntu-Assertions-Count", "0")
 	cs.rsp = ""
 	cs.status = http.StatusOK
 	a, err := cs.cli.Asserts("snap-revision", nil)
@@ -135,7 +135,7 @@ func (cs *clientSuite) TestClientAssertsNoAssertions(c *C) {
 
 func (cs *clientSuite) TestClientAssertsMissingAssertions(c *C) {
 	cs.header = http.Header{}
-	cs.header.Add("X-Assertions-Count", "4")
+	cs.header.Add("X-Ubuntu-Assertions-Count", "4")
 	cs.rsp = ""
 	cs.status = http.StatusOK
 	_, err := cs.cli.Asserts("snap-build", nil)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -224,18 +224,3 @@ func (cs *clientSuite) TestClientRemoveCapabilityNotFound(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "DELETE")
 	c.Check(cs.req.URL.Path, check.Equals, "/2.0/capabilities/n")
 }
-
-func (cs *clientSuite) TestClientAssert(c *check.C) {
-	cs.rsp = `{
-		"type": "sync",
-		"result": {}
-	}`
-	a := []byte("Assertion.")
-	err := cs.cli.Assert(a)
-	c.Assert(err, check.IsNil)
-	body, err := ioutil.ReadAll(cs.req.Body)
-	c.Assert(err, check.IsNil)
-	c.Check(body, check.DeepEquals, a)
-	c.Check(cs.req.Method, check.Equals, "POST")
-	c.Check(cs.req.URL.Path, check.Equals, "/2.0/assertions")
-}

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -32,3 +32,6 @@ func (client *Client) SetDoer(d doer) {
 func (client *Client) Do(method, path string, body io.Reader, v interface{}) error {
 	return client.do(method, path, body, v)
 }
+
+// expose parseError for testing
+var ParseErrorInTest = parseError

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -992,9 +992,9 @@ func assertsFindMany(c *Command, r *http.Request) Response {
 	}
 	assertions, err := c.d.asserts.FindMany(assertType, headers)
 	if err == asserts.ErrNotFound {
-		return NotFound("no matching assertions found")
+		return AssertResponse(nil, true)
 	} else if err != nil {
-		return InternalError("findind assertion failed: %v", err)
+		return InternalError("searching assertions failed: %v", err)
 	}
 	return AssertResponse(assertions, true)
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -63,6 +63,7 @@ var api = []*Command{
 	capabilitiesCmd,
 	capabilityCmd,
 	assertsCmd,
+	assertsFindManyCmd,
 }
 
 var (
@@ -145,6 +146,11 @@ var (
 	assertsCmd = &Command{
 		Path: "/2.0/assertions",
 		POST: doAssert,
+	}
+
+	assertsFindManyCmd = &Command{
+		Path: "/2.0/assertions/{assertType}",
+		GET:  assertsFindMany,
 	}
 )
 
@@ -957,4 +963,24 @@ func doAssert(c *Command, r *http.Request) Response {
 		Type:   ResponseTypeSync,
 		Status: http.StatusOK,
 	}
+}
+
+func assertsFindMany(c *Command, r *http.Request) Response {
+	assertTypeName := muxVars(r)["assertType"]
+	assertType := asserts.Type(assertTypeName)
+	if assertType == nil {
+		return BadRequest("invalid assert type: %q", assertTypeName)
+	}
+	headers := map[string]string{}
+	q := r.URL.Query()
+	for k := range q {
+		headers[k] = q.Get(k)
+	}
+	assertions, err := c.d.asserts.FindMany(assertType, headers)
+	if err == asserts.ErrNotFound {
+		return NotFound("no matching assertions found")
+	} else if err != nil {
+		return InternalError("findind assertion failed: %v", err)
+	}
+	return AssertResponse(assertions, true)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1504,7 +1504,7 @@ func (s *apiSuite) TestAssertsFindManyAll(c *check.C) {
 	// Verify
 	c.Check(rec.Code, check.Equals, http.StatusOK, check.Commentf("body %q", rec.Body))
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
-	c.Check(rec.HeaderMap.Get("X-Assertions-Count"), check.Equals, "1")
+	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "1")
 	dec := asserts.NewDecoder(rec.Body)
 	a1, err := dec.Decode()
 	c.Assert(err, check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -27,6 +27,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -1447,4 +1448,57 @@ func (s *apiSuite) TestAssertError(c *check.C) {
 	// Verify (external)
 	c.Check(rec.Code, check.Equals, 400)
 	c.Check(rec.Body.String(), testutil.Contains, "assert failed")
+}
+
+func (s *apiSuite) TestAssertsFindManyAll(c *check.C) {
+	// Setup
+	os.MkdirAll(filepath.Dir(dirs.SnapTrustedAccountKey), 0755)
+	err := ioutil.WriteFile(dirs.SnapTrustedAccountKey, []byte(testTrustedKey), 0640)
+	c.Assert(err, check.IsNil)
+	d := newTestDaemon()
+	a, err := asserts.Decode([]byte(testAccKey))
+	c.Assert(err, check.IsNil)
+	err = d.asserts.Add(a)
+	c.Assert(err, check.IsNil)
+	// Execute
+	req, err := http.NewRequest("POST", "/2.0/assertions/account-key", nil)
+	c.Assert(err, check.IsNil)
+	s.vars = map[string]string{"assertType": "account-key"}
+	rec := httptest.NewRecorder()
+	assertsFindManyCmd.GET(assertsFindManyCmd, req).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, http.StatusOK, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
+	dec := asserts.NewDecoder(rec.Body)
+	a1, err := dec.Decode()
+	c.Assert(err, check.IsNil)
+	c.Check(a1.Type(), check.Equals, asserts.AccountKeyType)
+	// XXX should be two actually
+}
+
+func (s *apiSuite) TestAssertsFindManyFilter(c *check.C) {
+	// Setup
+	os.MkdirAll(filepath.Dir(dirs.SnapTrustedAccountKey), 0755)
+	err := ioutil.WriteFile(dirs.SnapTrustedAccountKey, []byte(testTrustedKey), 0640)
+	c.Assert(err, check.IsNil)
+	d := newTestDaemon()
+	a, err := asserts.Decode([]byte(testAccKey))
+	c.Assert(err, check.IsNil)
+	err = d.asserts.Add(a)
+	c.Assert(err, check.IsNil)
+	// Execute
+	req, err := http.NewRequest("POST", "/2.0/assertions/account-key?account-id=developer1", nil)
+	c.Assert(err, check.IsNil)
+	s.vars = map[string]string{"assertType": "account-key"}
+	rec := httptest.NewRecorder()
+	assertsFindManyCmd.GET(assertsFindManyCmd, req).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, http.StatusOK, check.Commentf("body %q", rec.Body))
+	dec := asserts.NewDecoder(rec.Body)
+	a1, err := dec.Decode()
+	c.Assert(err, check.IsNil)
+	c.Check(a1.Type(), check.Equals, asserts.AccountKeyType)
+	c.Check(a1.(*asserts.AccountKey).AccountID(), check.Equals, "developer1")
+	_, err = dec.Decode()
+	c.Check(err, check.Equals, io.EOF)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1504,6 +1504,7 @@ func (s *apiSuite) TestAssertsFindManyAll(c *check.C) {
 	// Verify
 	c.Check(rec.Code, check.Equals, http.StatusOK, check.Commentf("body %q", rec.Body))
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
+	c.Check(rec.HeaderMap.Get("X-Assertions-Count"), check.Equals, "1")
 	dec := asserts.NewDecoder(rec.Body)
 	a1, err := dec.Decode()
 	c.Assert(err, check.IsNil)
@@ -1537,3 +1538,19 @@ func (s *apiSuite) TestAssertsFindManyFilter(c *check.C) {
 	_, err = dec.Decode()
 	c.Check(err, check.Equals, io.EOF)
 }
+
+func (s *apiSuite) TestAssertsInvalidType(c *check.C) {
+	// Setup
+	newTestDaemon()
+	// Execute
+	req, err := http.NewRequest("POST", "/2.0/assertions/foo", nil)
+	c.Assert(err, check.IsNil)
+	s.vars = map[string]string{"assertType": "foo"}
+	rec := httptest.NewRecorder()
+	assertsFindManyCmd.GET(assertsFindManyCmd, req).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, 400)
+	c.Check(rec.Body.String(), testutil.Contains, "invalid assert type")
+}
+
+// XXX: NoResults

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1504,12 +1504,20 @@ func (s *apiSuite) TestAssertsFindManyAll(c *check.C) {
 	// Verify
 	c.Check(rec.Code, check.Equals, http.StatusOK, check.Commentf("body %q", rec.Body))
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
-	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "1")
+	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "2")
 	dec := asserts.NewDecoder(rec.Body)
 	a1, err := dec.Decode()
 	c.Assert(err, check.IsNil)
 	c.Check(a1.Type(), check.Equals, asserts.AccountKeyType)
-	// XXX should be two actually
+
+	a2, err := dec.Decode()
+	c.Assert(err, check.IsNil)
+
+	_, err = dec.Decode()
+	c.Assert(err, check.Equals, io.EOF)
+
+	ids := []string{a1.(*asserts.AccountKey).AccountID(), a2.(*asserts.AccountKey).AccountID()}
+	c.Check(ids, check.DeepEquals, []string{"can0nical", "developer1"})
 }
 
 func (s *apiSuite) TestAssertsFindManyFilter(c *check.C) {
@@ -1530,11 +1538,36 @@ func (s *apiSuite) TestAssertsFindManyFilter(c *check.C) {
 	assertsFindManyCmd.GET(assertsFindManyCmd, req).ServeHTTP(rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, http.StatusOK, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "1")
 	dec := asserts.NewDecoder(rec.Body)
 	a1, err := dec.Decode()
 	c.Assert(err, check.IsNil)
 	c.Check(a1.Type(), check.Equals, asserts.AccountKeyType)
 	c.Check(a1.(*asserts.AccountKey).AccountID(), check.Equals, "developer1")
+	_, err = dec.Decode()
+	c.Check(err, check.Equals, io.EOF)
+}
+
+func (s *apiSuite) TestAssertsFindManyNoResults(c *check.C) {
+	// Setup
+	os.MkdirAll(filepath.Dir(dirs.SnapTrustedAccountKey), 0755)
+	err := ioutil.WriteFile(dirs.SnapTrustedAccountKey, []byte(testTrustedKey), 0640)
+	c.Assert(err, check.IsNil)
+	d := newTestDaemon()
+	a, err := asserts.Decode([]byte(testAccKey))
+	c.Assert(err, check.IsNil)
+	err = d.asserts.Add(a)
+	c.Assert(err, check.IsNil)
+	// Execute
+	req, err := http.NewRequest("POST", "/2.0/assertions/account-key?account-id=xyzzyx", nil)
+	c.Assert(err, check.IsNil)
+	s.vars = map[string]string{"assertType": "account-key"}
+	rec := httptest.NewRecorder()
+	assertsFindManyCmd.GET(assertsFindManyCmd, req).ServeHTTP(rec, req)
+	// Verify
+	c.Check(rec.Code, check.Equals, http.StatusOK, check.Commentf("body %q", rec.Body))
+	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "0")
+	dec := asserts.NewDecoder(rec.Body)
 	_, err = dec.Decode()
 	c.Check(err, check.Equals, io.EOF)
 }
@@ -1552,5 +1585,3 @@ func (s *apiSuite) TestAssertsInvalidType(c *check.C) {
 	c.Check(rec.Code, check.Equals, 400)
 	c.Check(rec.Body.String(), testutil.Contains, "invalid assert type")
 }
-
-// XXX: NoResults

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -191,7 +191,7 @@ func (ar assertResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		t = mime.FormatMediaType(t, map[string]string{"bundle": "y"})
 	}
 	w.Header().Set("Content-Type", t)
-	w.Header().Set("X-Assertions-Count", strconv.Itoa(len(ar.assertions)))
+	w.Header().Set("X-Ubuntu-Assertions-Count", strconv.Itoa(len(ar.assertions)))
 	enc := asserts.NewEncoder(w)
 	for _, a := range ar.assertions {
 		err := enc.Encode(a)

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -196,7 +196,7 @@ func (ar assertResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, a := range ar.assertions {
 		err := enc.Encode(a)
 		if err != nil {
-			logger.Noticef("unable write encoded assertion into response: %v", err)
+			logger.Noticef("unable to write encoded assertion into response: %v", err)
 			break
 
 		}

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -25,6 +25,7 @@ import (
 	"mime"
 	"net/http"
 	"path/filepath"
+	"strconv"
 
 	"github.com/ubuntu-core/snappy/asserts"
 	"github.com/ubuntu-core/snappy/logger"
@@ -190,10 +191,15 @@ func (ar assertResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		t = mime.FormatMediaType(t, map[string]string{"bundle": "y"})
 	}
 	w.Header().Set("Content-Type", t)
+	w.Header().Set("X-Assertions-Count", strconv.Itoa(len(ar.assertions)))
 	enc := asserts.NewEncoder(w)
 	for _, a := range ar.assertions {
-		enc.Encode(a)
-		// XXX what to do with errors?
+		err := enc.Encode(a)
+		if err != nil {
+			logger.Noticef("unable write encoded assertion into response: %v", err)
+			break
+
+		}
 	}
 }
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -22,9 +22,11 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"path/filepath"
 
+	"github.com/ubuntu-core/snappy/asserts"
 	"github.com/ubuntu-core/snappy/logger"
 )
 
@@ -165,6 +167,34 @@ func (f FileResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	filename := fmt.Sprintf("attachment; filename=%s", filepath.Base(string(f)))
 	w.Header().Add("Content-Disposition", filename)
 	http.ServeFile(w, r, string(f))
+}
+
+type assertResponse struct {
+	assertions []asserts.Assertion
+	bundle     bool
+}
+
+// AssertResponse builds a response whose ServerHTTP method serves one or a bundle of assertions.
+func AssertResponse(asserts []asserts.Assertion, bundle bool) Response {
+	if len(asserts) > 1 {
+		bundle = true
+	}
+	return &assertResponse{assertions: asserts, bundle: bundle}
+}
+
+func (ar assertResponse) Self(*Command, *http.Request) Response { return ar }
+
+func (ar assertResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t := asserts.MediaType
+	if ar.bundle {
+		t = mime.FormatMediaType(t, map[string]string{"bundle": "y"})
+	}
+	w.Header().Set("Content-Type", t)
+	enc := asserts.NewEncoder(w)
+	for _, a := range ar.assertions {
+		enc.Encode(a)
+		// XXX what to do with errors?
+	}
 }
 
 // errorResponder is a callable that produces an error Response.

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -690,4 +690,6 @@ prerequisite in the database.
 * Operation: sync
 * Return: stream of assertions
 
-The response is a stream of assertions each with a separating double newline at its end.
+The response is a stream of assertions each with a separating double
+newline at its end. The X-Ubuntu-Assertions-Count header is set to the
+number of returned assertions, 0 or more.

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -681,3 +681,13 @@ may also be a newer revision of a preexisting assertion that it will replace.
 To succeed the assertion must be valid, its signature verified with a
 known public key and the assertion consistent with and its
 prerequisite in the database.
+
+## /2.0/assertions/[assertionType]
+### GET
+
+* Description: Get all the assertions in the system assertion database of the given type matching the header filters passed as query parameters
+* Access: authenticated
+* Operation: sync
+* Return: stream of assertions
+
+The response is a stream of assertions each with a separating double newline at its end.


### PR DESCRIPTION
This adds support in the daemon and client library to query for assertions in the system assertion database.

The added end point is /2.0/assertions/[assertionType] with query params for assertion header filtering.