### PR TITLE
cmd/snapd,daemon,snappy: gadget endpoint in snapd API

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -64,6 +64,7 @@ var api = []*Command{
 	capabilityCmd,
 	assertsCmd,
 	assertsFindManyCmd,
+	gadgetCmd,
 }
 
 var (
@@ -151,6 +152,11 @@ var (
 	assertsFindManyCmd = &Command{
 		Path: "/2.0/assertions/{assertType}",
 		GET:  assertsFindMany,
+	}
+
+	gadgetCmd = &Command{
+		Path: "/2.0/gadget",
+		GET:  getGadget,
 	}
 )
 
@@ -1005,4 +1011,15 @@ func assertsFindMany(c *Command, r *http.Request) Response {
 		return InternalError("searching assertions failed: %v", err)
 	}
 	return AssertResponse(assertions, true)
+}
+
+func getGadget(c *Command, r *http.Request) Response {
+	branding, err := snappy.GadgetBranding()
+	if err != nil {
+		return NotFound(err.Error())
+	}
+
+	return SyncResponse(map[string]interface{}{
+		"branding": branding,
+	})
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -124,12 +124,15 @@ version: %s
 	}
 }
 
-func (s *apiSuite) mkGadget(c *check.C, store string) {
+func (s *apiSuite) mkGadget(c *check.C, store, extraYaml string) {
 	content := []byte(fmt.Sprintf(`name: test
 version: 1
 type: gadget
-gadget: {store: {id: %q}}
-`, store))
+gadget:
+  store:
+    id: %q
+%s
+`, store, extraYaml))
 
 	d := filepath.Join(dirs.SnapSnapsDir, "test")
 	m := filepath.Join(d, "1", "meta")
@@ -359,7 +362,7 @@ func (s *apiSuite) TestSysInfoStore(c *check.C) {
 	c.Check(sysInfoCmd.Path, check.Equals, "/2.0/system-info")
 
 	s.mkrelease()
-	s.mkGadget(c, "some-store")
+	s.mkGadget(c, "some-store", "")
 
 	sysInfoCmd.GET(sysInfoCmd, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1599,3 +1599,32 @@ func (s *apiSuite) TestAssertsInvalidType(c *check.C) {
 	c.Check(rec.Code, check.Equals, 400)
 	c.Check(rec.Body.String(), testutil.Contains, "invalid assert type")
 }
+
+func (s *apiSuite) TestGetGadgetNoGadget(c *check.C) {
+	req, err := http.NewRequest("GET", "/2.0/gadget", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getGadget(gadgetCmd, req).(*resp)
+	c.Assert(rsp.Status, check.Equals, http.StatusNotFound)
+}
+
+func (s *apiSuite) TestGetGadget(c *check.C) {
+	branding := `
+  branding:
+    name: brand-name
+    subname: brand-subname
+`
+	s.mkGadget(c, "foo", branding)
+
+	req, err := http.NewRequest("GET", "/2.0/gadget", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getGadget(gadgetCmd, req).(*resp)
+	c.Assert(rsp.Status, check.Equals, http.StatusOK)
+	c.Assert(rsp.Result, check.DeepEquals, map[string]interface{}{
+		"branding": snappy.Branding{
+			Name:    "brand-name",
+			SubName: "brand-subname",
+		},
+	})
+}

--- a/snappy/gadget.go
+++ b/snappy/gadget.go
@@ -40,6 +40,7 @@ import (
 // of a gadget package type.
 type Gadget struct {
 	Store                Store    `yaml:"store,omitempty"`
+	Branding             Branding `yaml:"branding,omitempty"`
 	Hardware             Hardware `yaml:"hardware,omitempty"`
 	Software             Software `yaml:"software,omitempty"`
 	SkipIfupProvisioning bool     `yaml:"skip-ifup-provisioning"`
@@ -55,6 +56,12 @@ type Hardware struct {
 // Store holds information relevant to the store provided by a Gadget snap
 type Store struct {
 	ID string `yaml:"id,omitempty"`
+}
+
+// Branding allows for some custom branding of the system
+type Branding struct {
+	Name    string `yaml:"name,omitempty" json:"name,omitempty"`
+	SubName string `yaml:"subname,omitempty" json:"subname,omitempty"`
 }
 
 // Software describes the installed software provided by a Gadget snap
@@ -170,6 +177,16 @@ func StoreID() string {
 	}
 
 	return gadget.Gadget.Store.ID
+}
+
+// GadgetBranding returns the branding configuration of the gadget
+func GadgetBranding() (Branding, error) {
+	gadget, err := getGadget()
+	if err != nil {
+		return Branding{}, err
+	}
+
+	return gadget.Gadget.Branding, nil
 }
 
 // IsBuiltInSoftware returns true if the package is part of the built-in software

--- a/snappy/gadget_test.go
+++ b/snappy/gadget_test.go
@@ -23,6 +23,7 @@
 package snappy
 
 import (
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 
@@ -43,6 +44,7 @@ func (s *GadgetSuite) SetUpTest(c *C) {
 			Gadget: Gadget{
 				Software: Software{[]string{"makeuppackage", "anotherpackage"}},
 				Store:    Store{"ninjablocks"},
+				Branding: Branding{Name: "brand name", SubName: "brand subname"},
 			},
 		}, nil
 	}
@@ -60,6 +62,24 @@ func (s *GadgetSuite) TestIsBuildIn(c *C) {
 
 func (s *GadgetSuite) TestStoreID(c *C) {
 	c.Assert(StoreID(), Equals, "ninjablocks")
+}
+
+func (s *GadgetSuite) TestGadgetBrandingNoGadget(c *C) {
+	getGadget = func() (*snapYaml, error) {
+		return nil, errors.New("fail")
+	}
+
+	_, err := GadgetBranding()
+	c.Assert(err, NotNil)
+}
+
+func (s *GadgetSuite) TestGadgetBranding(c *C) {
+	branding, err := GadgetBranding()
+	c.Assert(err, IsNil)
+	c.Assert(branding, DeepEquals, Branding{
+		Name:    "brand name",
+		SubName: "brand subname",
+	})
 }
 
 func (s *GadgetSuite) TestWriteApparmorAdditionalFile(c *C) {


### PR DESCRIPTION
A first pass at adding a `/2.0/gadget` endpoint to the `snapd` API.

__WebDM__ currently needs to know about the [branding of the installed gadget snap](https://github.com/ubuntu-core/snappy/blob/master/docs/gadget.md#branding) and so this endpoint will exposure this and only this information.

Any feedback on what data I'm returning here, how I'm doing it and the testing of it would be greatly appreciated!