### PR TITLE
daemon: support config snippets

### DIFF
--- a/cmd/snappy/cmd_config.go
+++ b/cmd/snappy/cmd_config.go
@@ -72,7 +72,7 @@ func (x *cmdConfig) Execute(args []string) (err error) {
 	}
 
 	// output the new configuration
-	fmt.Println(newConfig)
+	os.Stdout.Write(newConfig)
 
 	return nil
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -529,7 +529,7 @@ func snapService(c *Command, r *http.Request) Response {
 
 type configurator interface {
 	Configure(*snappy.SnapPart, []byte) ([]byte, error)
-	ConfigureFromSnippet(*snappy.SnapPart, []string, string) (string, error)
+	ConfigureFromSnippet(*snappy.SnapPart, []string, string) (interface{}, error)
 }
 
 var getConfigurator = func() configurator {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -33,7 +34,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"fmt"
 	"github.com/ubuntu-core/snappy/asserts"
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/lockfile"

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -788,7 +788,7 @@ func (o *fakeOverlord) Configure(s *snappy.SnapPart, c []byte) ([]byte, error) {
 	return []byte(config), nil
 }
 
-func (o *fakeOverlord) ConfigureFromSnippet(s *snappy.SnapPart, p []string, v string) (string, error) {
+func (o *fakeOverlord) ConfigureFromSnippet(s *snappy.SnapPart, p []string, v string) (interface{}, error) {
 	k := strings.Join(p, ".")
 	if v != "" {
 		o.snips[s.Name()] = map[string]string{k: v}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -63,6 +63,7 @@ type Command struct {
 	PUT    ResponseFunc
 	POST   ResponseFunc
 	DELETE ResponseFunc
+	PATCH  ResponseFunc
 	// can guest GET?
 	GuestOK bool
 	// can non-admin GET?
@@ -115,6 +116,8 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rspf = c.POST
 	case "DELETE":
 		rspf = c.DELETE
+	case "PATCH":
+		rspf = c.PATCH
 	}
 
 	if rspf != nil {

--- a/snappy/config.go
+++ b/snappy/config.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/ubuntu-core/snappy/coreconfig"
 )
@@ -83,18 +82,6 @@ func runConfigScriptImpl(configScript, appArmorProfile string, rawConfig []byte,
 	}
 
 	return output, nil
-}
-
-// snippet2path extracts the path, whether it's a setter (i.e. it has
-// =<value>) and, if it's a setter, the value.
-func snippet2path(snippet string) (path []string, isSet bool, value string) {
-	eqIdx := strings.IndexByte(snippet, '=')
-	if eqIdx >= 0 {
-		value = snippet[eqIdx+1:]
-		snippet = snippet[:eqIdx]
-	}
-
-	return strings.Split(snippet, "."), eqIdx >= 0, value
 }
 
 // snip2yaml turns the snippet path and value (as from snippet2path)

--- a/snappy/config.go
+++ b/snappy/config.go
@@ -84,7 +84,7 @@ func runConfigScriptImpl(configScript, appArmorProfile string, rawConfig []byte,
 	return output, nil
 }
 
-// snip2yaml turns the snippet path and value (as from snippet2path)
+// snip2yaml turns the snippet path and value
 // into the yaml expected by config for the named package
 func snip2yaml(name string, path []string, value string) []byte {
 	var buf bytes.Buffer

--- a/snappy/config_test.go
+++ b/snappy/config_test.go
@@ -180,36 +180,39 @@ config:
   hello-app:
     foo:
       bar:
-        42
+        hello
 `)
 	bs, err := ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "")
 	c.Assert(err, IsNil)
 	c.Check(ins, DeepEquals, []string{""})
-	c.Check(bs, Equals, "42")
+	c.Check(bs, Equals, "hello")
 
 	bs, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "8")
 	c.Assert(err, IsNil)
 	c.Check(ins, DeepEquals, []string{"", "config: {hello-app: {foo: {bar: 8}}}"})
-	c.Check(bs, Equals, "42")
+	c.Check(bs, Equals, "hello")
 
 	errOut = fmt.Errorf("hi")
-	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "hello")
 	c.Check(err, Equals, errOut)
 
 	errOut = nil
 	out = []byte(`hello`)
-	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "hello")
 	c.Check(err, ErrorMatches, `configuration succeeded but can't unmarshal result: (?m).*`)
 
-	out = []byte(`foo: {bar: 42}`)
-	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
+	out = []byte(`foo: {bar: hello}`)
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "hello")
 	c.Check(err, ErrorMatches, `configuration succeeded but returned unexpected value: (?m).*`)
 
-	out = []byte(`config: {hello-app: {foo: 42}}`)
-	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
-	c.Check(err, ErrorMatches, `configuration succeeded but got unexpected value in which to look for "bar": 42`)
+	out = []byte(`config: {hello-app: {foo: hello}}`)
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "hello")
+	c.Check(err, ErrorMatches, `configuration succeeded but got unexpected value in which to look for "bar": hello`)
 
 	out = []byte(`config: {hello-app: {foo: {a: b}}}`)
-	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "hello")
 	c.Check(err, ErrorMatches, `configuration succeeded but result has no entry "bar"`)
+
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo"}, "hello")
+	c.Check(err, ErrorMatches, `configuration succeeded but value at \["foo"\] is not a simple value.*`)
 }

--- a/snappy/config_test.go
+++ b/snappy/config_test.go
@@ -156,20 +156,6 @@ func (s *SnapTestSuite) TestSnip2Yaml(c *C) {
 	c.Check(string(bs), Equals, "config: {hello-world: {foo: {bar: 42}}}")
 }
 
-func (s *SnapTestSuite) TestSnippet2PathSet(c *C) {
-	path, isSet, value := snippet2path("foo.bar.baz=42")
-	c.Check(path, DeepEquals, []string{"foo", "bar", "baz"})
-	c.Check(isSet, Equals, true)
-	c.Check(value, Equals, "42")
-}
-
-func (s *SnapTestSuite) TestSnippet2PathGet(c *C) {
-	path, isSet, value := snippet2path("foo.bar.baz")
-	c.Check(path, DeepEquals, []string{"foo", "bar", "baz"})
-	c.Check(isSet, Equals, false)
-	c.Check(value, Equals, "")
-}
-
 func (s *SnapTestSuite) TestConfigSnippetGetIntegration(c *C) {
 	ins := []string{}
 	out := []byte{}
@@ -196,34 +182,34 @@ config:
       bar:
         42
 `)
-	bs, err := ov.ConfigureFromSnippet(snap, "foo.bar")
+	bs, err := ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "")
 	c.Assert(err, IsNil)
 	c.Check(ins, DeepEquals, []string{""})
 	c.Check(bs, Equals, "42")
 
-	bs, err = ov.ConfigureFromSnippet(snap, "foo.bar=8")
+	bs, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "8")
 	c.Assert(err, IsNil)
 	c.Check(ins, DeepEquals, []string{"", "config: {hello-app: {foo: {bar: 8}}}"})
 	c.Check(bs, Equals, "42")
 
 	errOut = fmt.Errorf("hi")
-	_, err = ov.ConfigureFromSnippet(snap, "foo.bar=42")
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
 	c.Check(err, Equals, errOut)
 
 	errOut = nil
 	out = []byte(`hello`)
-	_, err = ov.ConfigureFromSnippet(snap, "foo.bar=42")
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
 	c.Check(err, ErrorMatches, `configuration succeeded but can't unmarshal result: (?m).*`)
 
 	out = []byte(`foo: {bar: 42}`)
-	_, err = ov.ConfigureFromSnippet(snap, "foo.bar=42")
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
 	c.Check(err, ErrorMatches, `configuration succeeded but returned unexpected value: (?m).*`)
 
 	out = []byte(`config: {hello-app: {foo: 42}}`)
-	_, err = ov.ConfigureFromSnippet(snap, "foo.bar=42")
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
 	c.Check(err, ErrorMatches, `configuration succeeded but got unexpected value in which to look for "bar": 42`)
 
 	out = []byte(`config: {hello-app: {foo: {a: b}}}`)
-	_, err = ov.ConfigureFromSnippet(snap, "foo.bar=42")
+	_, err = ov.ConfigureFromSnippet(snap, []string{"foo", "bar"}, "42")
 	c.Check(err, ErrorMatches, `configuration succeeded but result has no entry "bar"`)
 }

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -345,8 +345,9 @@ func (o *Overlord) SetActive(s *SnapPart, active bool, meter progress.Meter) err
 	return s.deactivate(false, meter)
 }
 
