### PR TITLE
scripts: move the script to get dependencies to a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ To obtain the correct dependencies for the project, run:
 
     godeps -t -u dependencies.tsv
 
+You can use the script `get-deps.sh` to run the two previous steps.
+
 If the dependencies need updating
 
     godeps -t ./... > dependencies.tsv

--- a/get-deps.sh
+++ b/get-deps.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+echo Installing godeps
+go get launchpad.net/godeps
+export PATH=$PATH:$GOPATH/bin
+
+echo Obtaining dependencies
+godeps -u dependencies.tsv

--- a/run-checks
+++ b/run-checks
@@ -72,12 +72,7 @@ append_coverage() {
     fi
 }
 
-echo Installing godeps
-go get launchpad.net/godeps
-export PATH=$PATH:$GOPATH/bin
-
-echo Obtaining dependencies
-godeps -u dependencies.tsv
+sh ./get-deps.sh
 
 if [ ! -z "$STATIC" ]; then
     # Run static tests.


### PR DESCRIPTION
This will help us writing cleaner scripts for the different integration
tests scenarios.