### PR TITLE
snappy: generate desktop files from snap.yaml

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -46,6 +46,7 @@ var (
 
 	SnapBinariesDir  string
 	SnapServicesDir  string
+	SnapDesktopDir   string
 	SnapBusPolicyDir string
 
 	CloudMetaDataFile string
@@ -89,6 +90,7 @@ func SetRootDir(rootdir string) {
 	SnapTrustedAccountKey = filepath.Join(rootdir, "/usr/share/snappy/trusted.acckey")
 
 	SnapBinariesDir = filepath.Join(SnapSnapsDir, "bin")
+	SnapDesktopDir = filepath.Join(rootdir, snappyDir, "applications")
 	SnapServicesDir = filepath.Join(rootdir, "/etc/systemd/system")
 	SnapBusPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/system.d")
 

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -1202,3 +1202,68 @@ apps:
 	c.Assert(helpers.FileExists(binaryWrapper), Equals, false)
 	c.Assert(helpers.FileExists(snapDir), Equals, false)
 }
+
+func (s *SnapTestSuite) TestSnappyGenerateSnapDesktopFileNotNeeded(c *C) {
+	app := &AppYaml{Name: "pastebinit", Command: "bin/pastebinit"}
+	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
+	m := &snapYaml{
+		Name:    "pastebinit",
+		Version: "1.4.0.0.1",
+	}
+
+	generatedDesktopFile, err := generateSnapDesktopFile(app, pkgPath, m)
+	c.Assert(err, IsNil)
+	c.Assert(generatedDesktopFile, Equals, "")
+}
+
+func (s *SnapTestSuite) TestSnappyGenerateSnapDesktopFile(c *C) {
+	app := &AppYaml{
+		Name:       "pastebinit",
+		Command:    "bin/pastebinit",
+		Comment:    "Best evar",
+		Icon:       "something.png",
+		Categories: []string{"Game", "LogicGame"},
+	}
+	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
+	m := &snapYaml{
+		Name:    "pastebinit",
+		Version: "1.4.0.0.1",
+	}
+
+	generatedDesktopFile, err := generateSnapDesktopFile(app, pkgPath, m)
+	c.Assert(err, IsNil)
+	c.Assert(generatedDesktopFile, Equals, `[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+Name=pastebinit
+Comment=Best evar
+Icon=/snaps/pastebinit.mvo/1.4.0.0.1/something.png
+Exec=/snaps/bin/pastebinit.pastebinit
+Categories=Game;LogicGame;
+`)
+}
+
+func (s *SnapTestSuite) TestSnappyGenerateSnapDesktopFileNoCategories(c *C) {
+	app := &AppYaml{
+		Name:       "pastebinit",
+		Command:    "bin/pastebinit",
+		Comment:    "Best evar",
+		Icon:       "something.png",
+		Categories: nil,
+	}
+	pkgPath := "/snaps/pastebinit.mvo/1.4.0.0.1/"
+	m := &snapYaml{
+		Name:    "pastebinit",
+		Version: "1.4.0.0.1",
+	}
+	generatedDesktopFile, err := generateSnapDesktopFile(app, pkgPath, m)
+	c.Assert(err, IsNil)
+	c.Assert(generatedDesktopFile, Equals, `[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+Name=pastebinit
+Comment=Best evar
+Icon=/snaps/pastebinit.mvo/1.4.0.0.1/something.png
+Exec=/snaps/bin/pastebinit.pastebinit
+`)
+}

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -63,6 +63,11 @@ type AppYaml struct {
 	Command string `yaml:"command"`
 	Daemon  string `yaml:"daemon"`
 
+	// desktop file stuff
+	Icon       string   `yaml:"icon,omitempty"`
+	Comment    string   `yaml:"comment,omitempty"`
+	Categories []string `yaml:"categories,omitempty"`
+
 	Description string          `yaml:"description,omitempty" json:"description,omitempty"`
 	Stop        string          `yaml:"stop,omitempty"`
 	PostStop    string          `yaml:"poststop,omitempty"`


### PR DESCRIPTION
There was a discussion today with key members of the desktop teams (and also Jamie of the security team) and the consensus was that we want to auto-generate desktop files instead of letting upstream ship them.

The reasons are:
- security: much easier for us to control the security
- forward portability: when unity8 comes along we can use the same yaml to generate something other than desktop files for u8

This branch is a start to generate the desktop files. It will generate a desktop file if it finds a "Icon" or "Comment" key in the apps sub-yaml. We will probably want to expand this later to support more of the desktop file keys https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html and also to support launching with %F like parameters.