### PR TITLE
asserts,docs/rest.md: change Encoder not to add extra newlines at the end of the stream

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -233,7 +233,7 @@ const (
 	MaxSignatureSize = 128 * 1024
 )
 
-// Decoder parses a stream of assertions bundled by ensuring double newlines at the end of each assertion.
+// Decoder parses a stream of assertions bundled by separating them with double newlines.
 type Decoder struct {
 	rd             io.Reader
 	initialBufSize int

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -690,6 +690,6 @@ prerequisite in the database.
 * Operation: sync
 * Return: stream of assertions
 
-The response is a stream of assertions each with a separating double
-newline at its end. The X-Ubuntu-Assertions-Count header is set to the
-number of returned assertions, 0 or more.
+The response is a stream of assertions separated by double newlines.
+The X-Ubuntu-Assertions-Count header is set to the number of
+returned assertions, 0 or more.


### PR DESCRIPTION
Change Encoder not to add extra newlines at the end of the stream, but only insert them as separator between two assertions. Both formats are still supported by Decoder as tested. This solves the asymmetry of Encode() working as input for Decoder, but not Encoder used with one assertion working with Decode().