### PR TITLE
cmd,po: add snap subcommands for working with skills

### DIFF
--- a/cmd/snap/cmd_add_cap.go
+++ b/cmd/snap/cmd_add_cap.go
@@ -20,45 +20,10 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
 )
-
-// AttributePair contains a pair of key-value strings
-type AttributePair struct {
-	// The key
-	Key string
-	// The value
-	Value string
-}
-
-// UnmarshalFlag parses a string into an AttributePair
-func (ap *AttributePair) UnmarshalFlag(value string) error {
-	parts := strings.SplitN(value, "=", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("expected attribute in key=value format")
-	}
-	ap.Key, ap.Value = parts[0], parts[1]
-	return nil
-}
-
-// MarshalFlag converts a AttributePair into a string
-func (ap *AttributePair) MarshalFlag() (string, error) {
-	return fmt.Sprintf("%s=%q", ap.Key, ap.Value), nil
-}
-
-// AttributePairSliceToMap converts a slice of AttributePair into a map
-func AttributePairSliceToMap(attrs []AttributePair) map[string]string {
-	result := make(map[string]string)
-	for _, attr := range attrs {
-		result[attr.Key] = attr.Value
-	}
-	return result
-}
 
 type cmdAddCap struct {
 	Name  string          `long:"name" required:"true" description:"unique capability name"`

--- a/cmd/snap/cmd_add_skill.go
+++ b/cmd/snap/cmd_add_skill.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type cmdAddSkill struct {
+	Positionals struct {
+		Snap  string `positional-arg-name:"snap" description:"name of the snap containing the skill"`
+		Skill string `positional-arg-name:"skill" description:"name of the skill within the snap"`
+		Type  string `positional-arg-name:"type" description:"name of the skill type"`
+	} `positional-args:"true" required:"true"`
+	Attrs []AttributePair `short:"a" description:"key=value attributes"`
+	Apps  []string        `long:"app" description:"list of apps providing this skill"`
+	Label string          `long:"label" description:"human-friendly label"`
+}
+
+var (
+	shortAddSkillHelp = i18n.G("Add a skill to the system")
+	longAddSkillHelp  = i18n.G("This command adds a skill to the system")
+)
+
+func init() {
+	var err error
+	if develCommand == nil {
+		err = fmt.Errorf("devel command not found")
+	} else {
+		_, err = develCommand.AddCommand("add-skill", shortAddSkillHelp, longAddSkillHelp, &cmdAddSkill{})
+	}
+	if err != nil {
+		logger.Panicf("unable to add add-skill command: %v", err)
+	}
+}
+
+func (x *cmdAddSkill) Execute(args []string) error {
+	attrs := make(map[string]interface{})
+	for k, v := range AttributePairSliceToMap(x.Attrs) {
+		attrs[k] = v
+	}
+	return client.New().AddSkill(&client.Skill{
+		Snap:  x.Positionals.Snap,
+		Name:  x.Positionals.Skill,
+		Type:  x.Positionals.Type,
+		Attrs: attrs,
+		Apps:  x.Apps,
+		Label: x.Label,
+	})
+}

--- a/cmd/snap/cmd_add_slot.go
+++ b/cmd/snap/cmd_add_slot.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type cmdAddSlot struct {
+	Positionals struct {
+		Snap string `positional-arg-name:"snap" description:"name of the snap containing the slot"`
+		Slot string `positional-arg-name:"slot" description:"name of the slot within the snap"`
+		Type string `positional-arg-name:"type" description:"name of the skill type"`
+	} `positional-args:"true" required:"true"`
+	Attrs []AttributePair `short:"a" description:"key=value attributes"`
+	Apps  []string        `long:"app" description:"list of apps using this slot"`
+	Label string          `long:"label" description:"human-friendly label"`
+}
+
+var (
+	shortAddSlotHelp = i18n.G("Add a skill slot to the system")
+	longAddSlotHelp  = i18n.G("This command adds a skill slot to the system")
+)
+
+func init() {
+	var err error
+	if develCommand == nil {
+		err = fmt.Errorf("devel command not found")
+	} else {
+		_, err = develCommand.AddCommand("add-slot", shortAddSlotHelp, longAddSlotHelp, &cmdAddSlot{})
+	}
+	if err != nil {
+		logger.Panicf("unable to add add-slot command: %v", err)
+	}
+}
+
+func (x *cmdAddSlot) Execute(args []string) error {
+	attrs := make(map[string]interface{})
+	for k, v := range AttributePairSliceToMap(x.Attrs) {
+		attrs[k] = v
+	}
+	return client.New().AddSlot(&client.Slot{
+		Snap:  x.Positionals.Snap,
+		Name:  x.Positionals.Slot,
+		Type:  x.Positionals.Type,
+		Attrs: attrs,
+		Apps:  x.Apps,
+		Label: x.Label,
+	})
+}

--- a/cmd/snap/cmd_devel.go
+++ b/cmd/snap/cmd_devel.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/ubuntu-core/snappy/i18n"
+)
+
+type cmdDevel struct{}
+
+var (
+	shortDevelHelp = i18n.G("Unsupported development commands")
+	longDevelHelp  = i18n.G(`Additional development commands.
+
+Development commands may not work on non-development systems.
+`)
+)
+
+var develCommand, _ = parser.AddCommand("devel", shortDevelHelp, longDevelHelp, &cmdDevel{})

