### PR TITLE
Remove model's authority-id == brand-id restriction.

### DIFF
--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -20,7 +20,6 @@
 package asserts
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -33,7 +32,7 @@ type Model struct {
 	timestamp     time.Time
 }
 
-// BrandID returns the brand identifier. Same as the authority id.
+// BrandID returns the brand identifier.
 func (mod *Model) BrandID() string {
 	return mod.Header("brand-id")
 }
@@ -106,10 +105,6 @@ var _ consistencyChecker = (*Model)(nil)
 var modelMandatory = []string{"os", "architecture", "gadget", "kernel", "store", "class"}
 
 func assembleModel(assert assertionBase) (Assertion, error) {
-	if assert.headers["brand-id"] != assert.headers["authority-id"] {
-		return nil, fmt.Errorf("authority-id and brand-id must match, model assertions are expected to be signed by the brand: %q != %q", assert.headers["authority-id"], assert.headers["brand-id"])
-	}
-
 	for _, mandatory := range modelMandatory {
 		if _, err := checkMandatory(assert.headers, mandatory); err != nil {
 			return nil, err

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -103,7 +103,6 @@ func (mods *modelSuite) TestDecodeInvalid(c *C) {
 	encoded := strings.Replace(modelExample, "TSLINE", mods.tsLine, 1)
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
-		{"brand-id: brand-id1\n", "brand-id: random\n", `authority-id and brand-id must match, model assertions are expected to be signed by the brand: "brand-id1" != "random"`},
 		{"required-snaps: foo, bar\n", "required-snaps: foo,\n", `empty entry in comma separated "required-snaps" header: "foo,"`},
 		{"allowed-modes: \n", "allowed-modes: ,\n", `empty entry in comma separated "allowed-modes" header: ","`},
 		{mods.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},


### PR DESCRIPTION
WARNING: probably a temporary change

Removing the restriction means that a trusted authority, e.g. Canonical,
can sign a brand's model assertion. (Devices must still verify that the
`model` assertion is signed by a trusted authority, as they must do if
it signed by the brand's key.)

It's quite likely this will be reverted in favour of a formal "signed on
behalf of" solution.

Also note that the model shouldn't actually have an `authority-id`
header field anyway.