### PR TITLE
integration-tests: add the http proxy argument

### DIFF
--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -78,6 +78,7 @@ func main() {
 		outputDir     = flag.String("output-dir", defaultOutputDir, "Directory where test artifacts will be stored.")
 		shellOnFail   = flag.Bool("shell-fail", false, "Run a shell in the testbed if the suite fails.")
 		testBuildTags = flag.String("test-build-tags", "", "Build tags to be passed to the go test command")
+		httpProxy     = flag.String("http-proxy", "", "HTTP proxy to set in the testbed.")
 	)
 
 	flag.Parse()
@@ -114,6 +115,7 @@ func main() {
 		TestFilter:          *testFilter,
 		IntegrationTestName: build.IntegrationTestName,
 		ShellOnFail:         *shellOnFail,
+		Env:                 map[string]string{"http_proxy": *httpProxy, "https_proxy": *httpProxy},
 	}
 	if !remoteTestbed {
 		img := &image.Image{

--- a/integration-tests/testutils/autopkgtest/autopkgtest.go
+++ b/integration-tests/testutils/autopkgtest/autopkgtest.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -54,6 +54,8 @@ type AutoPkgTest struct {
 	IntegrationTestName string
 	// ShellOnFail is used in case of failure to open a shell on the testbed before shutting it down.
 	ShellOnFail bool
+	// Env is a map with the environment variables to set on the test bed and their values.adtrunCommonCmd
+	Env map[string]string
 }
 
 // AdtRunLocal starts a kvm running the image passed as argument and runs the
@@ -79,10 +81,14 @@ func (a *AutoPkgTest) adtRun(testbedOptions string) (err error) {
 
 	cmd := []string{
 		"adt-run", "-B",
-		"--setup-commands", "touch /run/autopkgtest_no_reboot.stamp",
 		"--override-control", controlFile,
 		"--built-tree", a.SourceCodePath,
-		"--output-dir", outputDir}
+		"--output-dir", outputDir,
+		"--setup-commands", "touch /run/autopkgtest_no_reboot.stamp"}
+	for envVar, value := range a.Env {
+		cmd = append(cmd, "--env")
+		cmd = append(cmd, fmt.Sprintf("%s=%s", envVar, value))
+	}
 	if a.ShellOnFail {
 		cmd = append(cmd, "--shell-fail")
 	}


### PR DESCRIPTION
We need to use an http proxy to run the tests in scalingstack.