### PR TITLE
cmd/snappy,snappy: remove "Details" from the repository interface

### DIFF
--- a/cmd/snappy/cmd_info.go
+++ b/cmd/snappy/cmd_info.go
@@ -75,10 +75,7 @@ func snapInfo(pkgname string, includeStore, verbose bool) error {
 	snap := snappy.ActiveSnapByName(pkgname)
 	if snap == nil && includeStore {
 		m := snappy.NewUbuntuStoreSnapRepository()
-		snaps, err := m.Details(snappy.SplitOrigin(pkgname))
-		if err == nil && len(snaps) == 1 {
-			snap = snaps[0]
-		}
+		snap, _ = m.Snap(pkgname)
 	}
 
 	if snap == nil {

--- a/cmd/snappy/cmd_info.go
+++ b/cmd/snappy/cmd_info.go
@@ -75,11 +75,15 @@ func snapInfo(pkgname string, includeStore, verbose bool) error {
 	snap := snappy.ActiveSnapByName(pkgname)
 	if snap == nil && includeStore {
 		m := snappy.NewUbuntuStoreSnapRepository()
-		snap, _ = m.Snap(pkgname)
+		var err error
+		snap, err = m.Snap(pkgname)
+		if err != nil {
+			return fmt.Errorf("cannot get details for snap %q: %s", pkgname, err)
+		}
 	}
 
 	if snap == nil {
-		return fmt.Errorf("No snap '%s' found", pkgname)
+		return fmt.Errorf("no snap '%s' found", pkgname)
 	}
 
 	// TRANSLATORS: the %s is a channel name

--- a/integration-tests/tests/installApp_test.go
+++ b/integration-tests/tests/installApp_test.go
@@ -84,7 +84,7 @@ func (s *installAppSuite) TestInstallUnexistingAppMustPrintError(c *check.C) {
 		check.Commentf("Trying to install an unexisting snap did not exit with an error"))
 	c.Assert(string(output), check.Equals,
 		"Installing unexisting.canonical\n"+
-			"unexisting failed to install: snappy package not found\n",
+			"unexisting.canonical failed to install: snappy package not found\n",
 		check.Commentf("Wrong error message"))
 }
 

--- a/snappy/install.go
+++ b/snappy/install.go
@@ -35,7 +35,7 @@ import (
 type InstallFlags uint
 
 const (
-	// AllowUnauthenticated allows to install a snap even if it can not be authenticated
+	// AllowUnauthenticated allows to install a snap even if it cannot be authenticated
 	AllowUnauthenticated InstallFlags = 1 << iota
 	// InhibitHooks will ensure that the hooks are not run
 	InhibitHooks
@@ -130,7 +130,7 @@ func Update(name string, flags InstallFlags, meter progress.Meter) ([]Part, erro
 	}
 	upd := FindSnapsByName(QualifiedName(cur[0]), updates)
 	if len(upd) < 1 {
-		return nil, fmt.Errorf("no update found for %s", name)
+		return nil, fmt.Errorf("cannot find any update for %q", name)
 	}
 
 	if err := doUpdate(mStore, upd[0], flags, meter); err != nil {

--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -21,8 +21,6 @@ package snappy
 
 import (
 	"fmt"
-	"net"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -117,9 +115,6 @@ type Repository interface {
 	// query
 	Description() string
 
-	// action
-	Details(name string, origin string) ([]Part, error)
-
 	Updates() ([]Part, error)
 	Installed() ([]Part, error)
 
@@ -209,31 +204,9 @@ func (m *MetaRepository) Updates() (parts []Part, err error) {
 	return parts, err
 }
 
-// Details returns details for the given snap name
-func (m *MetaRepository) Details(name string, origin string) ([]Part, error) {
-	var parts []Part
-
-	for _, r := range m.all {
-		results, err := r.Details(name, origin)
-		// ignore network errors here, we will also collect
-		// local results
-		_, netError := err.(net.Error)
-		_, urlError := err.(*url.Error)
-		switch {
-		case err == ErrPackageNotFound || netError || urlError:
-			continue
-		case err != nil:
-			return nil, err
-		}
-		parts = append(parts, results...)
-	}
-
-	return parts, nil
-}
-
 // ActiveSnapsByType returns all installed snaps with the given type
 func ActiveSnapsByType(snapTs ...snap.Type) (res []Part, err error) {
-	m := NewMetaRepository()
+	m := NewMetaLocalRepository()
 	installed, err := m.Installed()
 	if err != nil {
 		return nil, err

--- a/snappy/parts_test.go
+++ b/snappy/parts_test.go
@@ -112,20 +112,6 @@ type: framework`)
 	c.Check(nm, DeepEquals, map[string]bool{"fwk": true, "app." + testOrigin: true})
 }
 
-func (s *SnapTestSuite) TestMetaRepositoryDetails(c *C) {
-	_, err := makeInstalledMockSnap(s.tempdir, "")
-	c.Assert(err, IsNil)
-
-	m := NewMetaRepository()
-	c.Assert(m, NotNil)
-
-	parts, err := m.Details("hello-app", "")
-	c.Assert(err, IsNil)
-	c.Assert(parts, HasLen, 1)
-	c.Assert(parts[0].Name(), Equals, "hello-app")
-	c.Assert(parts[0].Origin(), Equals, testOrigin)
-}
-
 func (s *SnapTestSuite) TestFindSnapsByNameNotAvailable(c *C) {
 	_, err := makeInstalledMockSnap(s.tempdir, "")
 	repo := NewLocalSnapRepository(dirs.SnapSnapsDir)

--- a/snappy/snap_local_repo.go
+++ b/snappy/snap_local_repo.go
@@ -49,23 +49,6 @@ func (s *SnapLocalRepository) Description() string {
 	return fmt.Sprintf("Snap local repository for %s", s.path)
 }
 
-// Details returns details for the given snap
-func (s *SnapLocalRepository) Details(name string, origin string) (versions []Part, err error) {
-	if origin == "" || origin == SideloadedOrigin {
-		origin = "*"
-	}
-	appParts, err := s.partsForGlobExpr(filepath.Join(s.path, name+"."+origin, "*", "meta", "snap.yaml"))
-	fmkParts, err := s.partsForGlobExpr(filepath.Join(s.path, name, "*", "meta", "snap.yaml"))
-
-	parts := append(appParts, fmkParts...)
-
-	if len(parts) == 0 {
-		return nil, ErrPackageNotFound
-	}
-
-	return parts, nil
-}
-
 // Updates returns the available updates
 func (s *SnapLocalRepository) Updates() (parts []Part, err error) {
 	return nil, err

--- a/snappy/snap_remote_repo.go
+++ b/snappy/snap_remote_repo.go
@@ -191,12 +191,8 @@ func (s *SnapUbuntuStoreRepository) Description() string {
 	return fmt.Sprintf("Snap remote repository for %s", s.searchURI)
 }
 
-// Details returns details for the given snap in this repository
-func (s *SnapUbuntuStoreRepository) Details(name string, origin string) (parts []Part, err error) {
-	snapName := name
-	if origin != "" {
-		snapName = name + "." + origin
-	}
+// Snap returns the SnapRemotePart for the given name or an error
+func (s *SnapUbuntuStoreRepository) Snap(snapName string) (*RemoteSnapPart, error) {
 
 	url, err := s.detailsURI.Parse(snapName)
 	if err != nil {
@@ -223,7 +219,7 @@ func (s *SnapUbuntuStoreRepository) Details(name string, origin string) (parts [
 	case resp.StatusCode == 404:
 		return nil, ErrPackageNotFound
 	case resp.StatusCode != 200:
-		return parts, fmt.Errorf("SnapUbuntuStoreRepository: unexpected http statusCode %v for %s", resp.StatusCode, snapName)
+		return nil, fmt.Errorf("SnapUbuntuStoreRepository: unexpected http statusCode %v for %s", resp.StatusCode, snapName)
 	}
 
 	// and decode json
@@ -233,10 +229,20 @@ func (s *SnapUbuntuStoreRepository) Details(name string, origin string) (parts [
 		return nil, err
 	}
 
-	snap := NewRemoteSnapPart(detailsData)
-	parts = append(parts, snap)
+	return NewRemoteSnapPart(detailsData), nil
+}
 
-	return parts, nil
+// Details returns details for the given snap in this repository
+func (s *SnapUbuntuStoreRepository) Details(name string, origin string) (parts []Part, err error) {
+	snapName := name
+	if origin != "" {
+		snapName = name + "." + origin
+	}
+	snap, err := s.Snap(snapName)
+	if err != nil {
+		return nil, err
+	}
+	return []Part{snap}, nil
 }
 
 // All (installable) parts from the store

--- a/snappy/snap_remote_repo.go
+++ b/snappy/snap_remote_repo.go
@@ -191,7 +191,7 @@ func (s *SnapUbuntuStoreRepository) Description() string {
 	return fmt.Sprintf("Snap remote repository for %s", s.searchURI)
 }
 
-// Snap returns the SnapRemotePart for the given name or an error
+// Snap returns the RemoteSnapPart for the given name or an error.
 func (s *SnapUbuntuStoreRepository) Snap(snapName string) (*RemoteSnapPart, error) {
 
 	url, err := s.detailsURI.Parse(snapName)
@@ -219,7 +219,7 @@ func (s *SnapUbuntuStoreRepository) Snap(snapName string) (*RemoteSnapPart, erro
 	case resp.StatusCode == 404:
 		return nil, ErrPackageNotFound
 	case resp.StatusCode != 200:
-		return nil, fmt.Errorf("SnapUbuntuStoreRepository: unexpected http statusCode %v for %s", resp.StatusCode, snapName)
+		return nil, fmt.Errorf("SnapUbuntuStoreRepository: unexpected HTTP status code %d while looking forsnap %q", resp.StatusCode, snapName)
 	}
 
 	// and decode json

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -625,16 +625,15 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Assert(snap, NotNil)
 
 	// the actual test
-	results, err := snap.Details(funkyAppName, funkyAppOrigin)
+	result, err := snap.Snap(funkyAppName + "." + funkyAppOrigin)
 	c.Assert(err, IsNil)
-	c.Assert(results, HasLen, 1)
-	c.Check(results[0].Name(), Equals, funkyAppName)
-	c.Check(results[0].Origin(), Equals, funkyAppOrigin)
-	c.Check(results[0].Version(), Equals, "42")
-	c.Check(results[0].Hash(), Equals, "5364253e4a988f4f5c04380086d542f410455b97d48cc6c69ca2a5877d8aef2a6b2b2f83ec4f688cae61ebc8a6bf2cdbd4dbd8f743f0522fc76540429b79df42")
-	c.Check(results[0].Date().String(), Equals, "2015-04-15 18:30:16 +0000 UTC")
-	c.Check(results[0].DownloadSize(), Equals, int64(65375))
-	c.Check(results[0].Channel(), Equals, "edge")
+	c.Check(result.Name(), Equals, funkyAppName)
+	c.Check(result.Origin(), Equals, funkyAppOrigin)
+	c.Check(result.Version(), Equals, "42")
+	c.Check(result.Hash(), Equals, "5364253e4a988f4f5c04380086d542f410455b97d48cc6c69ca2a5877d8aef2a6b2b2f83ec4f688cae61ebc8a6bf2cdbd4dbd8f743f0522fc76540429b79df42")
+	c.Check(result.Date().String(), Equals, "2015-04-15 18:30:16 +0000 UTC")
+	c.Check(result.DownloadSize(), Equals, int64(65375))
+	c.Check(result.Channel(), Equals, "edge")
 }
 
 func (s *SnapTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
@@ -654,9 +653,9 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 	c.Assert(snap, NotNil)
 
 	// the actual test
-	results, err := snap.Details("no-such-pkg", "")
-	c.Assert(results, HasLen, 0)
+	result, err := snap.Snap("no-such-pkg")
 	c.Assert(err, NotNil)
+	c.Assert(result, IsNil)
 }
 
 func (s *SnapTestSuite) TestMakeConfigEnv(c *C) {
@@ -949,7 +948,7 @@ type: gadget
 	c.Assert(repo, NotNil)
 
 	// we just ensure that the right header is set
-	repo.Details("xkcd", "")
+	repo.Snap("xkcd")
 }
 
 func (s *SnapTestSuite) TestUninstallBuiltIn(c *C) {


### PR DESCRIPTION
[manual merge because automatic merged conflicted (needleessly?)]

Small cleanup to remove the "Details" method from the generic repository interface.
