### PR TITLE
skills: provide different security snippets for skill and slot side

### DIFF
--- a/skills/core.go
+++ b/skills/core.go
@@ -55,13 +55,23 @@ type Type interface {
 	// Sanitize checks if a skill is correct, altering if necessary.
 	Sanitize(skill *Skill) error
 
-	// SecuritySnippet returns the configuration snippet that should be used by
-	// the given security system to enable this skill to be consumed.
+	// SkillSecuritySnippet returns the configuration snippet needed by the
+	// given security system to allow a snap to offer a skill of this type.
+	//
 	// An empty snippet is returned when the skill doesn't require anything
-	// from the security system to work, in addition to the default configuration.
-	// ErrUnknownSecurity is returned when the skill cannot deal with the
-	// requested security system.
-	SecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error)
+	// from the security system to work, in addition to the default
+	// configuration.  ErrUnknownSecurity is returned when the skill cannot
+	// deal with the requested security system.
+	SkillSecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error)
+
+	// SlotSecuritySnippet returns the configuration snippet needed by the
+	// given security system to allow a snap to use a skill of this type.
+	//
+	// An empty snippet is returned when the skill doesn't require anything
+	// from the security system to work, in addition to the default
+	// configuration.  ErrUnknownSecurity is returned when the skill cannot
+	// deal with the requested security system.
+	SlotSecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // SecuritySystem is a name of a security system.

--- a/skills/testtype.go
+++ b/skills/testtype.go
@@ -53,8 +53,14 @@ func (t *TestType) Sanitize(skill *Skill) error {
 	return nil
 }
 
-// SecuritySnippet returns the configuration snippet "required" to use a test skill.
+// SkillSecuritySnippet returns the configuration snippet "required" to offer a test skill.
+// Providers don't gain any extra permissions.
+func (t *TestType) SkillSecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+// SlotSecuritySnippet returns the configuration snippet "required" to use a test skill.
 // Consumers don't gain any extra permissions.
-func (t *TestType) SecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error) {
+func (t *TestType) SlotSecuritySnippet(skill *Skill, securitySystem SecuritySystem) ([]byte, error) {
 	return nil, nil
 }

--- a/skills/testtype_test.go
+++ b/skills/testtype_test.go
@@ -72,21 +72,40 @@ func (s *TestTypeSuite) TestSanitizeWrongType(c *C) {
 	c.Assert(func() { s.t.Sanitize(skill) }, Panics, "skill is not of type \"test\"")
 }
 
-// TestType hands out empty security snippets
-func (s *TestTypeSuite) TestSecuritySnippet(c *C) {
+// TestType hands out empty skill security snippets
+func (s *TestTypeSuite) TestSkillSecuritySnippet(c *C) {
 	skill := &Skill{
 		Type: "test",
 	}
-	snippet, err := s.t.SecuritySnippet(skill, SecurityApparmor)
+	snippet, err := s.t.SkillSecuritySnippet(skill, SecurityApparmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.t.SecuritySnippet(skill, SecuritySeccomp)
+	snippet, err = s.t.SkillSecuritySnippet(skill, SecuritySeccomp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.t.SecuritySnippet(skill, SecurityDBus)
+	snippet, err = s.t.SkillSecuritySnippet(skill, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.t.SecuritySnippet(skill, "foo")
+	snippet, err = s.t.SkillSecuritySnippet(skill, "foo")
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+// TestType hands out empty slot security snippets
+func (s *TestTypeSuite) TestSlotSecuritySnippet(c *C) {
+	skill := &Skill{
+		Type: "test",
+	}
+	snippet, err := s.t.SlotSecuritySnippet(skill, SecurityApparmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.t.SlotSecuritySnippet(skill, SecuritySeccomp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.t.SlotSecuritySnippet(skill, SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.t.SlotSecuritySnippet(skill, "foo")
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }


### PR DESCRIPTION
Security snippets allow snaps to gain the permission needed to interact
with a skill. So far only the consumer (use) side of the security was
taken care of. This patch replaces the Type.SecuritySnippet() with two
methods: Type.SkillSecuritySnippet() and Type.SlotSecuritySnippet().

A snap that offers a skill will be granted additional permissions
expressed by SkillSecuritySnippet(). A snap that uses a skill will be
granted additional permissions expressed by SlotSecuritySnippet().

For a practical example, a snap that offers GPIOs as bool-files might
gain access to /sys/class/gpio/{export,unexport} while a snap that uses
those skills will only gain access to /sys/class/gpio/gpio$number/value.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>