### PR TITLE
daemon: add a progress meter to tasks

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -615,7 +615,7 @@ func (s *apiSuite) TestGetOpInfoIntegration(c *check.C) {
 	t := d.AddTask(func() interface{} {
 		ch <- struct{}{}
 		return "hello"
-	})
+	}, &progress.NullProgress{})
 
 	id := t.UUID()
 	s.vars = map[string]string{"uuid": id}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/skills"
 )
 
@@ -209,8 +210,8 @@ func (d *Daemon) Dying() <-chan struct{} {
 }
 
 // AddTask runs the given function as a task
-func (d *Daemon) AddTask(f func() interface{}) *Task {
-	t := RunTask(f)
+func (d *Daemon) AddTask(f func() interface{}, meter progress.Meter) *Task {
+	t := RunTask(f, meter)
 	d.Lock()
 	defer d.Unlock()
 	d.tasks[t.UUID()] = t

--- a/daemon/task.go
+++ b/daemon/task.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"gopkg.in/tomb.v2"
+
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 // A Task encapsulates an asynchronous operation.
@@ -33,6 +35,7 @@ type Task struct {
 	t0     time.Time
 	tf     time.Time
 	output interface{}
+	meter  progress.Meter
 }
 
 // A task can be in one of three states
@@ -114,13 +117,14 @@ func (t *Task) Map(route *mux.Route) map[string]interface{} {
 }
 
 // RunTask creates a Task for the given function and runs it.
-func RunTask(f func() interface{}) *Task {
+func RunTask(f func() interface{}, meter progress.Meter) *Task {
 	id := UUID4()
 	t0 := time.Now()
 	t := &Task{
-		id: id,
-		t0: t0,
-		tf: t0,
+		id:    id,
+		t0:    t0,
+		tf:    t0,
+		meter: meter,
 	}
 
 	t.tomb.Go(func() error {

--- a/daemon/task_test.go
+++ b/daemon/task_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 type taskSuite struct{}
@@ -40,7 +42,7 @@ func (s *taskSuite) TestTask(c *check.C) {
 	t := RunTask(func() interface{} {
 		ch <- struct{}{}
 		return 42
-	})
+	}, &progress.NullProgress{})
 
 	c.Check(t.UUID(), check.Equals, t.id.String())
 	c.Check(t.Output(), check.IsNil)
@@ -66,7 +68,7 @@ func (s *taskSuite) TestFails(c *check.C) {
 	t := RunTask(func() interface{} {
 		ch <- struct{}{}
 		return err
-	})
+	}, &progress.NullProgress{})
 
 	c.Check(t.UUID(), check.Equals, t.id.String())
 	c.Check(t.Output(), check.IsNil)


### PR DESCRIPTION
The situation as it stands is that we need to be able to determine the progress of longer running background tasks via the REST API. These tasks are mostly those that involve downloading remote snaps for installation and stopping/starting services.

My proposed first step towards this goal is to simply add a `progress.Meter` into `daemon.Task`.

Next steps from this would be:

* decide on how the progress will be rendered in the output from the `/2.0/operations/{uuid}` endpoint
* create a meter that satisfies the `progress.Meter` interface and enables us to provide the information for the above
* replace the use of `progress.NullMeter` with this meter

Do we think this is a valid strategy?