-// ConfigureFromSnippet turns snippet into a snap configuration
-// and calls Configure on the result.
+// ConfigureFromSnippet turns a snippet (e.g. foo.bar.baz=quux, parsed
+// into separate path array and value) into a snap configuration and
+// calls Configure on the result.
 func (o *Overlord) ConfigureFromSnippet(s *SnapPart, path []string, value string) (interface{}, error) {
 	var bs []byte
 	name := s.Name()
@@ -370,7 +371,7 @@ func (o *Overlord) ConfigureFromSnippet(s *SnapPart, path []string, value string
 	v, ok := m["config"][name]
 	if !ok {
 		// is this an error?
-		// config succeeded but returned the wrong lind of thing...
+		// config succeeded but returned the wrong kind of thing...
 		return "", fmt.Errorf("%sreturned unexpected value: %v", msgprefix, m)
 	}
 

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -346,11 +346,10 @@ func (o *Overlord) SetActive(s *SnapPart, active bool, meter progress.Meter) err
 
 // ConfigureFromSnippet turns snippet into a snap configuration
 // and calls Configure on the result.
-func (o *Overlord) ConfigureFromSnippet(s *SnapPart, snippet string) (string, error) {
+func (o *Overlord) ConfigureFromSnippet(s *SnapPart, path []string, value string) (string, error) {
 	var bs []byte
-	path, isSet, value := snippet2path(snippet)
 	name := s.Name()
-	if isSet {
+	if value != "" {
 		bs = snip2yaml(name, path, value)
 	}
 


### PR DESCRIPTION
For GET, via `.../config?snippet=<path>`; for setting use PATCH with a `{<path>: <value>}` JSON body.

For review, use [compare](https://github.com/chipaca/snappy/compare/snippet...chipaca:rest-snippet).