### PR TITLE
cmd/snappy,daemon,snappy,snap: remove config from parts interface

### DIFF
--- a/cmd/snappy/cmd_config.go
+++ b/cmd/snappy/cmd_config.go
@@ -88,7 +88,8 @@ func configurePackage(pkgName, configFile string) (string, error) {
 		return "", snappy.ErrPackageNotFound
 	}
 
-	return snap.Config(config)
+	overlord := &snappy.Overlord{}
+	return overlord.Configure(snap.(*snappy.SnapPart), config)
 }
 
 func readConfiguration(configInput string) (config []byte, err error) {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -541,6 +541,14 @@ func snapService(c *Command, r *http.Request) Response {
 	}).Map(route))
 }
 
+type configurator interface {
+	Configure(*snappy.SnapPart, []byte) (string, error)
+}
+
+var getConfigurator = func() configurator {
+	return &snappy.Overlord{}
+}
+
 func snapConfig(c *Command, r *http.Request) Response {
 	vars := muxVars(r)
 	name := vars["name"]
@@ -576,7 +584,8 @@ func snapConfig(c *Command, r *http.Request) Response {
 		return BadRequest("reading config request body gave %v", err)
 	}
 
-	config, err := part.Config(bs)
+	overlord := getConfigurator()
+	config, err := overlord.Configure(part.(*snappy.SnapPart), bs)
 	if err != nil {
 		return InternalError("unable to retrieve config for %s: %v", pkgName, err)
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/skills"
 	"github.com/ubuntu-core/snappy/snap"
-	"github.com/ubuntu-core/snappy/snap/lightweight"
 	"github.com/ubuntu-core/snappy/snappy"
 	"github.com/ubuntu-core/snappy/systemd"
 	"github.com/ubuntu-core/snappy/testutil"
@@ -57,6 +56,7 @@ type apiSuite struct {
 	err        error
 	vars       map[string]string
 	searchTerm string
+	overlord   *fakeOverlord
 }
 
 var _ = check.Suite(&apiSuite{})
@@ -98,6 +98,9 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	s.parts = nil
 	s.err = nil
 	s.vars = nil
+	s.overlord = &fakeOverlord{
+		configs: map[string]string{},
+	}
 }
 
 func (s *apiSuite) TearDownTest(c *check.C) {
@@ -291,6 +294,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"pkgActionDispatch",
 		// snapInstruction vars:
 		"snappyInstall",
+		"getConfigurator",
 	}
 	c.Check(found, check.Equals, len(api)+len(exceptions),
 		check.Commentf(`At a glance it looks like you've not added all the Commands defined in api to the api list. If that is not the case, please add the exception to the "exceptions" list in this test.`))
@@ -767,19 +771,31 @@ func (c cfgc) Load(string) (snappy.Part, error) {
 	return &tP{name: "foo", version: "v1", origin: "bar", isActive: true, config: c.cfg, configErr: c.err}, nil
 }
 
+type fakeOverlord struct {
+	configs map[string]string
+}
+
+func (o *fakeOverlord) Configure(s *snappy.SnapPart, c []byte) (string, error) {
+	if len(c) > 0 {
+		o.configs[s.Name()] = string(c)
+	}
+	config, ok := o.configs[s.Name()]
+	if !ok {
+		return "", fmt.Errorf("no config for %q", s.Name())
+	}
+	return config, nil
+}
+
 func (s *apiSuite) TestSnapGetConfig(c *check.C) {
 	req, err := http.NewRequest("GET", "/2.0/snaps/foo.bar/config", bytes.NewBuffer(nil))
 	c.Assert(err, check.IsNil)
 
-	configStr := "some: config"
-	oldConcrete := lightweight.NewConcrete
-	defer func() {
-		lightweight.NewConcrete = oldConcrete
-	}()
-	lightweight.NewConcrete = func(*lightweight.PartBag, string) lightweight.Concreter {
-		return &cfgc{cfg: configStr}
+	getConfigurator = func() configurator {
+		return s.overlord
 	}
 
+	configStr := "some: config"
+	s.overlord.configs["foo"] = configStr
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
 	s.mkInstalled(c, "foo", "bar", "v1", true, "")
 
@@ -818,9 +834,11 @@ func (s *apiSuite) TestSnapGetConfigInactive(c *check.C) {
 
 func (s *apiSuite) TestSnapGetConfigNoConfig(c *check.C) {
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
+	getConfigurator = func() configurator {
+		return s.overlord
+	}
 
 	s.mkInstalled(c, "foo", "bar", "v1", true, "")
-
 	req, err := http.NewRequest("GET", "/2.0/snaps/foo.bar/config", bytes.NewBuffer(nil))
 	c.Assert(err, check.IsNil)
 
@@ -834,13 +852,9 @@ func (s *apiSuite) TestSnapPutConfig(c *check.C) {
 	req, err := http.NewRequest("PUT", "/2.0/snaps/foo.bar/config", bytes.NewBufferString(newConfigStr))
 	c.Assert(err, check.IsNil)
 
-	configStr := "some: config"
-	oldConcrete := lightweight.NewConcrete
-	defer func() {
-		lightweight.NewConcrete = oldConcrete
-	}()
-	lightweight.NewConcrete = func(*lightweight.PartBag, string) lightweight.Concreter {
-		return &cfgc{cfg: configStr}
+	//configStr := "some: config"
+	getConfigurator = func() configurator {
+		return s.overlord
 	}
 
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}

--- a/snap/removed/removed_test.go
+++ b/snap/removed/removed_test.go
@@ -87,9 +87,7 @@ func (s *removedSuite) TestNoStore(c *check.C) {
 
 	prog := &progress.NullProgress{}
 	c.Check(part.SetActive(true, prog), check.Equals, ErrRemoved)
-	_, err := part.Config(nil)
-	c.Check(err, check.Equals, ErrRemoved)
-	_, err = part.Frameworks()
+	_, err := part.Frameworks()
 	c.Check(err, check.Equals, ErrRemoved)
 }
 
@@ -121,8 +119,6 @@ func (s *removedSuite) TestWithStore(c *check.C) {
 
 	prog := &progress.NullProgress{}
 	c.Check(part.SetActive(true, prog), check.Equals, ErrRemoved)
-	_, err := part.Config(nil)
-	c.Check(err, check.Equals, ErrRemoved)
-	_, err = part.Frameworks()
+	_, err := part.Frameworks()
 	c.Check(err, check.Equals, ErrRemoved)
 }

--- a/snappy/config_test.go
+++ b/snappy/config_test.go
@@ -106,7 +106,7 @@ func (s *SnapTestSuite) TestConfigOS(c *C) {
 	}
 	defer func() { coreConfig = coreConfigImpl }()
 
-	_, err = snap.Config(inCfg)
+	_, err = (&Overlord{}).Configure(snap, inCfg)
 	c.Assert(err, IsNil)
 	c.Assert(cfg, DeepEquals, inCfg)
 }

--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -51,6 +51,14 @@ func wrapConfig(pkgName string, conf interface{}) ([]byte, error) {
 
 var newPartMap = newPartMapImpl
 
+type configurator interface {
+	Configure(*SnapPart, []byte) (string, error)
+}
+
+var newOverlord = func() configurator {
+	return (&Overlord{})
+}
+
 func newPartMapImpl() (map[string]Part, error) {
 	repo := NewMetaLocalRepository()
 	all, err := repo.All()
@@ -108,7 +116,8 @@ func gadgetConfig() error {
 			return err
 		}
 
-		if _, err := snap.Config(configData); err != nil {
+		overlord := newOverlord()
+		if _, err := overlord.Configure(snap.(*SnapPart), configData); err != nil {
 			return err
 		}
 	}

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -338,6 +338,17 @@ func (o *Overlord) SetActive(sp *SnapPart, active bool, meter progress.Meter) er
 	return ErrNotImplemented
 }
 
+// Configure configures the given snap
+//
+// It returns an error on failure
+func (o *Overlord) Configure(s *SnapPart, configuration []byte) (string, error) {
+	if s.m.Type == snap.TypeOS {
+		return coreConfig(configuration)
+	}
+
+	return snapConfig(s.basedir, s.origin, string(configuration))
+}
+
 // Installed returns the installed snaps from this repository
 func (o *Overlord) Installed() ([]*SnapPart, error) {
 	globExpr := filepath.Join(dirs.SnapSnapsDir, "*", "*", "meta", "snap.yaml")

--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -99,9 +99,6 @@ type Part interface {
 	InstalledSize() int64
 	DownloadSize() int64
 
-	// Config takes a yaml configuration and returns the full snap
-	// config with the changes. Note that "configuration" may be empty.
-	Config(configuration []byte) (newConfig string, err error)
 	// make an inactive part active, or viceversa
 	SetActive(bool, progress.Meter) error
 

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -361,15 +361,6 @@ func (s *SnapPart) deactivate(inhibitHooks bool, inter interacter) error {
 	return nil
 }
 
-// Config is used to to configure the snap
-func (s *SnapPart) Config(configuration []byte) (new string, err error) {
-	if s.m.Type == snap.TypeOS {
-		return coreConfig(configuration)
-	}
-
-	return snapConfig(s.basedir, s.origin, string(configuration))
-}
-
 // NeedsReboot returns true if the snap becomes active on the next reboot
 func (s *SnapPart) NeedsReboot() bool {
 	return kernelOrOsRebootRequired(s)

--- a/snappy/snap_remote_repo.go
+++ b/snappy/snap_remote_repo.go
@@ -426,6 +426,7 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *RemoteSnapPart, pbar pr
 		return "", err
 	}
 
+	// TODO: Sync() is not the whole dance for ensuring it's on disc
 	return w.Name(), w.Sync()
 }
 


### PR DESCRIPTION
This branch removes the "Config" part from the Part interface and into the overlord.

From #398.