### PR TITLE
systemd,docs: use correct values for restart

### DIFF
--- a/docs/meta.md
+++ b/docs/meta.md
@@ -40,7 +40,7 @@ The following keys are optional:
     * `stop-timeout`: (optional) the time in seconds to wait for the
                       service to stop
     * `restart-condition`: (optional) if specified, use the given restart
-      condition. Can be one of `on-failure` (default), `never`, `on-success`,
+      condition. Can be one of `on-failure` (default), `no`, `on-success`,
       `on-abnormal`, `on-abort`, and `always`. See `systemd.service(5)`
       (search for `Restart=`) for details.
     * `poststop`: (optional) a command that runs after the service has stopped

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -109,7 +109,7 @@ type RestartCondition string
 
 // These are the supported restart conditions
 const (
-	RestartNever      RestartCondition = "never"
+	RestartNo         RestartCondition = "no"
 	RestartOnSuccess  RestartCondition = "on-success"
 	RestartOnFailure  RestartCondition = "on-failure"
 	RestartOnAbnormal RestartCondition = "on-abnormal"
@@ -118,7 +118,7 @@ const (
 )
 
 var restartMap = map[string]RestartCondition{
-	"never":       RestartNever,
+	"no":          RestartNo,
 	"on-success":  RestartOnSuccess,
 	"on-failure":  RestartOnFailure,
 	"on-abnormal": RestartOnAbnormal,


### PR DESCRIPTION
The manpage for systemd.service does not state the existence of
`never` to be a valid value, what seems to be the appropriate
one for the `restart-condition` is the value of `no`.

From the man page:

> Takes one of no, on-success, on-failure, on-abnormal, on-watchdog,
> on-abort, or always.

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>