### PR TITLE
overlord: start with a skeleton and stubs for Overlord, StateEngine, StateJournal and managers

### DIFF
--- a/overlord/assertmgr.go
+++ b/overlord/assertmgr.go
@@ -1,0 +1,52 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord
+
+// AssertManager is responsible for the enforcement of assertions
+// in system states. It manipulates observed states to ensure nothing
+// in them violates existing assertions, or misses required ones.
+type AssertManager struct {
+	o *Overlord
+}
+
+// NewAssertManager returns a new assertion manager.
+func NewAssertManager(o *Overlord) (*AssertManager, error) {
+	return &AssertManager{o: o}, nil
+}
+
+// Apply implements StateManager.Apply.
+func (m *AssertManager) Apply(s *State) error {
+	return nil
+}
+
+// Learn implements StateManager.Learn.
+func (m *AssertManager) Learn(s *State) error {
+	return nil
+}
+
+// Sanitize implements StateManager.Sanitize.
+func (m *AssertManager) Sanitize(s *State) error {
+	return nil
+}
+
+// Delta implements StateManager.Delta.
+func (m *AssertManager) Delta(a, b *State) (Delta, error) {
+	return nil, nil
+}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -1,0 +1,84 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package overlord implements the policies for state transitions for the operation of a snappy system.
+package overlord
+
+// Overlord is the central manager of a snappy system, keeping
+// track of all available state managers and related helpers.
+type Overlord struct {
+	// managers
+	snapMgr   *SnapManager
+	assertMgr *AssertManager
+	skillMgr  *SkillManager
+}
+
+// New creates a new Overlord with all its state managers.
+func New() (*Overlord, error) {
+	stateEng := NewStateEngine()
+
+	o := &Overlord{}
+	snapMgr, err := NewSnapManager(o)
+	if err != nil {
+		return nil, err
+	}
+	o.snapMgr = snapMgr
+	stateEng.AddManager(o.snapMgr)
+
+	assertMgr, err := NewAssertManager(o)
+	if err != nil {
+		return nil, err
+	}
+	o.assertMgr = assertMgr
+	stateEng.AddManager(o.assertMgr)
+
+	skillMgr, err := NewSkillManager(o)
+	if err != nil {
+		return nil, err
+	}
+	o.skillMgr = skillMgr
+	stateEng.AddManager(o.skillMgr)
+
+	// XXX: setup the StateJournal
+
+	return o, nil
+}
+
+// StateJournal returns the StateJournal used by the overlord.
+func (o *Overlord) StateJournal() *StateJournal {
+	return nil
+}
+
+// SnapManager returns the snap manager responsible for snaps under
+// the overlord.
+func (o *Overlord) SnapManager() *SnapManager {
+	return o.snapMgr
+}
+
+// AssertManager returns the assertion manager enforcing assertions
+// under the overlord.
+func (o *Overlord) AssertManager() *AssertManager {
+	return o.assertMgr
+}
+
+// SkillManager returns the skill manager mantaining skill assignments
+// under the overlord.
+func (o *Overlord) SkillManager() *SkillManager {
+	return o.skillMgr
+}

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -1,0 +1,45 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/overlord"
+)
+
+func TestOverlord(t *testing.T) { TestingT(t) }
+
+type overlordSuite struct{}
+
+var _ = Suite(&overlordSuite{})
+
+func (os *overlordSuite) TestNew(c *C) {
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+	c.Check(o, NotNil)
+
+	c.Check(o.SnapManager(), NotNil)
+	c.Check(o.AssertManager(), NotNil)
+	c.Check(o.SkillManager(), NotNil)
+	// TODO: c.Check(o.StateJournal(), NotNil)
+}

