### PR TITLE
cmd: add support for experimental commands

### DIFF
--- a/cmd/snap/cmd_experimental.go
+++ b/cmd/snap/cmd_experimental.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/ubuntu-core/snappy/i18n"
+)
+
+type cmdExperimental struct{}
+
+var (
+	shortExperimentalHelp = i18n.G("Unsupported experimental commands")
+	longExperimentalHelp  = i18n.G(`Additional experimental commands.
+
+Experimental commands can be removed without notice and may not work on
+non-development systems.`)
+)

--- a/cmd/snap/cmd_experimental.go
+++ b/cmd/snap/cmd_experimental.go
@@ -25,10 +25,10 @@ import (
 
 type cmdExperimental struct{}
 
-var (
-	shortExperimentalHelp = i18n.G("Unsupported experimental commands")
-	longExperimentalHelp  = i18n.G(`Additional experimental commands.
+var shortExperimentalHelp = i18n.G("Runs unsupported experimental commands")
+var longExperimentalHelp = i18n.G(`
+The experimental command contains a selection of additional sub-commands.
 
 Experimental commands can be removed without notice and may not work on
-non-development systems.`)
-)
+non-development systems.
+`)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -43,10 +43,25 @@ type cmdInfo struct {
 // commands holds information about all non-experimental commands.
 var commands []cmdInfo
 
+// experimentalCommands holds information about all experimental commands.
+var experimentalCommands []cmdInfo
+
 // addCommand replaces parser.addCommand() in a way that is compatible with
 // re-constructing a pristine parser.
 func addCommand(name, shortHelp, longHelp string, builder func() interface{}) {
 	commands = append(commands, cmdInfo{
+		name:      name,
+		shortHelp: shortHelp,
+		longHelp:  longHelp,
+		builder:   builder,
+	})
+}
+
+// addExperimentalCommand replaces parser.addCommand() in a way that is
+// compatible with re-constructing a pristine parser. It is meant for
+// adding experimental commands.
+func addExperimentalCommand(name, shortHelp, longHelp string, builder func() interface{}) {
+	experimentalCommands = append(experimentalCommands, cmdInfo{
 		name:      name,
 		shortHelp: shortHelp,
 		longHelp:  longHelp,
@@ -62,6 +77,17 @@ func Parser() *flags.Parser {
 	// Add all regular commands
 	for _, c := range commands {
 		if _, err := parser.AddCommand(c.name, c.shortHelp, c.longHelp, c.builder()); err != nil {
+			logger.Panicf("cannot add command %q: %v", c.name, err)
+		}
+	}
+	// Add the experimental command
+	experimentalCommand, err := parser.AddCommand("experimental", shortExperimentalHelp, longExperimentalHelp, &cmdExperimental{})
+	if err != nil {
+		logger.Panicf("cannot add command %q: %v", "experimental", err)
+	}
+	// Add all the sub-commands of the experimental command
+	for _, c := range experimentalCommands {
+		if _, err = experimentalCommand.AddCommand(c.name, c.shortHelp, c.longHelp, c.builder()); err != nil {
 			logger.Panicf("cannot add command %q: %v", c.name, err)
 		}
 	}

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -88,7 +88,7 @@ func Parser() *flags.Parser {
 	// Add all the sub-commands of the experimental command
 	for _, c := range experimentalCommands {
 		if _, err = experimentalCommand.AddCommand(c.name, c.shortHelp, c.longHelp, c.builder()); err != nil {
-			logger.Panicf("cannot add command %q: %v", c.name, err)
+			logger.Panicf("cannot add experimental command %q: %v", c.name, err)
 		}
 	}
 	return parser

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-02-03 18:30+0100\n"
+        "POT-Creation-Date: 2016-02-05 13:47+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,6 +63,12 @@ msgid   "Activate a package that has previously been deactivated. If the package
 msgstr  ""
 
 msgid   "Add a capability to the system"
+msgstr  ""
+
+msgid   "Additional experimental commands.\n"
+        "\n"
+        "Experimental commands can be removed without notice and may not work on\n"
+        "non-development systems."
 msgstr  ""
 
 msgid   "Allows rollback of a snap to a previous installed version. Without any arguments, the previous installed version is selected. It is also possible to specify the version to rollback to as a additional argument.\n"
@@ -397,6 +403,9 @@ msgid   "This command tries to add an assertion to the system assertion database
 msgstr  ""
 
 msgid   "Unassign a hardware device to a package"
+msgstr  ""
+
+msgid   "Unsupported experimental commands"
 msgstr  ""
 
 msgid   "Update all installed parts"

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-02-05 13:47+0100\n"
+        "POT-Creation-Date: 2016-02-05 14:37+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,12 +63,6 @@ msgid   "Activate a package that has previously been deactivated. If the package
 msgstr  ""
 
 msgid   "Add a capability to the system"
-msgstr  ""
-
-msgid   "Additional experimental commands.\n"
-        "\n"
-        "Experimental commands can be removed without notice and may not work on\n"
-        "non-development systems."
 msgstr  ""
 
 msgid   "Allows rollback of a snap to a previous installed version. Without any arguments, the previous installed version is selected. It is also possible to specify the version to rollback to as a additional argument.\n"
@@ -285,6 +279,9 @@ msgstr  ""
 msgid   "Run snappy shell interface"
 msgstr  ""
 
+msgid   "Runs unsupported experimental commands"
+msgstr  ""
+
 msgid   "Set configuration for a specific installed package"
 msgstr  ""
 
@@ -405,13 +402,17 @@ msgstr  ""
 msgid   "Unassign a hardware device to a package"
 msgstr  ""
 
-msgid   "Unsupported experimental commands"
-msgstr  ""
-
 msgid   "Update all installed parts"
 msgstr  ""
 
 msgid   "Username for the login"
+msgstr  ""
+
+msgid   "\n"
+        "The experimental command contains a selection of additional sub-commands.\n"
+        "\n"
+        "Experimental commands can be removed without notice and may not work on\n"
+        "non-development systems.\n"
 msgstr  ""
 
 msgid   "\n"


### PR DESCRIPTION
Some commands (such as the upcoming commands for manipulating skills)
are not meant for normal use and will be removed or changed later. This
patch adds a way to group all such commands under the "experimental"
subcommand.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>