### PR TITLE
cmd: don't treat help as an error

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -45,14 +45,7 @@ func init() {
 
 func main() {
 	if err := run(); err != nil {
-		isHelp := false
-		switch err.(type) {
-		case *flags.Error:
-			if err.(*flags.Error).Type == flags.ErrHelp {
-				isHelp = true
-			}
-		}
-		if isHelp {
+		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
 			fmt.Fprintf(os.Stdout, "%v\n", err)
 			os.Exit(0)
 		} else {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -45,8 +45,20 @@ func init() {
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		isHelp := false
+		switch err.(type) {
+		case *flags.Error:
+			if err.(*flags.Error).Type == flags.ErrHelp {
+				isHelp = true
+			}
+		}
+		if isHelp {
+			fmt.Fprintf(os.Stdout, "%v\n", err)
+			os.Exit(0)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }
 


### PR DESCRIPTION
This makes ```snap foo --help | sensible-pager``` work correctly and also gets rid of the annoying "error: " prefix in the usage string.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>