### PR TITLE
client,deaemon,docs: rename skills to interfaces on the wire

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -26,10 +26,9 @@ import (
 
 // Plug represents a capacity offered by a snap.
 type Plug struct {
-	Name string `json:"name"`
-	Snap string `json:"snap"`
-	// NOTE: json format intentionally using old "skill" terminology
-	Interface string                 `json:"type,omitempty"`
+	Name      string                 `json:"name"`
+	Snap      string                 `json:"snap"`
+	Interface string                 `json:"interface,omitempty"`
 	Attrs     map[string]interface{} `json:"attrs,omitempty"`
 	Apps      []string               `json:"apps,omitempty"`
 	Label     string                 `json:"label,omitempty"`
@@ -37,10 +36,9 @@ type Plug struct {
 
 // Slot represents the potential of a given snap to connect to a given plug.
 type Slot struct {
-	Name string `json:"name"`
-	Snap string `json:"snap"`
-	// NOTE: json format intentionally using old "skill" terminology
-	Interface string                 `json:"type,omitempty"`
+	Name      string                 `json:"name"`
+	Snap      string                 `json:"snap"`
+	Interface string                 `json:"interface,omitempty"`
 	Attrs     map[string]interface{} `json:"attrs,omitempty"`
 	Apps      []string               `json:"apps,omitempty"`
 	Label     string                 `json:"label,omitempty"`
@@ -49,21 +47,19 @@ type Slot struct {
 // PlugConnections represents a single plug and slots that are connected to it.
 type PlugConnections struct {
 	Plug
-	// NOTE: json format intentionally using old "skill" terminology
-	Connections []Slot `json:"granted_to"`
+	Connections []Slot `json:"connections"`
 }
 
 // InterfaceAction represents an action performed on the interface system.
 type InterfaceAction struct {
 	Action string `json:"action"`
-	// NOTE: json format intentionally using old "skill" terminology
-	Plug *Plug `json:"skill,omitempty"`
-	Slot *Slot `json:"slot,omitempty"`
+	Plug   *Plug  `json:"plug,omitempty"`
+	Slot   *Slot  `json:"slot,omitempty"`
 }
 
 // AllPlugs returns information about all the plugs and their connections.
 func (client *Client) AllPlugs() (connections []PlugConnections, err error) {
-	err = client.doSync("GET", "/2.0/skills", nil, nil, &connections)
+	err = client.doSync("GET", "/2.0/interfaces", nil, nil, &connections)
 	return
 }
 
@@ -74,7 +70,7 @@ func (client *Client) performInterfaceAction(sa *InterfaceAction) error {
 		return err
 	}
 	var rsp interface{}
-	if err := client.doSync("POST", "/2.0/skills", nil, bytes.NewReader(b), &rsp); err != nil {
+	if err := client.doSync("POST", "/2.0/interfaces", nil, bytes.NewReader(b), &rsp); err != nil {
 		return err
 	}
 	return nil
@@ -84,7 +80,7 @@ func (client *Client) performInterfaceAction(sa *InterfaceAction) error {
 // The plug and the slot must have the same interface.
 func (client *Client) Connect(plugSnapName, plugName, slotSnapName, slotName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
-		Action: "grant",
+		Action: "connect",
 		Plug: &Plug{
 			Snap: plugSnapName,
 			Name: plugName,
@@ -99,7 +95,7 @@ func (client *Client) Connect(plugSnapName, plugName, slotSnapName, slotName str
 // Disconnect breaks the connection between a plug and a slot.
 func (client *Client) Disconnect(plugSnapName, plugName, slotSnapName, slotName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
-		Action: "revoke",
+		Action: "disconnect",
 		Plug: &Plug{
 			Snap: plugSnapName,
 			Name: plugName,
@@ -114,7 +110,7 @@ func (client *Client) Disconnect(plugSnapName, plugName, slotSnapName, slotName 
 // AddPlug adds a plug to the interface system.
 func (client *Client) AddPlug(plug *Plug) error {
 	return client.performInterfaceAction(&InterfaceAction{
-		Action: "add-skill",
+		Action: "add-plug",
 		Plug:   plug,
 	})
 }
@@ -122,7 +118,7 @@ func (client *Client) AddPlug(plug *Plug) error {
 // RemovePlug removes a plug from the interface system.
 func (client *Client) RemovePlug(snapName, plugName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
-		Action: "remove-skill",
+		Action: "remove-plug",
 		Plug: &Plug{
 			Snap: snapName,
 			Name: plugName,

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -26,7 +26,7 @@ import (
 
 // Plug represents a capacity offered by a snap.
 type Plug struct {
-	Name      string                 `json:"name"`
+	Name      string                 `json:"plug"`
 	Snap      string                 `json:"snap"`
 	Interface string                 `json:"interface,omitempty"`
 	Attrs     map[string]interface{} `json:"attrs,omitempty"`
@@ -36,7 +36,7 @@ type Plug struct {
 
 // Slot represents the potential of a given snap to connect to a given plug.
 type Slot struct {
-	Name      string                 `json:"name"`
+	Name      string                 `json:"slot"`
 	Snap      string                 `json:"snap"`
 	Interface string                 `json:"interface,omitempty"`
 	Attrs     map[string]interface{} `json:"attrs,omitempty"`

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -30,7 +30,7 @@ import (
 func (cs *clientSuite) TestClientAllPlugsCallsEndpoint(c *check.C) {
 	_, _ = cs.cli.AllPlugs()
 	c.Check(cs.req.Method, check.Equals, "GET")
-	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
 
 func (cs *clientSuite) TestClientAllPlugs(c *check.C) {
@@ -40,17 +40,17 @@ func (cs *clientSuite) TestClientAllPlugs(c *check.C) {
 			{
 				"snap": "canonical-pi2",
 				"name": "pin-13",
-				"type": "bool-file",
+				"interface": "bool-file",
 				"label": "Pin 13",
-				"granted_to": [
+				"connections": [
 					{"snap": "keyboard-lights", "name": "capslock-led"}
 				]
 			}
 		]
 	}`
-	skills, err := cs.cli.AllPlugs()
+	interfaces, err := cs.cli.AllPlugs()
 	c.Assert(err, check.IsNil)
-	c.Check(skills, check.DeepEquals, []client.PlugConnections{
+	c.Check(interfaces, check.DeepEquals, []client.PlugConnections{
 		{
 			Plug: client.Plug{
 				Snap:      "canonical-pi2",
@@ -69,9 +69,9 @@ func (cs *clientSuite) TestClientAllPlugs(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientConnectCallsEndpoint(c *check.C) {
-	_ = cs.cli.Connect("producer", "skill", "consumer", "slot")
+	_ = cs.cli.Connect("producer", "plug", "consumer", "slot")
 	c.Check(cs.req.Method, check.Equals, "POST")
-	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
 
 func (cs *clientSuite) TestClientConnect(c *check.C) {
@@ -79,17 +79,17 @@ func (cs *clientSuite) TestClientConnect(c *check.C) {
 		"type": "sync",
 		"result": { }
 	}`
-	err := cs.cli.Connect("producer", "skill", "consumer", "slot")
+	err := cs.cli.Connect("producer", "plug", "consumer", "slot")
 	c.Check(err, check.IsNil)
 	var body map[string]interface{}
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"action": "grant",
-		"skill": map[string]interface{}{
+		"action": "connect",
+		"plug": map[string]interface{}{
 			"snap": "producer",
-			"name": "skill",
+			"name": "plug",
 		},
 		"slot": map[string]interface{}{
 			"snap": "consumer",
@@ -99,9 +99,9 @@ func (cs *clientSuite) TestClientConnect(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientDisconnectCallsEndpoint(c *check.C) {
-	_ = cs.cli.Disconnect("producer", "skill", "consumer", "slot")
+	_ = cs.cli.Disconnect("producer", "plug", "consumer", "slot")
 	c.Check(cs.req.Method, check.Equals, "POST")
-	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
 
 func (cs *clientSuite) TestClientDisconnect(c *check.C) {
@@ -109,17 +109,17 @@ func (cs *clientSuite) TestClientDisconnect(c *check.C) {
 		"type": "sync",
 		"result": { }
 	}`
-	err := cs.cli.Disconnect("producer", "skill", "consumer", "slot")
+	err := cs.cli.Disconnect("producer", "plug", "consumer", "slot")
 	c.Check(err, check.IsNil)
 	var body map[string]interface{}
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"action": "revoke",
-		"skill": map[string]interface{}{
+		"action": "disconnect",
+		"plug": map[string]interface{}{
 			"snap": "producer",
-			"name": "skill",
+			"name": "plug",
 		},
 		"slot": map[string]interface{}{
 			"snap": "consumer",
@@ -131,7 +131,7 @@ func (cs *clientSuite) TestClientDisconnect(c *check.C) {
 func (cs *clientSuite) TestClientAddPlugCallsEndpoint(c *check.C) {
 	_ = cs.cli.AddPlug(&client.Plug{})
 	c.Check(cs.req.Method, check.Equals, "POST")
-	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
 
 func (cs *clientSuite) TestClientAddPlug(c *check.C) {
@@ -142,7 +142,7 @@ func (cs *clientSuite) TestClientAddPlug(c *check.C) {
 	err := cs.cli.AddPlug(&client.Plug{
 		Snap:      "snap",
 		Name:      "name",
-		Interface: "type",
+		Interface: "interface",
 		Attrs: map[string]interface{}{
 			"attr": "value",
 		},
@@ -155,11 +155,11 @@ func (cs *clientSuite) TestClientAddPlug(c *check.C) {
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"action": "add-skill",
-		"skill": map[string]interface{}{
-			"name": "name",
-			"snap": "snap",
-			"type": "type",
+		"action": "add-plug",
+		"plug": map[string]interface{}{
+			"name":      "name",
+			"snap":      "snap",
+			"interface": "interface",
 			"attrs": map[string]interface{}{
 				"attr": "value",
 			},
@@ -172,7 +172,7 @@ func (cs *clientSuite) TestClientAddPlug(c *check.C) {
 func (cs *clientSuite) TestClientRemovePlugCallsEndpoint(c *check.C) {
 	_ = cs.cli.RemovePlug("snap", "name")
 	c.Check(cs.req.Method, check.Equals, "POST")
-	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
 
 func (cs *clientSuite) TestClientRemovePlug(c *check.C) {
@@ -187,8 +187,8 @@ func (cs *clientSuite) TestClientRemovePlug(c *check.C) {
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"action": "remove-skill",
-		"skill": map[string]interface{}{
+		"action": "remove-plug",
+		"plug": map[string]interface{}{
 			"name": "name",
 			"snap": "snap",
 		},
@@ -198,7 +198,7 @@ func (cs *clientSuite) TestClientRemovePlug(c *check.C) {
 func (cs *clientSuite) TestClientAddSlotCallsEndpoint(c *check.C) {
 	_ = cs.cli.AddSlot(&client.Slot{})
 	c.Check(cs.req.Method, check.Equals, "POST")
-	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
 
 func (cs *clientSuite) TestClientAddSlot(c *check.C) {
@@ -209,7 +209,7 @@ func (cs *clientSuite) TestClientAddSlot(c *check.C) {
 	err := cs.cli.AddSlot(&client.Slot{
 		Snap:      "snap",
 		Name:      "name",
-		Interface: "type",
+		Interface: "interface",
 		Attrs: map[string]interface{}{
 			"attr": "value",
 		},
@@ -224,9 +224,9 @@ func (cs *clientSuite) TestClientAddSlot(c *check.C) {
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "add-slot",
 		"slot": map[string]interface{}{
-			"name": "name",
-			"snap": "snap",
-			"type": "type",
+			"name":      "name",
+			"snap":      "snap",
+			"interface": "interface",
 			"attrs": map[string]interface{}{
 				"attr": "value",
 			},
@@ -239,7 +239,7 @@ func (cs *clientSuite) TestClientAddSlot(c *check.C) {
 func (cs *clientSuite) TestClientRemoveSlotCallsEndpoint(c *check.C) {
 	_ = cs.cli.RemoveSlot("snap", "name")
 	c.Check(cs.req.Method, check.Equals, "POST")
-	c.Check(cs.req.URL.Path, check.Equals, "/2.0/skills")
+	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
 
 func (cs *clientSuite) TestClientRemoveSlot(c *check.C) {

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -39,11 +39,11 @@ func (cs *clientSuite) TestClientAllPlugs(c *check.C) {
 		"result": [
 			{
 				"snap": "canonical-pi2",
-				"name": "pin-13",
+				"plug": "pin-13",
 				"interface": "bool-file",
 				"label": "Pin 13",
 				"connections": [
-					{"snap": "keyboard-lights", "name": "capslock-led"}
+					{"snap": "keyboard-lights", "slot": "capslock-led"}
 				]
 			}
 		]
@@ -89,11 +89,11 @@ func (cs *clientSuite) TestClientConnect(c *check.C) {
 		"action": "connect",
 		"plug": map[string]interface{}{
 			"snap": "producer",
-			"name": "plug",
+			"plug": "plug",
 		},
 		"slot": map[string]interface{}{
 			"snap": "consumer",
-			"name": "slot",
+			"slot": "slot",
 		},
 	})
 }
@@ -119,11 +119,11 @@ func (cs *clientSuite) TestClientDisconnect(c *check.C) {
 		"action": "disconnect",
 		"plug": map[string]interface{}{
 			"snap": "producer",
-			"name": "plug",
+			"plug": "plug",
 		},
 		"slot": map[string]interface{}{
 			"snap": "consumer",
-			"name": "slot",
+			"slot": "slot",
 		},
 	})
 }
@@ -141,7 +141,7 @@ func (cs *clientSuite) TestClientAddPlug(c *check.C) {
 	}`
 	err := cs.cli.AddPlug(&client.Plug{
 		Snap:      "snap",
-		Name:      "name",
+		Name:      "plug",
 		Interface: "interface",
 		Attrs: map[string]interface{}{
 			"attr": "value",
@@ -157,7 +157,7 @@ func (cs *clientSuite) TestClientAddPlug(c *check.C) {
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "add-plug",
 		"plug": map[string]interface{}{
-			"name":      "name",
+			"plug":      "plug",
 			"snap":      "snap",
 			"interface": "interface",
 			"attrs": map[string]interface{}{
@@ -170,7 +170,7 @@ func (cs *clientSuite) TestClientAddPlug(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientRemovePlugCallsEndpoint(c *check.C) {
-	_ = cs.cli.RemovePlug("snap", "name")
+	_ = cs.cli.RemovePlug("snap", "plug")
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
@@ -180,7 +180,7 @@ func (cs *clientSuite) TestClientRemovePlug(c *check.C) {
 		"type": "sync",
 		"result": { }
 	}`
-	err := cs.cli.RemovePlug("snap", "name")
+	err := cs.cli.RemovePlug("snap", "plug")
 	c.Check(err, check.IsNil)
 	var body map[string]interface{}
 	decoder := json.NewDecoder(cs.req.Body)
@@ -189,7 +189,7 @@ func (cs *clientSuite) TestClientRemovePlug(c *check.C) {
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "remove-plug",
 		"plug": map[string]interface{}{
-			"name": "name",
+			"plug": "plug",
 			"snap": "snap",
 		},
 	})
@@ -208,7 +208,7 @@ func (cs *clientSuite) TestClientAddSlot(c *check.C) {
 	}`
 	err := cs.cli.AddSlot(&client.Slot{
 		Snap:      "snap",
-		Name:      "name",
+		Name:      "slot",
 		Interface: "interface",
 		Attrs: map[string]interface{}{
 			"attr": "value",
@@ -224,7 +224,7 @@ func (cs *clientSuite) TestClientAddSlot(c *check.C) {
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "add-slot",
 		"slot": map[string]interface{}{
-			"name":      "name",
+			"slot":      "slot",
 			"snap":      "snap",
 			"interface": "interface",
 			"attrs": map[string]interface{}{
@@ -237,7 +237,7 @@ func (cs *clientSuite) TestClientAddSlot(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientRemoveSlotCallsEndpoint(c *check.C) {
-	_ = cs.cli.RemoveSlot("snap", "name")
+	_ = cs.cli.RemoveSlot("snap", "slot")
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/2.0/interfaces")
 }
@@ -247,7 +247,7 @@ func (cs *clientSuite) TestClientRemoveSlot(c *check.C) {
 		"type": "sync",
 		"result": { }
 	}`
-	err := cs.cli.RemoveSlot("snap", "name")
+	err := cs.cli.RemoveSlot("snap", "slot")
 	c.Check(err, check.IsNil)
 	var body map[string]interface{}
 	decoder := json.NewDecoder(cs.req.Body)
@@ -256,7 +256,7 @@ func (cs *clientSuite) TestClientRemoveSlot(c *check.C) {
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "remove-slot",
 		"slot": map[string]interface{}{
-			"name": "name",
+			"slot": "slot",
 			"snap": "snap",
 		},
 	})

--- a/cmd/snap/cmd_add_plug_test.go
+++ b/cmd/snap/cmd_add_plug_test.go
@@ -58,18 +58,18 @@ Help Options:
 func (s *SnapSuite) TestAddInterfaceExplicitEverything(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "add-skill",
-			"skill": map[string]interface{}{
-				"snap": "producer",
-				"name": "plug",
-				"type": "interface",
+			"action": "add-plug",
+			"plug": map[string]interface{}{
+				"snap":      "producer",
+				"plug":      "plug",
+				"interface": "interface",
 				"attrs": map[string]interface{}{
 					"attr": "value",
 				},
 				"apps": []interface{}{
-					"meta/hooks/skill",
+					"meta/hooks/interface",
 				},
 				"label": "label",
 			},
@@ -78,7 +78,7 @@ func (s *SnapSuite) TestAddInterfaceExplicitEverything(c *C) {
 	})
 	rest, err := Parser().ParseArgs([]string{
 		"experimental", "add-plug", "producer", "plug", "interface",
-		"-a", "attr=value", "--app=meta/hooks/skill", "--label=label",
+		"-a", "attr=value", "--app=meta/hooks/interface", "--label=label",
 	})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})

--- a/cmd/snap/cmd_add_slot_test.go
+++ b/cmd/snap/cmd_add_slot_test.go
@@ -58,13 +58,13 @@ Help Options:
 func (s *SnapSuite) TestAddSlotExplicitEverything(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "add-slot",
 			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"name": "slot",
-				"type": "interface",
+				"snap":      "consumer",
+				"slot":      "slot",
+				"interface": "interface",
 				"attrs": map[string]interface{}{
 					"attr": "value",
 				},

--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -67,16 +67,16 @@ Help Options:
 func (s *SnapSuite) TestConnectExplicitEverything(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "grant",
-			"skill": map[string]interface{}{
+			"action": "connect",
+			"plug": map[string]interface{}{
 				"snap": "producer",
-				"name": "plug",
+				"plug": "plug",
 			},
 			"slot": map[string]interface{}{
 				"snap": "consumer",
-				"name": "slot",
+				"slot": "slot",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -89,16 +89,16 @@ func (s *SnapSuite) TestConnectExplicitEverything(c *C) {
 func (s *SnapSuite) TestConnectExplicitPlugImplicitSlot(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "grant",
-			"skill": map[string]interface{}{
+			"action": "connect",
+			"plug": map[string]interface{}{
 				"snap": "producer",
-				"name": "plug",
+				"plug": "plug",
 			},
 			"slot": map[string]interface{}{
 				"snap": "consumer",
-				"name": "",
+				"slot": "",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -111,16 +111,16 @@ func (s *SnapSuite) TestConnectExplicitPlugImplicitSlot(c *C) {
 func (s *SnapSuite) TestConnectImplicitPlugExplicitSlot(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "grant",
-			"skill": map[string]interface{}{
+			"action": "connect",
+			"plug": map[string]interface{}{
 				"snap": "",
-				"name": "plug",
+				"plug": "plug",
 			},
 			"slot": map[string]interface{}{
 				"snap": "consumer",
-				"name": "slot",
+				"slot": "slot",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -133,16 +133,16 @@ func (s *SnapSuite) TestConnectImplicitPlugExplicitSlot(c *C) {
 func (s *SnapSuite) TestConnectImplicitPlugImplicitSlot(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "grant",
-			"skill": map[string]interface{}{
+			"action": "connect",
+			"plug": map[string]interface{}{
 				"snap": "",
-				"name": "plug",
+				"plug": "plug",
 			},
 			"slot": map[string]interface{}{
 				"snap": "consumer",
-				"name": "",
+				"slot": "",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -62,16 +62,16 @@ Help Options:
 func (s *SnapSuite) TestDisconnectExplicitEverything(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "revoke",
-			"skill": map[string]interface{}{
+			"action": "disconnect",
+			"plug": map[string]interface{}{
 				"snap": "producer",
-				"name": "plug",
+				"plug": "plug",
 			},
 			"slot": map[string]interface{}{
 				"snap": "consumer",
-				"name": "slot",
+				"slot": "slot",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -86,16 +86,16 @@ func (s *SnapSuite) TestDisconnectExplicitEverything(c *C) {
 func (s *SnapSuite) TestDisconnectEverythingFromSpecificSlot(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "revoke",
-			"skill": map[string]interface{}{
+			"action": "disconnect",
+			"plug": map[string]interface{}{
 				"snap": "",
-				"name": "",
+				"plug": "",
 			},
 			"slot": map[string]interface{}{
 				"snap": "consumer",
-				"name": "slot",
+				"slot": "slot",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -110,16 +110,16 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSlot(c *C) {
 func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnap(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "revoke",
-			"skill": map[string]interface{}{
+			"action": "disconnect",
+			"plug": map[string]interface{}{
 				"snap": "",
-				"name": "",
+				"plug": "",
 			},
 			"slot": map[string]interface{}{
 				"snap": "consumer",
-				"name": "",
+				"slot": "",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -66,7 +66,7 @@ Help Options:
 func (s *SnapSuite) TestInterfacesZeroSlots(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		body, err := ioutil.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
@@ -98,7 +98,7 @@ func (s *SnapSuite) TestInterfacesZeroSlots(c *C) {
 func (s *SnapSuite) TestInterfacesOneSlot(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		body, err := ioutil.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
@@ -135,7 +135,7 @@ func (s *SnapSuite) TestInterfacesOneSlot(c *C) {
 func (s *SnapSuite) TestInterfacesTwoSlots(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		body, err := ioutil.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
@@ -176,7 +176,7 @@ func (s *SnapSuite) TestInterfacesTwoSlots(c *C) {
 func (s *SnapSuite) TestInterfacesSlotsWithCommonName(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		body, err := ioutil.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
@@ -217,7 +217,7 @@ func (s *SnapSuite) TestInterfacesSlotsWithCommonName(c *C) {
 func (s *SnapSuite) TestInterfacesTwoPlugsAndFiltering(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		body, err := ioutil.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
@@ -268,7 +268,7 @@ func (s *SnapSuite) TestInterfacesTwoPlugsAndFiltering(c *C) {
 func (s *SnapSuite) TestInterfacesOfSpecificSnap(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		body, err := ioutil.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})
@@ -314,7 +314,7 @@ func (s *SnapSuite) TestInterfacesOfSpecificSnap(c *C) {
 func (s *SnapSuite) TestInterfacesOfSpecificSnapAndPlug(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		body, err := ioutil.ReadAll(r.Body)
 		c.Check(err, IsNil)
 		c.Check(body, DeepEquals, []byte{})

--- a/cmd/snap/cmd_remove_plug_test.go
+++ b/cmd/snap/cmd_remove_plug_test.go
@@ -53,12 +53,12 @@ Help Options:
 func (s *SnapSuite) TestRemovePlug(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
-			"action": "remove-skill",
-			"skill": map[string]interface{}{
+			"action": "remove-plug",
+			"plug": map[string]interface{}{
 				"snap": "producer",
-				"name": "plug",
+				"plug": "plug",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/cmd/snap/cmd_remove_slot_test.go
+++ b/cmd/snap/cmd_remove_slot_test.go
@@ -52,12 +52,12 @@ Help Options:
 func (s *SnapSuite) TestRemoveSlot(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "POST")
-		c.Check(r.URL.Path, Equals, "/2.0/skills")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "remove-slot",
 			"slot": map[string]interface{}{
 				"snap": "consumer",
-				"name": "slot",
+				"slot": "slot",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -921,13 +921,13 @@ func appIconGet(c *Command, r *http.Request) Response {
 // plugConnection holds the identification of a slot that has been connected to a plug.
 type plugConnection struct {
 	Snap string `json:"snap"`
-	Name string `json:"name"` // This is the slot name
+	Name string `json:"slot"` // This is the slot name
 }
 
 // plugInfo holds details for a plug as returned by the REST API.
 type plugInfo struct {
 	Snap        string           `json:"snap"`
-	Name        string           `json:"name"`
+	Name        string           `json:"plug"`
 	Interface   string           `json:"interface"`
 	Label       string           `json:"label"`
 	Connections []plugConnection `json:"connections"`

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -129,7 +129,7 @@ var (
 	}
 
 	interfacesCmd = &Command{
-		Path:   "/2.0/skills",
+		Path:   "/2.0/interfaces",
 		UserOK: true,
 		GET:    getPlugs,
 		POST:   changeInterfaces,
@@ -928,9 +928,9 @@ type plugConnection struct {
 type plugInfo struct {
 	Snap        string           `json:"snap"`
 	Name        string           `json:"name"`
-	Interface   string           `json:"type"`
+	Interface   string           `json:"interface"`
 	Label       string           `json:"label"`
-	Connections []plugConnection `json:"granted_to"`
+	Connections []plugConnection `json:"connections"`
 }
 
 // getPlugs returns a response with a list of all the plugs and which slots use them.
@@ -975,17 +975,17 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 	if a.Action == "" {
 		return BadRequest("interface action not specified")
 	}
-	if !c.d.enableInternalInterfaceActions && a.Action != "grant" && a.Action != "revoke" {
+	if !c.d.enableInternalInterfaceActions && a.Action != "connect" && a.Action != "disconnect" {
 		return BadRequest("internal interface actions are disabled")
 	}
 	switch a.Action {
-	case "grant":
+	case "connect":
 		err := c.d.interfaces.Connect(a.Plug.Snap, a.Plug.Name, a.Slot.Snap, a.Slot.Name)
 		if err != nil {
 			return BadRequest("%v", err)
 		}
 		return SyncResponse(nil)
-	case "revoke":
+	case "disconnect":
 		err := c.d.interfaces.Disconnect(a.Plug.Snap, a.Plug.Name, a.Slot.Snap, a.Slot.Name)
 		if err != nil {
 			return BadRequest("%v", err)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -958,7 +958,7 @@ func getPlugs(c *Command, r *http.Request) Response {
 // interfaceAction is an action performed on the plug system.
 type interfaceAction struct {
 	Action string          `json:"action"`
-	Plug   interfaces.Plug `json:"skill,omitempty"`
+	Plug   interfaces.Plug `json:"plug,omitempty"`
 	Slot   interfaces.Slot `json:"slot,omitempty"`
 }
 
@@ -991,7 +991,7 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 			return BadRequest("%v", err)
 		}
 		return SyncResponse(nil)
-	case "add-skill":
+	case "add-plug":
 		err := c.d.interfaces.AddPlug(&a.Plug)
 		if err != nil {
 			return BadRequest("%v", err)
@@ -1000,7 +1000,7 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 			Type:   ResponseTypeSync,
 			Status: http.StatusCreated,
 		}
-	case "remove-skill":
+	case "remove-plug":
 		err := c.d.interfaces.RemovePlug(a.Plug.Snap, a.Plug.Name)
 		if err != nil {
 			return BadRequest("%v", err)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1608,7 +1608,7 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 	d := newTestDaemon()
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	action := &interfaceAction{
-		Action: "add-skill",
+		Action: "add-plug",
 		Plug: interfaces.Plug{
 			Snap:      "snap",
 			Name:      "name",
@@ -1647,7 +1647,7 @@ func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
 	})
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
-		Action: "add-skill",
+		Action: "add-plug",
 		Plug: interfaces.Plug{
 			Snap:      "producer",
 			Name:      "plug",
@@ -1690,7 +1690,7 @@ func (s *apiSuite) TestAddPlugFailure(c *check.C) {
 		},
 	})
 	action := &interfaceAction{
-		Action: "add-skill",
+		Action: "add-plug",
 		Plug: interfaces.Plug{
 			Snap:      "snap",
 			Name:      "name",
@@ -1729,7 +1729,7 @@ func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
-		Action: "remove-skill",
+		Action: "remove-plug",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1761,7 +1761,7 @@ func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
-		Action: "remove-skill",
+		Action: "remove-plug",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1796,7 +1796,7 @@ func (s *apiSuite) TestRemovePlugFailure(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
-		Action: "remove-skill",
+		Action: "remove-plug",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1265,13 +1265,13 @@ func (s *apiSuite) TestGetPlugs(c *check.C) {
 		"result": []interface{}{
 			map[string]interface{}{
 				"snap":      "producer",
-				"name":      "plug",
+				"plug":      "plug",
 				"interface": "interface",
 				"label":     "label",
 				"connections": []interface{}{
 					map[string]interface{}{
 						"snap": "consumer",
-						"name": "slot",
+						"slot": "slot",
 					},
 				},
 			},

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1245,7 +1245,7 @@ func (s *apiSuite) TestInstallLicensedIntegration(c *check.C) {
 	c.Check(task.State(), check.Equals, TaskSucceeded)
 }
 
-// Tests for GET /2.0/skills
+// Tests for GET /2.0/interfaces
 
 func (s *apiSuite) TestGetPlugs(c *check.C) {
 	d := newTestDaemon()
@@ -1253,7 +1253,7 @@ func (s *apiSuite) TestGetPlugs(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface", Label: "label"})
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
-	req, err := http.NewRequest("GET", "/2.0/skills", nil)
+	req, err := http.NewRequest("GET", "/2.0/interfaces", nil)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.GET(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1264,11 +1264,11 @@ func (s *apiSuite) TestGetPlugs(c *check.C) {
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": []interface{}{
 			map[string]interface{}{
-				"snap":  "producer",
-				"name":  "plug",
-				"type":  "interface",
-				"label": "label",
-				"granted_to": []interface{}{
+				"snap":      "producer",
+				"name":      "plug",
+				"interface": "interface",
+				"label":     "label",
+				"connections": []interface{}{
 					map[string]interface{}{
 						"snap": "consumer",
 						"name": "slot",
@@ -1282,7 +1282,7 @@ func (s *apiSuite) TestGetPlugs(c *check.C) {
 	})
 }
 
-// Test for POST /2.0/skills
+// Test for POST /2.0/interfaces
 
 func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	d := newTestDaemon()
@@ -1290,7 +1290,7 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
-		Action: "grant",
+		Action: "connect",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1303,7 +1303,7 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1342,7 +1342,7 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "other-interface"})
 	action := &interfaceAction{
-		Action: "grant",
+		Action: "connect",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1355,7 +1355,7 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1380,7 +1380,7 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
-		Action: "grant",
+		Action: "connect",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1393,7 +1393,7 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1418,7 +1418,7 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
-		Action: "grant",
+		Action: "connect",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1431,7 +1431,7 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1458,7 +1458,7 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
-		Action: "revoke",
+		Action: "disconnect",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1471,7 +1471,7 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1494,7 +1494,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
-		Action: "revoke",
+		Action: "disconnect",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1507,7 +1507,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1532,7 +1532,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
-		Action: "revoke",
+		Action: "disconnect",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1545,7 +1545,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1571,7 +1571,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
-		Action: "revoke",
+		Action: "disconnect",
 		Plug: interfaces.Plug{
 			Snap: "producer",
 			Name: "plug",
@@ -1584,7 +1584,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1623,7 +1623,7 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1662,7 +1662,7 @@ func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1705,7 +1705,7 @@ func (s *apiSuite) TestAddPlugFailure(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1738,7 +1738,7 @@ func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1770,7 +1770,7 @@ func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1805,7 +1805,7 @@ func (s *apiSuite) TestRemovePlugFailure(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1843,7 +1843,7 @@ func (s *apiSuite) TestAddSlotSuccess(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1882,7 +1882,7 @@ func (s *apiSuite) TestAddSlotDisabled(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1925,7 +1925,7 @@ func (s *apiSuite) TestAddSlotFailure(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1958,7 +1958,7 @@ func (s *apiSuite) TestRemoveSlotSuccess(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -1990,7 +1990,7 @@ func (s *apiSuite) TestRemoveSlotDisabled(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -2025,7 +2025,7 @@ func (s *apiSuite) TestRemoveSlotFailure(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -2046,7 +2046,7 @@ func (s *apiSuite) TestRemoveSlotFailure(c *check.C) {
 
 func (s *apiSuite) TestUnsupportedInterfaceRequest(c *check.C) {
 	buf := bytes.NewBuffer([]byte(`garbage`))
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -2069,7 +2069,7 @@ func (s *apiSuite) TestMissingInterfaceAction(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)
@@ -2095,7 +2095,7 @@ func (s *apiSuite) TestUnsupportedInterfaceAction(c *check.C) {
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/2.0/skills", buf)
+	req, err := http.NewRequest("POST", "/2.0/interfaces", buf)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	interfacesCmd.POST(interfacesCmd, req).ServeHTTP(rec, req)

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -629,7 +629,7 @@ Sample result:
         “name”:  "pin-13",
         “label”: "Pin 13",
         “connections”: [
-            {"snap": "keyboard-lights", "name": "capslock-led"}
+            {"snap": "keyboard-lights", "slot": "capslock-led"}
         ]
     }
 ]
@@ -652,7 +652,7 @@ Sample input:
 ```javascript
 {
     “action”: “connect”,
-    “plug”: {“snap”: “canonical-pi2”,   “name”: “pin-13”},
-    “slot”: {“snap”: “keyboard-lights”, “name”: “capslock-led”}
+    “plug”: {“snap”: “canonical-pi2”,   “plug”: “pin-13”},
+    “slot”: {“snap”: “keyboard-lights”, “slot”: “capslock-led”}
 }
 ```

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -610,14 +610,14 @@ The response is a stream of assertions separated by double newlines.
 The X-Ubuntu-Assertions-Count header is set to the number of
 returned assertions, 0 or more.
 
-## /2.0/skills
+## /2.0/interfaces
 
 ### GET
 
-* Description: Get all the skills and information about where they are granted
+* Description: Get all the plugs and slots and information about what is connected to them.
 * Access: authenticated
 * Operation: sync
-* Return: array of skills containing array of slots using each skill.
+* Return: array of plugs containing array of slots using each skill.
 
 Sample result:
 
@@ -625,10 +625,10 @@ Sample result:
 [
     {
         “snap”:  "canonical-pi2",
-        “type”:  "bool-file",
+        “interface”:  "bool-file",
         “name”:  "pin-13",
         “label”: "Pin 13",
-        “granted-to”: [
+        “connections”: [
             {"snap": "keyboard-lights", "name": "capslock-led"}
         ]
     }
@@ -637,22 +637,22 @@ Sample result:
 
 ### POST
 
-* Description: Issue an action to the skill system
+* Description: Issue an action to the interface system
 * Access: authenticated
 * Operation: sync
 * Return: nothing
 
 Available actions are:
 
-- grant: grant the skill to the given skill slot.
-- revoke: revoke the given skill from the given skill slot.
+- connect: connect the plug to the given slot.
+- disconnect: disconnect the given plug from the given slot.
 
 Sample input:
 
 ```javascript
 {
-    “action”: “grant”,
-    “skill”:  {“snap”: “canonical-pi2”,   “name”: “pin-13”},
-    “slot”:   {“snap”: “keyboard-lights”, “name”: “capslock-led”}
+    “action”: “connect”,
+    “plug”: {“snap”: “canonical-pi2”,   “name”: “pin-13”},
+    “slot”: {“snap”: “keyboard-lights”, “name”: “capslock-led”}
 }
 ```

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -614,7 +614,7 @@ returned assertions, 0 or more.
 
 ### GET
 
-* Description: Get all the plugs and slots and information about what is connected to them.
+* Description: Get all the plugs and information about the slots connected to them.
 * Access: authenticated
 * Operation: sync
 * Return: array of plugs containing array of slots using each skill.

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -626,7 +626,7 @@ Sample result:
     {
         “snap”:  "canonical-pi2",
         “interface”:  "bool-file",
-        “name”:  "pin-13",
+        “plug”:  "pin-13",
         “label”: "Pin 13",
         “connections”: [
             {"snap": "keyboard-lights", "slot": "capslock-led"}


### PR DESCRIPTION
This branch changes the wire format to not refer to skills, types and skill slots but to plugs, interfaces and just slots. Some more changes are coming up to clean up bits and pieces of the Go api.