### PR TITLE
classic: cleanup downloaded lxd tarball

### DIFF
--- a/classic/create.go
+++ b/classic/create.go
@@ -280,6 +280,7 @@ func Create(pbar progress.Meter) (err error) {
 	if err != nil {
 		return err
 	}
+	defer os.Remove(lxdRootfsTar)
 
 	if err := unpackLxdRootfs(lxdRootfsTar); err != nil {
 		return err

--- a/classic/create_test.go
+++ b/classic/create_test.go
@@ -165,6 +165,9 @@ func (t *CreateTestSuite) TestCreate(c *C) {
 	for _, canary := range []string{"/etc/nsswitch.conf", "/etc/hosts", "/usr/sbin/policy-rc.d"} {
 		c.Assert(helpers.FileExists(filepath.Join(dirs.ClassicDir, canary)), Equals, true)
 	}
+	leftovers, err := filepath.Glob(filepath.Join(os.TempDir(), "classic*"))
+	c.Assert(err, IsNil)
+	c.Assert(leftovers, HasLen, 0)
 }
 
 func (t *CreateTestSuite) TestCreateFailDestroys(c *C) {


### PR DESCRIPTION
Fix missing cleanup of the downloaded lxd tarball when creating
the classic environment.

Thanks: Leo Arias