### PR TITLE
cmd/snap: fix integration tests for the "cmd_asserts"

### DIFF
--- a/cmd/snap/cmd_asserts.go
+++ b/cmd/snap/cmd_asserts.go
@@ -30,7 +30,7 @@ import (
 type cmdAsserts struct {
 	AssertsOptions struct {
 		AssertTypeName string   `positional-arg-name:"<assertion type>" description:"assertion type name" required:"true"`
-		HeaderFilters  []string `positional-arg-name:"<header filters>" description:"header=value" required:"false"`
+		HeaderFilters  []string `positional-arg-name:"<header filters>" description:"header=value" required:"0"`
 	} `positional-args:"true" required:"true"`
 }
 


### PR DESCRIPTION
Either the new go-flags or the workaround in
https://github.com/ubuntu-core/snappy/pull/467 broke the integration
tests. The commandline parser does no longer considere "HeaderFilters"
optional and it errors if "snap asserts foo" is used. 

This branch fixes this. The semantic of "required" for slice is slightly different
now and it needs the number of arguments.