### PR TITLE
docs: add docs for arm64 cross building

### DIFF
--- a/docs/cross-build.md
+++ b/docs/cross-build.md
@@ -1,3 +1,5 @@
+= armhf =
+
 To cross build for arm you need to install:
 
     sudo apt-get install golang-go-linux-arm
@@ -16,3 +18,18 @@ As usual, for one-off commands you can simply prepend the environment
 to the command, e.g.
 
     GOARCH=arm GOARM=7 CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc go build -o snappy_armhf github.com/ubuntu-core/snappy/cmd/snappy
+
+
+= arm64 =
+
+Install:
+
+    sudo apt-get install gcc-aarch64-linux-gnu
+
+Setup the environment:
+
+    export GOARCH=arm64 CC=aarch64-linux-gnu-gcc CGO_ENABLED=1
+
+And then run:
+
+    go build -o snappy_arm64 github.com/ubuntu-core/snappy/cmd/snappy


### PR DESCRIPTION
Tiny branch that adds instructions how to cross build for arm64