### PR TITLE
integration-tests,cmd: add integration tests coverage measurement

### DIFF
--- a/cmd/snap/integration_coverage_test.go
+++ b/cmd/snap/integration_coverage_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build integrationcoverage
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/testutils"
+)
+
+func TestRunMain(t *testing.T) {
+	testutils.RemoveTestFlags()
+	main()
+}

--- a/cmd/snapd/integration_coverage_test.go
+++ b/cmd/snapd/integration_coverage_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build integrationcoverage
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/testutils"
+)
+
+func TestRunMain(t *testing.T) {
+	testutils.RemoveTestFlags()
+	main()
+}

--- a/cmd/snappy/integration_coverage_test.go
+++ b/cmd/snappy/integration_coverage_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build integrationcoverage
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/testutils"
+)
+
+func TestRunMain(t *testing.T) {
+	testutils.RemoveTestFlags()
+	main()
+}

--- a/integration-tests/tests/console_test.go
+++ b/integration-tests/tests/console_test.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os/exec"
 
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
@@ -49,7 +50,12 @@ func (s *consoleSuite) SetUpTest(c *check.C) {
 	s.SnappySuite.SetUpTest(c)
 
 	var err error
-	s.cmd = exec.Command("snappy", "console")
+
+	cmdsIn := []string{"snappy", "console"}
+	cmdsOut, err := cli.AddOptionsToCommand(cmdsIn)
+	c.Assert(err, check.IsNil, check.Commentf("Error adding coverage options, %q", err))
+
+	s.cmd = exec.Command(cmdsOut[0], cmdsOut[1:]...)
 	s.stdin, err = s.cmd.StdinPipe()
 	c.Assert(err, check.IsNil, check.Commentf("Expected nil error, got %s", err))
 	s.stdout, err = s.cmd.StdoutPipe()

--- a/integration-tests/tests/examples_test.go
+++ b/integration-tests/tests/examples_test.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -187,7 +187,11 @@ type licensedExampleSuite struct {
 }
 
 func (s *licensedExampleSuite) TestAcceptLicenseMustInstallSnap(c *check.C) {
-	cmd := exec.Command("sudo", "snappy", "install", "licensed.canonical/edge")
+	cmds := []string{"sudo", "snappy", "install", "licensed.canonical/edge"}
+	cmdsCover, err := cli.AddOptionsToCommand(cmds)
+	c.Assert(err, check.IsNil, check.Commentf("Error adding coverage options, %q", err))
+
+	cmd := exec.Command(cmdsCover[0], cmdsCover[1:]...)
 	f, err := pty.Start(cmd)
 	c.Assert(err, check.IsNil, check.Commentf("Error starting pty: %s", err))
 	defer common.RemoveSnap(c, "licensed.canonical")
@@ -203,7 +207,11 @@ func (s *licensedExampleSuite) TestAcceptLicenseMustInstallSnap(c *check.C) {
 }
 
 func (s *licensedExampleSuite) TestDeclineLicenseMustNotInstallSnap(c *check.C) {
-	cmd := exec.Command("sudo", "snappy", "install", "licensed.canonical/edge")
+	cmds := []string{"sudo", "snappy", "install", "licensed.canonical/edge"}
+	cmdsCover, err := cli.AddOptionsToCommand(cmds)
+	c.Assert(err, check.IsNil, check.Commentf("Error adding coverage options, %q", err))
+
+	cmd := exec.Command(cmdsCover[0], cmdsCover[1:]...)
 	f, err := pty.Start(cmd)
 	c.Assert(err, check.IsNil, check.Commentf("Error starting pty: %s", err))
 

--- a/integration-tests/tests/login_test.go
+++ b/integration-tests/tests/login_test.go
@@ -2,7 +2,7 @@
 // +build !excludeintegration
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -132,7 +132,8 @@ func ipTablesCommand(action, serverAddrPort string) []string {
 }
 
 func (s *loginSuite) writeCredentials(loginName string) error {
-	cmd := exec.Command("snappy", "login", loginName)
+	cmds, _ := cli.AddOptionsToCommand([]string{"snappy", "login", loginName})
+	cmd := exec.Command(cmds[0], cmds[1:]...)
 	f, err := pty.Start(cmd)
 	if err != nil {
 		return err

--- a/integration-tests/testutils/cli/cli_test.go
+++ b/integration-tests/testutils/cli/cli_test.go
@@ -25,15 +25,19 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/config"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/testutils"
 
 	"gopkg.in/check.v1"
 )
 
 const (
 	execCmd       = "mycmd"
-	execOutput    = "myoutput"
+	execOutput    = "myoutput\n"
 	defaultDir    = "/tmp"
 	defaultEnvVar = "VAR"
 	defaultEnvVal = "VAL"
@@ -44,9 +48,14 @@ const (
 func Test(t *testing.T) { check.TestingT(t) }
 
 type cliTestSuite struct {
-	backExecCommand func(string, ...string) *exec.Cmd
-	helperProcess   string
-	cmd             *exec.Cmd
+	backExecCommand  func(string, ...string) *exec.Cmd
+	helperProcess    string
+	execArgs         []string
+	backAdtArtifacts string
+	tmpDir           string
+	cmd              *exec.Cmd
+	configFile       string
+	targetCoverCmds  []string
 }
 
 var _ = check.Suite(&cliTestSuite{})
@@ -54,6 +63,8 @@ var _ = check.Suite(&cliTestSuite{})
 func (s *cliTestSuite) SetUpSuite(c *check.C) {
 	s.backExecCommand = execCommand
 	execCommand = s.fakeExecCommand
+	s.configFile = config.DefaultFileName
+	s.targetCoverCmds = []string{"snappy", "snap", "snapd"}
 }
 
 func (s *cliTestSuite) TearDownSuite(c *check.C) {
@@ -63,9 +74,32 @@ func (s *cliTestSuite) TearDownSuite(c *check.C) {
 func (s *cliTestSuite) SetUpTest(c *check.C) {
 	s.helperProcess = "TestHelperProcess"
 	s.cmd = execCommand(execCmd)
+	s.execArgs = []string{}
+	s.backAdtArtifacts = os.Getenv("ADT_ARTIFACTS")
+
+	var err error
+	s.tmpDir, err = ioutil.TempDir("", "")
+	c.Assert(err, check.IsNil)
+
+	os.Setenv("ADT_ARTIFACTS", s.tmpDir)
+
+	err = s.writeFromBranchConfig(true)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *cliTestSuite) TearDownTest(c *check.C) {
+	os.Setenv("ADT_ARTIFACTS", s.backAdtArtifacts)
+	os.Remove(s.tmpDir)
+	s.cmd = execCommand(execCmd)
+	// in these unit tests the config file is created under
+	// integration-tests/testutils/cli/integration-tests/data/output, we
+	// need to remove the integration-tests dir under cli
+	err := os.RemoveAll(filepath.Dir(filepath.Dir(filepath.Dir(s.configFile))))
+	c.Assert(err, check.IsNil)
 }
 
 func (s *cliTestSuite) fakeExecCommand(command string, args ...string) *exec.Cmd {
+	s.execArgs = args
 	cs := []string{"-check.f=cliTestSuite." + s.helperProcess, "--", command}
 	cs = append(cs, args...)
 	cmd := exec.Command(os.Args[0], cs...)
@@ -74,14 +108,22 @@ func (s *cliTestSuite) fakeExecCommand(command string, args ...string) *exec.Cmd
 }
 
 func (s *cliTestSuite) TestHelperProcess(c *check.C) {
-	baseHelperProcess(0)
+	baseHelperProcess(0, execOutput)
 }
 
 func (s *cliTestSuite) TestHelperProcessErr(c *check.C) {
-	baseHelperProcess(1)
+	baseHelperProcess(1, execOutput)
 }
 
-func baseHelperProcess(exitValue int) {
+func (s *cliTestSuite) TestHelperProcessCoverage(c *check.C) {
+	baseHelperProcess(0, execOutput+"PASS\ncoverage: blabla\n")
+}
+
+func (s *cliTestSuite) TestHelperProcessCoverageEmptyOutput(c *check.C) {
+	baseHelperProcess(0, "PASS\ncoverage: blabla\n")
+}
+
+func baseHelperProcess(exitValue int, output string) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}
@@ -91,7 +133,7 @@ func baseHelperProcess(exitValue int) {
 	if val != "" {
 		env = []string{"GO_WANT_HELPER_PROCESS=1", defaultEnvVar + "=" + val}
 	}
-	fmt.Fprintf(os.Stdout, getParamOuput(&exec.Cmd{Dir: dir, Env: env}))
+	fmt.Fprintf(os.Stdout, getParamOuput(output, &exec.Cmd{Dir: dir, Env: env}))
 	os.Exit(exitValue)
 }
 
@@ -99,6 +141,53 @@ func (s *cliTestSuite) TestExecCommand(c *check.C) {
 	actualOutput := ExecCommand(c, execCmd)
 
 	c.Assert(actualOutput, check.Equals, execOutput)
+}
+
+func (s *cliTestSuite) TestExecCommandAddsCoverageOptionsToTargetCmd(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		ExecCommand(c, cmd)
+
+		c.Check(checkPrefixInSlice("-test.run", s.execArgs) &&
+			checkPrefixInSlice("-test.coverprofile", s.execArgs),
+			check.Equals, true)
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandAddsCoverageOptionsToComplexTargetCmd(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		ExecCommand(c, "sudo", "TMPDIR=/var/tmp", cmd,
+			"build", "--squashfs", "/var/tmp/snap-build-633342069")
+
+		c.Check(checkPrefixInSlice("-test.run", s.execArgs) &&
+			checkPrefixInSlice("-test.coverprofile", s.execArgs),
+			check.Equals, true)
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandDoesNotAddCoverageOptionsToNonTargetCmd(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		for _, badCmd := range []string{cmd + "mycmd", "mycmd" + cmd} {
+			ExecCommand(c, badCmd)
+
+			c.Check(checkPrefixInSlice("-test.run", s.execArgs) ||
+				checkPrefixInSlice("-test.coverprofile", s.execArgs),
+				check.Equals, false)
+		}
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandDoesNotAddCoverageOptionsToTargetCmdWhenNotBuiltFromBranch(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		s.writeFromBranchConfig(false)
+		s.execArgs = []string{}
+
+		ExecCommand(c, cmd)
+
+		c.Check(checkPrefixInSlice("-test.run", s.execArgs) ||
+			checkPrefixInSlice("-test.coverprofile", s.execArgs),
+			check.Equals, false)
+
+	}
 }
 
 func (s *cliTestSuite) TestExecCommandToFile(c *check.C) {
@@ -112,6 +201,52 @@ func (s *cliTestSuite) TestExecCommandToFile(c *check.C) {
 	actualFileContents, err := ioutil.ReadFile(outputFile.Name())
 	c.Assert(err, check.IsNil)
 	c.Assert(string(actualFileContents), check.Equals, execOutput)
+}
+
+func (s *cliTestSuite) TestExecCommandToFileAddsCoverageOptionsToSnappyCmd(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		outputFile, err := ioutil.TempFile("", "snappy-exec")
+		c.Check(err, check.IsNil)
+		outputFile.Close()
+		defer os.Remove(outputFile.Name())
+
+		ExecCommandToFile(c, outputFile.Name(), cmd)
+
+		c.Check(checkPrefixInSlice("-test.run", s.execArgs) &&
+			checkPrefixInSlice("-test.coverprofile", s.execArgs),
+			check.Equals, true)
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandToFileDoesNotAddCoverageOptionsToNonSnappyCmd(c *check.C) {
+	outputFile, err := ioutil.TempFile("", "snappy-exec")
+	c.Assert(err, check.IsNil)
+	outputFile.Close()
+	defer os.Remove(outputFile.Name())
+
+	ExecCommandToFile(c, outputFile.Name(), "mycmd")
+
+	c.Assert(checkPrefixInSlice("-test.run", s.execArgs) ||
+		checkPrefixInSlice("-test.coverprofile", s.execArgs),
+		check.Equals, false)
+}
+
+func (s *cliTestSuite) TestExecCommandToFileDoesNotAddCoverageOptionsToSnappyCmdWhenNotBuiltFromBranch(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		s.writeFromBranchConfig(false)
+		s.execArgs = []string{}
+
+		outputFile, err := ioutil.TempFile("", "snappy-exec")
+		c.Check(err, check.IsNil)
+		outputFile.Close()
+		defer os.Remove(outputFile.Name())
+
+		ExecCommandToFile(c, outputFile.Name(), cmd)
+
+		c.Check(checkPrefixInSlice("-test.run", s.execArgs) ||
+			checkPrefixInSlice("-test.coverprofile", s.execArgs),
+			check.Equals, false)
+	}
 }
 
 func (s *cliTestSuite) TestExecCommandErr(c *check.C) {
@@ -129,11 +264,128 @@ func (s *cliTestSuite) TestExecCommandErrWithError(c *check.C) {
 	c.Assert(err, check.NotNil)
 }
 
+func (s *cliTestSuite) TestExecCommandErrAddsCoverageOptionsToSnappyCmd(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		ExecCommandErr(cmd)
+
+		c.Check(checkPrefixInSlice("-test.run", s.execArgs) &&
+			checkPrefixInSlice("-test.coverprofile", s.execArgs),
+			check.Equals, true)
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandErrDoesNotAddCoverageOptionsToNonSnappyCmd(c *check.C) {
+	ExecCommandErr("mycmd")
+
+	c.Assert(checkPrefixInSlice("-test.run", s.execArgs) ||
+		checkPrefixInSlice("-test.coverprofile", s.execArgs),
+		check.Equals, false)
+}
+
+func (s *cliTestSuite) TestExecCommandErrDoesNotAddCoverageOptionsToSnappyCmdWhenNotBuiltFromBranch(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		s.writeFromBranchConfig(false)
+		s.execArgs = []string{}
+
+		ExecCommandErr(cmd)
+
+		c.Check(checkPrefixInSlice("-test.run", s.execArgs) ||
+			checkPrefixInSlice("-test.coverprofile", s.execArgs),
+			check.Equals, false)
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandRemovesCoverageLines(c *check.C) {
+	s.helperProcess = "TestHelperProcessCoverage"
+	for _, cmd := range s.targetCoverCmds {
+		actualOutput := ExecCommand(c, cmd)
+
+		c.Check(actualOutput, check.Equals, execOutput)
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandRemovesCoverageLinesForEmptyOutput(c *check.C) {
+	s.helperProcess = "TestHelperProcessCoverageEmptyOutput"
+	for _, cmd := range s.targetCoverCmds {
+		actualOutput := ExecCommand(c, cmd)
+
+		c.Check(actualOutput, check.Equals, "\n")
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandCreatesCoverageDir(c *check.C) {
+	s.helperProcess = "TestHelperProcessCoverage"
+	for _, cmd := range s.targetCoverCmds {
+		ExecCommand(c, cmd)
+
+		expectedDir := filepath.Join(s.tmpDir, "coverage")
+		_, err := os.Stat(expectedDir)
+		c.Check(err, check.IsNil)
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandReturnsCreateCoverageDirError(c *check.C) {
+	targetDir := filepath.Join(s.tmpDir, "existingDir")
+	err := os.Mkdir(targetDir, os.ModeDir)
+	c.Assert(err, check.IsNil)
+
+	os.Setenv("ADT_ARTIFACTS", targetDir)
+
+	s.helperProcess = "TestHelperProcessCoverage"
+	for _, cmd := range s.targetCoverCmds {
+		_, err = ExecCommandErr(cmd)
+
+		c.Check(err, check.NotNil)
+		c.Check(err, check.FitsTypeOf, &os.PathError{})
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandCoverageFilesDontDuplicateCoverageDir(c *check.C) {
+	s.helperProcess = "TestHelperProcessCoverage"
+	for _, cmd := range s.targetCoverCmds {
+		ExecCommand(c, cmd)
+
+		coverFile := strings.Split(s.execArgs[1], "=")[1]
+
+		c.Check(strings.Count(coverFile, getCoveragePath()), check.Equals, 1)
+	}
+}
+
+func (s *cliTestSuite) TestExecCommandCreatesOneCoverageFilePerCall(c *check.C) {
+	s.helperProcess = "TestHelperProcessCoverage"
+
+	expectedTotal := 3
+
+	for _, cmd := range s.targetCoverCmds {
+		coverFileNames := []string{}
+
+		for i := 0; i < expectedTotal; i++ {
+			ExecCommand(c, cmd)
+			// s.execArgs is of the form:
+			// [-test.run=^TestRunMain$ -test.coverprofile=/tmp/832295861/coverage/coverage.out]
+			coverFile := strings.Split(s.execArgs[1], "=")[1]
+			coverFileNames = append(coverFileNames, filepath.Base(coverFile))
+		}
+		c.Check(coverFileNames[0] != coverFileNames[1], check.Equals, true)
+		c.Check(coverFileNames[1] != coverFileNames[2], check.Equals, true)
+		c.Check(coverFileNames[0] != coverFileNames[2], check.Equals, true)
+	}
+}
+
+func checkPrefixInSlice(prefix string, elements []string) bool {
+	for _, item := range elements {
+		if strings.HasPrefix(item, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *cliTestSuite) TestExecCommandWrapperHonoursDir(c *check.C) {
 	s.cmd.Dir = defaultDir
 	actualOutput, err := ExecCommandWrapper(s.cmd)
 
-	c.Assert(actualOutput, check.Equals, getParamOuput(s.cmd))
+	c.Assert(actualOutput, check.Equals, getParamOuput(execOutput, s.cmd))
 	c.Assert(err, check.IsNil)
 }
 
@@ -141,7 +393,7 @@ func (s *cliTestSuite) TestExecCommandWrapperHonoursEnv(c *check.C) {
 	s.cmd.Env = append(s.cmd.Env, defaultEnv)
 	actualOutput, err := ExecCommandWrapper(s.cmd)
 
-	c.Assert(actualOutput, check.Equals, getParamOuput(s.cmd))
+	c.Assert(actualOutput, check.Equals, getParamOuput(execOutput, s.cmd))
 	c.Assert(err, check.IsNil)
 }
 
@@ -153,8 +405,22 @@ func (s *cliTestSuite) TestExecCommandWrapperReturnsErr(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func getParamOuput(cmd *exec.Cmd) string {
-	output := execOutput
+func (s *cliTestSuite) TestAddOptionsToSnappyCommand(c *check.C) {
+	for _, cmd := range s.targetCoverCmds {
+		cmdsIn := []string{cmd, "subcommand"}
+
+		cmdsOut, err := AddOptionsToCommand(cmdsIn)
+
+		c.Check(err, check.IsNil)
+		c.Check(len(cmdsOut), check.Equals, 4)
+		c.Check(cmdsOut[0], check.Equals, cmd)
+		c.Check(cmdsOut[3], check.Equals, "subcommand")
+		c.Check(cmdsOut[1], check.Equals, "-test.run=^TestRunMain$")
+		c.Check(strings.HasPrefix(cmdsOut[2], "-test.coverprofile="), check.Equals, true)
+	}
+}
+
+func getParamOuput(output string, cmd *exec.Cmd) string {
 	if len(cmd.Env) == 1 && cmd.Env[0] == defaultEnv {
 		output += "\nEnv variables: " + strings.Join(cmd.Env, ", ")
 	}
@@ -164,4 +430,16 @@ func getParamOuput(cmd *exec.Cmd) string {
 	}
 
 	return output
+}
+
+func (s *cliTestSuite) writeFromBranchConfig(fromBranch bool) error {
+	testutils.PrepareTargetDir(filepath.Dir(s.configFile))
+
+	cfg := config.Config{
+		FileName:   s.configFile,
+		FromBranch: fromBranch,
+	}
+	cfg.Write()
+
+	return nil
 }

--- a/integration-tests/testutils/testutils/testutils.go
+++ b/integration-tests/testutils/testutils/testutils.go
@@ -60,3 +60,16 @@ func ExecCommand(cmds ...string) error {
 	}
 	return err
 }
+
+// RemoveTestFlags strips the flags beginning with "-test." from os.Args,
+// useful for the test binaries compiled as the original cmds for measuring
+// integration test coverage
+func RemoveTestFlags() {
+	outputArgs := []string{}
+	for _, item := range os.Args {
+		if !strings.HasPrefix(item, "-test.") {
+			outputArgs = append(outputArgs, item)
+		}
+	}
+	os.Args = outputArgs
+}

--- a/integration-tests/testutils/updates/updates.go
+++ b/integration-tests/testutils/updates/updates.go
@@ -105,7 +105,10 @@ func copySnap(c *check.C, snap, targetDir string) {
 
 func buildSnap(c *check.C, snapDir, targetDir string) {
 	// build in /var/tmp (which is not a tempfs)
-	cmd := exec.Command("sudo", "TMPDIR=/var/tmp", "snappy", "build", "--squashfs", snapDir)
+	cmds, _ := cli.AddOptionsToCommand([]string{
+		"sudo", "TMPDIR=/var/tmp", "snappy", "build", "--squashfs", snapDir,
+	})
+	cmd := exec.Command(cmds[0], cmds[1:]...)
 	cmd.Dir = targetDir
 	cli.ExecCommandWrapper(cmd)
 }


### PR DESCRIPTION
Requires #541 for getting snapd integration tests coverage data.

These changes implement the technique described in [1] and [2]. 

Basically, for each production binary a dummy test is defined, which is guarded by a build tag (currently `integrationcoverage`). These tests just call the package's `main()` method. When the suite is instructed to build the binaries from the branch, these dummy tests are compiled instead of the production binaries, passing the required options for measuring coverage to the compilation command, which in this case is of the form `go test -c -tags integrationcoverage -coverpkgs <pkgs_list> -o <binary> ./cmd/<binary>`. 

There is also code for adding test flags to each binary call, required for specifying which test to execute (the dummy test) and where to put the coverage data. These flags are removed from `os.Args` before calling the `main()` methods. Also, the textual coverage output is filtered after each binary call, so that our checks of the command's output keep working.

This is how the metrics look like in jenkins [3].

Some points to take into account:

* The coverage is only measured for the happy execution paths. In other words, if the execution of the binary is somehow interrupted (calling for instance `os.Exit(1)`) the coverage data is not recorded.

* There are some packages excluded from the coverage metrics, specifically the `helper`, `osutil` and `progress` packages, without excluding them we were getting this errors when compiling the binaries:

```
/home/fgimenez/src/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1                                                                                  
/tmp/go-link-492921396/000003.o: In function `_cgo_b95aca69b89e_Cfunc_isatty':                                                                                      
/home/fgimenez/workspace/gocode/src/github.com/ubuntu-core/snappy/progress/isatty.go:50: multiple definition of `_cgo_b95aca69b89e_Cfunc_isatty'                    
/tmp/go-link-492921396/000002.o:/home/fgimenez/workspace/gocode/src/github/ubuntu-core/snappy/progress/isatty.go:50: first defined here                     
```

[1] https://blog.cloudflare.com/go-coverage-with-external-tests/
[2] https://www.elastic.co/blog/code-coverage-for-your-golang-system-tests
[3] http://10.55.60.201:8080/job/coverage/7/cobertura/
