### PR TITLE
cmd/snappy,daemon,snap,snappy: remove SetActive from parts

### DIFF
--- a/snap/removed/removed.go
+++ b/snap/removed/removed.go
@@ -29,7 +29,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snap/remote"
 	"github.com/ubuntu-core/snappy/snappy"
@@ -131,9 +130,6 @@ func (r *Removed) DownloadSize() int64 {
 
 // Config from the snappy.Part interface
 func (r *Removed) Config(configuration []byte) (newConfig string, err error) { return "", ErrRemoved }
-
-// SetActive from the snappy.Part interface
-func (r *Removed) SetActive(bool, progress.Meter) error { return ErrRemoved }
 
 // Frameworks from the snappy.Part interface
 func (r *Removed) Frameworks() ([]string, error) { return nil, ErrRemoved }

--- a/snap/removed/removed_test.go
+++ b/snap/removed/removed_test.go
@@ -28,7 +28,6 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/ubuntu-core/snappy/dirs"
-	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snappy"
 )
@@ -84,11 +83,6 @@ func (s *removedSuite) TestNoStore(c *check.C) {
 	c.Check(part.IsActive(), check.Equals, false)
 	c.Check(part.IsInstalled(), check.Equals, false)
 	c.Check(part.NeedsReboot(), check.Equals, false)
-
-	prog := &progress.NullProgress{}
-	c.Check(part.SetActive(true, prog), check.Equals, ErrRemoved)
-	_, err := part.Frameworks()
-	c.Check(err, check.Equals, ErrRemoved)
 }
 
 func (s *removedSuite) TestNoOrigin(c *check.C) {
@@ -116,9 +110,4 @@ func (s *removedSuite) TestWithStore(c *check.C) {
 	c.Check(part.IsActive(), check.Equals, false)
 	c.Check(part.IsInstalled(), check.Equals, false)
 	c.Check(part.NeedsReboot(), check.Equals, false)
-
-	prog := &progress.NullProgress{}
-	c.Check(part.SetActive(true, prog), check.Equals, ErrRemoved)
-	_, err := part.Frameworks()
-	c.Check(err, check.Equals, ErrRemoved)
 }

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -222,13 +222,14 @@ func SyncBoot() error {
 		return fmt.Errorf("failed to run SyncBoot: %s", err)
 	}
 
+	overlord := &Overlord{}
 	for _, snap := range []string{kernelSnap, osSnap} {
 		name, ver := nameAndVersionFromSnap(snap)
 		found := FindSnapsByNameAndVersion(name, ver, installed)
 		if len(found) != 1 {
 			return fmt.Errorf("can not SyncBoot, expected 1 snap for %s %s found %d", name, ver, len(found))
 		}
-		if err := found[0].SetActive(true, nil); err != nil {
+		if err := overlord.SetActive(found[0].(*SnapPart), true, nil); err != nil {
 			return fmt.Errorf("can not SyncBoot, failed to make %s active: %s", found[0].Name(), err)
 		}
 	}

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -334,8 +334,12 @@ func (o *Overlord) Uninstall(s *SnapPart, meter progress.Meter) error {
 // SetActive sets the active state of the given snap
 //
 // It returns an error on failure
-func (o *Overlord) SetActive(sp *SnapPart, active bool, meter progress.Meter) error {
-	return ErrNotImplemented
+func (o *Overlord) SetActive(s *SnapPart, active bool, meter progress.Meter) error {
+	if active {
+		return s.activate(false, meter)
+	}
+
+	return s.deactivate(false, meter)
 }
 
 // Configure configures the given snap

--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -99,9 +99,6 @@ type Part interface {
 	InstalledSize() int64
 	DownloadSize() int64
 
-	// make an inactive part active, or viceversa
-	SetActive(bool, progress.Meter) error
-
 	// get the list of frameworks needed by the part
 	Frameworks() ([]string, error)
 }
@@ -307,12 +304,13 @@ func makeSnapActiveByNameAndVersion(pkg, ver string, inter progress.Meter) error
 		return err
 	}
 
+	overlord := &Overlord{}
 	parts := FindSnapsByNameAndVersion(pkg, ver, installed)
 	switch len(parts) {
 	case 0:
 		return fmt.Errorf("Can not find %s with version %s", pkg, ver)
 	case 1:
-		return parts[0].SetActive(true, inter)
+		return overlord.SetActive(parts[0].(*SnapPart), true, inter)
 	default:
 		return fmt.Errorf("More than one %s with version %s", pkg, ver)
 	}

--- a/snappy/set_active.go
+++ b/snappy/set_active.go
@@ -49,5 +49,6 @@ func SetActive(fullName string, active bool, meter progress.Meter) error {
 		}
 	}
 
-	return part.SetActive(active, meter)
+	overlord := &Overlord{}
+	return overlord.SetActive(part.(*SnapPart), active, meter)
 }

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -20,7 +20,6 @@
 package snappy
 
 import (
-	"fmt"
 	"path/filepath"
 	"time"
 
@@ -138,11 +137,6 @@ func (s *SnapFile) Icon() string {
 // IsActive returns whether it is active.
 func (s *SnapFile) IsActive() bool {
 	return false
-}
-
-// SetActive sets the snap to the new active state
-func (s *SnapFile) SetActive(bool, progress.Meter) error {
-	return fmt.Errorf("not possible for a SnapFile")
 }
 
 // IsInstalled returns if its installed

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -232,15 +232,6 @@ func (s *SnapPart) Install(inter progress.Meter, flags InstallFlags) (name strin
 	return "", ErrAlreadyInstalled
 }
 
-// SetActive sets the snap active
-func (s *SnapPart) SetActive(active bool, pb progress.Meter) (err error) {
-	if active {
-		return s.activate(false, pb)
-	}
-
-	return s.deactivate(false, pb)
-}
-
 func (s *SnapPart) activate(inhibitHooks bool, inter interacter) error {
 	currentActiveSymlink := filepath.Join(s.basedir, "..", "current")
 	currentActiveDir, _ := filepath.EvalSymlinks(currentActiveSymlink)

--- a/snappy/snap_remote.go
+++ b/snappy/snap_remote.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
-	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snap/remote"
 )
@@ -128,11 +127,6 @@ func (s *RemoteSnapPart) saveStoreManifest() error {
 
 	// don't worry about previous contents
 	return helpers.AtomicWriteFile(RemoteManifestPath(s), content, 0644, 0)
-}
-
-// SetActive sets the snap active
-func (s *RemoteSnapPart) SetActive(bool, progress.Meter) error {
-	return ErrNotInstalled
 }
 
 // Config is used to to configure the snap

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -786,13 +786,6 @@ architectures:
 	c.Assert(err.Error(), Equals, errorMsg)
 }
 
-func (s *SnapTestSuite) TestRemoteSnapErrors(c *C) {
-	snap := RemoteSnapPart{}
-
-	c.Assert(snap.SetActive(true, nil), Equals, ErrNotInstalled)
-	c.Assert(snap.SetActive(false, nil), Equals, ErrNotInstalled)
-}
-
 func (s *SnapTestSuite) TestServicesWithPorts(c *C) {
 	const packageHello = `name: hello-app
 version: 1.10


### PR DESCRIPTION
This branch removes SetActive from the parts interface.

from #399