--- a/cmd/snap/cmd_grant.go
+++ b/cmd/snap/cmd_grant.go
@@ -1,0 +1,54 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type cmdGrant struct {
+	Positionals struct {
+		SkillSnap string `positional-arg-name:"skill-snap" description:"name of the snap containing the skill"`
+		SkillName string `positional-arg-name:"skill-name" description:"name of the skill"`
+		SlotSnap  string `positional-arg-name:"slot-snap" description:"name of the snap containing the skill slot"`
+		SlotName  string `positional-arg-name:"slot-name" description:"name of the skill slot"`
+	} `positional-args:"true" required:"true"`
+}
+
+var (
+	shortGrantHelp = i18n.G("Grant a skill to a skill slot")
+	longGrantHelp  = i18n.G(`This command grants a skill to a skill slot.
+
+Both the skill and the slot must exist and must be of the same type.
+`)
+)
+
+func init() {
+	_, err := parser.AddCommand("grant", shortGrantHelp, longGrantHelp, &cmdGrant{})
+	if err != nil {
+		logger.Panicf("unable to add grant command: %v", err)
+	}
+}
+
+func (x *cmdGrant) Execute(args []string) error {
+	return client.New().Grant(x.Positionals.SkillSnap, x.Positionals.SkillName, x.Positionals.SlotSnap, x.Positionals.SlotName)
+}

--- a/cmd/snap/cmd_remove_skill.go
+++ b/cmd/snap/cmd_remove_skill.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type cmdRemoveSkill struct {
+	Positionals struct {
+		Snap  string `positional-arg-name:"snap" description:"name of the snap containing the skill"`
+		Skill string `positional-arg-name:"skill" description:"name of the skill within the snap"`
+	} `positional-args:"true" required:"true"`
+}
+
+var (
+	shortRemoveSkillHelp = i18n.G("Remove a skill from the system")
+	longRemoveSkillHelp  = i18n.G("This command removes a skill from the system")
+)
+
+func init() {
+	var err error
+	if develCommand == nil {
+		err = fmt.Errorf("devel command not found")
+	} else {
+		_, err = develCommand.AddCommand("remove-skill", shortRemoveSkillHelp, longRemoveSkillHelp, &cmdRemoveSkill{})
+	}
+	if err != nil {
+		logger.Panicf("unable to add remove-skill command: %v", err)
+	}
+}
+
+func (x *cmdRemoveSkill) Execute(args []string) error {
+	return client.New().RemoveSkill(x.Positionals.Snap, x.Positionals.Skill)
+}

--- a/cmd/snap/cmd_remove_slot.go
+++ b/cmd/snap/cmd_remove_slot.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type cmdRemoveSlot struct {
+	Positionals struct {
+		Snap string `positional-arg-name:"snap" description:"name of the snap containing the skill slot"`
+		Slot string `positional-arg-name:"slot" description:"name of the skill slot within the snap"`
+	} `positional-args:"true" required:"true"`
+}
+
+var (
+	shortRemoveSlotHelp = i18n.G("Remove a skill slot from the system")
+	longRemoveSlotHelp  = i18n.G("This command removes a skill slot from the system")
+)
+
+func init() {
+	var err error
+	if develCommand == nil {
+		err = fmt.Errorf("devel command not found")
+	} else {
+		_, err = develCommand.AddCommand("remove-slot", shortRemoveSlotHelp, longRemoveSlotHelp, &cmdRemoveSlot{})
+	}
+	if err != nil {
+		logger.Panicf("unable to add remove-slot command: %v", err)
+	}
+}
+
+func (x *cmdRemoveSlot) Execute(args []string) error {
+	return client.New().RemoveSlot(x.Positionals.Snap, x.Positionals.Slot)
+}