--- a/overlord/skillmgr.go
+++ b/overlord/skillmgr.go
@@ -1,0 +1,62 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord
+
+// SkillManager is responsible for the maintenance of skills in system states.
+// It maintains skills assignments, and also observes installed snaps to track
+// the current set of available skills and skill slots.
+type SkillManager struct {
+	o *Overlord
+}
+
+// NewSkillManager returns a new SkillManager.
+func NewSkillManager(o *Overlord) (*SkillManager, error) {
+	return &SkillManager{o: o}, nil
+}
+
+// Grant records the intent of granting the skill in state s.
+func (m *SkillManager) Grant(s *State, skillSnap, skillName, slotSnap, slotName string) error {
+	return nil
+}
+
+// Revoke records the intent of revoking the skill in state s.
+func (m *SkillManager) Revoke(s *State, skillSnap, skillName, slotSnap, slotName string) error {
+	return nil
+}
+
+// Apply implements StateManager.Apply.
+func (m *SkillManager) Apply(s *State) error {
+	return nil
+}
+
+// Learn implements StateManager.Learn.
+func (m *SkillManager) Learn(s *State) error {
+	return nil
+}
+
+// Sanitize implements StateManager.Sanitize.
+func (m *SkillManager) Sanitize(s *State) error {
+	return nil
+}
+
+// Delta implements StateManager.Delta.
+func (m *SkillManager) Delta(a, b *State) (Delta, error) {
+	return nil, nil
+}

--- a/overlord/snapmgr.go
+++ b/overlord/snapmgr.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord
+
+// SnapManager is responsible for the installation and removal of snaps.
+type SnapManager struct {
+	o *Overlord
+}
+
+// NewSnapManager returns a new snap manager.
+func NewSnapManager(o *Overlord) (*SnapManager, error) {
+	return &SnapManager{o: o}, nil
+}
+
+// Install records the intent of installing snap in state s.
+func (m *SnapManager) Install(s *State, snap string) error {
+	return nil
+}
+
+// Remove records the intent of removing snap in state s.
+func (m *SnapManager) Remove(s *State, snap string) error {
+	return nil
+}
+
+// Apply implements StateManager.Apply.
+func (m *SnapManager) Apply(s *State) error {
+	return nil
+}
+
+// Learn implements StateManager.Learn.
+func (m *SnapManager) Learn(s *State) error {
+	return nil
+}
+
+// Sanitize implements StateManager.Sanitize.
+func (m *SnapManager) Sanitize(s *State) error {
+	return nil
+}
+
+// Delta implements StateManager.Delta.
+func (m *SnapManager) Delta(a, b *State) (Delta, error) {
+	return nil, nil
+}

