### PR TITLE
integration-tests: skip tests affected by LP: #1544507

### DIFF
--- a/integration-tests/tests/ubuntuFan_test.go
+++ b/integration-tests/tests/ubuntuFan_test.go
@@ -86,6 +86,8 @@ func (s *fanTestSuite) TestFanCommandCreatesFanBridge(c *check.C) {
 }
 
 func (s *fanTestSuite) TestDockerCreatesAContainerInsideTheFan(c *check.C) {
+	c.Skip("Skipping until LP: #1544507 is fixed")
+
 	setUpDocker(c)
 	defer tearDownDocker(c)
 	s.configureDockerToUseBridge(c)
@@ -101,6 +103,8 @@ func (s *fanTestSuite) TestDockerCreatesAContainerInsideTheFan(c *check.C) {
 }
 
 func (s *fanTestSuite) TestContainersInTheFanAreReachable(c *check.C) {
+	c.Skip("Skipping until LP: #1544507 is fixed")
+
 	setUpDocker(c)
 	defer tearDownDocker(c)
 	s.configureDockerToUseBridge(c)


### PR DESCRIPTION
This patch skips tests affected by https://bugs.launchpad.net/snappy/+bug/1544507