### PR TITLE
cmd/snap: update tests for go-flags changes

### DIFF
--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -54,10 +54,6 @@ proceeds as above.
 
 Help Options:
   -h, --help               Show this help message
-
-[connect command arguments]
-  <snap>:<plug>
-  <snap>:<slot>
 `
 	rest, err := Parser().ParseArgs([]string{"connect", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -49,10 +49,6 @@ Disconnects all plugs from the provided snap.
 
 Help Options:
   -h, --help               Show this help message
-
-[disconnect command arguments]
-  <snap>:<plug>
-  <snap>:<slot>
 `
 	rest, err := Parser().ParseArgs([]string{"disconnect", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,7 +4,7 @@ github.com/gorilla/context	git	1c83b3eabd45b6d76072b66b746c20815fb2872d	2015-08-
 github.com/gorilla/mux	git	ee1815431e497d3850809578c93ab6705f1a19f7	2015-08-20T05:15:06Z
 github.com/gorilla/websocket	git	234959944d9cf05229b02e8b386e5cffe1e4e04a	2016-01-28T16:48:56Z
 github.com/gosexy/gettext	git	98b7b91596d20b96909e6b60d57411547dd9959c	2013-02-21T11:21:43Z
-github.com/jessevdk/go-flags	git	97448c91aac742cbca3d020b3e769013a420a06f	2016-02-07T07:45:15Z
+github.com/jessevdk/go-flags	git	6b9493b3cb60367edd942144879646604089e3f7	2016-02-27T09:34:38Z
 github.com/kr/pty	git	05017fcccf23c823bfdea560dcc958a136e54fb7	2014-12-17T21:19:37Z
 github.com/mvo5/goconfigparser	git	26426272dda20cc76aa1fa44286dc743d2972fe8	2015-02-12T09:37:50Z
 github.com/mvo5/uboot-go	git	361f6ebcbb54f389d15dc9faefa000e996ba3e37	2015-07-22T06:53:46Z


### PR DESCRIPTION
Upstream go-flags now merged our patch to treat empty description on
positional arguments as a hint that the argument does not need to be
displayed in --help. This patch updates dependencies and our test suite
to reflect this.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>