### PR TITLE
cmd: allow to construct a fresh parser

### DIFF
--- a/cmd/snap/cmd_add_cap.go
+++ b/cmd/snap/cmd_add_cap.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
-	"github.com/ubuntu-core/snappy/logger"
 )
 
 // AttributePair contains a pair of key-value strings
@@ -73,10 +72,12 @@ var (
 )
 
 func init() {
-	_, err := parser.AddCommand("add-cap", shortAddCapHelp, longAddCapHelp, &cmdAddCap{})
-	if err != nil {
-		logger.Panicf("unable to add add-caps command: %v", err)
-	}
+	commands = append(commands, cmdInfo{
+		name:      "add-cap",
+		shortHelp: shortAddCapHelp,
+		longHelp:  longAddCapHelp,
+		callback:  func() interface{} { return &cmdAddCap{} },
+	})
 }
 
 func (x *cmdAddCap) Execute(args []string) error {

--- a/cmd/snap/cmd_add_cap.go
+++ b/cmd/snap/cmd_add_cap.go
@@ -76,7 +76,7 @@ func init() {
 		name:      "add-cap",
 		shortHelp: shortAddCapHelp,
 		longHelp:  longAddCapHelp,
-		builder:  func() interface{} { return &cmdAddCap{} },
+		builder:   func() interface{} { return &cmdAddCap{} },
 	})
 }
 

--- a/cmd/snap/cmd_add_cap.go
+++ b/cmd/snap/cmd_add_cap.go
@@ -76,7 +76,7 @@ func init() {
 		name:      "add-cap",
 		shortHelp: shortAddCapHelp,
 		longHelp:  longAddCapHelp,
-		callback:  func() interface{} { return &cmdAddCap{} },
+		builder:  func() interface{} { return &cmdAddCap{} },
 	})
 }
 

--- a/cmd/snap/cmd_add_cap.go
+++ b/cmd/snap/cmd_add_cap.go
@@ -72,11 +72,8 @@ var (
 )
 
 func init() {
-	commands = append(commands, cmdInfo{
-		name:      "add-cap",
-		shortHelp: shortAddCapHelp,
-		longHelp:  longAddCapHelp,
-		builder:   func() interface{} { return &cmdAddCap{} },
+	addCommand("add-cap", shortAddCapHelp, longAddCapHelp, func() interface{} {
+		return &cmdAddCap{}
 	})
 }
 

--- a/cmd/snap/cmd_assert.go
+++ b/cmd/snap/cmd_assert.go
@@ -48,7 +48,7 @@ func init() {
 		name:      "assert",
 		shortHelp: shortAssertHelp,
 		longHelp:  longAssertHelp,
-		builder:  func() interface{} { return &cmdAssert{} },
+		builder:   func() interface{} { return &cmdAssert{} },
 	})
 }
 

--- a/cmd/snap/cmd_assert.go
+++ b/cmd/snap/cmd_assert.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
-	"github.com/ubuntu-core/snappy/logger"
 )
 
 type assertOptions struct {
@@ -45,10 +44,12 @@ To succeed the assertion must be valid, its signature verified with a known publ
 )
 
 func init() {
-	_, err := parser.AddCommand("assert", shortAssertHelp, longAssertHelp, &cmdAssert{})
-	if err != nil {
-		logger.Panicf("unable to add assert command: %v", err)
-	}
+	commands = append(commands, cmdInfo{
+		name:      "assert",
+		shortHelp: shortAssertHelp,
+		longHelp:  longAssertHelp,
+		callback:  func() interface{} { return &cmdAssert{} },
+	})
 }
 
 func (x *cmdAssert) Execute(args []string) error {

--- a/cmd/snap/cmd_assert.go
+++ b/cmd/snap/cmd_assert.go
@@ -44,11 +44,8 @@ To succeed the assertion must be valid, its signature verified with a known publ
 )
 
 func init() {
-	commands = append(commands, cmdInfo{
-		name:      "assert",
-		shortHelp: shortAssertHelp,
-		longHelp:  longAssertHelp,
-		builder:   func() interface{} { return &cmdAssert{} },
+	addCommand("assert", shortAssertHelp, longAssertHelp, func() interface{} {
+		return &cmdAssert{}
 	})
 }
 

--- a/cmd/snap/cmd_assert.go
+++ b/cmd/snap/cmd_assert.go
@@ -48,7 +48,7 @@ func init() {
 		name:      "assert",
 		shortHelp: shortAssertHelp,
 		longHelp:  longAssertHelp,
-		callback:  func() interface{} { return &cmdAssert{} },
+		builder:  func() interface{} { return &cmdAssert{} },
 	})
 }
 

