### PR TITLE
interfaces: initial work on "security commands"

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -536,6 +536,23 @@ func (r *Repository) SecurityFilesForSnap(snapName string) (map[string][]byte, e
 	return blobs, nil
 }
 
+// SecurityCommandsForSnap returns the commands required to change effective security for a given snap.
+func (r *Repository) SecurityCommandsForSnap(snapName string) (cmds [][]string, err error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	for _, helper := range r.securityHelpers {
+		for _, appName := range appInSnap(snapName) {
+			cmds = append(cmds, helper.cmdsToRun(snapName, appName)...)
+		}
+	}
+	return
+}
+
+// XXX: this is a dummy implementation
+func appInSnap(snapName string) []string {
+	return nil
+}
+
 func (r *Repository) collectFilesFromSecurityHelper(snapName string, helper securityHelper, buffers map[string]*bytes.Buffer) error {
 	securitySystem := helper.securitySystem()
 	appSnippets, err := r.securitySnippetsForSnap(snapName, securitySystem)


### PR DESCRIPTION
This branch commences the work on "security commands". This is driven by apparmor requirements. Please inspect the two patches and post comments. The key bit I need to continue (and to write tests) is how the interface code (perhaps the interface manager) can ask the snap manager to enumerate apps in a given snap (installed, activated). Once that is decided I can easily write the rest of the code needed to test this.