### PR TITLE
debian: remove obsolete /etc/grub.d/09_snappy on upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-snappy (1.7.3ubuntu1) UNRELEASED; urgency=medium
+
+  * New git snapshot
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Mon, 01 Feb 2016 11:10:35 +0100
+
 ubuntu-snappy (1.7.2+20160113ubuntu1) xenial; urgency=medium
 
   * New git snapshot

--- a/debian/ubuntu-snappy.maintscript
+++ b/debian/ubuntu-snappy.maintscript
@@ -1,0 +1,3 @@
+
+# we used to ship a custom grub config that is no longer needed
+rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1


### PR DESCRIPTION
Closes: LP#1537548