### PR TITLE
interfaces,daemon: rename package holding built-in interfaces

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/helpers"
 	"github.com/ubuntu-core/snappy/interfaces"
-	"github.com/ubuntu-core/snappy/interfaces/types"
+	"github.com/ubuntu-core/snappy/interfaces/builtin"
 	"github.com/ubuntu-core/snappy/logger"
 )
 
@@ -262,7 +262,7 @@ func New() *Daemon {
 		panic(err.Error())
 	}
 	interfacesRepo := interfaces.NewRepository()
-	for _, iface := range types.AllInterfaces() {
+	for _, iface := range builtin.AllInterfaces() {
 		if err := interfacesRepo.AddInterface(iface); err != nil {
 			panic(err.Error())
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -262,7 +262,7 @@ func New() *Daemon {
 		panic(err.Error())
 	}
 	interfacesRepo := interfaces.NewRepository()
-	for _, iface := range builtin.AllInterfaces() {
+	for _, iface := range builtin.Interfaces() {
 		if err := interfacesRepo.AddInterface(iface); err != nil {
 			panic(err.Error())
 		}

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -17,20 +17,17 @@
  *
  */
 
-package types_test
+package builtin
 
 import (
-	"github.com/ubuntu-core/snappy/interfaces/types"
-	. "github.com/ubuntu-core/snappy/testutil"
-
-	. "gopkg.in/check.v1"
+	"github.com/ubuntu-core/snappy/interfaces"
 )
 
-type AllSuite struct{}
+var allInterfaces = []interfaces.Interface{
+	&BoolFileInterface{},
+}
 
-var _ = Suite(&AllSuite{})
-
-func (s *AllSuite) TestAllInterfaces(c *C) {
-	allInterfaces := types.AllInterfaces()
-	c.Check(allInterfaces, Contains, &types.BoolFileInterface{})
+// AllInterfaces returns a slice of all the interfaces.
+func AllInterfaces() []interfaces.Interface {
+	return allInterfaces
 }

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -27,7 +27,7 @@ var allInterfaces = []interfaces.Interface{
 	&BoolFileInterface{},
 }
 
-// AllInterfaces returns a slice of all the interfaces.
-func AllInterfaces() []interfaces.Interface {
+// Interfaces returns all of the built-in interfaces.
+func Interfaces() []interfaces.Interface {
 	return allInterfaces
 }

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -30,7 +30,7 @@ type AllSuite struct{}
 
 var _ = Suite(&AllSuite{})
 
-func (s *AllSuite) TestAllInterfaces(c *C) {
-	allInterfaces := builtin.AllInterfaces()
-	c.Check(allInterfaces, Contains, &builtin.BoolFileInterface{})
+func (s *AllSuite) TestInterfaces(c *C) {
+	all := builtin.Interfaces()
+	c.Check(all, Contains, &builtin.BoolFileInterface{})
 }

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -17,14 +17,20 @@
  *
  */
 
-package types
+package builtin_test
 
 import (
-	"path/filepath"
+	"github.com/ubuntu-core/snappy/interfaces/builtin"
+	. "github.com/ubuntu-core/snappy/testutil"
+
+	. "gopkg.in/check.v1"
 )
 
-type evalSymlinksFn func(string) (string, error)
+type AllSuite struct{}
 
-// evalSymlinks is either filepath.EvalSymlinks or a mocked function for
-// applicable for testing.
-var evalSymlinks = filepath.EvalSymlinks
+var _ = Suite(&AllSuite{})
+
+func (s *AllSuite) TestAllInterfaces(c *C) {
+	allInterfaces := builtin.AllInterfaces()
+	c.Check(allInterfaces, Contains, &builtin.BoolFileInterface{})
+}

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -17,7 +17,7 @@
  *
  */
 
-package types
+package builtin
 
 import (
 	"fmt"

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package types_test
+package builtin_test
 
 import (
 	"bytes"
@@ -27,7 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/ubuntu-core/snappy/interfaces"
-	"github.com/ubuntu-core/snappy/interfaces/types"
+	"github.com/ubuntu-core/snappy/interfaces/builtin"
 	"github.com/ubuntu-core/snappy/testutil"
 )
 
@@ -49,7 +49,7 @@ type BoolFileInterfaceSuite struct {
 }
 
 var _ = Suite(&BoolFileInterfaceSuite{
-	iface: &types.BoolFileInterface{},
+	iface: &builtin.BoolFileInterface{},
 	gpioPlug: &interfaces.Plug{
 		Interface: "bool-file",
 		Attrs: map[string]interface{}{
@@ -123,7 +123,7 @@ func (s *BoolFileInterfaceSuite) TestSanitizeSlot(c *C) {
 
 func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetHandlesSymlinkErrors(c *C) {
 	// Symbolic link traversal is handled correctly
-	types.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "", fmt.Errorf("broken symbolic link")
 	})
 	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
@@ -133,7 +133,7 @@ func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetHandlesSymlinkErrors(c *
 
 func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetDereferencesSymlinks(c *C) {
 	// Use a fake (successful) dereferencing function for the remainder of the test.
-	types.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "(dereferenced)" + path, nil
 	})
 	// Extra apparmor permission to access GPIO value
@@ -152,7 +152,7 @@ func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetDereferencesSymlinks(c *
 
 func (s *BoolFileInterfaceSuite) TestSlotSecurityDoesNotContainPlugSecurity(c *C) {
 	// Use a fake (successful) dereferencing function for the remainder of the test.
-	types.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return path, nil
 	})
 	var err error

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -17,17 +17,14 @@
  *
  */
 
-package types
+package builtin
 
 import (
-	"github.com/ubuntu-core/snappy/testutil"
+	"path/filepath"
 )
 
-// MockEvalSymlinks replaces the path/filepath.EvalSymlinks function used inside the caps package.
-func MockEvalSymlinks(test *testutil.BaseTest, fn func(string) (string, error)) {
-	orig := evalSymlinks
-	evalSymlinks = fn
-	test.AddCleanup(func() {
-		evalSymlinks = orig
-	})
-}
+type evalSymlinksFn func(string) (string, error)
+
+// evalSymlinks is either filepath.EvalSymlinks or a mocked function for
+// applicable for testing.
+var evalSymlinks = filepath.EvalSymlinks

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -17,17 +17,17 @@
  *
  */
 
-package types
+package builtin
 
 import (
-	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/testutil"
 )
 
-var allInterfaces = []interfaces.Interface{
-	&BoolFileInterface{},
-}
-
-// AllInterfaces returns a slice of all the interfaces.
-func AllInterfaces() []interfaces.Interface {
-	return allInterfaces
+// MockEvalSymlinks replaces the path/filepath.EvalSymlinks function used inside the caps package.
+func MockEvalSymlinks(test *testutil.BaseTest, fn func(string) (string, error)) {
+	orig := evalSymlinks
+	evalSymlinks = fn
+	test.AddCleanup(func() {
+		evalSymlinks = orig
+	})
 }


### PR DESCRIPTION
Earlier branches that changed skills to interfaces left the ``skills/types`` package unchanged as there was no consensus on how to call it when the concept of types was renamed to interfaces (and ``interfaces/interfaces`` does not look too good). Now this is settled on ``interfaces/builtin`` so this branch does just that.

The way to access all built in interfaces was also simplified to just ``builtin.Interfaces()``