### PR TITLE
client,cmd: make client.New() configurable

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -80,12 +80,12 @@ func New(config *Config) *Client {
 // raw performs a request and returns the resulting http.Response and
 // error you usually only need to call this directly if you expect the
 // response to not be JSON, otherwise you'd call Do(...) instead.
-func (client *Client) raw(method, aPath string, query url.Values, body io.Reader) (*http.Response, error) {
+func (client *Client) raw(method, urlpath string, query url.Values, body io.Reader) (*http.Response, error) {
 	// fake a url to keep http.Client happy
 	u := url.URL{
 		Scheme:   client.baseURL.Scheme,
 		Host:     client.baseURL.Host,
-		Path:     path.Join(client.baseURL.Path, aPath),
+		Path:     path.Join(client.baseURL.Path, urlpath),
 		RawQuery: query.Encode(),
 	}
 	req, err := http.NewRequest(method, u.String(), body)

--- a/client/client.go
+++ b/client/client.go
@@ -82,12 +82,9 @@ func New(config *Config) *Client {
 // response to not be JSON, otherwise you'd call Do(...) instead.
 func (client *Client) raw(method, urlpath string, query url.Values, body io.Reader) (*http.Response, error) {
 	// fake a url to keep http.Client happy
-	u := url.URL{
-		Scheme:   client.baseURL.Scheme,
-		Host:     client.baseURL.Host,
-		Path:     path.Join(client.baseURL.Path, urlpath),
-		RawQuery: query.Encode(),
-	}
+	u := client.baseURL
+	u.Path = path.Join(client.baseURL.Path, urlpath)
+	u.RawQuery = query.Encode()
 	req, err := http.NewRequest(method, u.String(), body)
 	if err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -69,7 +69,7 @@ func New(config *Config) *Client {
 	}
 	baseURL, err := url.Parse(config.BaseURL)
 	if err != nil {
-		panic(err.Error())
+		panic(fmt.Sprintf("cannot parse server base URL: %q (%v)", config.BaseURL, err))
 	}
 	return &Client{
 		baseURL: *baseURL,

--- a/client/client.go
+++ b/client/client.go
@@ -43,7 +43,7 @@ type doer interface {
 // Config allows to customize client behavior.
 type Config struct {
 	// BaseURL contains the base URL where snappy daemon is expected to be.
-	// It can be empty for a default behavior of talking over an UNIX socket.
+	// It can be empty for a default behavior of talking over a unix socket.
 	BaseURL string
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -49,7 +49,7 @@ type Config struct {
 
 // A Client knows how to talk to the snappy daemon.
 type Client struct {
-	baseURL *url.URL
+	baseURL url.URL
 	doer    doer
 }
 
@@ -58,7 +58,7 @@ func New(config *Config) *Client {
 	// By default talk over an UNIX socket.
 	if config == nil || config.BaseURL == "" {
 		return &Client{
-			baseURL: &url.URL{
+			baseURL: url.URL{
 				Scheme: "http",
 				Host:   "localhost",
 			},
@@ -72,7 +72,7 @@ func New(config *Config) *Client {
 		panic(err.Error())
 	}
 	return &Client{
-		baseURL: baseURL,
+		baseURL: *baseURL,
 		doer:    &http.Client{},
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/ubuntu-core/snappy/dirs"
@@ -39,29 +40,52 @@ type doer interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
-// A Client knows how to talk to the snappy daemon
+// Config allows to customize client behavior.
+type Config struct {
+	// BaseURL contains the base URL where snappy daemon is expected to be.
+	// It can be empty for a default behavior of talking over an UNIX socket.
+	BaseURL string
+}
+
+// A Client knows how to talk to the snappy daemon.
 type Client struct {
-	doer doer
+	baseURL *url.URL
+	doer    doer
 }
 
 // New returns a new instance of Client
-func New() *Client {
-	tr := &http.Transport{Dial: unixDialer}
-
+func New(config *Config) *Client {
+	// By default talk over an UNIX socket.
+	if config == nil || config.BaseURL == "" {
+		return &Client{
+			baseURL: &url.URL{
+				Scheme: "http",
+				Host:   "localhost",
+			},
+			doer: &http.Client{
+				Transport: &http.Transport{Dial: unixDialer},
+			},
+		}
+	}
+	baseURL, err := url.Parse(config.BaseURL)
+	if err != nil {
+		panic(err.Error())
+	}
 	return &Client{
-		doer: &http.Client{Transport: tr},
+		baseURL: baseURL,
+		doer:    &http.Client{},
 	}
 }
 
 // raw performs a request and returns the resulting http.Response and
 // error you usually only need to call this directly if you expect the
 // response to not be JSON, otherwise you'd call Do(...) instead.
-func (client *Client) raw(method, path string, query url.Values, body io.Reader) (*http.Response, error) {
+func (client *Client) raw(method, aPath string, query url.Values, body io.Reader) (*http.Response, error) {
 	// fake a url to keep http.Client happy
 	u := url.URL{
-		Scheme:   "http",
-		Host:     "localhost",
-		Path:     path,
+		Scheme:   client.baseURL.Scheme,
+		Host:     client.baseURL.Host,
+		Path:     path.Join(client.baseURL.Path, aPath),
 		RawQuery: query.Encode(),
 	}
 	req, err := http.NewRequest(method, u.String(), body)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -53,7 +53,7 @@ type clientSuite struct {
 var _ = check.Suite(&clientSuite{})
 
 func (cs *clientSuite) SetUpTest(c *check.C) {
-	cs.cli = client.New()
+	cs.cli = client.New(nil)
 	cs.cli.SetDoer(cs)
 	cs.err = nil
 	cs.rsp = ""
@@ -133,7 +133,7 @@ func (cs *clientSuite) TestClientIntegration(c *check.C) {
 	srv.Start()
 	defer srv.Close()
 
-	cli := client.New()
+	cli := client.New(nil)
 	si, err := cli.SysInfo()
 	c.Check(err, check.IsNil)
 	c.Check(si.Store, check.Equals, "X")

--- a/cmd/snap/cmd_add_cap.go
+++ b/cmd/snap/cmd_add_cap.go
@@ -86,5 +86,5 @@ func (x *cmdAddCap) Execute(args []string) error {
 		Type:  x.Type,
 		Attrs: AttributePairSliceToMap(x.Attrs),
 	}
-	return client.New().AddCapability(cap)
+	return client.New(nil).AddCapability(cap)
 }

--- a/cmd/snap/cmd_assert.go
+++ b/cmd/snap/cmd_assert.go
@@ -59,5 +59,5 @@ func (x *cmdAssert) Execute(args []string) error {
 		return err
 	}
 
-	return client.New().Assert(assertData)
+	return client.New(nil).Assert(assertData)
 }

--- a/cmd/snap/cmd_asserts.go
+++ b/cmd/snap/cmd_asserts.go
@@ -64,7 +64,7 @@ func (x *cmdAsserts) Execute(args []string) error {
 		headers[parts[0]] = parts[1]
 	}
 
-	assertions, err := client.New().Asserts(x.AssertTypeName, headers)
+	assertions, err := client.New(nil).Asserts(x.AssertTypeName, headers)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 func (x *cmdFind) Execute([]string) error {
-	cli := client.New()
+	cli := client.New(nil)
 	filter := client.SnapFilter{
 		Query:   x.Positional.Query,
 		Sources: []string{"store"},

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -45,7 +45,7 @@ func init() {
 }
 
 func (x *cmdListCaps) Execute(args []string) error {
-	cli := client.New()
+	cli := client.New(nil)
 	caps, err := cli.Capabilities()
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_remove_cap.go
+++ b/cmd/snap/cmd_remove_cap.go
@@ -46,5 +46,5 @@ func init() {
 }
 
 func (x *cmdRemoveCap) Execute(args []string) error {
-	return client.New().RemoveCapability(x.Name)
+	return client.New(nil).RemoveCapability(x.Name)
 }


### PR DESCRIPTION
This patch makes client.New() configurable with an optional
client.Config structure. This allows re-directing the client to point at
a different (e.g. test) server.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>