--- a/overlord/state.go
+++ b/overlord/state.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord
+
+import (
+	"io"
+)
+
+// State represents a snapshot of the system state.
+type State struct{}
+
+// Get unmarshals the stored value associated with the provided key
+// into the value parameter.
+func (s *State) Get(key string, value interface{}) {
+}
+
+// Set associates value with key for future consulting by managers.
+// The provided value must properly marshal and unmarshal with encoding/json.
+func (s *State) Set(key string, value interface{}) {
+}
+
+// Copy returns an indepent copy of the state.
+func (s *State) Copy() *State {
+	return nil
+}
+
+// WriteState serializes the provided state into w.
+func WriteState(s *State, w io.Writer) error {
+	return nil
+}
+
+// ReadState returns the state deserialized from r.
+func ReadState(r io.Reader) (*State, error) {
+	return nil, nil
+}
+
+// Delta represents a list of state changes.
+type Delta []DeltaItem
+
+// DeltaItem represent a single state change, possibly with a reason for it.
+type DeltaItem struct {
+	Header  string // Header for grouping
+	Summary string // Summary with textual description
+	Reason  string // Optional reason for the change, available with sanitization
+}
+
+// MarshalText returns a human-oriented textual representation of the delta.
+//
+// This function turns Delta into an encoding.TextMarshaler.
+func (d Delta) MarshalText() ([]byte, error) {
+	return nil, nil
+}

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -1,0 +1,86 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord
+
+import (
+	"encoding"
+)
+
+// StateManager is implemented by types responsible for observing
+// the system state and directly manipulating it.
+//
+// See the interface of StateEngine for details on those methods.
+type StateManager interface {
+	Apply(s *State) error
+	Learn(s *State) error
+	Sanitize(s *State) error
+	Delta(a, b *State) (Delta, error)
+}
+
+// sanity
+var _ encoding.TextMarshaler = Delta(nil)
+
+// StateEngine controls the dispatching of state changes to state managers.
+//
+// The operations performed by StateEngine resemble in some ways a
+// transaction system, but it needs to deal with the fact that many of the
+// system changes involved in a snappy system are not atomic, and may
+// actually become invalid without notice (e.g. USB device physically removed).
+type StateEngine struct{}
+
+// NewStateEngine returns a new state engine.
+func NewStateEngine() *StateEngine {
+	return &StateEngine{}
+}
+
+// Apply attempts to perform the necessary changes in the system to make s
+// the current state.
+func (se *StateEngine) Apply(s *State) error {
+	return nil
+}
+
+// Learn records the current state into s.
+func (se *StateEngine) Learn(s *State) error {
+	return nil
+}
+
+// Delta returns the differences between state a and b,
+// or nil if there are no relevant differences.
+func (se *StateEngine) Delta(a, b *State) (Delta, error) {
+	return nil, nil
+}
+
+// Sanitize attempts to make the necessary changes in the
+// provided state to make it ready for applying. It returns
+// a Delta with the changes performed and the reasoning for them.
+func (se *StateEngine) Sanitize(s *State) (Delta, error) {
+	return nil, nil
+}
+
+// Validate checks whether the s state might be applied as-is if desired.
+// It's implemented in terms of Sanitize and Delta.
+func (se *StateEngine) Validate(s *State) error {
+	return nil
+}
+
+// AddManager adds the provided manager to take part in state operations.
+func (se *StateEngine) AddManager(m StateManager) {
+	// XXX: how is Apply and Sanitize order picked?
+}

--- a/overlord/statejournal.go
+++ b/overlord/statejournal.go
@@ -1,0 +1,65 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord
+
+// StateJournal is responsible for keeping track of multiple states
+// persistently and recording intended state changes so that the system
+// may be properly recovered from an interruption by moving into the
+// intended state completely, or retroceding to a prior good state.
+type StateJournal struct {
+	eng *StateEngine
+}
+
+// NewStateJournal returns a new state journal using dir as its configuration directory.
+func NewStateJournal(engine *StateEngine, dir string) (*StateJournal, error) {
+	// XXX: get current state or be lazy?
+	return &StateJournal{eng: engine}, nil
+}
+
+// Current returns the current system state.
+func (j *StateJournal) Current() (*State, error) {
+	return nil, nil
+}
+
+// Commit attempts to apply the s state, recording it in the journal
+// first to ensure the operation may be continued later if necessary.
+func (j *StateJournal) Commit(s *State) error {
+	return nil
+}
+
+// Pending returns the last attempted but unfinished commit, if any.
+// It returns ErrNotPending if there are no pending states.
+func (j *StateJournal) Pending() (*State, error) {
+	return nil, nil
+}
+
+// Recover attempts to apply the currently pending state, if any.
+// If applying the pending state fails for any reason and there's
+// a previous good state, applying that will be attempted instead.
+func (j *StateJournal) Recover() error {
+	return nil
+}
+
+// Revert attempts to revert the system to the previous known good
+// state, whether the current state is valid or not. This is unlike
+// Recover in that it ignores whether a pending state exists.
+func (j *StateJournal) Revert() error {
+	return nil
+}


### PR DESCRIPTION
This starts with a skeleton and stubs for Overlord, StateEngine, StateJournal and snap, assertion and skill managers and State and other state management related types.
