### PR TITLE
snappy: fix crash in snapd when there is no local repo

### DIFF
--- a/snappy/parts.go
+++ b/snappy/parts.go
@@ -105,7 +105,12 @@ type Part interface {
 
 // ActiveSnapsByType returns all installed snaps with the given type
 func ActiveSnapsByType(snapTs ...snap.Type) (res []Part, err error) {
-	installed, err := NewLocalSnapRepository().Installed()
+	repo := NewLocalSnapRepository()
+	if repo == nil {
+		return nil, fmt.Errorf("No local snap repository")
+	}
+
+	installed, err := repo.Installed()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add null pointer check in parts query to handle nil return from NewLocalSnapRepository.