### PR TITLE
A simple notification system

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -2,6 +2,7 @@ github.com/cheggaaa/pb	git	e8c7cc515bfde3e267957a3b110080ceed51354e	2014-12-02T0
 github.com/coreos/go-systemd	git	f743bc15d6bddd23662280b4ad20f7c874cdd5ad	2014-05-03T19:37:39Z
 github.com/gorilla/context	git	1c83b3eabd45b6d76072b66b746c20815fb2872d	2015-08-20T05:12:45Z
 github.com/gorilla/mux	git	ee1815431e497d3850809578c93ab6705f1a19f7	2015-08-20T05:15:06Z
+github.com/gorilla/websocket	git	234959944d9cf05229b02e8b386e5cffe1e4e04a	2016-01-28T16:48:56Z
 github.com/gosexy/gettext	git	98b7b91596d20b96909e6b60d57411547dd9959c	2013-02-21T11:21:43Z
 github.com/jessevdk/go-flags	git	1acbbaff2f347c412a0c7884873bd72cc9c1f5b4	2015-08-16T10:05:21Z
 github.com/kr/pty	git	05017fcccf23c823bfdea560dcc958a136e54fb7	2014-12-17T21:19:37Z

--- a/notifications/hub.go
+++ b/notifications/hub.go
@@ -51,6 +51,10 @@ func (h *Hub) Unsubscribe(s *Subscriber) {
 	h.Lock()
 	defer h.Unlock()
 
+	h.doUnsubscribe(s)
+}
+
+func (h *Hub) doUnsubscribe(s *Subscriber) {
 	delete(h.subscribers, s.uuid)
 }
 
@@ -60,6 +64,9 @@ func (h *Hub) Publish(n *Notification) {
 	defer h.Unlock()
 
 	for _, s := range h.subscribers {
-		s.Notify(n)
+		err := s.Notify(n)
+		if err != nil {
+			h.doUnsubscribe(s)
+		}
 	}
 }

--- a/notifications/hub.go
+++ b/notifications/hub.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notifications
+
+import (
+	"sync"
+)
+
+// A Hub allows subscribers to receive notifications.
+type Hub struct {
+	sync.Mutex
+	subscribers Subscribers
+}
+
+// NewHub returns an initialised hub
+func NewHub() *Hub {
+	return &Hub{
+		subscribers: make(Subscribers),
+	}
+}
+
+// Subscribe registers a subscriber to receive notifications.
+func (h *Hub) Subscribe(s *Subscriber) {
+	h.Lock()
+	defer h.Unlock()
+
+	if _, ok := h.subscribers[s.uuid]; !ok {
+		h.subscribers[s.uuid] = s
+	}
+}
+
+// Unsubscribe unregisters a subscriber from notifications.
+func (h *Hub) Unsubscribe(s *Subscriber) {
+	h.Lock()
+	defer h.Unlock()
+
+	delete(h.subscribers, s.uuid)
+}

--- a/notifications/hub.go
+++ b/notifications/hub.go
@@ -53,3 +53,13 @@ func (h *Hub) Unsubscribe(s *Subscriber) {
 
 	delete(h.subscribers, s.uuid)
 }
+
+// Publish broadcasts a notification to subscribers.
+func (h *Hub) Publish(n *Notification) {
+	h.Lock()
+	defer h.Unlock()
+
+	for _, s := range h.subscribers {
+		s.Notify(n)
+	}
+}

