### PR TITLE
snappy,snap: move icon under meta/gui/

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -116,7 +116,10 @@ func (s *apiSuite) mkInstalled(c *check.C, name, origin, version string, active 
 	metadir := filepath.Join(dirs.SnapSnapsDir, fullname, version, "meta")
 	c.Assert(os.MkdirAll(metadir, 0755), check.IsNil)
 
-	c.Check(ioutil.WriteFile(filepath.Join(metadir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
+	guidir := filepath.Join(metadir, "gui")
+	c.Assert(os.MkdirAll(guidir, 0755), check.IsNil)
+
+	c.Check(ioutil.WriteFile(filepath.Join(guidir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
 
 	content := fmt.Sprintf(`
 name: %s
@@ -158,7 +161,7 @@ func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {
 		origin:       "bar",
 		isInstalled:  true,
 		isActive:     true,
-		icon:         "meta/icon.svg",
+		icon:         "meta/gui/icon.svg",
 		_type:        snap.TypeApp,
 		downloadSize: 2,
 	}}
@@ -1031,7 +1034,8 @@ func (s *apiSuite) TestAppIconGet(c *check.C) {
 	s.mkInstalled(c, "foo", "bar", "v1", true, "")
 
 	// have an icon for it in the package itself
-	iconfile := filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "icon.ick")
+	iconfile := filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "gui", "icon.ick")
+	c.Assert(os.MkdirAll(filepath.Dir(iconfile), 0755), check.IsNil)
 	c.Check(ioutil.WriteFile(iconfile, []byte("ick"), 0644), check.IsNil)
 
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
@@ -1050,7 +1054,9 @@ func (s *apiSuite) TestAppIconGetInactive(c *check.C) {
 	s.mkInstalled(c, "foo", "bar", "v1", false, "")
 
 	// have an icon for it in the package itself
-	iconfile := filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "icon.ick")
+
+	iconfile := filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "gui", "icon.ick")
+	c.Assert(os.MkdirAll(filepath.Dir(iconfile), 0755), check.IsNil)
 	c.Check(ioutil.WriteFile(iconfile, []byte("ick"), 0644), check.IsNil)
 
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}
@@ -1069,7 +1075,7 @@ func (s *apiSuite) TestAppIconGetNoIcon(c *check.C) {
 	s.mkInstalled(c, "foo", "bar", "v1", true, "")
 
 	// NO ICON!
-	err := os.RemoveAll(filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "icon.svg"))
+	err := os.RemoveAll(filepath.Join(dirs.SnapSnapsDir, "foo.bar", "v1", "meta", "gui", "icon.svg"))
 	c.Assert(err, check.IsNil)
 
 	s.vars = map[string]string{"name": "foo", "origin": "bar"}

--- a/snap/lightweight/lightweight_test.go
+++ b/snap/lightweight/lightweight_test.go
@@ -74,7 +74,9 @@ func (s *lightweightSuite) MkInstalled(c *check.C, _type snap.Type, appdir, name
 	yaml := fmt.Sprintf("name: %s\nversion: %s\ntype: %s\n", name, version, _type)
 	c.Check(os.MkdirAll(apath, 0755), check.IsNil)
 	c.Check(ioutil.WriteFile(filepath.Join(apath, "snap.yaml"), []byte(yaml), 0644), check.IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(apath, "icon.png"), nil, 0644), check.IsNil)
+	guipath := filepath.Join(apath, "gui")
+	c.Check(os.MkdirAll(guipath, 0755), check.IsNil)
+	c.Check(ioutil.WriteFile(filepath.Join(guipath, "icon.png"), nil, 0644), check.IsNil)
 
 	if active {
 		c.Check(os.Symlink(version, filepath.Join(appdir, qn, "current")), check.IsNil)
@@ -103,7 +105,7 @@ func (s *lightweightSuite) TestMapFmkNoPart(c *check.C) {
 		"origin":             "sideload",
 		"status":             "active",
 		"version":            "120",
-		"icon":               filepath.Join(s.d, "snaps", "fmk", "120", "meta/icon.png"),
+		"icon":               filepath.Join(s.d, "snaps", "fmk", "120", "meta/gui/icon.png"),
 		"type":               "framework",
 		"vendor":             "",
 		"download_size":      int64(-1),
@@ -175,7 +177,7 @@ func (s *lightweightSuite) TestMapAppNoPart(c *check.C) {
 		"origin":        "bar",
 		"status":        "active",
 		"version":       "1.0",
-		"icon":          filepath.Join(s.d, "snaps", "foo.bar", "1.0", "meta/icon.png"),
+		"icon":          filepath.Join(s.d, "snaps", "foo.bar", "1.0", "meta/gui/icon.png"),
 		"type":          "app",
 		"vendor":        "",
 		"download_size": int64(-1),
@@ -204,7 +206,7 @@ func (s *lightweightSuite) TestMapAppWithPart(c *check.C) {
 		"origin":           "bar",
 		"status":           "active",
 		"version":          "1.0",
-		"icon":             filepath.Join(s.d, "snaps", "foo.bar", "1.0", "meta/icon.png"),
+		"icon":             filepath.Join(s.d, "snaps", "foo.bar", "1.0", "meta/gui/icon.png"),
 		"type":             "app",
 		"vendor":           "",
 		"download_size":    int64(42),
@@ -269,7 +271,7 @@ func (s *lightweightSuite) TestMapInactiveGadgetNoPart(c *check.C) {
 		"origin":        "sideload", // best guess
 		"status":        "installed",
 		"version":       "3",
-		"icon":          filepath.Join(s.d, "snaps", "a-gadget", "3", "meta/icon.png"),
+		"icon":          filepath.Join(s.d, "snaps", "a-gadget", "3", "meta/gui/icon.png"),
 		"type":          "gadget",
 		"vendor":        "",
 		"download_size": int64(-1),

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -167,7 +167,7 @@ func (s *SnapPart) Channel() string {
 
 // Icon returns the path to the icon
 func (s *SnapPart) Icon() string {
-	found, _ := filepath.Glob(filepath.Join(s.basedir, "meta", "icon.*"))
+	found, _ := filepath.Glob(filepath.Join(s.basedir, "meta", "gui", "icon.*"))
 	if len(found) == 0 {
 		return ""
 	}

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -1570,10 +1570,12 @@ func (s *SnapTestSuite) TestIcon(c *C) {
 	snapYaml, err := s.makeInstalledMockSnap()
 	part, err := NewInstalledSnapPart(snapYaml, testOrigin)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(part.basedir, "meta", "icon.png"), nil, 0644)
+	err = os.MkdirAll(filepath.Join(part.basedir, "meta", "gui"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(part.basedir, "meta", "gui", "icon.png"), nil, 0644)
 	c.Assert(err, IsNil)
 
-	c.Check(part.Icon(), Matches, filepath.Join(dirs.SnapSnapsDir, QualifiedName(part), part.Version(), "meta/icon.png"))
+	c.Check(part.Icon(), Matches, filepath.Join(dirs.SnapSnapsDir, QualifiedName(part), part.Version(), "meta/gui/icon.png"))
 }
 
 func (s *SnapTestSuite) TestIconEmpty(c *C) {


### PR DESCRIPTION
As discussed with Gustavo we agreed to move the snap icon from `meta/icon.*`  to `meta/gui/icon.*`.