### PR TITLE
snappy: never return nil in NewLocalSnapRepository()

### DIFF
--- a/snappy/snap_local_repo.go
+++ b/snappy/snap_local_repo.go
@@ -20,7 +20,6 @@
 package snappy
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/ubuntu-core/snappy/dirs"
@@ -39,11 +38,9 @@ type SnapLocalRepository struct {
 // NewLocalSnapRepository returns a new SnapLocalRepository for the given
 // path
 func NewLocalSnapRepository() *SnapLocalRepository {
-	path := dirs.SnapSnapsDir
-	if s, err := os.Stat(path); err != nil || !s.IsDir() {
-		return nil
+	return &SnapLocalRepository{
+		path: dirs.SnapSnapsDir,
 	}
-	return &SnapLocalRepository{path: path}
 }
 
 // Installed returns the installed snaps from this repository

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -171,10 +171,14 @@ frameworks:
 	c.Check(fmk, DeepEquals, []string{"one", "two"})
 }
 
-func (s *SnapTestSuite) TestLocalSnapRepositoryInvalid(c *C) {
+func (s *SnapTestSuite) TestLocalSnapRepositoryInvalidIsStillOk(c *C) {
 	dirs.SnapSnapsDir = "invalid-path"
 	snap := NewLocalSnapRepository()
-	c.Assert(snap, IsNil)
+	c.Assert(snap, NotNil)
+
+	installed, err := snap.Installed()
+	c.Assert(err, IsNil)
+	c.Assert(installed, HasLen, 0)
 }
 
 func (s *SnapTestSuite) TestLocalSnapRepositorySimple(c *C) {


### PR DESCRIPTION
If the directory is not (yet) there do not return nil and cause
potential crashes.