### PR TITLE
integration-tests: properly stop snapd from branch

### DIFF
--- a/integration-tests/tests/base_test.go
+++ b/integration-tests/tests/base_test.go
@@ -21,7 +21,6 @@
 package tests
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -100,6 +99,5 @@ func stopDaemonProcess() error {
 		"ubuntu-snappy.snapd.service"); err != nil {
 		return err
 	}
-	fmt.Println("after stopping daemon")
 	return nil
 }

--- a/integration-tests/tests/base_test.go
+++ b/integration-tests/tests/base_test.go
@@ -91,6 +91,9 @@ func setUpSnapdFromBranch(c *check.C) {
 	err = writeEnvConfig()
 	c.Assert(err, check.IsNil)
 
+	_, err = cli.ExecCommandErr("sudo", "systemctl", "daemon-reload")
+	c.Assert(err, check.IsNil)
+
 	_, err = cli.ExecCommandErr("sudo", "systemctl", "start", "ubuntu-snappy.snapd.service")
 	c.Assert(err, check.IsNil)
 }
@@ -106,6 +109,10 @@ func tearDownSnapdFromBranch() error {
 	}
 
 	if _, err := cli.ExecCommandErr("sudo", "umount", "/usr/bin/snapd"); err != nil {
+		return err
+	}
+
+	if _, err := cli.ExecCommandErr("sudo", "systemctl", "daemon-reload"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Requires #538 

With these changes when building from branch we manage the snapd process using the systemd tools, being able to start and stop the service with the built binary properly, and restoring the system's service once the test is over.