### PR TITLE
daemon: don't log confusing error message

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -102,7 +102,6 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var rspf ResponseFunc
-	var rsp = BadMethod("method %q not allowed", r.Method)
 
 	switch r.Method {
 	case "GET":
@@ -116,10 +115,10 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if rspf != nil {
-		rsp = rspf(c, r)
+		rspf(c, r).ServeHTTP(w, r)
+	} else {
+		BadMethod("method %q not allowed", r.Method).ServeHTTP(w, r)
 	}
-
-	rsp.ServeHTTP(w, r)
 }
 
 type wrappedWriter struct {


### PR DESCRIPTION
The API dispatcher always logs a message like:

    2016/02/01 22:25:18.196328 response.go:118: method "GET" not allowed

This is caused by the fact that the message is logged before we even
determine the method type and check if it is valid or not. This patch
moves error construction to the spot when it is really needed.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>