### PR TITLE
snappy,daemon: remove the meta repositories abstractions

### DIFF
--- a/cmd/snappy/cmd_rollback.go
+++ b/cmd/snappy/cmd_rollback.go
@@ -70,8 +70,7 @@ func (x *cmdRollback) doRollback() error {
 	// TRANSLATORS: the first %s is a pkgname, the second %s is the new version
 	fmt.Printf(i18n.G("Setting %s to version %s\n"), pkg, nowVersion)
 
-	m := snappy.NewMetaRepository()
-	installed, err := m.Installed()
+	installed, err := snappy.NewLocalSnapRepository().Installed()
 	if err != nil {
 		return err
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -94,6 +94,7 @@ func (s *apiSuite) TearDownSuite(c *check.C) {
 func (s *apiSuite) SetUpTest(c *check.C) {
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapLockFile), 0755), check.IsNil)
+	c.Assert(os.MkdirAll(dirs.SnapSnapsDir, 0755), check.IsNil)
 
 	s.parts = nil
 	s.err = nil

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -365,7 +365,7 @@ func (s *SnapTestSuite) TestClickSetActive(c *C) {
 	c.Assert(err, IsNil)
 
 	// ensure v2 is active
-	repo := NewLocalSnapRepository(filepath.Join(s.tempdir, "snaps"))
+	repo := NewLocalSnapRepository()
 	parts, err := repo.Installed()
 	c.Assert(err, IsNil)
 	c.Assert(parts, HasLen, 2)

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -258,8 +258,7 @@ func makeTwoTestSnaps(c *C, snapType snap.Type, extra ...string) {
 	c.Assert(n, Equals, "foo")
 	c.Assert(storeMinimalRemoteManifest(qn, "foo", testOrigin, "2.0", "", "remote-channel"), IsNil)
 
-	m := NewMetaRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 2)
 }

--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -60,7 +60,7 @@ var newOverlord = func() configurator {
 }
 
 func newPartMapImpl() (map[string]Part, error) {
-	repo := NewMetaLocalRepository()
+	repo := NewLocalSnapRepository()
 	all, err := repo.All()
 	if err != nil {
 		return nil, err
@@ -136,7 +136,7 @@ var getActivator = func() activator {
 // enableSystemSnaps activates the installed kernel/os/gadget snaps
 // on the first boot
 func enableSystemSnaps() error {
-	repo := NewMetaLocalRepository()
+	repo := NewLocalSnapRepository()
 	all, err := repo.All()
 	if err != nil {
 		return nil

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -59,6 +59,7 @@ var _ = Suite(&FirstBootTestSuite{})
 func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	tempdir := c.MkDir()
 	dirs.SetRootDir(tempdir)
+	os.MkdirAll(dirs.SnapSnapsDir, 0755)
 	stampFile = filepath.Join(c.MkDir(), "stamp")
 
 	// mock the world!
@@ -151,8 +152,7 @@ func (s *FirstBootTestSuite) TestSoftwareActivate(c *C) {
 
 	s.m = &snapYaml{Gadget: Gadget{Software: Software{BuiltIn: []string{name}}}}
 
-	repo := NewMetaLocalRepository()
-	all, err := repo.All()
+	all, err := NewLocalSnapRepository().All()
 	c.Check(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Check(all[0].Name(), Equals, name)
@@ -162,8 +162,7 @@ func (s *FirstBootTestSuite) TestSoftwareActivate(c *C) {
 	s.partMap = map[string]Part{name: all[0]}
 	c.Assert(FirstBoot(), IsNil)
 
-	repo = NewMetaLocalRepository()
-	all, err = repo.All()
+	all, err = NewLocalSnapRepository().All()
 	c.Check(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Check(all[0].Name(), Equals, name)
@@ -246,8 +245,7 @@ func (s *FirstBootTestSuite) ensureSystemSnapIsEnabledOnFirstBoot(c *C, yaml str
 	_, err := makeInstalledMockSnap(dirs.GlobalRootDir, yaml)
 	c.Assert(err, IsNil)
 
-	repo := NewMetaLocalRepository()
-	all, err := repo.All()
+	all, err := NewLocalSnapRepository().All()
 	c.Check(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Check(all[0].IsInstalled(), Equals, true)
@@ -255,8 +253,7 @@ func (s *FirstBootTestSuite) ensureSystemSnapIsEnabledOnFirstBoot(c *C, yaml str
 
 	c.Assert(FirstBoot(), IsNil)
 
-	repo = NewMetaLocalRepository()
-	all, err = repo.All()
+	all, err = NewLocalSnapRepository().All()
 	c.Check(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Check(all[0].IsInstalled(), Equals, true)

--- a/snappy/install.go
+++ b/snappy/install.go
@@ -92,7 +92,7 @@ func doUpdate(mStore *SnapUbuntuStoreRepository, part Part, flags InstallFlags, 
 // convertToInstalledSnaps takes a slice of remote snaps that got
 // updated and returns the corresponding local snap parts.
 func convertToInstalledSnaps(remoteUpdates []Part) ([]Part, error) {
-	installed, err := NewMetaLocalRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func convertToInstalledSnaps(remoteUpdates []Part) ([]Part, error) {
 
 // Update updates the selected name
 func Update(name string, flags InstallFlags, meter progress.Meter) ([]Part, error) {
-	installed, err := NewMetaLocalRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func doInstall(name string, flags InstallFlags, meter progress.Meter) (snapName 
 
 	// check repos next
 	mStore := NewUbuntuStoreSnapRepository()
-	installed, err := NewMetaLocalRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return "", err
 	}
@@ -231,8 +231,7 @@ func GarbageCollect(name string, flags InstallFlags, pb progress.Meter) error {
 		return nil
 	}
 
-	m := NewMetaRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return err
 	}

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -49,8 +49,7 @@ func (s *SnapTestSuite) TestInstallInstall(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "foo")
 
-	repo := NewMetaLocalRepository()
-	all, err := repo.All()
+	all, err := NewLocalSnapRepository().All()
 	c.Check(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	part := all[0]
@@ -65,8 +64,7 @@ func (s *SnapTestSuite) TestInstallNoHook(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "foo")
 
-	repo := NewMetaLocalRepository()
-	all, err := repo.All()
+	all, err := NewLocalSnapRepository().All()
 	c.Check(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	part := all[0]
@@ -237,7 +235,8 @@ func (s *SnapTestSuite) TestUpdate(c *C) {
 	yamlPath, err := s.makeInstalledMockSnap("name: foo\nversion: 1")
 	c.Assert(err, IsNil)
 	makeSnapActive(yamlPath)
-	installed, _ := NewMetaLocalRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
+	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
 	c.Assert(ActiveSnapByName("foo"), NotNil)
 

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -217,7 +217,7 @@ func SyncBoot() error {
 	kernelSnap, _ := bootloader.GetBootVar("snappy_kernel")
 	osSnap, _ := bootloader.GetBootVar("snappy_os")
 
-	installed, err := NewMetaLocalRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return fmt.Errorf("failed to run SyncBoot: %s", err)
 	}

--- a/snappy/kernel_os_test.go
+++ b/snappy/kernel_os_test.go
@@ -73,7 +73,7 @@ func (s *kernelTestSuite) TestSyncBoot(c *C) {
 	c.Assert(err, IsNil)
 
 	// ensure our mock env is correct, 3 snaps (1 os + 2 kernels)
-	installed, err := NewMetaLocalRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 3)
 	// ensure that v2 is the active one
@@ -96,7 +96,7 @@ func (s *kernelTestSuite) TestSyncBoot(c *C) {
 	c.Assert(err, IsNil)
 
 	// ensure that v1 is active now
-	installed, err = NewMetaLocalRepository().Installed()
+	installed, err = NewLocalSnapRepository().Installed()
 	c.Assert(err, IsNil)
 	found = FindSnapsByNameAndVersion("linux", "v1", installed)
 	c.Assert(found, HasLen, 1)

--- a/snappy/list.go
+++ b/snappy/list.go
@@ -21,14 +21,10 @@ package snappy
 
 // ListInstalled returns all installed snaps
 func ListInstalled() ([]Part, error) {
-	m := NewMetaRepository()
-
-	return m.Installed()
+	return NewLocalSnapRepository().Installed()
 }
 
 // ListUpdates returns all snaps with updates
 func ListUpdates() ([]Part, error) {
-	m := NewMetaRepository()
-
-	return m.Updates()
+	return NewUbuntuStoreSnapRepository().Updates()
 }

--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -103,105 +103,9 @@ type Part interface {
 	Frameworks() ([]string, error)
 }
 
-// Repository is the interface for a collection of snaps
-type Repository interface {
-
-	// query
-	Description() string
-
-	Updates() ([]Part, error)
-	Installed() ([]Part, error)
-
-	All() ([]Part, error)
-}
-
-// MetaRepository contains all available single repositories can can be used
-// to query in a single place
-type MetaRepository struct {
-	all []Repository
-}
-
-// NewMetaStoreRepository returns a MetaRepository of stores
-func NewMetaStoreRepository() *MetaRepository {
-	m := new(MetaRepository)
-	m.all = []Repository{}
-
-	if repo := NewUbuntuStoreSnapRepository(); repo != nil {
-		m.all = append(m.all, repo)
-	}
-
-	return m
-}
-
-// NewMetaLocalRepository returns a MetaRepository of stores
-func NewMetaLocalRepository() *MetaRepository {
-	m := new(MetaRepository)
-	m.all = []Repository{}
-
-	if repo := NewLocalSnapRepository(dirs.SnapSnapsDir); repo != nil {
-		m.all = append(m.all, repo)
-	}
-
-	return m
-}
-
-// NewMetaRepository returns a new MetaRepository
-func NewMetaRepository() *MetaRepository {
-	// FIXME: make this a configuration file
-
-	m := NewMetaLocalRepository()
-	if repo := NewUbuntuStoreSnapRepository(); repo != nil {
-		m.all = append(m.all, repo)
-	}
-
-	return m
-}
-
-// Installed returns all installed parts
-func (m *MetaRepository) Installed() (parts []Part, err error) {
-	for _, r := range m.all {
-		installed, err := r.Installed()
-		if err != nil {
-			return parts, err
-		}
-		parts = append(parts, installed...)
-	}
-
-	return parts, err
-}
-
-// All the parts
-func (m *MetaRepository) All() ([]Part, error) {
-	var parts []Part
-
-	for _, r := range m.all {
-		all, err := r.All()
-		if err != nil {
-			return nil, err
-		}
-		parts = append(parts, all...)
-	}
-
-	return parts, nil
-}
-
-// Updates returns all updatable parts
-func (m *MetaRepository) Updates() (parts []Part, err error) {
-	for _, r := range m.all {
-		updates, err := r.Updates()
-		if err != nil {
-			return parts, err
-		}
-		parts = append(parts, updates...)
-	}
-
-	return parts, err
-}
-
 // ActiveSnapsByType returns all installed snaps with the given type
 func ActiveSnapsByType(snapTs ...snap.Type) (res []Part, err error) {
-	m := NewMetaLocalRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return nil, err
 	}
@@ -237,8 +141,7 @@ func activeSnapIterByTypeImpl(f func(Part) string, snapTs ...snap.Type) ([]strin
 
 // ActiveSnapByName returns all active snaps with the given name
 func ActiveSnapByName(needle string) Part {
-	m := NewMetaRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return nil
 	}
@@ -298,8 +201,7 @@ func FindSnapsByNameAndVersion(needle, version string, haystack []Part) []Part {
 // MakeSnapActiveByNameAndVersion makes the given snap version the active
 // version
 func makeSnapActiveByNameAndVersion(pkg, ver string, inter progress.Meter) error {
-	m := NewMetaRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return err
 	}

--- a/snappy/parts_test.go
+++ b/snappy/parts_test.go
@@ -26,7 +26,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
 )
@@ -114,7 +113,7 @@ type: framework`)
 
 func (s *SnapTestSuite) TestFindSnapsByNameNotAvailable(c *C) {
 	_, err := makeInstalledMockSnap(s.tempdir, "")
-	repo := NewLocalSnapRepository(dirs.SnapSnapsDir)
+	repo := NewLocalSnapRepository()
 	installed, err := repo.Installed()
 	c.Assert(err, IsNil)
 
@@ -124,7 +123,7 @@ func (s *SnapTestSuite) TestFindSnapsByNameNotAvailable(c *C) {
 
 func (s *SnapTestSuite) TestFindSnapsByNameFound(c *C) {
 	_, err := makeInstalledMockSnap(s.tempdir, "")
-	repo := NewLocalSnapRepository(dirs.SnapSnapsDir)
+	repo := NewLocalSnapRepository()
 	installed, err := repo.Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
@@ -136,7 +135,7 @@ func (s *SnapTestSuite) TestFindSnapsByNameFound(c *C) {
 
 func (s *SnapTestSuite) TestFindSnapsByNameWithOrigin(c *C) {
 	_, err := makeInstalledMockSnap(s.tempdir, "")
-	repo := NewLocalSnapRepository(dirs.SnapSnapsDir)
+	repo := NewLocalSnapRepository()
 	installed, err := repo.Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
@@ -148,7 +147,7 @@ func (s *SnapTestSuite) TestFindSnapsByNameWithOrigin(c *C) {
 
 func (s *SnapTestSuite) TestFindSnapsByNameWithOriginNotThere(c *C) {
 	_, err := makeInstalledMockSnap(s.tempdir, "")
-	repo := NewLocalSnapRepository(dirs.SnapSnapsDir)
+	repo := NewLocalSnapRepository()
 	installed, err := repo.Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
@@ -180,7 +179,7 @@ func (s *SnapTestSuite) TestPackageNameInstalled(c *C) {
 
 func (s *SnapTestSuite) TestFindSnapsByNameAndVersion(c *C) {
 	_, err := makeInstalledMockSnap(s.tempdir, "")
-	repo := NewLocalSnapRepository(dirs.SnapSnapsDir)
+	repo := NewLocalSnapRepository()
 	installed, err := repo.Installed()
 	c.Assert(err, IsNil)
 
@@ -203,7 +202,7 @@ func (s *SnapTestSuite) TestFindSnapsByNameAndVersion(c *C) {
 
 func (s *SnapTestSuite) TestFindSnapsByNameAndVersionFmk(c *C) {
 	_, err := makeInstalledMockSnap(s.tempdir, "name: fmk\ntype: framework\nversion: 1")
-	repo := NewLocalSnapRepository(dirs.SnapSnapsDir)
+	repo := NewLocalSnapRepository()
 	installed, err := repo.Installed()
 	c.Assert(err, IsNil)
 

--- a/snappy/remove.go
+++ b/snappy/remove.go
@@ -38,7 +38,7 @@ const (
 func Remove(partSpec string, flags RemoveFlags, meter progress.Meter) error {
 	var parts BySnapVersion
 
-	installed, err := NewMetaRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return err
 	}

--- a/snappy/remove_test.go
+++ b/snappy/remove_test.go
@@ -38,8 +38,7 @@ func (s *SnapTestSuite) TestSnapRemoveByVersion(c *C) {
 
 	err := Remove("foo=1.0", 0, &progress.NullProgress{})
 
-	m := NewMetaRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed[0].Version(), Equals, "2.0")
 }
@@ -49,8 +48,7 @@ func (s *SnapTestSuite) TestSnapRemoveActive(c *C) {
 
 	err := Remove("foo", 0, &progress.NullProgress{})
 
-	m := NewMetaRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed[0].Version(), Equals, "1.0")
 }
@@ -67,8 +65,7 @@ func (s *SnapTestSuite) TestSnapRemoveActiveGadgetFails(c *C) {
 	err = Remove("foo", 0, &progress.NullProgress{})
 	c.Assert(err, DeepEquals, ErrPackageNotRemovable)
 
-	m := NewMetaRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed[0].Name(), Equals, "foo")
 	c.Assert(installed[0].Type(), Equals, snap.TypeGadget)
@@ -80,8 +77,8 @@ func (s *SnapTestSuite) TestSnapRemoveGC(c *C) {
 	makeTwoTestSnaps(c, snap.TypeApp)
 	err := Remove("foo", DoRemoveGC, &progress.NullProgress{})
 	c.Assert(err, IsNil)
-	m := NewMetaRepository()
-	installed, err := m.Installed()
+
+	installed, err := NewLocalSnapRepository().Installed()
 	c.Assert(err, IsNil)
 	c.Check(installed, HasLen, 0)
 }

--- a/snappy/rollback.go
+++ b/snappy/rollback.go
@@ -34,8 +34,7 @@ func Rollback(pkg, ver string, inter progress.Meter) (version string, err error)
 
 	// no version specified, find the previous one
 	if ver == "" {
-		m := NewMetaRepository()
-		installed, err := m.Installed()
+		installed, err := NewLocalSnapRepository().Installed()
 		if err != nil {
 			return "", err
 		}

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -954,7 +954,7 @@ func GeneratePolicyFromFile(fn string, force bool) error {
 
 // RegenerateAllPolicy will re-generate all policy that needs re-generating
 func RegenerateAllPolicy(force bool) error {
-	installed, err := NewMetaLocalRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return err
 	}

--- a/snappy/service.go
+++ b/snappy/service.go
@@ -67,9 +67,7 @@ type serviceActor struct {
 func FindServices(snapName string, serviceName string, pb progress.Meter) (ServiceActor, error) {
 	var svcs []*svcT
 
-	repo := NewMetaLocalRepository()
-	installed, _ := repo.Installed()
-
+	installed, _ := NewLocalSnapRepository().Installed()
 	foundSnap := false
 	for _, part := range installed {
 		if !part.IsActive() {

--- a/snappy/service_test.go
+++ b/snappy/service_test.go
@@ -76,6 +76,8 @@ func (s *ServiceActorSuite) SetUpTest(c *C) {
 	os.Setenv("TZ", "")
 
 	dirs.SetRootDir(c.MkDir())
+	os.MkdirAll(dirs.SnapSnapsDir, 0755)
+
 	// TODO: this mkdir hack is so enable doesn't fail; remove when enable is the same as the rest
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/multi-user.target.wants"), 0755), IsNil)
 	systemd.SystemctlCmd = s.myRun
@@ -116,6 +118,8 @@ func (s *ServiceActorSuite) TestFindServicesNoPackages(c *C) {
 func (s *ServiceActorSuite) TestFindServicesNoPackagesNoPattern(c *C) {
 	// tricky way of hiding the installed package ;)
 	dirs.SetRootDir(c.MkDir())
+	os.MkdirAll(dirs.SnapSnapsDir, 0755)
+
 	actor, err := FindServices("", "", s.pb)
 	c.Check(err, IsNil)
 	c.Assert(actor, NotNil)

--- a/snappy/set_active.go
+++ b/snappy/set_active.go
@@ -28,8 +28,7 @@ import (
 // SetActive sets the active state of the given package
 func SetActive(fullName string, active bool, meter progress.Meter) error {
 	// TODO: switch this to using lightweights
-	m := NewMetaLocalRepository()
-	installed, err := m.Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return err
 	}

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -391,7 +391,7 @@ func (s *SnapPart) Dependents() ([]*SnapPart, error) {
 
 	var needed []*SnapPart
 
-	installed, err := NewMetaRepository().Installed()
+	installed, err := NewLocalSnapRepository().Installed()
 	if err != nil {
 		return nil, err
 	}

--- a/snappy/snap_local_repo.go
+++ b/snappy/snap_local_repo.go
@@ -20,9 +20,10 @@
 package snappy
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/ubuntu-core/snappy/dirs"
 )
 
 const (
@@ -37,21 +38,29 @@ type SnapLocalRepository struct {
 
 // NewLocalSnapRepository returns a new SnapLocalRepository for the given
 // path
-func NewLocalSnapRepository(path string) *SnapLocalRepository {
+func NewLocalSnapRepository() *SnapLocalRepository {
+	path := dirs.SnapSnapsDir
 	if s, err := os.Stat(path); err != nil || !s.IsDir() {
 		return nil
 	}
 	return &SnapLocalRepository{path: path}
 }
 
-// Description describes the local repository
-func (s *SnapLocalRepository) Description() string {
-	return fmt.Sprintf("Snap local repository for %s", s.path)
-}
+// Details returns details for the given snap
+func (s *SnapLocalRepository) Details(name string, origin string) (versions []Part, err error) {
+	if origin == "" || origin == SideloadedOrigin {
+		origin = "*"
+	}
+	appParts, err := s.partsForGlobExpr(filepath.Join(s.path, name+"."+origin, "*", "meta", "snap.yaml"))
+	fmkParts, err := s.partsForGlobExpr(filepath.Join(s.path, name, "*", "meta", "snap.yaml"))
 
-// Updates returns the available updates
-func (s *SnapLocalRepository) Updates() (parts []Part, err error) {
-	return nil, err
+	parts := append(appParts, fmkParts...)
+
+	if len(parts) == 0 {
+		return nil, ErrPackageNotFound
+	}
+
+	return parts, nil
 }
 
 // Installed returns the installed snaps from this repository
@@ -66,6 +75,7 @@ func (s *SnapLocalRepository) Installed() (parts []Part, err error) {
 func (s *SnapLocalRepository) All() ([]Part, error) {
 	return s.Installed()
 }
+
 func (s *SnapLocalRepository) partsForGlobExpr(globExpr string) (parts []Part, err error) {
 	matches, err := filepath.Glob(globExpr)
 	if err != nil {

--- a/snappy/snap_local_repo.go
+++ b/snappy/snap_local_repo.go
@@ -46,23 +46,6 @@ func NewLocalSnapRepository() *SnapLocalRepository {
 	return &SnapLocalRepository{path: path}
 }
 
-// Details returns details for the given snap
-func (s *SnapLocalRepository) Details(name string, origin string) (versions []Part, err error) {
-	if origin == "" || origin == SideloadedOrigin {
-		origin = "*"
-	}
-	appParts, err := s.partsForGlobExpr(filepath.Join(s.path, name+"."+origin, "*", "meta", "snap.yaml"))
-	fmkParts, err := s.partsForGlobExpr(filepath.Join(s.path, name, "*", "meta", "snap.yaml"))
-
-	parts := append(appParts, fmkParts...)
-
-	if len(parts) == 0 {
-		return nil, ErrPackageNotFound
-	}
-
-	return parts, nil
-}
-
 // Installed returns the installed snaps from this repository
 func (s *SnapLocalRepository) Installed() (parts []Part, err error) {
 	globExpr := filepath.Join(s.path, "*", "*", "meta", "snap.yaml")

--- a/snappy/snap_remote_repo.go
+++ b/snappy/snap_remote_repo.go
@@ -186,11 +186,6 @@ func setUbuntuStoreHeaders(req *http.Request) {
 	}
 }
 
-// Description describes the repository
-func (s *SnapUbuntuStoreRepository) Description() string {
-	return fmt.Sprintf("Snap remote repository for %s", s.searchURI)
-}
-
 // Snap returns the RemoteSnapPart for the given name or an error.
 func (s *SnapUbuntuStoreRepository) Snap(snapName string) (*RemoteSnapPart, error) {
 
@@ -388,11 +383,6 @@ func (s *SnapUbuntuStoreRepository) Updates() (parts []Part, err error) {
 	return parts, nil
 }
 
-// Installed returns the installed snaps from this repository
-func (s *SnapUbuntuStoreRepository) Installed() (parts []Part, err error) {
-	return nil, err
-}
-
 // Download downloads the given snap and returns its filename.
 // The file is saved in temporary storage, and should be removed
 // after use to prevent the disk from running out of space.
@@ -426,7 +416,6 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *RemoteSnapPart, pbar pr
 		return "", err
 	}
 
-	// TODO: Sync() is not the whole dance for ensuring it's on disc
 	return w.Name(), w.Sync()
 }
 

--- a/snappy/snap_remote_repo_test.go
+++ b/snappy/snap_remote_repo_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/progress"
 
@@ -43,6 +44,8 @@ var _ = Suite(&remoteRepoTestSuite{})
 func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 	t.store = NewUbuntuStoreSnapRepository()
 	t.origDownloadFunc = download
+	dirs.SetRootDir(c.MkDir())
+	c.Assert(os.MkdirAll(dirs.SnapSnapsDir, 0755), IsNil)
 }
 
 func (t *remoteRepoTestSuite) TearDownTest(c *C) {

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -73,6 +73,7 @@ func (s *SquashfsTestSuite) SetUpTest(c *C) {
 
 	dirs.SetRootDir(c.MkDir())
 	os.MkdirAll(filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants"), 0755)
+	os.MkdirAll(dirs.SnapSnapsDir, 0755)
 
 	// ensure we do not run a real systemd
 	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -57,6 +57,7 @@ func (s *SnapTestSuite) SetUpTest(c *C) {
 	policy.SecBase = filepath.Join(s.tempdir, "security")
 	os.MkdirAll(dirs.SnapServicesDir, 0755)
 	os.MkdirAll(dirs.SnapSeccompDir, 0755)
+	os.MkdirAll(dirs.SnapSnapsDir, 0755)
 
 	release.Override(release.Release{Flavor: "core", Series: "15.04"})
 
@@ -171,7 +172,8 @@ frameworks:
 }
 
 func (s *SnapTestSuite) TestLocalSnapRepositoryInvalid(c *C) {
-	snap := NewLocalSnapRepository("invalid-path")
+	dirs.SnapSnapsDir = "invalid-path"
+	snap := NewLocalSnapRepository()
 	c.Assert(snap, IsNil)
 }
 
@@ -181,7 +183,7 @@ func (s *SnapTestSuite) TestLocalSnapRepositorySimple(c *C) {
 	err = makeSnapActive(yamlPath)
 	c.Assert(err, IsNil)
 
-	snap := NewLocalSnapRepository(filepath.Join(s.tempdir, "snaps"))
+	snap := NewLocalSnapRepository()
 	c.Assert(snap, NotNil)
 
 	installed, err := snap.Installed()
@@ -965,7 +967,7 @@ type: gadget
 
 	p := &MockProgressMeter{}
 
-	r := NewLocalSnapRepository(filepath.Join(s.tempdir, "snaps"))
+	r := NewLocalSnapRepository()
 	c.Assert(r, NotNil)
 	installed, err := r.Installed()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This is a mostly mechanical branch. It removes the Meta*Repository abstractions. They were useful when we had multiple local snap directories and a system-image component. Because we have only a single /snaps directory now and no system-image we don't need the abstractions anymore.

from #430