### PR TITLE
cmd/snap: support testing command output

### DIFF
--- a/cmd/snap/cmd_asserts.go
+++ b/cmd/snap/cmd_asserts.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/ubuntu-core/snappy/asserts"
@@ -69,7 +68,7 @@ func (x *cmdAsserts) Execute(args []string) error {
 		return err
 	}
 
-	enc := asserts.NewEncoder(os.Stdout)
+	enc := asserts.NewEncoder(Stdout)
 	for _, a := range assertions {
 		enc.Encode(a)
 	}

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"text/tabwriter"
 
@@ -75,7 +74,7 @@ func (x *cmdFind) Execute([]string) error {
 	}
 	sort.Strings(names)
 
-	w := tabwriter.NewWriter(os.Stdout, 5, 3, 1, ' ', 0)
+	w := tabwriter.NewWriter(Stdout, 5, 3, 1, ' ', 0)
 	defer w.Flush()
 
 	fmt.Fprintln(w, i18n.G("Name\tVersion\tSummary"))

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/ubuntu-core/snappy/logger"
@@ -45,13 +46,13 @@ var parser = flags.NewParser(&optionsData, flags.HelpFlag|flags.PassDoubleDash)
 func init() {
 	err := logger.SimpleSetup()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %s\n", err)
+		fmt.Fprintf(Stderr, "WARNING: failed to activate logging: %s\n", err)
 	}
 }
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		fmt.Fprintf(Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -28,6 +28,12 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
+// Stdout is the standard output stream, it is redirected for testing.
+var Stdout io.Writer = os.Stdout
+
+// Stderr is the standard error stream, it is redirected for testing.
+var Stderr io.Writer = os.Stderr
+
 type options struct {
 	// No global options yet
 }

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type SnapSuite struct {
+}
+
+var _ = Suite(&SnapSuite{})

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -22,6 +22,7 @@ package main_test
 import (
 	"testing"
 
+	"github.com/ubuntu-core/snappy/testutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -29,6 +30,7 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type SnapSuite struct {
+	testutil.BaseTest
 }
 
 var _ = Suite(&SnapSuite{})

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -20,8 +20,11 @@
 package main_test
 
 import (
+	"bytes"
+	"os"
 	"testing"
 
+	. "github.com/ubuntu-core/snappy/cmd/snap"
 	"github.com/ubuntu-core/snappy/testutil"
 	. "gopkg.in/check.v1"
 )
@@ -31,6 +34,18 @@ func Test(t *testing.T) { TestingT(t) }
 
 type SnapSuite struct {
 	testutil.BaseTest
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
 }
 
 var _ = Suite(&SnapSuite{})
+
+func (s *SnapSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.stdout = bytes.NewBuffer(nil)
+	s.stderr = bytes.NewBuffer(nil)
+	Stdout = s.stdout
+	Stderr = s.stderr
+	s.BaseTest.AddCleanup(func() { Stdout = os.Stdout })
+	s.BaseTest.AddCleanup(func() { Stderr = os.Stderr })
+}

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -47,8 +47,12 @@ func (s *SnapSuite) SetUpTest(c *C) {
 	s.stderr = bytes.NewBuffer(nil)
 	Stdout = s.stdout
 	Stderr = s.stderr
-	s.BaseTest.AddCleanup(func() { Stdout = os.Stdout })
-	s.BaseTest.AddCleanup(func() { Stderr = os.Stderr })
+}
+
+func (s *SnapSuite) TearDownTest(c *C) {
+	Stdout = os.Stdout
+	Stderr = os.Stderr
+	s.BaseTest.TearDownTest(c)
 }
 
 func (s *SnapSuite) Stdout() string {

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -24,9 +24,10 @@ import (
 	"os"
 	"testing"
 
+	. "gopkg.in/check.v1"
+
 	. "github.com/ubuntu-core/snappy/cmd/snap"
 	"github.com/ubuntu-core/snappy/testutil"
-	. "gopkg.in/check.v1"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -49,3 +49,11 @@ func (s *SnapSuite) SetUpTest(c *C) {
 	s.BaseTest.AddCleanup(func() { Stdout = os.Stdout })
 	s.BaseTest.AddCleanup(func() { Stderr = os.Stderr })
 }
+
+func (s *SnapSuite) Stdout() string {
+	return s.stdout.String()
+}
+
+func (s *SnapSuite) Stderr() string {
+	return s.stderr.String()
+}


### PR DESCRIPTION
This branch contains simple primitives for writing tests that check command output. This is used further down the line to test the new skill commands.