--- a/cmd/snap/cmd_asserts.go
+++ b/cmd/snap/cmd_asserts.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ubuntu-core/snappy/asserts"
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
-	"github.com/ubuntu-core/snappy/logger"
 )
 
 type assertsOptions struct {
@@ -45,10 +44,12 @@ var (
 )
 
 func init() {
-	_, err := parser.AddCommand("asserts", shortAssertsHelp, longAssertsHelp, &cmdAsserts{})
-	if err != nil {
-		logger.Panicf("cannot add asserts command: %v", err)
-	}
+	commands = append(commands, cmdInfo{
+		name:      "asserts",
+		shortHelp: shortAssertsHelp,
+		longHelp:  longAssertsHelp,
+		callback:  func() interface{} { return &cmdAsserts{} },
+	})
 }
 
 var nl = []byte{'\n'}

--- a/cmd/snap/cmd_asserts.go
+++ b/cmd/snap/cmd_asserts.go
@@ -48,7 +48,7 @@ func init() {
 		name:      "asserts",
 		shortHelp: shortAssertsHelp,
 		longHelp:  longAssertsHelp,
-		callback:  func() interface{} { return &cmdAsserts{} },
+		builder:  func() interface{} { return &cmdAsserts{} },
 	})
 }
 

--- a/cmd/snap/cmd_asserts.go
+++ b/cmd/snap/cmd_asserts.go
@@ -44,11 +44,8 @@ var (
 )
 
 func init() {
-	commands = append(commands, cmdInfo{
-		name:      "asserts",
-		shortHelp: shortAssertsHelp,
-		longHelp:  longAssertsHelp,
-		builder:   func() interface{} { return &cmdAsserts{} },
+	addCommand("asserts", shortAssertsHelp, longAssertsHelp, func() interface{} {
+		return &cmdAsserts{}
 	})
 }
 

--- a/cmd/snap/cmd_asserts.go
+++ b/cmd/snap/cmd_asserts.go
@@ -48,7 +48,7 @@ func init() {
 		name:      "asserts",
 		shortHelp: shortAssertsHelp,
 		longHelp:  longAssertsHelp,
-		builder:  func() interface{} { return &cmdAsserts{} },
+		builder:   func() interface{} { return &cmdAsserts{} },
 	})
 }
 

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -41,11 +41,8 @@ type cmdFind struct {
 }
 
 func init() {
-	commands = append(commands, cmdInfo{
-		name:      "find",
-		shortHelp: shortFindHelp,
-		longHelp:  longFindHelp,
-		builder:   func() interface{} { return &cmdFind{} },
+	addCommand("find", shortFindHelp, longFindHelp, func() interface{} {
+		return &cmdFind{}
 	})
 }
 

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -45,7 +45,7 @@ func init() {
 		name:      "find",
 		shortHelp: shortFindHelp,
 		longHelp:  longFindHelp,
-		callback:  func() interface{} { return &cmdFind{} },
+		builder:  func() interface{} { return &cmdFind{} },
 	})
 }
 

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
-	"github.com/ubuntu-core/snappy/logger"
 )
 
 var (
@@ -42,10 +41,12 @@ type cmdFind struct {
 }
 
 func init() {
-	_, err := parser.AddCommand("find", shortFindHelp, longFindHelp, &cmdFind{})
-	if err != nil {
-		logger.Panicf("unable to add find command: %v", err)
-	}
+	commands = append(commands, cmdInfo{
+		name:      "find",
+		shortHelp: shortFindHelp,
+		longHelp:  longFindHelp,
+		callback:  func() interface{} { return &cmdFind{} },
+	})
 }
 
 func (x *cmdFind) Execute([]string) error {

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -45,7 +45,7 @@ func init() {
 		name:      "find",
 		shortHelp: shortFindHelp,
 		longHelp:  longFindHelp,
-		builder:  func() interface{} { return &cmdFind{} },
+		builder:   func() interface{} { return &cmdFind{} },
 	})
 }
 

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -37,11 +37,8 @@ var (
 )
 
 func init() {
-	commands = append(commands, cmdInfo{
-		name:      "list-caps",
-		shortHelp: shortListCapsHelp,
-		longHelp:  longListCapsHelp,
-		builder:   func() interface{} { return &cmdListCaps{} },
+	addCommand("list-caps", shortListCapsHelp, longListCapsHelp, func() interface{} {
+		return &cmdListCaps{}
 	})
 }
 

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
-	"github.com/ubuntu-core/snappy/logger"
 )
 
 type cmdListCaps struct {
@@ -38,10 +37,12 @@ var (
 )
 
 func init() {
-	_, err := parser.AddCommand("list-caps", shortListCapsHelp, longListCapsHelp, &cmdListCaps{})
-	if err != nil {
-		logger.Panicf("unable to add list-caps command: %v", err)
-	}
+	commands = append(commands, cmdInfo{
+		name:      "list-caps",
+		shortHelp: shortListCapsHelp,
+		longHelp:  longListCapsHelp,
+		callback:  func() interface{} { return &cmdListCaps{} },
+	})
 }
 
 func (x *cmdListCaps) Execute(args []string) error {

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -41,7 +41,7 @@ func init() {
 		name:      "list-caps",
 		shortHelp: shortListCapsHelp,
 		longHelp:  longListCapsHelp,
-		builder:  func() interface{} { return &cmdListCaps{} },
+		builder:   func() interface{} { return &cmdListCaps{} },
 	})
 }
 

--- a/cmd/snap/cmd_list_caps.go
+++ b/cmd/snap/cmd_list_caps.go
@@ -41,7 +41,7 @@ func init() {
 		name:      "list-caps",
 		shortHelp: shortListCapsHelp,
 		longHelp:  longListCapsHelp,
-		callback:  func() interface{} { return &cmdListCaps{} },
+		builder:  func() interface{} { return &cmdListCaps{} },
 	})
 }
 

