### PR TITLE
exclude ppc from testutils tests, endless loop

### DIFF
--- a/testutil/checkers_test.go
+++ b/testutil/checkers_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !ppc
 
 /*
  * Copyright (C) 2015 Canonical Ltd

--- a/testutil/checkers_test.go
+++ b/testutil/checkers_test.go
@@ -1,4 +1,10 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// 20160229: The tests with gccgo on powerpc fails for this file
+//           and it will loop endlessly. This is not reproducable
+//           with gccgo on amd64. Given that its a relatively little
+//           used arch we disable the tests in here to workaround this
+//           gccgo bug.
 // +build !ppc
 
 /*


### PR DESCRIPTION
Workaround for a endless loop in the tests for powerpc. Fwiw, I did not manage to reproduce this on amd64 with gccgo-6 and only saw this on the buildds.