### PR TITLE
fix missing go -> ubuntu mapping for powerpc

### DIFF
--- a/arch/arch.go
+++ b/arch/arch.go
@@ -61,6 +61,7 @@ func ubuntuArchFromGoArch(goarch string) string {
 		"arm64":   "arm64",
 		"ppc64le": "ppc64el",
 		"s390x":   "s390x",
+		"ppc":     "powerpc",
 	}
 
 	ubuntuArch := goArchMapping[goarch]


### PR DESCRIPTION
Trivial branch that should fix a FTBFS on powerpc (now that power has a gccgo-6 based syscall.SetsockoptUcred this seems to be the remaining blocker).