### PR TITLE
interfaces: maintain Plug and Slot connection details

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -306,6 +306,14 @@ func (r *Repository) Connect(plugSnapName, plugName, slotSnapName, slotName stri
 	}
 	r.slotPlugs[slot][plug] = true
 	r.plugSlots[plug][slot] = true
+	slot.Connections = append(slot.Connections, PlugRef{
+		Snap: plug.Snap,
+		Name: plug.Name,
+	})
+	plug.Connections = append(plug.Connections, SlotRef{
+		Snap: slot.Snap,
+		Name: slot.Name,
+	})
 	return nil
 }
 
@@ -399,6 +407,28 @@ func (r *Repository) disconnect(plug *Plug, slot *Slot) {
 	delete(r.plugSlots[plug], slot)
 	if len(r.plugSlots[plug]) == 0 {
 		delete(r.plugSlots, plug)
+	}
+	for i := 0; i < len(slot.Connections); i++ {
+		plugRef := slot.Connections[i]
+		if plugRef.Snap == plug.Snap && plugRef.Name == plug.Name {
+			slot.Connections[i] = slot.Connections[len(slot.Connections)-1]
+			slot.Connections = slot.Connections[:len(slot.Connections)-1]
+			if len(slot.Connections) == 0 {
+				slot.Connections = nil
+			}
+			break
+		}
+	}
+	for i := 0; i < len(plug.Connections); i++ {
+		slotRef := plug.Connections[i]
+		if slotRef.Snap == slot.Snap && slotRef.Name == slot.Name {
+			plug.Connections[i] = plug.Connections[len(plug.Connections)-1]
+			plug.Connections = plug.Connections[:len(plug.Connections)-1]
+			if len(plug.Connections) == 0 {
+				plug.Connections = nil
+			}
+			break
+		}
 	}
 }
 

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -306,14 +306,8 @@ func (r *Repository) Connect(plugSnapName, plugName, slotSnapName, slotName stri
 	}
 	r.slotPlugs[slot][plug] = true
 	r.plugSlots[plug][slot] = true