--- a/cmd/snap/cmd_remove_cap.go
+++ b/cmd/snap/cmd_remove_cap.go
@@ -42,7 +42,7 @@ func init() {
 		name:      "remove-cap",
 		shortHelp: shortRemoveCapHelp,
 		longHelp:  longRemoveCapHelp,
-		builder:  func() interface{} { return &cmdRemoveCap{} },
+		builder:   func() interface{} { return &cmdRemoveCap{} },
 	})
 }
 

--- a/cmd/snap/cmd_remove_cap.go
+++ b/cmd/snap/cmd_remove_cap.go
@@ -38,11 +38,8 @@ var (
 )
 
 func init() {
-	commands = append(commands, cmdInfo{
-		name:      "remove-cap",
-		shortHelp: shortRemoveCapHelp,
-		longHelp:  longRemoveCapHelp,
-		builder:   func() interface{} { return &cmdRemoveCap{} },
+	addCommand("remove-cap", shortRemoveCapHelp, longRemoveCapHelp, func() interface{} {
+		return &cmdRemoveCap{}
 	})
 }
 

--- a/cmd/snap/cmd_remove_cap.go
+++ b/cmd/snap/cmd_remove_cap.go
@@ -42,7 +42,7 @@ func init() {
 		name:      "remove-cap",
 		shortHelp: shortRemoveCapHelp,
 		longHelp:  longRemoveCapHelp,
-		callback:  func() interface{} { return &cmdRemoveCap{} },
+		builder:  func() interface{} { return &cmdRemoveCap{} },
 	})
 }
 

