### PR TITLE
asserts: introduce device assertion

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -224,9 +224,13 @@ func parseHeaders(head []byte) (map[string]string, error) {
 //    BODY can be arbitrary,
 //    SIGNATURE is the signature
 //
-// A header line looks like:
+// A header entry for a single line value looks like:
 //
 //   NAME ": " VALUE
+//
+// A header entry for a multiline value (a value with "\n"s in it) looks like:
+//
+//   NAME ":\n"  1-space indented VALUE
 //
 // The following headers are mandatory:
 //

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -166,7 +166,7 @@ func parseHeaders(head []byte) (map[string]string, error) {
 		i++
 		nameValueSplit := strings.Index(entry, ":")
 		if nameValueSplit == -1 {
-			return nil, fmt.Errorf("header entry missing name/value ':' separator: %q", entry)
+			return nil, fmt.Errorf("header entry missing ':' separator: %q", entry)
 		}
 		name := entry[:nameValueSplit]
 		if !headerNameSanity.MatchString(name) {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -47,6 +47,7 @@ var (
 	AccountKeyType = &AssertionType{"account-key", []string{"account-id", "public-key-id"}, assembleAccountKey}
 	// XXX: is series actually part of the primary key?
 	ModelType        = &AssertionType{"model", []string{"brand-id", "model", "series"}, assembleModel}
+	DeviceType       = &AssertionType{"device", []string{"brand-id", "model", "serial"}, assembleDevice}
 	SnapBuildType    = &AssertionType{"snap-build", []string{"snap-id", "snap-digest"}, assembleSnapBuild}
 	SnapRevisionType = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}
 
@@ -56,6 +57,7 @@ var (
 var typeRegistry = map[string]*AssertionType{
 	AccountKeyType.Name:   AccountKeyType,
 	ModelType.Name:        ModelType,
+	DeviceType.Name:       DeviceType,
 	SnapBuildType.Name:    SnapBuildType,
 	SnapRevisionType.Name: SnapRevisionType,
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -220,11 +220,11 @@ func parseHeaders(head []byte) (map[string]string, error) {
 //
 // where:
 //
-//    HEADER is a set of header lines separated by "\n"
+//    HEADER is a set of header entries separated by "\n"
 //    BODY can be arbitrary,
 //    SIGNATURE is the signature
 //
-// A header entry for a single line value looks like:
+// A header entry for a single line value (no "\n" in it) looks like:
 //
 //   NAME ": " VALUE
 //

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -131,8 +131,11 @@ func (as *assertsSuite) TestDecodeNoSignatureSplit(c *C) {
 func (as *assertsSuite) TestDecodeHeaderParsingErrors(c *C) {
 	headerParsingErrorsTests := []struct{ encoded, expectedErr string }{
 		{string([]byte{255, '\n', '\n'}), "header is not utf8"},
-		{"foo: a\nbar\n\n", "header entry missing name value ': ' separation: \"bar\""},
+		{"foo: a\nbar\n\n", `header entry missing name/value ':' separator: "bar"`},
 		{"TYPE: foo\n\n", `invalid header name: "TYPE"`},
+		{"foo: a\nbar:>\n\n", `header entry should have a space or newline \(multiline\) before value: "bar:>"`},
+		{"foo: a\nbar:\n\n", `empty multiline header value: "bar:"`},
+		{"foo: a\nbar:\nbaz: x\n\n", `empty multiline header value: "bar:"`},
 	}
 
 	for _, test := range headerParsingErrorsTests {
@@ -411,6 +414,37 @@ func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 	decoded, err := asserts.Decode(asserts.Encode(a))
 	c.Assert(err, IsNil)
 	c.Check(decoded.Body(), DeepEquals, body)
+}
+
+func (as *assertsSuite) TestSignFormatSanitySupportMultilineHeaderValues(c *C) {
+	headers := map[string]string{
+		"authority-id": "auth-id1",
+		"primary-key":  "0",
+	}
+
+	multilineVals := []string{
+		"a\n",
+		"\na",
+		"a\n\b\nc",
+		"a\n\b\nc\n",
+		"\na\n",
+		"\n\na\n\nb\n\nc",
+	}
+
+	for _, multilineVal := range multilineVals {
+		headers["multiline"] = multilineVal
+		if len(multilineVal)%2 == 1 {
+			headers["odd"] = "true"
+		}
+
+		a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, asserts.OpenPGPPrivateKey(testPrivKey1))
+		c.Assert(err, IsNil)
+
+		decoded, err := asserts.Decode(asserts.Encode(a))
+		c.Assert(err, IsNil)
+
+		c.Check(decoded.Header("multiline"), Equals, multilineVal)
+	}
 }
 
 func (as *assertsSuite) TestHeaders(c *C) {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -131,7 +131,7 @@ func (as *assertsSuite) TestDecodeNoSignatureSplit(c *C) {
 func (as *assertsSuite) TestDecodeHeaderParsingErrors(c *C) {
 	headerParsingErrorsTests := []struct{ encoded, expectedErr string }{
 		{string([]byte{255, '\n', '\n'}), "header is not utf8"},
-		{"foo: a\nbar\n\n", `header entry missing name/value ':' separator: "bar"`},
+		{"foo: a\nbar\n\n", `header entry missing ':' separator: "bar"`},
 		{"TYPE: foo\n\n", `invalid header name: "TYPE"`},
 		{"foo: a\nbar:>\n\n", `header entry should have a space or newline \(multiline\) before value: "bar:>"`},
 		{"foo: a\nbar:\n\n", `empty multiline header value: "bar:"`},

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -141,3 +141,63 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		timestamp:     timestamp,
 	}, nil
 }
+
+// Device holds a device assertion, which is a statement binding
+// a device identity with the device public key.
+type Device struct {
+	assertionBase
+	timestamp time.Time
+	pubKey    PublicKey
+}
+
+// BrandID returns the brand identifier of the device.
+func (dev *Device) BrandID() string {
+	return dev.Header("brand-id")
+}
+
+// Model returns the model name identifier of the device.
+func (dev *Device) Model() string {
+	return dev.Header("model")
+}
+
+// Serial returns the serial of the device, together with brand id and model they form the unique identifier of the device.
+func (dev *Device) Serial() string {
+	return dev.Header("serial")
+}
+
+// DeviceKey returns the public key of the device.
+func (dev *Device) DeviceKey() PublicKey {
+	return dev.pubKey
+}
+
+// Timestamp returns the time when the device assertion was issued.
+func (dev *Device) Timestamp() time.Time {
+	return dev.timestamp
+}
+
+// TODO: implement further consistency checks for Device but first review approach
+
+func assembleDevice(assert assertionBase) (Assertion, error) {
+	// TODO: authority-id can only == canonical or brand-id
+
+	encodedKey, err := checkMandatory(assert.headers, "device-key")
+	if err != nil {
+		return nil, err
+	}
+	pubKey, err := decodePublicKey([]byte(encodedKey))
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp, err := checkRFC3339Date(assert.headers, "timestamp")
+	if err != nil {
+		return nil, err
+	}
+
+	// ignore extra headers and non-empty body for future compatibility
+	return &Device{
+		assertionBase: assert,
+		timestamp:     timestamp,
+		pubKey:        pubKey,
+	}, nil
+}

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -36,6 +36,7 @@ type modelSuite struct {
 
 var (
 	_ = Suite(&modelSuite{})
+	_ = Suite(&deviceSuite{})
 )
 
 func (mods *modelSuite) SetUpSuite(c *C) {
@@ -143,4 +144,71 @@ func (mods *modelSuite) TestModelCheckInconsistentTimestamp(c *C) {
 
 	err = db.Check(model)
 	c.Assert(err, ErrorMatches, "signature verifies but assertion violates other knowledge: model assertion timestamp outside of signing key validity")
+}
+
+type deviceSuite struct {
+	ts            time.Time
+	tsLine        string
+	deviceKey     asserts.PrivateKey
+	encodedDevKey string
+}
+
+func (devs *deviceSuite) SetUpSuite(c *C) {
+	devs.ts = time.Now().Truncate(time.Second).UTC()
+	devs.tsLine = "timestamp: " + devs.ts.Format(time.RFC3339) + "\n"
+
+	devs.deviceKey = asserts.OpenPGPPrivateKey(testPrivKey2)
+	encodedPubKey, err := asserts.EncodePublicKey(devs.deviceKey.PublicKey())
+	c.Assert(err, IsNil)
+	devs.encodedDevKey = string(encodedPubKey)
+}
+
+const deviceExample = "type: device\n" +
+	"authority-id: canonical\n" +
+	"brand-id: brand-id1\n" +
+	"model: baz-3000\n" +
+	"serial: 2700\n" +
+	"device-key:\n DEVICEKEY\n" +
+	"TSLINE" +
+	"body-length: 2\n\n" +
+	"HW" +
+	"\n\n" +
+	"openpgp c2ln"
+
+func (devs *deviceSuite) TestDecodeOK(c *C) {
+	encoded := strings.Replace(deviceExample, "TSLINE", devs.tsLine, 1)
+	encoded = strings.Replace(encoded, "DEVICEKEY", strings.Replace(devs.encodedDevKey, "\n", "\n ", -1), 1)
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.DeviceType)
+	device := a.(*asserts.Device)
+	c.Check(device.AuthorityID(), Equals, "canonical")
+	c.Check(device.Timestamp(), Equals, devs.ts)
+	c.Check(device.BrandID(), Equals, "brand-id1")
+	c.Check(device.Model(), Equals, "baz-3000")
+	c.Check(device.Serial(), Equals, "2700")
+	c.Check(device.DeviceKey().Fingerprint(), Equals, devs.deviceKey.PublicKey().Fingerprint())
+}
+
+const (
+	deviceErrPrefix = "assertion device: "
+)
+
+func (devs *deviceSuite) TestDecodeInvalid(c *C) {
+	encoded := strings.Replace(deviceExample, "TSLINE", devs.tsLine, 1)
+
+	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"serial: 2700\n", "", `"serial" header is mandatory`},
+		{"device-key:\n DEVICEKEY\n", "", `"device-key" header is mandatory`},
+		{"device-key:\n DEVICEKEY\n", "device-key: openpgp ZZZ\n", `public key: could not decode base64 data:.*`},
+		{devs.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
+	}
+
+	for _, test := range invalidTests {
+		invalid := strings.Replace(encoded, test.original, test.invalid, 1)
+		invalid = strings.Replace(invalid, "DEVICEKEY", strings.Replace(devs.encodedDevKey, "\n", "\n ", -1), 1)
+
+		_, err := asserts.Decode([]byte(invalid))
+		c.Check(err, ErrorMatches, deviceErrPrefix+test.expectedErr)
+	}
 }


### PR DESCRIPTION
This introduces the device assertion. 

In order to support putting the device key in the headers readably I added simple support for header values with newlines in them, they just get 1-space indented which is a reversible transformation, added test for this. 

This extension uses a fairly strict format, it could be relaxed in a backward compatible way by using one line look-ahead and some amount of space trimming if the flexibility on the creation side seems later useful.