-	slot.Connections = append(slot.Connections, PlugRef{
-		Snap: plug.Snap,
-		Name: plug.Name,
-	})
-	plug.Connections = append(plug.Connections, SlotRef{
-		Snap: slot.Snap,
-		Name: slot.Name,
-	})
+	slot.Connections = append(slot.Connections, PlugRef{plug.Snap, plug.Name})
+	plug.Connections = append(plug.Connections, SlotRef{slot.Snap, slot.Name})
 	return nil
 }
 

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -507,17 +507,11 @@ func (r *Repository) Interfaces() *Interfaces {
 		for _, plug := range plugs {
 			// Copy part of the data explicitly, leaving out attrs and apps.
 			p := &Plug{
-				Name:      plug.Name,
-				Snap:      plug.Snap,
-				Interface: plug.Interface,
-				Label:     plug.Label,
-			}
-			// Add connection details
-			for slot := range r.plugSlots[plug] {
-				p.Connections = append(p.Connections, SlotRef{
-					Name: slot.Name,
-					Snap: slot.Snap,
-				})
+				Name:        plug.Name,
+				Snap:        plug.Snap,
+				Interface:   plug.Interface,
+				Label:       plug.Label,
+				Connections: plug.Connections[:],
 			}
 			sort.Sort(bySlotRef(p.Connections))
 			ifaces.Plugs = append(ifaces.Plugs, p)
@@ -527,17 +521,11 @@ func (r *Repository) Interfaces() *Interfaces {
 		for _, slot := range slots {
 			// Copy part of the data explicitly, leaving out attrs and apps.
 			s := &Slot{
-				Name:      slot.Name,
-				Snap:      slot.Snap,
-				Interface: slot.Interface,
-				Label:     slot.Label,
-			}
-			// Add connection details
-			for plug := range r.slotPlugs[slot] {
-				s.Connections = append(s.Connections, PlugRef{
-					Name: plug.Name,
-					Snap: plug.Snap,
-				})
+				Name:        slot.Name,
+				Snap:        slot.Snap,
+				Interface:   slot.Interface,
+				Label:       slot.Label,
+				Connections: slot.Connections[:],
 			}
 			sort.Sort(byPlugRef(s.Connections))
 			ifaces.Slots = append(ifaces.Slots, s)

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -503,7 +503,7 @@ func (r *Repository) Interfaces() *Interfaces {
 				Snap:        plug.Snap,
 				Interface:   plug.Interface,
 				Label:       plug.Label,
-				Connections: plug.Connections[:],
+				Connections: append([]SlotRef(nil), plug.Connections...),
 			}
 			sort.Sort(bySlotRef(p.Connections))
 			ifaces.Plugs = append(ifaces.Plugs, p)
@@ -517,7 +517,7 @@ func (r *Repository) Interfaces() *Interfaces {
 				Snap:        slot.Snap,
 				Interface:   slot.Interface,
 				Label:       slot.Label,
-				Connections: slot.Connections[:],
+				Connections: append([]PlugRef(nil), slot.Connections...),
 			}
 			sort.Sort(byPlugRef(s.Connections))
 			ifaces.Slots = append(ifaces.Slots, s)

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -408,8 +408,7 @@ func (r *Repository) disconnect(plug *Plug, slot *Slot) {
 	if len(r.plugSlots[plug]) == 0 {
 		delete(r.plugSlots, plug)
 	}
-	for i := 0; i < len(slot.Connections); i++ {
-		plugRef := slot.Connections[i]
+	for i, plugRef := range slot.Connections {
 		if plugRef.Snap == plug.Snap && plugRef.Name == plug.Name {
 			slot.Connections[i] = slot.Connections[len(slot.Connections)-1]
 			slot.Connections = slot.Connections[:len(slot.Connections)-1]
@@ -419,8 +418,7 @@ func (r *Repository) disconnect(plug *Plug, slot *Slot) {
 			break
 		}
 	}
-	for i := 0; i < len(plug.Connections); i++ {
-		slotRef := plug.Connections[i]
+	for i, slotRef := range plug.Connections {
 		if slotRef.Snap == slot.Snap && slotRef.Name == slot.Name {
 			plug.Connections[i] = plug.Connections[len(plug.Connections)-1]
 			plug.Connections = plug.Connections[:len(plug.Connections)-1]

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -810,30 +810,20 @@ func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
 	c.Assert(ifaces, DeepEquals, &Interfaces{
 		Plugs: []*Plug{
 			&Plug{
-				Name:      s.plug.Name,
-				Snap:      s.plug.Snap,
-				Interface: s.plug.Interface,
-				Label:     s.plug.Label,
-				Connections: []SlotRef{
-					{
-						Snap: s.slot.Snap,
-						Name: s.slot.Name,
-					},
-				},
+				Name:        s.plug.Name,
+				Snap:        s.plug.Snap,
+				Interface:   s.plug.Interface,
+				Label:       s.plug.Label,
+				Connections: []SlotRef{{s.slot.Snap, s.slot.Name}},
 			},
 		},
 		Slots: []*Slot{
 			&Slot{
-				Snap:      s.slot.Snap,
-				Name:      s.slot.Name,
-				Interface: s.slot.Interface,
-				Label:     s.slot.Label,
-				Connections: []PlugRef{
-					{
-						Snap: s.plug.Snap,
-						Name: s.plug.Name,
-					},
-				},
+				Snap:        s.slot.Snap,
+				Name:        s.slot.Name,
+				Interface:   s.slot.Interface,
+				Label:       s.slot.Label,
+				Connections: []PlugRef{{s.plug.Snap, s.plug.Name}},
 			},
 		},
 	})

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -40,25 +40,25 @@ var _ = Suite(&RepositorySuite{
 	iface: &TestInterface{
 		InterfaceName: "interface",
 	},
-	plug: &Plug{
+})
+
+func (s *RepositorySuite) SetUpTest(c *C) {
+	s.plug = &Plug{
 		Snap:      "provider",
 		Name:      "plug",
 		Interface: "interface",
 		Label:     "label",
 		Attrs:     map[string]interface{}{"attr": "value"},
 		Apps:      []string{"meta/hooks/plug"},
-	},
-	slot: &Slot{
+	}
+	s.slot = &Slot{
 		Snap:      "consumer",
 		Name:      "slot",
 		Interface: "interface",
 		Label:     "label",
 		Attrs:     map[string]interface{}{"attr": "value"},
 		Apps:      []string{"app"},
-	},
-})
-
-func (s *RepositorySuite) SetUpTest(c *C) {
+	}
 	s.emptyRepo = NewRepository()
 	s.testRepo = NewRepository()
 	err := s.testRepo.AddInterface(s.iface)

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -796,6 +796,71 @@ func (s *RepositorySuite) TestPlugConnectionsReturnsCorrectData(c *C) {
 	c.Assert(s.testRepo.PlugConnections(s.plug.Snap, s.plug.Name), HasLen, 0)
 }
 
+// Tests for Repository.Interfaces()
+
+func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	// After connecting the result is as expected
+	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	c.Assert(err, IsNil)
+	ifaces := s.testRepo.Interfaces()
+	c.Assert(ifaces, DeepEquals, &Interfaces{
+		Plugs: []*Plug{
+			&Plug{
+				Name:      s.plug.Name,
+				Snap:      s.plug.Snap,
+				Interface: s.plug.Interface,
+				Label:     s.plug.Label,
+				Connections: []SlotRef{
+					{
+						Snap: s.slot.Snap,
+						Name: s.slot.Name,
+					},
+				},
+			},
+		},
+		Slots: []*Slot{
+			&Slot{
+				Snap:      s.slot.Snap,
+				Name:      s.slot.Name,
+				Interface: s.slot.Interface,
+				Label:     s.slot.Label,
+				Connections: []PlugRef{
+					{
+						Snap: s.plug.Snap,
+						Name: s.plug.Name,
+					},
+				},
+			},
+		},
+	})
+	// After disconnecting the connections become empty
+	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	c.Assert(err, IsNil)
+	ifaces = s.testRepo.Interfaces()
+	c.Assert(ifaces, DeepEquals, &Interfaces{
+		Plugs: []*Plug{
+			&Plug{
+				Name:      s.plug.Name,
+				Snap:      s.plug.Snap,
+				Interface: s.plug.Interface,
+				Label:     s.plug.Label,
+			},
+		},
+		Slots: []*Slot{
+			&Slot{
+				Snap:      s.slot.Snap,
+				Name:      s.slot.Name,
+				Interface: s.slot.Interface,
+				Label:     s.slot.Label,
+			},
+		},
+	})
+}
+
 // Tests for Repository.SecuritySnippetsForSnap()
 
 func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -732,7 +732,7 @@ func (s *RepositorySuite) TestConnectedSlotsReturnsCorrectData(c *C) {
 	c.Assert(s.testRepo.ConnectedSlots(s.slot.Snap), DeepEquals, map[*Slot][]*Plug{
 		s.slot: []*Plug{s.plug},
 	})
-	// After revoking the result is empty again
+	// After disconnecting the result is empty again
 	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.ConnectedSlots(s.slot.Snap), HasLen, 0)
@@ -762,7 +762,7 @@ func (s *RepositorySuite) TestConnectedPlugsReturnsCorrectData(c *C) {
 	c.Assert(connects, DeepEquals, map[*Plug][]*Slot{
 		s.plug: []*Slot{s.slot},
 	})
-	// After revoking the result is empty again
+	// After disconnecting the result is empty again
 	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.ConnectedPlugs(s.plug.Snap), HasLen, 0)
@@ -790,7 +790,7 @@ func (s *RepositorySuite) TestPlugConnectionsReturnsCorrectData(c *C) {
 	c.Assert(err, IsNil)
 	users := s.testRepo.PlugConnections(s.plug.Snap, s.plug.Name)
 	c.Assert(users, DeepEquals, []*Slot{s.slot})
-	// After revoking the result is empty again
+	// After disconnecting the result is empty again
 	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.PlugConnections(s.plug.Snap, s.plug.Name), HasLen, 0)

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -808,46 +808,38 @@ func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
 	c.Assert(err, IsNil)
 	ifaces := s.testRepo.Interfaces()
 	c.Assert(ifaces, DeepEquals, &Interfaces{
-		Plugs: []*Plug{
-			&Plug{
-				Name:        s.plug.Name,
-				Snap:        s.plug.Snap,
-				Interface:   s.plug.Interface,
-				Label:       s.plug.Label,
-				Connections: []SlotRef{{s.slot.Snap, s.slot.Name}},
-			},
-		},
-		Slots: []*Slot{
-			&Slot{
-				Snap:        s.slot.Snap,
-				Name:        s.slot.Name,
-				Interface:   s.slot.Interface,
-				Label:       s.slot.Label,
-				Connections: []PlugRef{{s.plug.Snap, s.plug.Name}},
-			},
-		},
+		Plugs: []*Plug{{
+			Name:        s.plug.Name,
+			Snap:        s.plug.Snap,
+			Interface:   s.plug.Interface,
+			Label:       s.plug.Label,
+			Connections: []SlotRef{{s.slot.Snap, s.slot.Name}},
+		}},
+		Slots: []*Slot{{
+			Snap:        s.slot.Snap,
+			Name:        s.slot.Name,
+			Interface:   s.slot.Interface,
+			Label:       s.slot.Label,
+			Connections: []PlugRef{{s.plug.Snap, s.plug.Name}},
+		}},
 	})
 	// After disconnecting the connections become empty
 	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
 	c.Assert(err, IsNil)
 	ifaces = s.testRepo.Interfaces()
 	c.Assert(ifaces, DeepEquals, &Interfaces{
-		Plugs: []*Plug{
-			&Plug{
-				Name:      s.plug.Name,
-				Snap:      s.plug.Snap,
-				Interface: s.plug.Interface,
-				Label:     s.plug.Label,
-			},
-		},
-		Slots: []*Slot{
-			&Slot{
-				Snap:      s.slot.Snap,
-				Name:      s.slot.Name,
-				Interface: s.slot.Interface,
-				Label:     s.slot.Label,
-			},
-		},
+		Plugs: []*Plug{{
+			Name:      s.plug.Name,
+			Snap:      s.plug.Snap,
+			Interface: s.plug.Interface,
+			Label:     s.plug.Label,
+		}},
+		Slots: []*Slot{{
+			Snap:      s.slot.Snap,
+			Name:      s.slot.Name,
+			Interface: s.slot.Interface,
+			Label:     s.slot.Label,
+		}},
 	})
 }
 


### PR DESCRIPTION
This branch is a continuation of the interface API changes where each Plug and Slot know about what they are connected to. In the past this data was only computed when Interfaces() was called and was actually not available at any other time. This branch changes that, making Interfaces() a trivial copy of what is already present and maintained by Connect() and Disconnect()