### PR TITLE
classic, oauth: update tests for change in MakeRandomString()

### DIFF
--- a/classic/run_test.go
+++ b/classic/run_test.go
@@ -30,5 +30,5 @@ var _ = Suite(&RunTestSuite{})
 
 func (t *RunTestSuite) TestGenScopeName(c *C) {
 	name := genClassicScopeName()
-	c.Assert(name, Matches, "snappy-classic_[0-9-]+_[0-9:]+_[a-zA-Z]+.scope")
+	c.Assert(name, Matches, "snappy-classic_[0-9-]+_[0-9:]+_[a-zA-Z0-9]+.scope")
 }

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -39,7 +39,7 @@ func (s *OAuthTestSuite) TestMakePlaintextSignature(c *C) {
 		TokenSecret:    "token-secret+",
 	}
 	sig := MakePlaintextSignature(&mockToken)
-	c.Assert(sig, Matches, `OAuth oauth_nonce="[a-zA-Z]+", oauth_timestamp="[0-9]+", oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="consumer-key%2B", oauth_token="token-key%2B", oauth_signature="consumer-secret%2B%26token-secret%2B"`)
+	c.Assert(sig, Matches, `OAuth oauth_nonce="[a-zA-Z0-9]+", oauth_timestamp="[0-9]+", oauth_version="1.0", oauth_signature_method="PLAINTEXT", oauth_consumer_key="consumer-key%2B", oauth_token="token-key%2B", oauth_signature="consumer-secret%2B%26token-secret%2B"`)
 }
 
 func (s *OAuthTestSuite) TestQuote(c *C) {


### PR DESCRIPTION
The recent change to the helpers.MakeRandomString() broke some tests. This branch fixes them again.