### PR TITLE
daemon: snapd API events endpoint

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -62,6 +62,7 @@ var api = []*Command{
 	skillsCmd,
 	assertsCmd,
 	assertsFindManyCmd,
+	eventsCmd,
 }
 
 var (
@@ -145,6 +146,11 @@ var (
 		Path:   "/2.0/assertions/{assertType}",
 		UserOK: true,
 		GET:    assertsFindMany,
+	}
+
+	eventsCmd = &Command{
+		Path: "/2.0/events",
+		GET:  getEvents,
 	}
 )
 
@@ -1063,4 +1069,8 @@ func assertsFindMany(c *Command, r *http.Request) Response {
 		return InternalError("searching assertions failed: %v", err)
 	}
 	return AssertResponse(assertions, true)
+}
+
+func getEvents(c *Command, r *http.Request) Response {
+	return EventResponse(c.d.hub)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2310,3 +2310,27 @@ func (s *apiSuite) TestAssertsInvalidType(c *check.C) {
 	c.Check(rec.Code, check.Equals, 400)
 	c.Check(rec.Body.String(), testutil.Contains, "invalid assert type")
 }
+
+func (s *apiSuite) TestGetEvents(c *check.C) {
+	d := newTestDaemon()
+	eventsCmd.d = d
+	c.Assert(d.hub.SubscriberCount(), check.Equals, 0)
+
+	ts := httptest.NewServer(http.HandlerFunc(eventsCmd.GET(eventsCmd, nil).ServeHTTP))
+	defer ts.Close()
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	c.Assert(err, check.IsNil)
+	req.Header.Add("Upgrade", "websocket")
+	req.Header.Add("Connection", "Upgrade")
+	req.Header.Add("Sec-WebSocket-Key", "xxx")
+	req.Header.Add("Sec-WebSocket-Version", "13")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	c.Assert(err, check.IsNil)
+	// upgrades request
+	c.Assert(resp.Header["Upgrade"], check.DeepEquals, []string{"websocket"})
+	// adds subscriber
+	c.Assert(d.hub.SubscriberCount(), check.Equals, 1)
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/notifications"
 	"github.com/ubuntu-core/snappy/skills"
 	"github.com/ubuntu-core/snappy/skills/types"
 )
@@ -49,6 +50,7 @@ type Daemon struct {
 	router       *mux.Router
 	asserts      *asserts.Database
 	skills       *skills.Repository
+	hub          *notifications.Hub
 	// enableInternalSkillActions controls if adding and removing skills and slots is allowed.
 	enableInternalSkillActions bool
 }
@@ -270,6 +272,7 @@ func New() *Daemon {
 	return &Daemon{
 		tasks:   make(map[string]*Task),
 		asserts: db,
+		hub:     notifications.NewHub(),
 		skills:  skillRepo,
 		// TODO: Decide when this should be disabled by default.
 		enableInternalSkillActions: true,

--- a/daemon/task.go
+++ b/daemon/task.go
@@ -24,11 +24,13 @@ import (
 
 	"github.com/gorilla/mux"
 	"gopkg.in/tomb.v2"
+
+	"github.com/ubuntu-core/snappy/uuid"
 )
 
 // A Task encapsulates an asynchronous operation.
 type Task struct {
-	id     UUID
+	id     uuid.UUID
 	tomb   tomb.Tomb
 	t0     time.Time
 	tf     time.Time
@@ -115,7 +117,7 @@ func (t *Task) Map(route *mux.Route) map[string]interface{} {
 
 // RunTask creates a Task for the given function and runs it.
 func RunTask(f func() interface{}) *Task {
-	id := UUID4()
+	id := uuid.UUID4()
 	t0 := time.Now()
 	t := &Task{
 		id: id,

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -656,3 +656,25 @@ Sample input:
     “slot”:   {“snap”: “keyboard-lights”, “name”: “capslock-led”}
 }
 ```
+
+## /2.0/events
+
+### GET
+
+* Description: Websocket upgrade
+* Access: trusted
+* Operation: sync
+* Return: nothing (never ending flow of events)
+
+### Parameters
+
+The default is for all notifications to be received but the following filters
+are supported:
+
+#### types
+
+Comma separated list of notification types, either `logging` or `operations`.
+
+#### resource
+
+Generally the UUID of a background operation you are interested in.

--- a/notifications/hub.go
+++ b/notifications/hub.go
@@ -55,6 +55,7 @@ func (h *Hub) Unsubscribe(s *Subscriber) {
 }
 
 func (h *Hub) doUnsubscribe(s *Subscriber) {
+	s.conn.Close()
 	delete(h.subscribers, s.uuid)
 }
 

--- a/notifications/hub.go
+++ b/notifications/hub.go
@@ -36,6 +36,11 @@ func NewHub() *Hub {
 	}
 }
 
+// SubscriberCount returns the number of subscribers
+func (h *Hub) SubscriberCount() int {
+	return len(h.subscribers)
+}
+
 // Subscribe registers a subscriber to receive notifications.
 func (h *Hub) Subscribe(s *Subscriber) {
 	h.Lock()

--- a/notifications/hub_test.go
+++ b/notifications/hub_test.go
@@ -91,7 +91,7 @@ func (s *HubSuite) TestPublishFilteredNotifications(c *C) {
 	conn1 := &fakeConn{}
 	conn2 := &fakeConn{}
 	sub1 := &Subscriber{uuid: "sub1", types: []string{"logging"}, conn: conn1}
-	sub2 := &Subscriber{uuid: "sub2", resource: "/2.0/operations/23", conn: conn2}
+	sub2 := &Subscriber{uuid: "sub2", resource: "23", conn: conn2}
 	s.h.Subscribe(sub1)
 	s.h.Subscribe(sub2)
 

--- a/notifications/hub_test.go
+++ b/notifications/hub_test.go
@@ -47,7 +47,7 @@ func (c *fakeConn) WriteMessage(messageType int, data []byte) error {
 	return c.err
 }
 
-var _ messageWriter = &fakeConn{}
+var _ websocketConnection = &fakeConn{}
 
 func (s *HubSuite) SetUpTest(c *C) {
 	s.h = NewHub()

--- a/notifications/hub_test.go
+++ b/notifications/hub_test.go
@@ -57,7 +57,7 @@ var _ websocketConnection = &fakeConn{}
 
 func (s *HubSuite) SetUpTest(c *C) {
 	s.h = NewHub()
-	c.Assert(s.h.subscribers, HasLen, 0)
+	c.Assert(s.h.SubscriberCount(), Equals, 0)
 }
 
 func (s *HubSuite) TestSubscribe(c *C) {

--- a/notifications/subscriber.go
+++ b/notifications/subscriber.go
@@ -42,6 +42,7 @@ type Subscribers map[string]*Subscriber
 
 type websocketConnection interface {
 	WriteMessage(messageType int, data []byte) error
+	Close() error
 }
 
 // NewSubscriber returns a new subscriber containing the given websocket

--- a/notifications/subscriber.go
+++ b/notifications/subscriber.go
@@ -81,7 +81,8 @@ func (s *Subscriber) Notify(n *Notification) error {
 
 func (s *Subscriber) canAccept(n *Notification) bool {
 	if s.resource != "" {
-		return s.resource == n.Resource
+		// notification has full resource path while we have the uuid portion
+		return strings.HasSuffix(n.Resource, s.resource)
 	}
 
 	if len(s.types) > 0 {

--- a/notifications/subscriber.go
+++ b/notifications/subscriber.go
@@ -28,7 +28,7 @@ import (
 // A Subscriber is interested in receiving notifications
 type Subscriber struct {
 	uuid     string
-	conn     messageWriter
+	conn     websocketConnection
 	types    []string
 	resource string
 }
@@ -36,7 +36,7 @@ type Subscriber struct {
 // Subscribers is a collection of subscribers
 type Subscribers map[string]*Subscriber
 
-type messageWriter interface {
+type websocketConnection interface {
 	WriteMessage(messageType int, data []byte) error
 }
 

--- a/notifications/subscriber.go
+++ b/notifications/subscriber.go
@@ -21,8 +21,12 @@ package notifications
 
 import (
 	"encoding/json"
+	"net/http"
+	"strings"
 
 	"github.com/gorilla/websocket"
+
+	"github.com/ubuntu-core/snappy/uuid"
 )
 
 // A Subscriber is interested in receiving notifications
@@ -38,6 +42,26 @@ type Subscribers map[string]*Subscriber
 
 type websocketConnection interface {
 	WriteMessage(messageType int, data []byte) error
+}
+
+// NewSubscriber returns a new subscriber containing the given websocket
+// connection and type/resource filters set from the query string params in the
+// supplied http request
+func NewSubscriber(c websocketConnection, r *http.Request) *Subscriber {
+	s := &Subscriber{
+		uuid: uuid.UUID4().String(),
+		conn: c,
+	}
+
+	q := r.URL.Query()
+	if len(q["types"]) > 0 {
+		s.types = strings.Split(q["types"][0], ",")
+	}
+	if len(q["resource"]) > 0 {
+		s.resource = q["resource"][0]
+	}
+
+	return s
 }
 
 // Notify receives a notification and if the subscriber is interested in it it

--- a/notifications/subscriber_test.go
+++ b/notifications/subscriber_test.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package notifications
+
+import (
+	"net/http"
+
+	. "gopkg.in/check.v1"
+)
+
+type SubscriberSuite struct{}
+
+var _ = Suite(&SubscriberSuite{})
+
+func (s *SubscriberSuite) TestNewSubscriber(c *C) {
+	tests := []struct {
+		path     string
+		types    []string
+		resource string
+	}{
+		{"/events", []string(nil), ""},
+		{"/events?types=logging", []string{"logging"}, ""},
+		{"/events?types=logging,operations", []string{"logging", "operations"}, ""},
+		{"/events?resource=123", []string(nil), "123"},
+		{"/events?types=logging&resource=123", []string{"logging"}, "123"},
+	}
+
+	for _, tt := range tests {
+		conn := &fakeConn{}
+		req, err := http.NewRequest("GET", tt.path, nil)
+		c.Assert(err, IsNil)
+
+		sub := NewSubscriber(conn, req)
+		c.Assert(sub.uuid, Not(Equals), "")
+		c.Assert(sub.conn, DeepEquals, conn)
+		c.Assert(sub.types, DeepEquals, tt.types)
+		c.Assert(sub.resource, DeepEquals, tt.resource)
+	}
+}

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package uuid
 
 import (
 	"fmt"

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package daemon
+package uuid
 
 import (
 	"gopkg.in/check.v1"


### PR DESCRIPTION
Contains cb01207ae27f139e0f3ba0d7973984fafb4af8f2 from #527 which will need to be rebased out.

This adds the `/2.0/events` endpoint to the `snapd` API. Requests to this will upgraded to a websocket connection and then subscribed to the notifications hub. The connection will be closed when the subscriber is removed.

Currently there isn't anything to generate events or consume them so there may well be some shortcomings but it's still reasonably self-contained enough to be landed.

Also, the test actually tests that a request upgrade is offered which is maybe overkill but was the rabbithole I initially went down.