### PR TITLE
Rename Device to DeviceSerial.

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -48,7 +48,7 @@ var (
 	IdentityType   = &AssertionType{"identity", []string{"account-id"}, assembleIdentity}
 	// XXX: is series actually part of the primary key?
 	ModelType           = &AssertionType{"model", []string{"brand-id", "model", "series"}, assembleModel}
-	DeviceType          = &AssertionType{"device", []string{"brand-id", "model", "serial"}, assembleDevice}
+	SerialType          = &AssertionType{"serial", []string{"brand-id", "model", "serial"}, assembleSerial}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
 	SnapBuildType       = &AssertionType{"snap-build", []string{"snap-id", "snap-digest"}, assembleSnapBuild}
 	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}
@@ -60,7 +60,7 @@ var typeRegistry = map[string]*AssertionType{
 	AccountKeyType.Name:      AccountKeyType,
 	IdentityType.Name:        IdentityType,
 	ModelType.Name:           ModelType,
-	DeviceType.Name:          DeviceType,
+	SerialType.Name:          SerialType,
 	SnapDeclarationType.Name: SnapDeclarationType,
 	SnapBuildType.Name:       SnapBuildType,
 	SnapRevisionType.Name:    SnapRevisionType,

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -44,11 +44,11 @@ type AssertionType struct {
 
 // Understood assertion types.
 var (
-	AccountKeyType = &AssertionType{"account-key", []string{"account-id", "public-key-id"}, assembleAccountKey}
-	IdentityType   = &AssertionType{"identity", []string{"account-id"}, assembleIdentity}
+	AccountKeyType   = &AssertionType{"account-key", []string{"account-id", "public-key-id"}, assembleAccountKey}
+	DeviceSerialType = &AssertionType{"device-serial", []string{"brand-id", "model", "serial"}, assembleDeviceSerial}
+	IdentityType     = &AssertionType{"identity", []string{"account-id"}, assembleIdentity}
 	// XXX: is series actually part of the primary key?
 	ModelType           = &AssertionType{"model", []string{"brand-id", "model", "series"}, assembleModel}
-	SerialType          = &AssertionType{"serial", []string{"brand-id", "model", "serial"}, assembleSerial}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
 	SnapBuildType       = &AssertionType{"snap-build", []string{"snap-id", "snap-digest"}, assembleSnapBuild}
 	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}
@@ -60,7 +60,7 @@ var typeRegistry = map[string]*AssertionType{
 	AccountKeyType.Name:      AccountKeyType,
 	IdentityType.Name:        IdentityType,
 	ModelType.Name:           ModelType,
-	SerialType.Name:          SerialType,
+	DeviceSerialType.Name:    DeviceSerialType,
 	SnapDeclarationType.Name: SnapDeclarationType,
 	SnapBuildType.Name:       SnapBuildType,
 	SnapRevisionType.Name:    SnapRevisionType,

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -142,42 +142,43 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 	}, nil
 }
 
-// Serial holds a serial assertion, which is a statement binding a device
-// identity with the device public key.
-type Serial struct {
+// DeviceSerial holds a device-serial assertion, which is a statement binding a
+// device identity with the device public key.
+type DeviceSerial struct {
 	assertionBase
 	timestamp time.Time
 	pubKey    PublicKey
 }
 
 // BrandID returns the brand identifier of the device.
-func (ser *Serial) BrandID() string {
-	return ser.Header("brand-id")
+func (ds *DeviceSerial) BrandID() string {
+	return ds.Header("brand-id")
 }
 
 // Model returns the model name identifier of the device.
-func (ser *Serial) Model() string {
-	return ser.Header("model")
+func (ds *DeviceSerial) Model() string {
+	return ds.Header("model")
 }
 
-// Serial returns the serial of the device, together with brand id and model they form the unique identifier of the device.
-func (ser *Serial) Serial() string {
-	return ser.Header("serial")
+// Serial returns the serial of the device, together with brand id and model
+// they form the unique identifier of the device.
+func (ds *DeviceSerial) Serial() string {
+	return ds.Header("serial")
 }
 
 // DeviceKey returns the public key of the device.
-func (ser *Serial) DeviceKey() PublicKey {
-	return ser.pubKey
+func (ds *DeviceSerial) DeviceKey() PublicKey {
+	return ds.pubKey
 }
 
-// Timestamp returns the time when the serial assertion was issued.
-func (ser *Serial) Timestamp() time.Time {
-	return ser.timestamp
+// Timestamp returns the time when the device-serial assertion was issued.
+func (ds *DeviceSerial) Timestamp() time.Time {
+	return ds.timestamp
 }
 
-// TODO: implement further consistency checks for Serial but first review approach
+// TODO: implement further consistency checks for DeviceSerial but first review approach
 
-func assembleSerial(assert assertionBase) (Assertion, error) {
+func assembleDeviceSerial(assert assertionBase) (Assertion, error) {
 	// TODO: authority-id can only == canonical or brand-id
 
 	encodedKey, err := checkMandatory(assert.headers, "device-key")
@@ -195,7 +196,7 @@ func assembleSerial(assert assertionBase) (Assertion, error) {
 	}
 
 	// ignore extra headers and non-empty body for future compatibility
-	return &Serial{
+	return &DeviceSerial{
 		assertionBase: assert,
 		timestamp:     timestamp,
 		pubKey:        pubKey,

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -142,42 +142,42 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 	}, nil
 }
 
-// Device holds a device assertion, which is a statement binding
-// a device identity with the device public key.
-type Device struct {
+// Serial holds a serial assertion, which is a statement binding a device
+// identity with the device public key.
+type Serial struct {
 	assertionBase
 	timestamp time.Time
 	pubKey    PublicKey
 }
 
 // BrandID returns the brand identifier of the device.
-func (dev *Device) BrandID() string {
-	return dev.Header("brand-id")
+func (ser *Serial) BrandID() string {
+	return ser.Header("brand-id")
 }
 
 // Model returns the model name identifier of the device.
-func (dev *Device) Model() string {
-	return dev.Header("model")
+func (ser *Serial) Model() string {
+	return ser.Header("model")
 }
 
 // Serial returns the serial of the device, together with brand id and model they form the unique identifier of the device.
-func (dev *Device) Serial() string {
-	return dev.Header("serial")
+func (ser *Serial) Serial() string {
+	return ser.Header("serial")
 }
 
 // DeviceKey returns the public key of the device.
-func (dev *Device) DeviceKey() PublicKey {
-	return dev.pubKey
+func (ser *Serial) DeviceKey() PublicKey {
+	return ser.pubKey
 }
 
-// Timestamp returns the time when the device assertion was issued.
-func (dev *Device) Timestamp() time.Time {
-	return dev.timestamp
+// Timestamp returns the time when the serial assertion was issued.
+func (ser *Serial) Timestamp() time.Time {
+	return ser.timestamp
 }
 
-// TODO: implement further consistency checks for Device but first review approach
+// TODO: implement further consistency checks for Serial but first review approach
 
-func assembleDevice(assert assertionBase) (Assertion, error) {
+func assembleSerial(assert assertionBase) (Assertion, error) {
 	// TODO: authority-id can only == canonical or brand-id
 
 	encodedKey, err := checkMandatory(assert.headers, "device-key")
@@ -195,7 +195,7 @@ func assembleDevice(assert assertionBase) (Assertion, error) {
 	}
 
 	// ignore extra headers and non-empty body for future compatibility
-	return &Device{
+	return &Serial{
 		assertionBase: assert,
 		timestamp:     timestamp,
 		pubKey:        pubKey,


### PR DESCRIPTION
Renamed as much as seems sensible. I left some doc comments alone as they made more sense (to me) still referring to "device".