### PR TITLE
asserts: check that primary keys are set when Decode()ing/assembling assertions

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -91,10 +91,6 @@ func checkPublicKey(ab *assertionBase, fingerprintName, keyIDName string) (Publi
 }
 
 func assembleAccountKey(assert assertionBase) (Assertion, error) {
-	_, err := checkMandatory(assert.headers, "account-id")
-	if err != nil {
-		return nil, err
-	}
 	since, err := checkRFC3339Date(assert.headers, "since")
 	if err != nil {
 		return nil, err

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -435,6 +435,12 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 		return nil, fmt.Errorf("unknown assertion type: %q", typ)
 	}
 
+	for _, primKey := range assertType.PrimaryKey {
+		if _, err := checkMandatory(headers, primKey); err != nil {
+			return nil, fmt.Errorf("assertion %s: %v", assertType.Name, err)
+		}
+	}
+
 	revision, err := checkRevision(headers)
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -67,18 +67,9 @@ func (snapdcl *SnapBuild) checkConsistency(db *Database, acck *AccountKey) error
 }
 
 func assembleSnapBuild(assert assertionBase) (Assertion, error) {
-	_, err := checkMandatory(assert.headers, "snap-id")
-	if err != nil {
-		return nil, err
-	}
+	// TODO: more parsing/checking of snap-digest
 
-	// TODO: more parsing/checking of this here?
-	_, err = checkMandatory(assert.headers, "snap-digest")
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = checkMandatory(assert.headers, "grade")
+	_, err := checkMandatory(assert.headers, "grade")
 	if err != nil {
 		return nil, err
 	}
@@ -153,16 +144,7 @@ func (assert *SnapRevision) checkConsistency(db *Database, acck *AccountKey) err
 }
 
 func assembleSnapRevision(assert assertionBase) (Assertion, error) {
-	_, err := checkMandatory(assert.headers, "snap-id")
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: more parsing/checking of this here?
-	_, err = checkMandatory(assert.headers, "snap-digest")
-	if err != nil {
-		return nil, err
-	}
+	// TODO: more parsing/checking of snap-digest
 
 	snapRevision, err := checkUint(assert.headers, "snap-revision", 64)
 	if err != nil {


### PR DESCRIPTION
This adds checks that primary keys are set when decoding and the other cases of assembling assertions. This was done when signing already. Some test data had to be adjusted.