### PR TITLE
[DO NOT MERGE] Tracking background task progress

### DIFF
--- a/daemon/steve_test.go
+++ b/daemon/steve_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gopkg.in/tomb.v2"
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/progress"
+)
+
+type steveSuite struct {}
+
+var _ = Suite(&steveSuite{})
+
+func (s *steveSuite) SetUpSuite(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *steveSuite) TestSteve(c *C) {
+	d := newTestDaemon()
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+
+	p := &progress.SimpleProgress{}
+	p.Start("test", 50)
+
+	task := d.AddTask(func() interface{} {
+		ch1 <- struct{}{}
+		p.Set(10.0)
+		ch1 <- struct{}{}
+		return "hello"
+	})
+
+	t := task.Tomb()
+
+	go func() {
+		ch2 <- struct{}{}
+		<-t.Dead()
+		p.Set(50.0)
+		ch2 <- struct{}{}
+	}()
+
+	c.Assert(p.Percentage(), Equals, 0.0)
+	c.Assert(t.Err(), Equals, tomb.ErrStillAlive)
+	<-ch1
+	c.Assert(p.Percentage(), Equals, 20.0)
+	c.Assert(t.Err(), Equals, tomb.ErrStillAlive)
+	<-ch1
+	<-ch2
+	c.Assert(t.Err(), Equals, tomb.ErrStillAlive)
+	<-ch2
+	c.Assert(t.Err(), IsNil)
+	c.Assert(p.Percentage(), Equals, 100.0)
+}

--- a/daemon/task.go
+++ b/daemon/task.go
@@ -42,6 +42,10 @@ const (
 	TaskFailed    = "failed"
 )
 
+func (t *Task) Tomb() *tomb.Tomb {
+	return &t.tomb
+}
+
 // CreatedAt returns the timestamp at which the task was created
 func (t *Task) CreatedAt() time.Time {
 	return t.t0

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -92,6 +92,28 @@ func (t *NullProgress) Agreed(intro, license string) bool {
 	return false
 }
 
+type SimpleProgress struct {
+	NullProgress
+	total   float64
+	current float64
+}
+
+func (t *SimpleProgress) Start(pkg string, total float64) {
+	t.total = total
+	t.current = 0
+}
+
+func (t *SimpleProgress) Set(current float64) {
+	t.current = current
+}
+
+func (t *SimpleProgress) Percentage() float64 {
+	if t.total > 0 {
+		return (t.current / t.total) * 100
+	}
+	return 0.0
+}
+
 // TextProgress show progress on the terminal
 type TextProgress struct {
 	Meter


### PR DESCRIPTION
So this PR is to stimulate conversation and @chipaca's thoughts in particular would be greatly appreciated seeing as @niemeyer is on holiday.

It has been previously decided that adding a [`progress.Meter`](https://github.com/ubuntu-core/snappy/blob/master/progress/progress.go#L32) into [`daemon.Task`](https://github.com/ubuntu-core/snappy/blob/master/daemon/task.go) was not the thing to do.

@niemeyer has expressed a vote of confidence for [`net/context`](https://godoc.org/golang.org/x/net/context) as a possible means to track the progress of background operations and @pedronis also has good things to say about it. However, there seems to be overlap with what [`tomb`](https://godoc.org/gopkg.in/tomb.v2) is already giving us in `Task`. The support for cancelation and timeouts is nice but the gist of the additional functionality seems to boils down to giving us a `map[interface{}]interface{}` to store arbitrary data in which is maybe not enough to warrant including yet another third party library.

`tomb` provides us with a `Err()` method which can be used to determined if the task is still running and a `Dead()` channel which can be used to determine when a task has ended.

Combining these two aspects we could potentially build a `/2.0/operations/[uuid]/progress` endpoint which would allow task progress to be tracked without adding noise to the output of `/2.0/operations/[uuid]`.

The worked example I have in the included test file contains a background operation which updates a progress meter which mimics what happens when a remote snap is downloaded and installed, the originating use-case for this effort. The meter automatically gets set to a completed state when the task ends. The control flow dictated by the channels is intended to simulate polling of the task's progress.

Feel free to tear my ideas and assumptions here apart, it's frustrating not having some more concrete to offer but a start has got to be made somewhere.