### PR TITLE
asserts: make assertion checkers used by db.Check modular and pluggable

### DIFF
--- a/asserts/database.go
+++ b/asserts/database.go
@@ -140,6 +140,8 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 	if len(checkers) == 0 {
 		checkers = DefaultCheckers
 	}
+	dbCheckers := make([]Checker, len(checkers))
+	copy(dbCheckers, checkers)
 
 	return &Database{
 		bs:         bs,
@@ -149,7 +151,7 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 		// findAccountKey depend on it, trusted should win over the
 		// general backstore!
 		backstores: []Backstore{trustedBackstore, bs},
-		checkers:   checkers,
+		checkers:   dbCheckers,
 	}, nil
 }
 

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -80,6 +80,8 @@ type DatabaseConfig struct {
 	Backstore Backstore
 	// manager/backstore for keypairs, mandatory
 	KeypairManager KeypairManager
+	// assertion checkers used by Database.Check, left unset DefaultCheckers will be used which is recommended
+	Checkers []Checker
 }
 
 // Well-known errors
@@ -87,11 +89,21 @@ var (
 	ErrNotFound = errors.New("assertion not found")
 )
 
-// A consistencyChecker performs further checks based on the full
-// assertion database knowledge and its own signing key.
-type consistencyChecker interface {
-	checkConsistency(db *Database, signingKey *AccountKey) error
+// A RODatabase exposes read-only access to an assertion database.
+type RODatabase interface {
+	// Find an assertion based on arbitrary headers.
+	// Provided headers must contain the primary key for the assertion type.
+	// It returns ErrNotFound if the assertion cannot be found.
+	Find(assertionType *AssertionType, headers map[string]string) (Assertion, error)
+	// FindMany finds assertions based on arbitrary headers.
+	// It returns ErrNotFound if no assertion can be found.
+	FindMany(assertionType *AssertionType, headers map[string]string) ([]Assertion, error)
 }
+
+// A Checker defines a check on an assertion considering aspects such as
+// its signature, the signing key, and consistency with other
+// assertions in the database.
+type Checker func(assert Assertion, signature Signature, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error
 
 // Database holds assertions and can be used to sign or check
 // further assertions.
@@ -100,6 +112,7 @@ type Database struct {
 	keypairMgr KeypairManager
 	trusted    Backstore
 	backstores []Backstore
+	checkers   []Checker
 }
 
 // OpenDatabase opens the assertion database based on the configuration.
@@ -123,6 +136,11 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 		}
 	}
 
+	checkers := cfg.Checkers
+	if len(checkers) == 0 {
+		checkers = DefaultCheckers
+	}
+
 	return &Database{
 		bs:         bs,
 		keypairMgr: keypairMgr,
@@ -131,6 +149,7 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 		// findAccountKey depend on it, trusted should win over the
 		// general backstore!
 		backstores: []Backstore{trustedBackstore, bs},
+		checkers:   checkers,
 	}, nil
 }
 
