### PR TITLE
debian: timeout after 20s when waiting for network

### DIFF
--- a/debian/snappy-wait4network.service
+++ b/debian/snappy-wait4network.service
@@ -5,6 +5,6 @@ After=network-online.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-TimeoutStartSec=0
+TimeoutStartSec=20
 ExecStart=/bin/sh -ec 'while [ -z "$( /sbin/ip route show 0/0 )" ]; do sleep 5; done'
 


### PR DESCRIPTION
The "wait4network" service is currently blocking the "multi-user.target" if there is no network attached to it. As a first fix we use a timeout so that the target is reached. 

The next step is to make services that need wait4network depend on network-online.target instead of multi-user.target. 