### PR TITLE
debian: do not create the snappypkg user, we don't need it anymore

### DIFF
--- a/debian/ubuntu-snappy-cli.postinst
+++ b/debian/ubuntu-snappy-cli.postinst
@@ -2,19 +2,4 @@
 
 set -e
 
-# TODO: we do not need this user anymore
-SNAPPYUSER=snappypkg
-if [ "$(lsb_release -c -s)" = "vivid" ]; then
-    SNAPPYUSER=clickpkg
-fi
-
-if [ "$1" = configure ]; then
-    adduser --system \
-        --disabled-password \
-        --home /nonexistent \
-        --no-create-home \
-        --group \
-        $SNAPPYUSER
-fi
-
 #DEBHELPER#


### PR DESCRIPTION
Trivial branch that removes the creation of the snappypkg user. We don't need this user anymore with the squashfs snaps.