### PR TITLE
cmd/snap: make the asssert command options public

### DIFF
--- a/cmd/snap/cmd_assert.go
+++ b/cmd/snap/cmd_assert.go
@@ -25,12 +25,10 @@ import (
 	"github.com/ubuntu-core/snappy/i18n"
 )
 
-type assertOptions struct {
-	AssertionFile string `positional-arg-name:"assertion-file" description:"assertion file"`
-}
-
 type cmdAssert struct {
-	assertOptions `positional-args:"true" required:"true"`
+	AssertOptions struct {
+		AssertionFile string `positional-arg-name:"assertion-file" description:"assertion file"`
+	} `positional-args:"true" required:"true"`
 }
 
 var shortAssertHelp = i18n.G("Adds an assertion to the system")
@@ -52,7 +50,7 @@ func init() {
 }
 
 func (x *cmdAssert) Execute(args []string) error {
-	assertFile := x.assertOptions.AssertionFile
+	assertFile := x.AssertOptions.AssertionFile
 
 	assertData, err := ioutil.ReadFile(assertFile)
 	if err != nil {

--- a/cmd/snap/cmd_asserts.go
+++ b/cmd/snap/cmd_asserts.go
@@ -27,13 +27,11 @@ import (
 	"github.com/ubuntu-core/snappy/i18n"
 )
 
-type assertsOptions struct {
-	AssertTypeName string   `positional-arg-name:"assertion-type" description:"assertion type name" required:"true"`
-	HeaderFilters  []string `positional-arg-name:"header-filters" description:"header=value" required:"false"`
-}
-
 type cmdAsserts struct {
-	assertsOptions `positional-args:"true" required:"true"`
+	AssertsOptions struct {
+		AssertTypeName string   `positional-arg-name:"assertion-type" description:"assertion type name" required:"true"`
+		HeaderFilters  []string `positional-arg-name:"header-filters" description:"header=value" required:"false"`
+	} `positional-args:"true" required:"true"`
 }
 
 var shortAssertsHelp = i18n.G("Shows known assertions of the provided type")
@@ -54,7 +52,7 @@ var nl = []byte{'\n'}
 func (x *cmdAsserts) Execute(args []string) error {
 	// TODO: share this kind of parsing once it's clearer how often is used in snap
 	headers := map[string]string{}
-	for _, headerFilter := range x.HeaderFilters {
+	for _, headerFilter := range x.AssertsOptions.HeaderFilters {
 		parts := strings.SplitN(headerFilter, "=", 2)
 		if len(parts) != 2 {
 			return fmt.Errorf("invalid header filter: %q (want key=value)", headerFilter)
@@ -62,7 +60,7 @@ func (x *cmdAsserts) Execute(args []string) error {
 		headers[parts[0]] = parts[1]
 	}
 
-	assertions, err := Client().Asserts(x.AssertTypeName, headers)
+	assertions, err := Client().Asserts(x.AssertsOptions.AssertTypeName, headers)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The recent xenial updates make the snap assert command to ignore its
options.
The other commands use a public field for their options, so this makes
the command work again.

LP: #1543266