### PR TITLE
cmd/snappy, coreconfig, daemon, snappy: move config to always be bytes (in and out)

### DIFF
--- a/cmd/snappy/cmd_config.go
+++ b/cmd/snappy/cmd_config.go
@@ -77,15 +77,15 @@ func (x *cmdConfig) Execute(args []string) (err error) {
 	return nil
 }
 
-func configurePackage(pkgName, configFile string) (string, error) {
+func configurePackage(pkgName, configFile string) ([]byte, error) {
 	config, err := readConfiguration(configFile)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	snap := snappy.ActiveSnapByName(pkgName)
 	if snap == nil {
-		return "", snappy.ErrPackageNotFound
+		return nil, snappy.ErrPackageNotFound
 	}
 
 	overlord := &snappy.Overlord{}

--- a/cmd/snappy/cmd_config.go
+++ b/cmd/snappy/cmd_config.go
@@ -72,7 +72,7 @@ func (x *cmdConfig) Execute(args []string) (err error) {
 	}
 
 	// output the new configuration
-	fmt.Println(newConfig)
+	os.Stdout.Write(newConfig)
 
 	return nil
 }

--- a/coreconfig/config_test.go
+++ b/coreconfig/config_test.go
@@ -148,7 +148,7 @@ func (cts *ConfigTestSuite) TestGet(c *C) {
 
 	rawConfig, err := Get()
 	c.Assert(err, IsNil)
-	c.Assert(rawConfig, Equals, expectedOutput)
+	c.Assert(string(rawConfig), Equals, expectedOutput)
 }
 
 // TestSet is a broad test, close enough to be an integration test.
@@ -163,9 +163,9 @@ func (cts *ConfigTestSuite) TestSet(c *C) {
 `
 
 	cmdAutoUpdateEnabled = []string{"-c", "echo enabled"}
-	rawConfig, err := Set(expected)
+	rawConfig, err := Set([]byte(expected))
 	c.Assert(err, IsNil)
-	c.Assert(rawConfig, Equals, expected)
+	c.Assert(string(rawConfig), Equals, expected)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -178,7 +178,7 @@ func (cts *ConfigTestSuite) TestSetBadValueDoesNotPanic(c *C) {
 		"config:\n",
 		"config:\n ubuntu-core:\n",
 	} {
-		_, err := Set(s)
+		_, err := Set([]byte(s))
 		c.Assert(err, Equals, ErrInvalidConfig)
 	}
 
@@ -197,9 +197,9 @@ func (cts *ConfigTestSuite) TestSetTimezone(c *C) {
     modprobe: ""
 `
 
-	rawConfig, err := Set(expected)
+	rawConfig, err := Set([]byte(expected))
 	c.Assert(err, IsNil)
-	c.Assert(rawConfig, Equals, expected)
+	c.Assert(string(rawConfig), Equals, expected)
 	c.Assert(helpers.FileExists(tzZoneInfoTarget), Equals, true)
 
 	// systemctl hasn't been called
@@ -219,9 +219,9 @@ func (cts *ConfigTestSuite) TestSetTimezoneAlreadyExists(c *C) {
 	err := ioutil.WriteFile(tzZoneInfoTarget, canary, 0644)
 	c.Assert(err, IsNil)
 
-	rawConfig, err := Set(expected)
+	rawConfig, err := Set([]byte(expected))
 	c.Assert(err, IsNil)
-	c.Assert(rawConfig, Equals, expected)
+	c.Assert(string(rawConfig), Equals, expected)
 	content, err := ioutil.ReadFile(tzZoneInfoTarget)
 	c.Assert(err, IsNil)
 	c.Assert(content, Not(DeepEquals), []byte(canary))
@@ -245,9 +245,9 @@ func (cts *ConfigTestSuite) TestSetAutoUpdate(c *C) {
 	getAutoUpdate = func() (bool, error) { return enabled, nil }
 	setAutoUpdate = func(state bool) error { enabled = state; return nil }
 
-	rawConfig, err := Set(expected)
+	rawConfig, err := Set([]byte(expected))
 	c.Assert(err, IsNil)
-	c.Assert(rawConfig, Equals, expected)
+	c.Assert(string(rawConfig), Equals, expected)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -263,9 +263,9 @@ func (cts *ConfigTestSuite) TestSetHostname(c *C) {
     modprobe: ""
 `
 
-	rawConfig, err := Set(expected)
+	rawConfig, err := Set([]byte(expected))
 	c.Assert(err, IsNil)
-	c.Assert(rawConfig, Equals, expected)
+	c.Assert(string(rawConfig), Equals, expected)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -280,9 +280,9 @@ func (cts *ConfigTestSuite) TestSetInvalid(c *C) {
     modprobe: ""
 `
 
-	rawConfig, err := Set(input)
+	rawConfig, err := Set([]byte(input))
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -297,9 +297,9 @@ func (cts *ConfigTestSuite) TestNoChangeSet(c *C) {
     modprobe: ""
 `
 
-	rawConfig, err := Set(input)
+	rawConfig, err := Set([]byte(input))
 	c.Assert(err, IsNil)
-	c.Assert(rawConfig, Equals, input)
+	c.Assert(string(rawConfig), Equals, input)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -321,9 +321,9 @@ func (cts *ConfigTestSuite) TestPartialInput(c *C) {
     modprobe: ""
 `
 
-	rawConfig, err := Set(input)
+	rawConfig, err := Set([]byte(input))
 	c.Assert(err, IsNil)
-	c.Assert(rawConfig, Equals, expected)
+	c.Assert(string(rawConfig), Equals, expected)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -340,15 +340,15 @@ func (cts *ConfigTestSuite) TestBadTzOnGet(c *C) {
 
 	rawConfig, err := Get()
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 }
 
 func (cts *ConfigTestSuite) TestBadTzOnSet(c *C) {
 	getTimezone = func() (string, error) { return "", errors.New("Bad mock tz") }
 
-	rawConfig, err := Set("config:")
+	rawConfig, err := Set([]byte("config:"))
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -365,9 +365,9 @@ func (cts *ConfigTestSuite) TestErrorOnTzSet(c *C) {
     modprobe: ""
 `
 
-	rawConfig, err := Set(input)
+	rawConfig, err := Set([]byte(input))
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -378,7 +378,7 @@ func (cts *ConfigTestSuite) TestBadAutoUpdateOnGet(c *C) {
 
 	rawConfig, err := Get()
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 }
 
 func (cts *ConfigTestSuite) TestErrorOnAutoUpdateSet(c *C) {
@@ -394,9 +394,9 @@ func (cts *ConfigTestSuite) TestErrorOnAutoUpdateSet(c *C) {
 	getAutoUpdate = func() (bool, error) { return enabled, nil }
 	setAutoUpdate = func(state bool) error { enabled = state; return errors.New("setAutoUpdate error") }
 
-	rawConfig, err := Set(input)
+	rawConfig, err := Set([]byte(input))
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -413,9 +413,9 @@ func (cts *ConfigTestSuite) TestErrorOnSetHostname(c *C) {
 
 	setHostname = func(string) error { return errors.New("this is bad") }
 
-	rawConfig, err := Set(input)
+	rawConfig, err := Set([]byte(input))
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -432,9 +432,9 @@ func (cts *ConfigTestSuite) TestErrorOnGetHostname(c *C) {
 
 	getHostname = func() (string, error) { return "", errors.New("this is bad") }
 
-	rawConfig, err := Set(input)
+	rawConfig, err := Set([]byte(input))
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 
 	// systemctl hasn't been called
 	c.Check(cts.sysctlargses, HasLen, 0)
@@ -447,7 +447,7 @@ func (cts *ConfigTestSuite) TestErrorOnUnmarshal(c *C) {
 
 	rawConfig, err := Get()
 	c.Assert(err, NotNil)
-	c.Assert(rawConfig, Equals, "")
+	c.Assert(rawConfig, IsNil)
 }
 
 func (cts *ConfigTestSuite) TestInvalidTzFile(c *C) {
@@ -551,7 +551,7 @@ func (cts *ConfigTestSuite) TestModprobeYaml(c *C) {
       blacklist floppy
       softdep mlx4_core post: mlx4_en
 `
-	_, err := Set(input)
+	_, err := Set([]byte(input))
 	c.Assert(err, IsNil)
 
 	// systemctl was called
@@ -701,7 +701,7 @@ func (cts *ConfigTestSuite) TestModulesYaml(c *C) {
   ubuntu-core:
     load-kernel-modules: [-foo, bar]
 `
-	_, err = Set(input)
+	_, err = Set([]byte(input))
 	c.Assert(err, IsNil)
 
 	// systemctl was called
@@ -727,7 +727,7 @@ func (cts *ConfigTestSuite) TestModulesErrorWrite(c *C) {
   ubuntu-core:
     load-kernel-modules: [foo]
 `
-	_, err := Set(input)
+	_, err := Set([]byte(input))
 	c.Check(err, NotNil)
 
 	_, err = getModules()
@@ -748,7 +748,7 @@ func (cts *ConfigTestSuite) TestModulesErrorRW(c *C) {
 	_, err = newSystemConfig()
 	c.Check(err, NotNil)
 
-	_, err = Set("config: {ubuntu-core: {modules: [foo]}}")
+	_, err = Set([]byte("config: {ubuntu-core: {modules: [foo]}}"))
 	c.Check(err, NotNil)
 }
 
@@ -827,7 +827,7 @@ config:
         - name: eth0
           content: auto dhcp
 `
-	_, err := Set(input)
+	_, err := Set([]byte(input))
 	c.Assert(err, IsNil)
 
 	// ensure it's really there
@@ -850,7 +850,7 @@ config:
         - name: chap-secret
           content: password
 `
-	_, err := Set(input)
+	_, err := Set([]byte(input))
 	c.Assert(err, IsNil)
 
 	// ensure it's really there
@@ -930,7 +930,7 @@ config:
       startup: some startup
       config: some config
 `
-	_, err := Set(input)
+	_, err := Set([]byte(input))
 	c.Assert(err, IsNil)
 
 	// ensure it's really there

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -526,7 +526,7 @@ func snapService(c *Command, r *http.Request) Response {
 }
 
 type configurator interface {
-	Configure(*snappy.SnapPart, []byte) (string, error)
+	Configure(*snappy.SnapPart, []byte) ([]byte, error)
 }
 
 var getConfigurator = func() configurator {
@@ -574,7 +574,7 @@ func snapConfig(c *Command, r *http.Request) Response {
 		return InternalError("unable to retrieve config for %s: %v", pkgName, err)
 	}
 
-	return SyncResponse(config)
+	return SyncResponse(string(config))
 }
 
 func getOpInfo(c *Command, r *http.Request) Response {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -775,15 +775,15 @@ type fakeOverlord struct {
 	configs map[string]string
 }
 
-func (o *fakeOverlord) Configure(s *snappy.SnapPart, c []byte) (string, error) {
+func (o *fakeOverlord) Configure(s *snappy.SnapPart, c []byte) ([]byte, error) {
 	if len(c) > 0 {
 		o.configs[s.Name()] = string(c)
 	}
 	config, ok := o.configs[s.Name()]
 	if !ok {
-		return "", fmt.Errorf("no config for %q", s.Name())
+		return nil, fmt.Errorf("no config for %q", s.Name())
 	}
-	return config, nil
+	return []byte(config), nil
 }
 
 func (s *apiSuite) TestSnapGetConfig(c *check.C) {

--- a/snappy/config_test.go
+++ b/snappy/config_test.go
@@ -84,12 +84,12 @@ func (s *SnapTestSuite) TestConfigSimple(c *C) {
 	snapDir, err := s.makeInstalledMockSnapWithConfig(c, mockConfig)
 	c.Assert(err, IsNil)
 
-	newConfig, err := snapConfig(snapDir, "sergiusens", configYaml)
+	newConfig, err := snapConfig(snapDir, "sergiusens", []byte(configYaml))
 	c.Assert(err, IsNil)
 	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "config.out"))
 	c.Assert(err, IsNil)
 	c.Assert(content, DeepEquals, []byte(configYaml))
-	c.Assert(newConfig, Equals, configYaml)
+	c.Assert(string(newConfig), Equals, configYaml)
 }
 
 func (s *SnapTestSuite) TestConfigOS(c *C) {
@@ -100,9 +100,9 @@ func (s *SnapTestSuite) TestConfigOS(c *C) {
 
 	var cfg []byte
 	inCfg := []byte(`something`)
-	coreConfig = func(configuration []byte) (string, error) {
+	coreConfig = func(configuration []byte) ([]byte, error) {
 		cfg = configuration
-		return string(cfg), nil
+		return cfg, nil
 	}
 	defer func() { coreConfig = coreConfigImpl }()
 
@@ -113,9 +113,9 @@ func (s *SnapTestSuite) TestConfigOS(c *C) {
 
 func (s *SnapTestSuite) TestConfigGeneratesRightAA(c *C) {
 	aas := []string{}
-	runConfigScript = func(cs, aa, rc string, env []string) (string, error) {
+	runConfigScript = func(cs, aa string, rc []byte, env []string) ([]byte, error) {
 		aas = append(aas, aa)
-		return "", nil
+		return nil, nil
 	}
 	defer func() { runConfigScript = runConfigScriptImpl }()
 
@@ -125,14 +125,14 @@ func (s *SnapTestSuite) TestConfigGeneratesRightAA(c *C) {
 type: framework
 version: 42`)
 	c.Assert(err, IsNil)
-	_, err = snapConfig(snapDir, testOrigin, configYaml)
+	_, err = snapConfig(snapDir, testOrigin, []byte(configYaml))
 	c.Assert(err, IsNil)
 
 	snapDir, err = s.makeInstalledMockSnapWithConfig(c, mockConfig, `name: potato
 type: potato
 version: 42`)
 	c.Assert(err, IsNil)
-	_, err = snapConfig(snapDir, testOrigin, configYaml)
+	_, err = snapConfig(snapDir, testOrigin, []byte(configYaml))
 	c.Assert(err, IsNil)
 
 	c.Check(aas, DeepEquals, []string{
@@ -145,8 +145,8 @@ func (s *SnapTestSuite) TestConfigError(c *C) {
 	snapDir, err := s.makeInstalledMockSnapWithConfig(c, configErrorScript)
 	c.Assert(err, IsNil)
 
-	newConfig, err := snapConfig(snapDir, "sergiusens", configYaml)
+	newConfig, err := snapConfig(snapDir, "sergiusens", []byte(configYaml))
 	c.Assert(err, NotNil)
-	c.Assert(newConfig, Equals, "")
+	c.Assert(newConfig, IsNil)
 	c.Assert(err, ErrorMatches, ".*failed with: 'error: some error'.*")
 }

--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -52,7 +52,7 @@ func wrapConfig(pkgName string, conf interface{}) ([]byte, error) {
 var newPartMap = newPartMapImpl
 
 type configurator interface {
-	Configure(*SnapPart, []byte) (string, error)
+	Configure(*SnapPart, []byte) ([]byte, error)
 }
 
 var newOverlord = func() configurator {

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -36,9 +36,9 @@ type fakeOverlord struct {
 	configs map[string]string
 }
 
-func (o *fakeOverlord) Configure(s *SnapPart, c []byte) (string, error) {
+func (o *fakeOverlord) Configure(s *SnapPart, c []byte) ([]byte, error) {
 	o.configs[s.Name()] = string(c)
-	return string(c), nil
+	return c, nil
 }
 
 type FirstBootTestSuite struct {

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -345,12 +345,12 @@ func (o *Overlord) SetActive(s *SnapPart, active bool, meter progress.Meter) err
 // Configure configures the given snap
 //
 // It returns an error on failure
-func (o *Overlord) Configure(s *SnapPart, configuration []byte) (string, error) {
+func (o *Overlord) Configure(s *SnapPart, configuration []byte) ([]byte, error) {
 	if s.m.Type == snap.TypeOS {
 		return coreConfig(configuration)
 	}
 
-	return snapConfig(s.basedir, s.origin, string(configuration))
+	return snapConfig(s.basedir, s.origin, configuration)
 }
 
 // Installed returns the installed snaps from this repository


### PR DESCRIPTION
Right now it seems like it's a wash (although having the same thing going in as a `[]byte` and come out as a `string` is rather weird), but in the next few branches it gets ridiculous.