### PR TITLE
client: add API for adding new skill type

### DIFF
--- a/client/skills.go
+++ b/client/skills.go
@@ -44,8 +44,8 @@ type Slot struct {
 	Label string                 `json:"label,omitempty"`
 }
 
-// SkillUsage represents the usage of a single skill.
-type SkillUsage struct {
+// SkillGrants represents a single skill and slots that are using it.
+type SkillGrants struct {
 	Skill
 	Slots []Slot `json:"slots"`
 }
@@ -58,7 +58,7 @@ type SkillAction struct {
 }
 
 // AllSkills returns information about all the skills and their usage.
-func (client *Client) AllSkills() (usage []SkillUsage, err error) {
+func (client *Client) AllSkills() (usage []SkillGrants, err error) {
 	err = client.doSync("GET", "/2.0/skills", nil, &usage)
 	return
 }

--- a/client/skills.go
+++ b/client/skills.go
@@ -55,6 +55,7 @@ type SkillAction struct {
 	Action string `json:"action"`
 	Skill  *Skill `json:"skill,omitempty"`
 	Slot   *Slot  `json:"slot,omitempty"`
+	Type   string `json:"type,omitempty"`
 }
 
 // AllSkills returns information about all the skills and their grants.
@@ -142,5 +143,13 @@ func (client *Client) RemoveSlot(snapName, slotName string) error {
 			Snap: snapName,
 			Name: slotName,
 		},
+	})
+}
+
+// AddType adds a test skill type to the system.
+func (client *Client) AddType(name string) error {
+	return client.performSkillAction(&SkillAction{
+		Action: "add-type",
+		Type:   name,
 	})
 }

