### PR TITLE
integration: add regression test for LP: #1541317

### DIFF
--- a/integration-tests/tests/installApp_test.go
+++ b/integration-tests/tests/installApp_test.go
@@ -89,3 +89,14 @@ func (s *installAppSuite) TestInstallUnexistingAppMustPrintError(c *check.C) {
 			"unexisting failed to install: snappy package not found\n",
 		check.Commentf("Wrong error message"))
 }
+
+func (s *installAppSuite) TestInstallFromStoreMetadata(c *check.C) {
+	cmd := exec.Command("sudo", "snappy", "install", "hello-world/edge")
+	_, err := cmd.CombinedOutput()
+	c.Check(err, check.IsNil)
+
+	cmd = exec.Command("sudo", "snappy", "info", "hello-world")
+	output, err := cmd.CombinedOutput()
+	c.Check(err, check.IsNil)
+	c.Check(output, check.Matches, "(?ms)^channel: edge")
+}

--- a/integration-tests/tests/installApp_test.go
+++ b/integration-tests/tests/installApp_test.go
@@ -91,13 +91,9 @@ func (s *installAppSuite) TestInstallUnexistingAppMustPrintError(c *check.C) {
 }
 
 func (s *installAppSuite) TestInstallFromStoreMetadata(c *check.C) {
-	cmd := exec.Command("sudo", "snappy", "install", "hello-world/edge")
-	_, err := cmd.CombinedOutput()
-	c.Check(err, check.IsNil)
+	common.InstallSnap(c, "hello-world/edge")
 	defer common.RemoveSnap(c, "hello-world")
 
-	cmd = exec.Command("sudo", "snappy", "info", "hello-world")
-	output, err := cmd.CombinedOutput()
-	c.Check(err, check.IsNil)
+	output := cli.ExecCommand(c, "snappy", "info", "hello-world")
 	c.Check(string(output), check.Matches, "(?ms)^channel: edge")
 }

--- a/integration-tests/tests/installApp_test.go
+++ b/integration-tests/tests/installApp_test.go
@@ -94,9 +94,10 @@ func (s *installAppSuite) TestInstallFromStoreMetadata(c *check.C) {
 	cmd := exec.Command("sudo", "snappy", "install", "hello-world/edge")
 	_, err := cmd.CombinedOutput()
 	c.Check(err, check.IsNil)
+	defer common.RemoveSnap(c, "hello-world")
 
 	cmd = exec.Command("sudo", "snappy", "info", "hello-world")
 	output, err := cmd.CombinedOutput()
 	c.Check(err, check.IsNil)
-	c.Check(output, check.Matches, "(?ms)^channel: edge")
+	c.Check(string(output), check.Matches, "(?ms)^channel: edge")
 }


### PR DESCRIPTION
This test ensures that selecting a channel is stored correctly. This is a regression test for https://bugs.launchpad.net/software-center-agent/+bug/1541317