### PR TITLE
daemon: move UUID into its own package

### DIFF
--- a/daemon/task.go
+++ b/daemon/task.go
@@ -24,11 +24,13 @@ import (
 
 	"github.com/gorilla/mux"
 	"gopkg.in/tomb.v2"
+
+	"github.com/ubuntu-core/snappy/uuid"
 )
 
 // A Task encapsulates an asynchronous operation.
 type Task struct {
-	id     UUID
+	id     uuid.UUID
 	tomb   tomb.Tomb
 	t0     time.Time
 	tf     time.Time
@@ -115,7 +117,7 @@ func (t *Task) Map(route *mux.Route) map[string]interface{} {
 
 // RunTask creates a Task for the given function and runs it.
 func RunTask(f func() interface{}) *Task {
-	id := UUID4()
+	id := uuid.UUID4()
 	t0 := time.Now()
 	t := &Task{
 		id: id,

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package uuid
 
 import (
 	"fmt"

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package uuid
 
 import (
 	"gopkg.in/check.v1"


### PR DESCRIPTION
I need to do some UUID generation but the current package layout causes a circular dependency so move this into it's own package.