--- a/client/skills.go
+++ b/client/skills.go
@@ -47,7 +47,7 @@ type Slot struct {
 // SkillGrants represents a single skill and slots that are using it.
 type SkillGrants struct {
 	Skill
-	Slots []Slot `json:"slots"`
+	GrantedTo []Slot `json:"granted-to"`
 }
 
 // SkillAction represents an action performed on the skill system.

--- a/client/skills.go
+++ b/client/skills.go
@@ -58,8 +58,8 @@ type SkillAction struct {
 }
 
 // AllSkills returns information about all the skills and their grants.
-func (client *Client) AllSkills() (usage []SkillGrants, err error) {
-	err = client.doSync("GET", "/2.0/skills", nil, nil, &usage)
+func (client *Client) AllSkills() (grants []SkillGrants, err error) {
+	err = client.doSync("GET", "/2.0/skills", nil, nil, &grants)
 	return
 }
 

--- a/client/skills.go
+++ b/client/skills.go
@@ -57,7 +57,7 @@ type SkillAction struct {
 	Slot   *Slot  `json:"slot,omitempty"`
 }
 
-// AllSkills returns information about all the skills and their usage.
+// AllSkills returns information about all the skills and their grants.
 func (client *Client) AllSkills() (usage []SkillGrants, err error) {
 	err = client.doSync("GET", "/2.0/skills", nil, nil, &usage)
 	return

--- a/client/skills.go
+++ b/client/skills.go
@@ -1,0 +1,149 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Skill represents a capacity offered by a snap.
+type Skill struct {
+	Name  string                 `json:"name"`
+	Snap  string                 `json:"snap"`
+	Type  string                 `json:"type,omitempty"`
+	Attrs map[string]interface{} `json:"attrs,omitempty"`
+	Apps  []string               `json:"apps,omitempty"`
+	Label string                 `json:"label,omitempty"`
+}
+
+// Slot represents the potential of a given snap to use a skill.
+type Slot struct {
+	Name  string                 `json:"name"`
+	Snap  string                 `json:"snap"`
+	Type  string                 `json:"type,omitempty"`
+	Attrs map[string]interface{} `json:"attrs,omitempty"`
+	Apps  []string               `json:"apps,omitempty"`
+	Label string                 `json:"label,omitempty"`
+}
+
+// SkillUsage represents the usage of a single skill.
+type SkillUsage struct {
+	Snap  string `json:"snap"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Label string `json:"label"`
+	Slots []Slot `json:"slots"`
+}
+
+// SkillAction represents an action performed on the skill system.
+type SkillAction struct {
+	Action string `json:"action"`
+	Skill  *Skill `json:"skill,omitempty"`
+	Slot   *Slot  `json:"slot,omitempty"`
+}
+
+// AllSkills returns information about all the skills and their usage.
+func (client *Client) AllSkills() (usage []SkillUsage, err error) {
+	err = client.doSync("GET", "/2.0/skills", nil, &usage)
+	return
+}
+
+// performSkillAction performs a single action on the skill system.
+func (client *Client) performSkillAction(sa *SkillAction) error {
+	b, err := json.Marshal(sa)
+	if err != nil {
+		return err
+	}
+	var rsp interface{}
+	if err := client.doSync("POST", "/2.0/skills", bytes.NewReader(b), &rsp); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Grant grants the named skill to the named slot of the given snap.
+// The skill and the slot must have the same type.
+func (client *Client) Grant(skillSnapName, skillName, slotSnapName, slotName string) error {
+	return client.performSkillAction(&SkillAction{
+		Action: "grant",
+		Skill: &Skill{
+			Snap: skillSnapName,
+			Name: skillName,
+		},
+		Slot: &Slot{
+			Snap: slotSnapName,
+			Name: slotName,
+		},
+	})
+}
+
+// Revoke revokes the named skill from the slot of the given snap.
+func (client *Client) Revoke(skillSnapName, skillName, slotSnapName, slotName string) error {
+	return client.performSkillAction(&SkillAction{
+		Action: "revoke",
+		Skill: &Skill{
+			Snap: skillSnapName,
+			Name: skillName,
+		},
+		Slot: &Slot{
+			Snap: slotSnapName,
+			Name: slotName,
+		},
+	})
+}
+
+// AddSkill adds a skill to the system.
+func (client *Client) AddSkill(skill *Skill) error {
+	return client.performSkillAction(&SkillAction{
+		Action: "add-skill",
+		Skill:  skill,
+	})
+}
+
+// RemoveSkill removes a skill from the system.
+func (client *Client) RemoveSkill(snapName, skillName string) error {
+	return client.performSkillAction(&SkillAction{
+		Action: "remove-skill",
+		Skill: &Skill{
+			Snap: snapName,
+			Name: skillName,
+		},
+	})
+}
+
+// AddSlot adds a slot to the system.
+func (client *Client) AddSlot(slot *Slot) error {
+	return client.performSkillAction(&SkillAction{
+		Action: "add-slot",
+		Slot:   slot,
+	})
+}
+
+// RemoveSlot removes a slot from the system.
+func (client *Client) RemoveSlot(snapName, slotName string) error {
+	return client.performSkillAction(&SkillAction{
+		Action: "remove-slot",
+		Slot: &Slot{
+			Snap: snapName,
+			Name: slotName,
+		},
+	})
+}

--- a/client/skills.go
+++ b/client/skills.go
@@ -46,10 +46,7 @@ type Slot struct {
 
 // SkillUsage represents the usage of a single skill.
 type SkillUsage struct {
-	Snap  string `json:"snap"`
-	Name  string `json:"name"`
-	Type  string `json:"type"`
-	Label string `json:"label"`
+	Skill
 	Slots []Slot `json:"slots"`
 }
 

--- a/client/skills_test.go
+++ b/client/skills_test.go
@@ -50,7 +50,7 @@ func (cs *clientSuite) TestClientAllSkills(c *check.C) {
 	}`
 	skills, err := cs.cli.AllSkills()
 	c.Assert(err, check.IsNil)
-	c.Check(skills, check.DeepEquals, []client.SkillUsage{
+	c.Check(skills, check.DeepEquals, []client.SkillGrants{
 		{
 			Skill: client.Skill{
 				Snap:  "canonical-pi2",

--- a/client/skills_test.go
+++ b/client/skills_test.go
@@ -261,3 +261,26 @@ func (cs *clientSuite) TestClientRemoveSlot(c *check.C) {
 		},
 	})
 }
+
+func (cs *clientSuite) TestClientAddSkillTypeEndpoint(c *check.C) {
+	_ = cs.cli.AddType("type")
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+}
+
+func (cs *clientSuite) TestClientAddSkillType(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": { }
+	}`
+	err := cs.cli.AddType("type")
+	c.Check(err, check.IsNil)
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"action": "add-type",
+		"type":   "type",
+	})
+}

--- a/client/skills_test.go
+++ b/client/skills_test.go
@@ -42,7 +42,7 @@ func (cs *clientSuite) TestClientAllSkills(c *check.C) {
 				"name": "pin-13",
 				"type": "bool-file",
 				"label": "Pin 13",
-				"slots": [
+				"granted-to": [
 					{"snap": "keyboard-lights", "name": "capslock-led"}
 				]
 			}
@@ -58,7 +58,7 @@ func (cs *clientSuite) TestClientAllSkills(c *check.C) {
 				Type:  "bool-file",
 				Label: "Pin 13",
 			},
-			Slots: []client.Slot{
+			GrantedTo: []client.Slot{
 				{
 					Snap: "keyboard-lights",
 					Name: "capslock-led",

--- a/client/skills_test.go
+++ b/client/skills_test.go
@@ -52,10 +52,12 @@ func (cs *clientSuite) TestClientAllSkills(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(skills, check.DeepEquals, []client.SkillUsage{
 		{
-			Snap:  "canonical-pi2",
-			Name:  "pin-13",
-			Type:  "bool-file",
-			Label: "Pin 13",
+			Skill: client.Skill{
+				Snap:  "canonical-pi2",
+				Name:  "pin-13",
+				Type:  "bool-file",
+				Label: "Pin 13",
+			},
 			Slots: []client.Slot{
 				{
 					Snap: "keyboard-lights",

--- a/client/skills_test.go
+++ b/client/skills_test.go
@@ -1,0 +1,261 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"encoding/json"
+
+	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/client"
+)
+
+func (cs *clientSuite) TestClientAllSkillsCallsEndpoint(c *check.C) {
+	_, _ = cs.cli.AllSkills()
+	c.Check(cs.req.Method, check.Equals, "GET")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+}
+
+func (cs *clientSuite) TestClientAllSkills(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": [
+			{
+				"snap": "canonical-pi2",
+				"name": "pin-13",
+				"type": "bool-file",
+				"label": "Pin 13",
+				"slots": [
+					{"snap": "keyboard-lights", "name": "capslock-led"}
+				]
+			}
+		]
+	}`
+	skills, err := cs.cli.AllSkills()
+	c.Assert(err, check.IsNil)
+	c.Check(skills, check.DeepEquals, []client.SkillUsage{
+		{
+			Snap:  "canonical-pi2",
+			Name:  "pin-13",
+			Type:  "bool-file",
+			Label: "Pin 13",
+			Slots: []client.Slot{
+				{
+					Snap: "keyboard-lights",
+					Name: "capslock-led",
+				},
+			},
+		},
+	})
+}
+
+func (cs *clientSuite) TestClientGrantCallsEndpoint(c *check.C) {
+	_ = cs.cli.Grant("producer", "skill", "consumer", "snap")
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+}
+
+func (cs *clientSuite) TestClientGrant(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": { }
+	}`
+	err := cs.cli.Grant("producer", "skill", "consumer", "snap")
+	c.Check(err, check.IsNil)
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"action": "grant",
+		"skill": map[string]interface{}{
+			"name": "skill",
+			"snap": "producer",
+		},
+		"slot": map[string]interface{}{
+			"name": "snap",
+			"snap": "consumer",
+		},
+	})
+}
+
+func (cs *clientSuite) TestClientRevokeCallsEndpoint(c *check.C) {
+	_ = cs.cli.Revoke("producer", "skill", "consumer", "snap")
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+}
+
+func (cs *clientSuite) TestClientRevoke(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": { }
+	}`
+	err := cs.cli.Revoke("producer", "skill", "consumer", "snap")
+	c.Check(err, check.IsNil)
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"action": "revoke",
+		"skill": map[string]interface{}{
+			"name": "skill",
+			"snap": "producer",
+		},
+		"slot": map[string]interface{}{
+			"name": "snap",
+			"snap": "consumer",
+		},
+	})
+}
+
+func (cs *clientSuite) TestClientAddSkillCallsEndpoint(c *check.C) {
+	_ = cs.cli.AddSkill(&client.Skill{})
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+}
+
+func (cs *clientSuite) TestClientAddSkill(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": { }
+	}`
+	err := cs.cli.AddSkill(&client.Skill{
+		Snap: "snap",
+		Name: "name",
+		Type: "type",
+		Attrs: map[string]interface{}{
+			"attr": "value",
+		},
+		Apps:  []string{"app"},
+		Label: "label",
+	})
+	c.Check(err, check.IsNil)
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"action": "add-skill",
+		"skill": map[string]interface{}{
+			"name": "name",
+			"snap": "snap",
+			"type": "type",
+			"attrs": map[string]interface{}{
+				"attr": "value",
+			},
+			"apps":  []interface{}{"app"},
+			"label": "label",
+		},
+	})
+}
+
+func (cs *clientSuite) TestClientRemoveSkillCallsEndpoint(c *check.C) {
+	_ = cs.cli.RemoveSkill("snap", "name")
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+}
+
+func (cs *clientSuite) TestClientRemoveSkill(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": { }
+	}`
+	err := cs.cli.RemoveSkill("snap", "name")
+	c.Check(err, check.IsNil)
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"action": "remove-skill",
+		"skill": map[string]interface{}{
+			"name": "name",
+			"snap": "snap",
+		},
+	})
+}
+
+func (cs *clientSuite) TestClientAddSlotCallsEndpoint(c *check.C) {
+	_ = cs.cli.AddSlot(&client.Slot{})
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+}
+
+func (cs *clientSuite) TestClientAddSlot(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": { }
+	}`
+	err := cs.cli.AddSlot(&client.Slot{
+		Snap: "snap",
+		Name: "name",
+		Type: "type",
+		Attrs: map[string]interface{}{
+			"attr": "value",
+		},
+		Apps:  []string{"app"},
+		Label: "label",
+	})
+	c.Check(err, check.IsNil)
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"action": "add-slot",
+		"slot": map[string]interface{}{
+			"name": "name",
+			"snap": "snap",
+			"type": "type",
+			"attrs": map[string]interface{}{
+				"attr": "value",
+			},
+			"apps":  []interface{}{"app"},
+			"label": "label",
+		},
+	})
+}
+
+func (cs *clientSuite) TestClientRemoveSlotCallsEndpoint(c *check.C) {
+	_ = cs.cli.RemoveSlot("snap", "name")
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+}
+
+func (cs *clientSuite) TestClientRemoveSlot(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": { }
+	}`
+	err := cs.cli.RemoveSlot("snap", "name")
+	c.Check(err, check.IsNil)
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"action": "remove-slot",
+		"slot": map[string]interface{}{
+			"name": "name",
+			"snap": "snap",
+		},
+	})
+}


### PR DESCRIPTION
This branch adds a new client method for adding test skill types. It is useful for integration testing of the skills CLI.
