### PR TITLE
snappy: treat commands with 'daemon' field as services

### DIFF
--- a/snappy/service.go
+++ b/snappy/service.go
@@ -86,6 +86,9 @@ func FindServices(snapName string, serviceName string, pb progress.Meter) (Servi
 
 		yamls := snap.Apps()
 		for name, app := range yamls {
+			if app.Daemon == "" {
+				continue
+			}
 			if serviceName != "" && serviceName != name {
 				continue
 			}

--- a/snappy/service_test.go
+++ b/snappy/service_test.go
@@ -88,6 +88,8 @@ apps:
  svc1:
    command: bin/hello
    daemon: forking
+ non-svc2:
+   command: something
 `)
 	c.Assert(err, IsNil)
 	f, err := makeInstalledMockSnap(dirs.GlobalRootDir, `name: hello-app
@@ -96,6 +98,8 @@ apps:
  svc1:
    command: bin/hello
    daemon: forking
+ non-svc2:
+   command: something
 `)
 	c.Assert(err, IsNil)
 	c.Assert(makeSnapActive(f), IsNil)
@@ -232,4 +236,9 @@ func (s *ServiceActorSuite) TestFindServicesReportsErrors(c *C) {
 	c.Check(err, NotNil)
 	_, err = actor.Loglines()
 	c.Check(err, NotNil)
+}
+
+func (s *ServiceActorSuite) TestFindServicesIgnoresForegroundApps(c *C) {
+	_, err := FindServices("hello-app", "non-svc2", s.pb)
+	c.Check(err, Equals, ErrServiceNotFound)
 }


### PR DESCRIPTION
This branch fixes an issue where *every* command would be considered to be a service.
Instead, with _services_ being removed and replaced by background apps, only apps that
have the ``daemon`` field should be treated as old-style services.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>