--- a/cmd/snap/cmd_remove_cap.go
+++ b/cmd/snap/cmd_remove_cap.go
@@ -22,7 +22,6 @@ package main
 import (
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
-	"github.com/ubuntu-core/snappy/logger"
 )
 
 type removeCapOptions struct {
@@ -39,10 +38,12 @@ var (
 )
 
 func init() {
-	_, err := parser.AddCommand("remove-cap", shortRemoveCapHelp, longRemoveCapHelp, &cmdRemoveCap{})
-	if err != nil {
-		logger.Panicf("unable to add remove-cap command: %v", err)
-	}
+	commands = append(commands, cmdInfo{
+		name:      "remove-cap",
+		shortHelp: shortRemoveCapHelp,
+		longHelp:  longRemoveCapHelp,
+		callback:  func() interface{} { return &cmdRemoveCap{} },
+	})
 }
 
 func (x *cmdRemoveCap) Execute(args []string) error {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -62,7 +62,7 @@ func Parser() *flags.Parser {
 	// Add all regular commands
 	for _, c := range commands {
 		if _, err := parser.AddCommand(c.name, c.shortHelp, c.longHelp, c.builder()); err != nil {
-			logger.Panicf("unable to add command %q: %v", c.name, err)
+			logger.Panicf("cannot add command %q: %v", c.name, err)
 		}
 	}
 	return parser

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -45,6 +45,17 @@ type cmdInfo struct {
 // commands holds information about all non-experimental commands.
 var commands []cmdInfo
 
+// addCommand replaces parser.addCommand() in a way that is compatible with
+// re-constructing a pristine parser.
+func addCommand(name, shortHelp, longHelp string, builder func() interface{}) {
+	commands = append(commands, cmdInfo{
+		name:      name,
+		shortHelp: shortHelp,
+		longHelp:  longHelp,
+		builder:   builder,
+	})
+}
+
 // Parser creates and populates a fresh parser.
 // Since commands have local state a fresh parser is required to isolate tests
 // from each other.

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -34,9 +34,33 @@ type options struct {
 
 var optionsData options
 
-var parser = flags.NewParser(&optionsData, flags.HelpFlag|flags.PassDoubleDash)
+var parser *flags.Parser
+
+// cmdInfo holds information needed to call parser.AddCommand(...).
+type cmdInfo struct {
+	name, shortHelp, longHelp string
+	callback                  func() interface{}
+}
+
+// commands holds information about all non-experimental commands.
+var commands []cmdInfo
+
+// Parser creates and populates a fresh parser.
+// Since commands have local state a fresh parser is required to isolate tests
+// from each other.
+func Parser() *flags.Parser {
+	parser := flags.NewParser(&optionsData, flags.HelpFlag|flags.PassDoubleDash)
+	// Add all regular commands
+	for _, c := range commands {
+		if _, err := parser.AddCommand(c.name, c.shortHelp, c.longHelp, c.callback()); err != nil {
+			logger.Panicf("unable to add command %q: %v", c.name, err)
+		}
+	}
+	return parser
+}
 
 func init() {
+	parser = Parser()
 	err := logger.SimpleSetup()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %s\n", err)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -34,8 +34,6 @@ type options struct {
 
 var optionsData options
 
-var parser *flags.Parser
-
 // cmdInfo holds information needed to call parser.AddCommand(...).
 type cmdInfo struct {
 	name, shortHelp, longHelp string
@@ -71,7 +69,6 @@ func Parser() *flags.Parser {
 }
 
 func init() {
-	parser = Parser()
 	err := logger.SimpleSetup()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %s\n", err)
@@ -86,6 +83,7 @@ func main() {
 }
 
 func run() error {
+	parser := Parser()
 	_, err := parser.Parse()
 	if err != nil {
 		return err

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -39,7 +39,7 @@ var parser *flags.Parser
 // cmdInfo holds information needed to call parser.AddCommand(...).
 type cmdInfo struct {
 	name, shortHelp, longHelp string
-	callback                  func() interface{}
+	builder                   func() interface{}
 }
 
 // commands holds information about all non-experimental commands.
@@ -52,7 +52,7 @@ func Parser() *flags.Parser {
 	parser := flags.NewParser(&optionsData, flags.HelpFlag|flags.PassDoubleDash)
 	// Add all regular commands
 	for _, c := range commands {
-		if _, err := parser.AddCommand(c.name, c.shortHelp, c.longHelp, c.callback()); err != nil {
+		if _, err := parser.AddCommand(c.name, c.shortHelp, c.longHelp, c.builder()); err != nil {
 			logger.Panicf("unable to add command %q: %v", c.name, err)
 		}
 	}


### PR DESCRIPTION
Add a way to create a fresh and complete parser in order for tests to
observe pristine state of each command.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>