### PR TITLE
daemon: use underscore in JSON interface

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -988,7 +988,7 @@ type skillInfo struct {
 	Name      string       `json:"name"`
 	Type      string       `json:"type"`
 	Label     string       `json:"label"`
-	GrantedTo []skillGrant `json:"granted-to"`
+	GrantedTo []skillGrant `json:"granted_to"`
 }
 
 // getSkills returns a response with a list of all the skills and which slots use them.

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1424,7 +1424,7 @@ func (s *apiSuite) TestGetSkills(c *check.C) {
 				"name":  "skill",
 				"type":  "type",
 				"label": "label",
-				"granted-to": []interface{}{
+				"granted_to": []interface{}{
 					map[string]interface{}{
 						"snap": "consumer",
 						"name": "slot",


### PR DESCRIPTION
This patch is matching the changes introduced in #386.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>