--- a/cmd/snap/cmd_revoke.go
+++ b/cmd/snap/cmd_revoke.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type cmdRevoke struct {
+	Positionals struct {
+		SkillSnap string `positional-arg-name:"skill-snap" description:"name of the snap containing the skill"`
+		SkillName string `positional-arg-name:"skill-name" description:"name of the skill"`
+		SlotSnap  string `positional-arg-name:"slot-snap" description:"name of the snap containing the skill slot"`
+		SlotName  string `positional-arg-name:"slot-name" description:"name of the skill slot"`
+	} `positional-args:"true" required:"true"`
+}
+
+var (
+	shortRevokeHelp = i18n.G("Revoke a skill granted to a skill slot")
+	longRevokeHelp  = i18n.G("This command revokes a skill from a skill slot.")
+)
+
+func init() {
+	_, err := parser.AddCommand("revoke", shortRevokeHelp, longRevokeHelp, &cmdRevoke{})
+	if err != nil {
+		logger.Panicf("unable to add revoke command: %v", err)
+	}
+}
+
+func (x *cmdRevoke) Execute(args []string) error {
+	return client.New().Revoke(x.Positionals.SkillSnap, x.Positionals.SkillName, x.Positionals.SlotSnap, x.Positionals.SlotName)
+}

--- a/cmd/snap/cmd_skills.go
+++ b/cmd/snap/cmd_skills.go
@@ -1,0 +1,112 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/ubuntu-core/snappy/client"
+	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/logger"
+)
+
+type snapAndSkill struct {
+	Snap  string
+	Skill string
+}
+
+func (sn *snapAndSkill) UnmarshalFlag(value string) error {
+	parts := strings.SplitN(value, ":", 2)
+	switch len(parts) {
+	case 0:
+		sn.Snap = ""
+		sn.Skill = ""
+	case 1:
+		sn.Snap = parts[0]
+		sn.Skill = ""
+	case 2:
+		sn.Snap = parts[0]
+		sn.Skill = parts[1]
+	default:
+		return fmt.Errorf("expected either snap or snap:skill")
+	}
+	return nil
+}
+
+func (sn *snapAndSkill) MarshalFlag() (string, error) {
+	if sn.Skill != "" {
+		return fmt.Sprintf("%s:%s", sn.Snap, sn.Skill), nil
+	}
+	return sn.Snap, nil
+}
+
+type cmdSkills struct {
+	Type        string `long:"type" description:"constrain listing to skills of this type"`
+	Positionals struct {
+		Query snapAndSkill `positional-arg-name:"query" description:"snap name or snap:skill name"`
+	} `positional-args:"true"`
+}
+
+var (
+	shortSkillsHelp = i18n.G("Lists skills in the system")
+	longSkillsHelp  = i18n.G(`This command skills in the system.
+
+By default all skills, used and offered by all snaps are displayed.
+
+Skills used and offered by a particular snap can be listed with: snap skills <snap name>
+`)
+)
+
+func init() {
+	_, err := parser.AddCommand("skills", shortSkillsHelp, longSkillsHelp, &cmdSkills{})
+	if err != nil {
+		logger.Panicf("unable to add skills command: %v", err)
+	}
+}
+
+func (x *cmdSkills) Execute(args []string) error {
+	skills, err := client.New().AllSkills()
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 1, ' ', 0)
+	fmt.Fprintln(w, i18n.G("Skill\tGranted To"))
+	defer w.Flush()
+	for _, skill := range skills {
+		// TODO: support filtering by snap:skill
+		if x.Type != "" && skill.Type != x.Type {
+			continue
+		}
+		switch len(skill.GrantedTo) {
+		case 0:
+			fmt.Fprintf(w, "%s:%s\t--\n", skill.Snap, skill.Name)
+		default:
+			fmt.Fprintf(w, "%s:%s\t%s:%s\n",
+				skill.Snap, skill.Name, skill.GrantedTo[0].Snap, skill.GrantedTo[0].Name)
+			for i := 1; i < len(skill.GrantedTo); i++ {
+				fmt.Fprintf(w, "\t%s:%s\n", skill.GrantedTo[i].Snap, skill.GrantedTo[i].Name)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/snap/common.go
+++ b/cmd/snap/common.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AttributePair contains a pair of key-value strings
+type AttributePair struct {
+	// The key
+	Key string
+	// The value
+	Value string
+}
+
+// UnmarshalFlag parses a string into an AttributePair
+func (ap *AttributePair) UnmarshalFlag(value string) error {
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("expected attribute in key=value format")
+	}
+	ap.Key, ap.Value = parts[0], parts[1]
+	return nil
+}
+
+// MarshalFlag converts a AttributePair into a string
+func (ap *AttributePair) MarshalFlag() (string, error) {
+	return fmt.Sprintf("%s=%q", ap.Key, ap.Value), nil
+}
+
+// AttributePairSliceToMap converts a slice of AttributePair into a map
+func AttributePairSliceToMap(attrs []AttributePair) map[string]string {
+	result := make(map[string]string)
+	for _, attr := range attrs {
+		result[attr.Key] = attr.Value
+	}
+	return result
+}

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-02-02 18:47+0000\n"
+        "POT-Creation-Date: 2016-02-03 12:56+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,6 +63,17 @@ msgid   "Activate a package that has previously been deactivated. If the package
 msgstr  ""
 
 msgid   "Add a capability to the system"
+msgstr  ""
+
+msgid   "Add a skill slot to the system"
+msgstr  ""
+
+msgid   "Add a skill to the system"
+msgstr  ""
+
+msgid   "Additional development commands.\n"
+        "\n"
+        "Development commands may not work on non-development systems.\n"
 msgstr  ""
 
 msgid   "Allows rollback of a snap to a previous installed version. Without any arguments, the previous installed version is selected. It is also possible to specify the version to rollback to as a additional argument.\n"
@@ -155,6 +166,9 @@ msgstr  ""
 msgid   "Generated '%s' snap\n"
 msgstr  ""
 
+msgid   "Grant a skill to a skill slot"
+msgstr  ""
+
 msgid   "Include information about packages from the snappy store"
 msgstr  ""
 
@@ -179,6 +193,9 @@ msgid   "List assigned hardware for a specific installed package"
 msgstr  ""
 
 msgid   "List system capabilities"
+msgstr  ""
+
+msgid   "Lists skills in the system"
 msgstr  ""
 
 msgid   "Log into the store"
@@ -253,6 +270,12 @@ msgstr  ""
 msgid   "Remove a capability from the system"
 msgstr  ""
 
+msgid   "Remove a skill from the system"
+msgstr  ""
+
+msgid   "Remove a skill slot from the system"
+msgstr  ""
+
 msgid   "Remove a snapp part"
 msgstr  ""
 
@@ -268,6 +291,9 @@ msgstr  ""
 #. TRANSLATORS: the %s is a pkgname
 #, c-format
 msgid   "Removing %s\n"
+msgstr  ""
+
+msgid   "Revoke a skill granted to a skill slot"
 msgstr  ""
 
 msgid   "Rollback to a previous version of a package"
@@ -306,6 +332,9 @@ msgid   "Show available updates (requires network)"
 msgstr  ""
 
 msgid   "Show channel information and expand all fields"
+msgstr  ""
+
+msgid   "Skill\tGranted To"
 msgstr  ""
 
 msgid   "Snap\tService\tState"
@@ -362,7 +391,18 @@ msgstr  ""
 msgid   "This command adds a capability to the system"
 msgstr  ""
 
+msgid   "This command adds a skill slot to the system"
+msgstr  ""
+
+msgid   "This command adds a skill to the system"
+msgstr  ""
+
 msgid   "This command adds access to a specific hardware device (e.g. /dev/ttyUSB0) for an installed package."
+msgstr  ""
+
+msgid   "This command grants a skill to a skill slot.\n"
+        "\n"
+        "Both the skill and the slot must exist and must be of the same type.\n"
 msgstr  ""
 
 msgid   "This command is no longer available, please use the \"list\" command"
@@ -377,10 +417,26 @@ msgstr  ""
 msgid   "This command removes a capability from the system"
 msgstr  ""
 
+msgid   "This command removes a skill from the system"
+msgstr  ""
+
+msgid   "This command removes a skill slot from the system"
+msgstr  ""
+
 msgid   "This command removes access of a specific hardware device (e.g. /dev/ttyUSB0) for an installed package."
 msgstr  ""
 
+msgid   "This command revokes a skill from a skill slot."
+msgstr  ""
+
 msgid   "This command shows all capabilities and their allocation"
+msgstr  ""
+
+msgid   "This command skills in the system.\n"
+        "\n"
+        "By default all skills, used and offered by all snaps are displayed.\n"
+        "\n"
+        "Skills used and offered by a particular snap can be listed with: snap skills <snap name>\n"
 msgstr  ""
 
 msgid   "This command tries to add an assertion to the system assertion database.\n"
@@ -391,6 +447,9 @@ msgid   "This command tries to add an assertion to the system assertion database
 msgstr  ""
 
 msgid   "Unassign a hardware device to a package"
+msgstr  ""
+
+msgid   "Unsupported development commands"
 msgstr  ""
 
 msgid   "Update all installed parts"


### PR DESCRIPTION
This patch adds three public commands for interacting with skills:

 - snap grant
 - snap revoke
 - snap skills

In addition, there are four extra development commands for exploring and
debugging the skill system. Those commands are:

 - snap devel add-skill
 - snap devel add-slot
 - snap devel remove-skill
 - snap devel remove-slot

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>