--- a/notifications/hub_test.go
+++ b/notifications/hub_test.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notifications
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type HubSuite struct {
+	h *Hub
+}
+
+var _ = Suite(&HubSuite{})
+
+func (s *HubSuite) SetUpTest(c *C) {
+	s.h = NewHub()
+	c.Assert(s.h.subscribers, HasLen, 0)
+}
+
+func (s *HubSuite) TestSubscribe(c *C) {
+	sub := &Subscriber{uuid: "sub"}
+
+	s.h.Subscribe(sub)
+	c.Assert(s.h.subscribers, DeepEquals, Subscribers{"sub": sub})
+
+	// can only subscribe once
+	s.h.Subscribe(sub)
+	c.Assert(s.h.subscribers, DeepEquals, Subscribers{"sub": sub})
+}
+
+func (s *HubSuite) TestUnsubscribe(c *C) {
+	sub1 := &Subscriber{uuid: "sub1"}
+	sub2 := &Subscriber{uuid: "sub2"}
+	s.h.subscribers = Subscribers{"sub1": sub1, "sub2": sub2}
+
+	s.h.Unsubscribe(sub1)
+	c.Assert(s.h.subscribers, DeepEquals, Subscribers{"sub2": sub2})
+}

--- a/notifications/notification.go
+++ b/notifications/notification.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notifications
+
+// A Notification is an event a subscriber is interested in knowing about.
+type Notification struct {
+	Timestamp int64                  `json:"timestamp"`
+	Type      string                 `json:"type"`
+	Resource  string                 `json:"resource"`
+	Metadata  map[string]interface{} `json:"metadata"`
+}

--- a/notifications/subscriber.go
+++ b/notifications/subscriber.go
@@ -19,10 +19,32 @@
 
 package notifications
 
+import (
+	"encoding/json"
+
+	"github.com/gorilla/websocket"
+)
+
 // A Subscriber is interested in receiving notifications
 type Subscriber struct {
 	uuid string
+	conn messageWriter
 }
 
 // Subscribers is a collection of subscribers
 type Subscribers map[string]*Subscriber
+
+type messageWriter interface {
+	WriteMessage(messageType int, data []byte) error
+}
+
+// Notify receives a notification which is then encoded as JSON and written to
+// the websocket.
+func (s *Subscriber) Notify(n *Notification) {
+	b, err := json.Marshal(n)
+	if err != nil {
+		return
+	}
+
+	s.conn.WriteMessage(websocket.TextMessage, b)
+}

--- a/notifications/subscriber.go
+++ b/notifications/subscriber.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notifications
+
+// A Subscriber is interested in receiving notifications
+type Subscriber struct {
+	uuid string
+}
+
+// Subscribers is a collection of subscribers
+type Subscribers map[string]*Subscriber

--- a/notifications/subscriber.go
+++ b/notifications/subscriber.go
@@ -40,11 +40,11 @@ type messageWriter interface {
 
 // Notify receives a notification which is then encoded as JSON and written to
 // the websocket.
-func (s *Subscriber) Notify(n *Notification) {
+func (s *Subscriber) Notify(n *Notification) error {
 	b, err := json.Marshal(n)
 	if err != nil {
-		return
+		return err
 	}
 
-	s.conn.WriteMessage(websocket.TextMessage, b)
+	return s.conn.WriteMessage(websocket.TextMessage, b)
 }


### PR DESCRIPTION
Notifications are described in the [Snappy over REST documentation](https://docs.google.com/document/d/1VqrEK3V_7jYMICy09tOVSaATb5KWu6Vs3CbDu9Nh1cQ/edit#heading=h.d10cqykq8uh0) and the intention is for them to be delivered to interested clients over websockets.

This PR introduces a `Hub` which handles subscribes, unsubscribes and publishing of notifications to subscribers. These subscribers are unregistered whenever they fail to process a notification and they have the option of only receiving certain types of notifications or those relating to a specific resource, i.e. a background operation.

The only thing actually related to websockets here is the appearance of `WriteMessage` in `Subscriber. Notify()` which is used to send a JSON representation of a notification to a websocket connection as provided by the [Gorilla websocket library](https://github.com/gorilla/websocket/), the rest is the plumbing that allows the connections to be managed and relevant notifications conveyed to them.

Next steps from here would be:

* add a `Hub` into `Daemon`
* create new subscribers when websocket connections are opened
* decide where notifications are going to originate from and what they'll contain
* add support for this into the client library
