### PR TITLE
daemon: snapd API branding endpoint

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -62,6 +62,7 @@ var api = []*Command{
 	interfacesCmd,
 	assertsCmd,
 	assertsFindManyCmd,
+	brandingCmd,
 }
 
 var (
@@ -145,6 +146,12 @@ var (
 		Path:   "/2.0/assertions/{assertType}",
 		UserOK: true,
 		GET:    assertsFindMany,
+	}
+
+	brandingCmd = &Command{
+		Path:    "/2.0/branding",
+		GuestOK: true,
+		GET:     getBranding,
 	}
 )
 
@@ -1063,4 +1070,13 @@ func assertsFindMany(c *Command, r *http.Request) Response {
 		return InternalError("searching assertions failed: %v", err)
 	}
 	return AssertResponse(assertions, true)
+}
+
+func getBranding(c *Command, r *http.Request) Response {
+	branding, err := snappy.GadgetBranding()
+	if err != nil {
+		return NotFound(err.Error())
+	}
+
+	return SyncResponse(branding)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2313,3 +2313,30 @@ func (s *apiSuite) TestAssertsInvalidType(c *check.C) {
 	c.Check(rec.Code, check.Equals, 400)
 	c.Check(rec.Body.String(), testutil.Contains, "invalid assert type")
 }
+
+func (s *apiSuite) TestGetBrandingNoGadget(c *check.C) {
+	req, err := http.NewRequest("GET", "/2.0/branding", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getBranding(brandingCmd, req).(*resp)
+	c.Assert(rsp.Status, check.Equals, http.StatusNotFound)
+}
+
+func (s *apiSuite) TestGetBranding(c *check.C) {
+	branding := `
+  branding:
+    name: brand-name
+    subname: brand-subname
+`
+	s.mkGadget(c, "foo", branding)
+
+	req, err := http.NewRequest("GET", "/2.0/branding", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getBranding(brandingCmd, req).(*resp)
+	c.Assert(rsp.Status, check.Equals, http.StatusOK)
+	c.Assert(rsp.Result, check.DeepEquals, snappy.Branding{
+		Name:    "brand-name",
+		SubName: "brand-subname",
+	})
+}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -128,12 +128,15 @@ version: %s
 	}
 }
 
-func (s *apiSuite) mkGadget(c *check.C, store string) {
+func (s *apiSuite) mkGadget(c *check.C, store, extraYaml string) {
 	content := []byte(fmt.Sprintf(`name: test
 version: 1
 type: gadget
-gadget: {store: {id: %q}}
-`, store))
+gadget:
+  store:
+    id: %q
+%s
+`, store, extraYaml))
 
 	d := filepath.Join(dirs.SnapSnapsDir, "test")
 	m := filepath.Join(d, "1", "meta")
@@ -364,7 +367,7 @@ func (s *apiSuite) TestSysInfoStore(c *check.C) {
 	c.Check(sysInfoCmd.Path, check.Equals, "/2.0/system-info")
 
 	s.mkrelease()
-	s.mkGadget(c, "some-store")
+	s.mkGadget(c, "some-store", "")
 
 	sysInfoCmd.GET(sysInfoCmd, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -656,3 +656,21 @@ Sample input:
     “slot”:   {“snap”: “keyboard-lights”, “name”: “capslock-led”}
 }
 ```
+
+## /2.0/branding
+
+### `GET`
+
+* Description: Branding details of the installed gadget
+* Access: guest
+* Operation: sync
+* Return: branding details or standard error if a gadget snap is not installed
+
+#### Sample result:
+
+:``javascript
+{
+    "name": "amd64",
+    "subname": "generic"
+}
+```

--- a/snappy/gadget.go
+++ b/snappy/gadget.go
@@ -40,6 +40,7 @@ import (
 // of a gadget package type.
 type Gadget struct {
 	Store                Store    `yaml:"store,omitempty"`
+	Branding             Branding `yaml:"branding,omitempty"`
 	Hardware             Hardware `yaml:"hardware,omitempty"`
 	Software             Software `yaml:"software,omitempty"`
 	SkipIfupProvisioning bool     `yaml:"skip-ifup-provisioning"`
@@ -55,6 +56,12 @@ type Hardware struct {
 // Store holds information relevant to the store provided by a Gadget snap
 type Store struct {
 	ID string `yaml:"id,omitempty"`
+}
+
+// Branding allows for some custom branding of the system
+type Branding struct {
+	Name    string `yaml:"name,omitempty" json:"name,omitempty"`
+	SubName string `yaml:"subname,omitempty" json:"subname,omitempty"`
 }
 
 // Software describes the installed software provided by a Gadget snap
@@ -170,6 +177,16 @@ func StoreID() string {
 	}
 
 	return gadget.Gadget.Store.ID
+}
+
+// GadgetBranding returns the branding configuration of the gadget
+func GadgetBranding() (Branding, error) {
+	gadget, err := getGadget()
+	if err != nil {
+		return Branding{}, err
+	}
+
+	return gadget.Gadget.Branding, nil
 }
 
 // IsBuiltInSoftware returns true if the package is part of the built-in software

--- a/snappy/gadget_test.go
+++ b/snappy/gadget_test.go
@@ -23,6 +23,7 @@
 package snappy
 
 import (
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 
@@ -43,6 +44,7 @@ func (s *GadgetSuite) SetUpTest(c *C) {
 			Gadget: Gadget{
 				Software: Software{[]string{"makeuppackage", "anotherpackage"}},
 				Store:    Store{"ninjablocks"},
+				Branding: Branding{Name: "brand name", SubName: "brand subname"},
 			},
 		}, nil
 	}
@@ -60,6 +62,24 @@ func (s *GadgetSuite) TestIsBuildIn(c *C) {
 
 func (s *GadgetSuite) TestStoreID(c *C) {
 	c.Assert(StoreID(), Equals, "ninjablocks")
+}
+
+func (s *GadgetSuite) TestGadgetBrandingNoGadget(c *C) {
+	getGadget = func() (*snapYaml, error) {
+		return nil, errors.New("fail")
+	}
+
+	_, err := GadgetBranding()
+	c.Assert(err, NotNil)
+}
+
+func (s *GadgetSuite) TestGadgetBranding(c *C) {
+	branding, err := GadgetBranding()
+	c.Assert(err, IsNil)
+	c.Assert(branding, DeepEquals, Branding{
+		Name:    "brand name",
+		SubName: "brand subname",
+	})
 }
 
 func (s *GadgetSuite) TestWriteApparmorAdditionalFile(c *C) {


### PR DESCRIPTION
From discussion at the sprint there may well be a lot more branding configuration available for the gadget snap.

As it stands there are currently just two fields, `name` and `subname` and these are used by __WebDM__ if a gadget is installed.

This PR introduces an endpoint into the API which makes this information available and will allow me to stop having __WebDM__ read the gadget yaml directly.