@@ -214,7 +233,7 @@ func (db *Database) findAccountKey(authorityID, keyID string) (*AccountKey, erro
 
 // Check tests whether the assertion is properly signed and consistent with all the stored knowledge.
 func (db *Database) Check(assert Assertion) error {
-	content, signature := assert.Signature()
+	_, signature := assert.Signature()
 	sig, err := decodeSignature(signature)
 	if err != nil {
 		return err
@@ -229,20 +248,10 @@ func (db *Database) Check(assert Assertion) error {
 	}
 
 	now := time.Now()
-	if !accKey.isKeyValidAt(now) {
-		return fmt.Errorf("assertion is signed with expired public key %q from %q", sig.KeyID(), assert.AuthorityID())
-	}
-
-	err = accKey.publicKey().verify(content, sig)
-	if err != nil {
-		return fmt.Errorf("failed signature verification: %v", err)
-	}
-
-	// see if the assertion requires further checks
-	if checker, ok := assert.(consistencyChecker); ok {
-		err := checker.checkConsistency(db, accKey)
+	for _, checker := range db.checkers {
+		err := checker(assert, sig, accKey, db, now)
 		if err != nil {
-			return fmt.Errorf("signature verifies but assertion violates other knowledge: %v", err)
+			return err
 		}
 	}
 
@@ -348,4 +357,69 @@ func (db *Database) FindMany(assertionType *AssertionType, headers map[string]st
 		return nil, ErrNotFound
 	}
 	return res, nil
+}
+
+// assertion checkers
+
+// CheckSigningKeyIsNotExpired checks that the signing key is not expired.
+func CheckSigningKeyIsNotExpired(assert Assertion, signature Signature, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error {
+	if !signingKey.isKeyValidAt(checkTime) {
+		return fmt.Errorf("assertion is signed with expired public key %q from %q", signature.KeyID(), assert.AuthorityID())
+	}
+	return nil
+}
+
+// CheckSignature checks that the signature is valid.
+func CheckSignature(assert Assertion, signature Signature, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error {
+	content, _ := assert.Signature()
+	err := signingKey.publicKey().verify(content, signature)
+	if err != nil {
+		return fmt.Errorf("failed signature verification: %v", err)
+	}
+	return nil
+}
+
+type timestamped interface {
+	Timestamp() time.Time
+}
+
+// CheckTimestampVsSigningKeyValidity verifies that the timestamp of
+// the assertion is within the signing key validity.
+func CheckTimestampVsSigningKeyValidity(assert Assertion, signature Signature, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error {
+	if tstamped, ok := assert.(timestamped); ok {
+		if !signingKey.isKeyValidAt(tstamped.Timestamp()) {
+			return fmt.Errorf("%s assertion timestamp outside of signing key validity", assert.Type().Name)
+		}
+	}
+	return nil
+}
+
+// XXX: keeping these in this form until we know better
+
+// A consistencyChecker performs further checks based on the full
+// assertion database knowledge and its own signing key.
+type consistencyChecker interface {
+	checkConsistency(roDB RODatabase, signingKey *AccountKey) error
+}
+
+// CheckCrossConsistency verifies that the assertion is consistent with the other statements in the database.
+func CheckCrossConsistency(assert Assertion, signature Signature, signingKey *AccountKey, roDB RODatabase, checkTime time.Time) error {
+	// see if the assertion requires further checks
+	if checker, ok := assert.(consistencyChecker); ok {
+		err := checker.checkConsistency(roDB, signingKey)
+		if err != nil {
+			return fmt.Errorf("%s assertion violates other knowledge: %v", assert.Type().Name, err)
+		}
+	}
+	return nil
+}
+
+// DefaultCheckers lists the default and recommended assertion
+// checkers used by Database if none are specified in the
+// DatabaseConfig.Checkers.
+var DefaultCheckers = []Checker{
+	CheckSigningKeyIsNotExpired,
+	CheckSignature,
+	CheckTimestampVsSigningKeyValidity,
+	CheckCrossConsistency,
 }

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -95,13 +95,13 @@ func (mod *Model) Timestamp() time.Time {
 }
 
 // Implement further consistency checks.
-func (mod *Model) checkConsistency(db *Database, acck *AccountKey) error {
+func (mod *Model) checkConsistency(db RODatabase, acck *AccountKey) error {
 	// TODO: double check trust level of authority depending on class and possibly allowed-modes
-	if !acck.isKeyValidAt(mod.timestamp) {
-		return fmt.Errorf("model assertion timestamp outside of signing key validity")
-	}
 	return nil
 }
+
+// sanity
+var _ consistencyChecker = (*Model)(nil)
 
 var modelMandatory = []string{"os", "architecture", "gadget", "kernel", "store", "class"}
 

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -142,5 +142,5 @@ func (mods *modelSuite) TestModelCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(model)
-	c.Assert(err, ErrorMatches, "signature verifies but assertion violates other knowledge: model assertion timestamp outside of signing key validity")
+	c.Assert(err, ErrorMatches, "model assertion timestamp outside of signing key validity")
 }

--- a/asserts/findwildcard_test.go
+++ b/asserts/findwildcard_test.go
@@ -26,29 +26,29 @@ import (
 	"path/filepath"
 	"sort"
 
-	. "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 )
 
 type findWildcardSuite struct{}
 
-var _ = Suite(&findWildcardSuite{})
+var _ = check.Suite(&findWildcardSuite{})
 
-func (fs *findWildcardSuite) TestFindWildcard(c *C) {
+func (fs *findWildcardSuite) TestFindWildcard(c *check.C) {
 	top := filepath.Join(c.MkDir(), "top")
 
 	err := os.MkdirAll(top, os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	err = os.MkdirAll(filepath.Join(top, "acc-id1"), os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	err = os.MkdirAll(filepath.Join(top, "acc-id2"), os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	err = ioutil.WriteFile(filepath.Join(top, "acc-id1", "abcd"), nil, os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	err = ioutil.WriteFile(filepath.Join(top, "acc-id1", "e5cd"), nil, os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	err = ioutil.WriteFile(filepath.Join(top, "acc-id2", "f444"), nil, os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	var res []string
 	foundCb := func(relpath string) error {
@@ -57,42 +57,42 @@ func (fs *findWildcardSuite) TestFindWildcard(c *C) {
 	}
 
 	err = findWildcard(top, []string{"*", "*"}, foundCb)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	sort.Strings(res)
-	c.Check(res, DeepEquals, []string{"acc-id1/abcd", "acc-id1/e5cd", "acc-id2/f444"})
+	c.Check(res, check.DeepEquals, []string{"acc-id1/abcd", "acc-id1/e5cd", "acc-id2/f444"})
 
 	res = nil
 	err = findWildcard(top, []string{"zoo", "*"}, foundCb)
-	c.Assert(err, IsNil)
-	c.Check(res, HasLen, 0)
+	c.Assert(err, check.IsNil)
+	c.Check(res, check.HasLen, 0)
 
 	res = nil
 	err = findWildcard(top, []string{"a*", "zoo"}, foundCb)
-	c.Assert(err, IsNil)
-	c.Check(res, HasLen, 0)
+	c.Assert(err, check.IsNil)
+	c.Check(res, check.HasLen, 0)
 
 	res = nil
 	err = findWildcard(top, []string{"acc-id1", "*cd"}, foundCb)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	sort.Strings(res)
-	c.Check(res, DeepEquals, []string{"acc-id1/abcd", "acc-id1/e5cd"})
+	c.Check(res, check.DeepEquals, []string{"acc-id1/abcd", "acc-id1/e5cd"})
 }
 
-func (fs *findWildcardSuite) TestFindWildcardSomeErrors(c *C) {
+func (fs *findWildcardSuite) TestFindWildcardSomeErrors(c *check.C) {
 	top := filepath.Join(c.MkDir(), "top-errors")
 
 	err := os.MkdirAll(top, os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	err = os.MkdirAll(filepath.Join(top, "acc-id1"), os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	err = os.MkdirAll(filepath.Join(top, "acc-id2"), os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	err = ioutil.WriteFile(filepath.Join(top, "acc-id1", "abcd"), nil, os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	err = os.MkdirAll(filepath.Join(top, "acc-id2", "dddd"), os.ModePerm)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	var res []string
 	var retErr error
@@ -104,10 +104,10 @@ func (fs *findWildcardSuite) TestFindWildcardSomeErrors(c *C) {
 	myErr := errors.New("boom")
 	retErr = myErr
 	err = findWildcard(top, []string{"acc-id1", "*"}, foundCb)
-	c.Check(err, Equals, myErr)
+	c.Check(err, check.Equals, myErr)
 
 	retErr = nil
 	res = nil
 	err = findWildcard(top, []string{"acc-id2", "*"}, foundCb)
-	c.Check(err, ErrorMatches, "expected a regular file: .*")
+	c.Check(err, check.ErrorMatches, "expected a regular file: .*")
 }

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -26,7 +26,7 @@ import (
 	"time"
 )
 
-// common checkers used when decoding/assembling assertions
+// common checks used when decoding/assembling assertions
 
 func checkMandatory(headers map[string]string, name string) (string, error) {
 	value, ok := headers[name]

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -20,7 +20,6 @@
 package asserts
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -56,14 +55,6 @@ func (snapdcl *SnapBuild) Grade() string {
 // Timestamp returns the time when the snap-build assertion was created.
 func (snapdcl *SnapBuild) Timestamp() time.Time {
 	return snapdcl.timestamp
-}
-
-// implement further consistency checks
-func (snapdcl *SnapBuild) checkConsistency(db *Database, acck *AccountKey) error {
-	if !acck.isKeyValidAt(snapdcl.timestamp) {
-		return fmt.Errorf("snap-build timestamp outside of signing key validity")
-	}
-	return nil
 }
 
 func assembleSnapBuild(assert assertionBase) (Assertion, error) {
@@ -133,15 +124,15 @@ func (assert *SnapRevision) Timestamp() time.Time {
 }
 
 // Implement further consistency checks.
-func (assert *SnapRevision) checkConsistency(db *Database, acck *AccountKey) error {
+func (assert *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) error {
 	// TODO: check the associated snap-build exists.
 	// TODO: check the associated snap-build's digest.
 	// TODO: check developer-id matches snap-build's authority-id.
-	if !acck.isKeyValidAt(assert.timestamp) {
-		return fmt.Errorf("snap-revision timestamp outside of signing key validity")
-	}
 	return nil
 }
+
+// sanity
+var _ consistencyChecker = (*SnapRevision)(nil)
 
 func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 	// TODO: more parsing/checking of snap-digest

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -181,7 +181,7 @@ func (sds *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapBuild)
-	c.Assert(err, ErrorMatches, "signature verifies but assertion violates other knowledge: snap-build timestamp outside of signing key validity")
+	c.Assert(err, ErrorMatches, "snap-build assertion timestamp outside of signing key validity")
 }
 
 type snapRevSuite struct {
@@ -288,7 +288,7 @@ func (suite *snapRevSuite) TestSnapRevisionCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapRev)
-	c.Assert(err, ErrorMatches, "signature verifies but assertion violates other knowledge: snap-revision timestamp outside of signing key validity")
+	c.Assert(err, ErrorMatches, "snap-revision assertion timestamp outside of signing key validity")
 }
 
 func (suite *snapRevSuite) TestPrimaryKey(c *C) {


### PR DESCRIPTION
This makes the checks used in db.Check modular and pluggable, with defaults matching the previous behaviour with some simplification.

This is a preparation step for having a way to globally recheck all assertions for sanity, also adding new assertions it became clear that the cross checks between assertions are still an area that will require some thoughts and refinement and also that the main usage for checks in the client may have different needs that other usages of the library.

This approach should be better prepared to deal with all that.