### PR TITLE
oauth: fix oauth & quoting in the oauth_signature

### DIFF
--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -75,6 +75,6 @@ func MakePlaintextSignature(token *Token) string {
 	nonce := helpers.MakeRandomString(60)
 	timestamp := time.Now().Unix()
 
-	s := fmt.Sprintf(`OAuth oauth_nonce="%s", oauth_timestamp="%v", oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="%s", oauth_token="%s", oauth_signature="%s&%s"`, nonce, timestamp, quote(token.ConsumerKey), quote(token.TokenKey), quote(token.ConsumerSecret), quote(token.TokenSecret))
+	s := fmt.Sprintf(`OAuth oauth_nonce="%s", oauth_timestamp="%v", oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="%s", oauth_token="%s", oauth_signature="%s%%26%s"`, nonce, timestamp, quote(token.ConsumerKey), quote(token.TokenKey), quote(token.ConsumerSecret), quote(token.TokenSecret))
 	return s
 }

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -39,7 +39,7 @@ func (s *OAuthTestSuite) TestMakePlaintextSignature(c *C) {
 		TokenSecret:    "token-secret+",
 	}
 	sig := MakePlaintextSignature(&mockToken)
-	c.Assert(sig, Matches, `OAuth oauth_nonce="[a-zA-Z]+", oauth_timestamp="[0-9]+", oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="consumer-key%2B", oauth_token="token-key%2B", oauth_signature="consumer-secret%2B&token-secret%2B"`)
+	c.Assert(sig, Matches, `OAuth oauth_nonce="[a-zA-Z]+", oauth_timestamp="[0-9]+", oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="consumer-key%2B", oauth_token="token-key%2B", oauth_signature="consumer-secret%2B%26token-secret%2B"`)
 }
 
 func (s *OAuthTestSuite) TestQuote(c *C) {


### PR DESCRIPTION
The http://oauth.net/core/1.0a/#anchor21 spec says that the '&'
separator must be encoded again.