### PR TITLE
client,daemon,cmd/snap: change POST /2.0/interfaces to work with lists

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -95,18 +95,8 @@ func (client *Client) performInterfaceAction(sa *InterfaceAction) error {
 func (client *Client) Connect(plugSnapName, plugName, slotSnapName, slotName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "connect",
-		Plugs: []Plug{
-			{
-				Snap: plugSnapName,
-				Name: plugName,
-			},
-		},
-		Slots: []Slot{
-			{
-				Snap: slotSnapName,
-				Name: slotName,
-			},
-		},
+		Plugs:  []Plug{{Snap: plugSnapName, Name: plugName}},
+		Slots:  []Slot{{Snap: slotSnapName, Name: slotName}},
 	})
 }
 
@@ -114,18 +104,8 @@ func (client *Client) Connect(plugSnapName, plugName, slotSnapName, slotName str
 func (client *Client) Disconnect(plugSnapName, plugName, slotSnapName, slotName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "disconnect",
-		Plugs: []Plug{
-			{
-				Snap: plugSnapName,
-				Name: plugName,
-			},
-		},
-		Slots: []Slot{
-			{
-				Snap: slotSnapName,
-				Name: slotName,
-			},
-		},
+		Plugs:  []Plug{{Snap: plugSnapName, Name: plugName}},
+		Slots:  []Slot{{Snap: slotSnapName, Name: slotName}},
 	})
 }
 
@@ -141,12 +121,7 @@ func (client *Client) AddPlug(plug *Plug) error {
 func (client *Client) RemovePlug(snapName, plugName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "remove-plug",
-		Plugs: []Plug{
-			{
-				Snap: snapName,
-				Name: plugName,
-			},
-		},
+		Plugs:  []Plug{{Snap: snapName, Name: plugName}},
 	})
 }
 
@@ -162,11 +137,6 @@ func (client *Client) AddSlot(slot *Slot) error {
 func (client *Client) RemoveSlot(snapName, slotName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "remove-slot",
-		Slots: []Slot{
-			{
-				Snap: snapName,
-				Name: slotName,
-			},
-		},
+		Slots:  []Slot{{Snap: snapName, Name: slotName}},
 	})
 }

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -67,8 +67,8 @@ type Interfaces struct {
 // InterfaceAction represents an action performed on the interface system.
 type InterfaceAction struct {
 	Action string `json:"action"`
-	Plug   *Plug  `json:"plug,omitempty"`
-	Slot   *Slot  `json:"slot,omitempty"`
+	Plugs  []Plug `json:"plugs,omitempty"`
+	Slots  []Slot `json:"slots,omitempty"`
 }
 
 // Interfaces returns all plugs, slots and their connections.
@@ -95,13 +95,17 @@ func (client *Client) performInterfaceAction(sa *InterfaceAction) error {
 func (client *Client) Connect(plugSnapName, plugName, slotSnapName, slotName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "connect",
-		Plug: &Plug{
-			Snap: plugSnapName,
-			Name: plugName,
+		Plugs: []Plug{
+			{
+				Snap: plugSnapName,
+				Name: plugName,
+			},
 		},
-		Slot: &Slot{
-			Snap: slotSnapName,
-			Name: slotName,
+		Slots: []Slot{
+			{
+				Snap: slotSnapName,
+				Name: slotName,
+			},
 		},
 	})
 }
@@ -110,13 +114,17 @@ func (client *Client) Connect(plugSnapName, plugName, slotSnapName, slotName str
 func (client *Client) Disconnect(plugSnapName, plugName, slotSnapName, slotName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "disconnect",
-		Plug: &Plug{
-			Snap: plugSnapName,
-			Name: plugName,
+		Plugs: []Plug{
+			{
+				Snap: plugSnapName,
+				Name: plugName,
+			},
 		},
-		Slot: &Slot{
-			Snap: slotSnapName,
-			Name: slotName,
+		Slots: []Slot{
+			{
+				Snap: slotSnapName,
+				Name: slotName,
+			},
 		},
 	})
 }
@@ -125,7 +133,7 @@ func (client *Client) Disconnect(plugSnapName, plugName, slotSnapName, slotName 
 func (client *Client) AddPlug(plug *Plug) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "add-plug",
-		Plug:   plug,
+		Plugs:  []Plug{*plug},
 	})
 }
 
@@ -133,9 +141,11 @@ func (client *Client) AddPlug(plug *Plug) error {
 func (client *Client) RemovePlug(snapName, plugName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "remove-plug",
-		Plug: &Plug{
-			Snap: snapName,
-			Name: plugName,
+		Plugs: []Plug{
+			{
+				Snap: snapName,
+				Name: plugName,
+			},
 		},
 	})
 }
@@ -144,7 +154,7 @@ func (client *Client) RemovePlug(snapName, plugName string) error {
 func (client *Client) AddSlot(slot *Slot) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "add-slot",
-		Slot:   slot,
+		Slots:  []Slot{*slot},
 	})
 }
 
@@ -152,9 +162,11 @@ func (client *Client) AddSlot(slot *Slot) error {
 func (client *Client) RemoveSlot(snapName, slotName string) error {
 	return client.performInterfaceAction(&InterfaceAction{
 		Action: "remove-slot",
-		Slot: &Slot{
-			Snap: snapName,
-			Name: slotName,
+		Slots: []Slot{
+			{
+				Snap: snapName,
+				Name: slotName,
+			},
 		},
 	})
 }

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -114,13 +114,17 @@ func (cs *clientSuite) TestClientConnect(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "connect",
-		"plug": map[string]interface{}{
-			"snap": "producer",
-			"plug": "plug",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"snap": "producer",
+				"plug": "plug",
+			},
 		},
-		"slot": map[string]interface{}{
-			"snap": "consumer",
-			"slot": "slot",
+		"slots": []interface{}{
+			map[string]interface{}{
+				"snap": "consumer",
+				"slot": "slot",
+			},
 		},
 	})
 }
@@ -144,13 +148,17 @@ func (cs *clientSuite) TestClientDisconnect(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "disconnect",
-		"plug": map[string]interface{}{
-			"snap": "producer",
-			"plug": "plug",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"snap": "producer",
+				"plug": "plug",
+			},
 		},
-		"slot": map[string]interface{}{
-			"snap": "consumer",
-			"slot": "slot",
+		"slots": []interface{}{
+			map[string]interface{}{
+				"snap": "consumer",
+				"slot": "slot",
+			},
 		},
 	})
 }
@@ -183,15 +191,17 @@ func (cs *clientSuite) TestClientAddPlug(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "add-plug",
-		"plug": map[string]interface{}{
-			"snap":      "snap",
-			"plug":      "plug",
-			"interface": "interface",
-			"attrs": map[string]interface{}{
-				"attr": "value",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"snap":      "snap",
+				"plug":      "plug",
+				"interface": "interface",
+				"attrs": map[string]interface{}{
+					"attr": "value",
+				},
+				"apps":  []interface{}{"app"},
+				"label": "label",
 			},
-			"apps":  []interface{}{"app"},
-			"label": "label",
 		},
 	})
 }
@@ -215,9 +225,11 @@ func (cs *clientSuite) TestClientRemovePlug(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "remove-plug",
-		"plug": map[string]interface{}{
-			"snap": "snap",
-			"plug": "plug",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"snap": "snap",
+				"plug": "plug",
+			},
 		},
 	})
 }
@@ -250,15 +262,17 @@ func (cs *clientSuite) TestClientAddSlot(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "add-slot",
-		"slot": map[string]interface{}{
-			"snap":      "snap",
-			"slot":      "slot",
-			"interface": "interface",
-			"attrs": map[string]interface{}{
-				"attr": "value",
+		"slots": []interface{}{
+			map[string]interface{}{
+				"snap":      "snap",
+				"slot":      "slot",
+				"interface": "interface",
+				"attrs": map[string]interface{}{
+					"attr": "value",
+				},
+				"apps":  []interface{}{"app"},
+				"label": "label",
 			},
-			"apps":  []interface{}{"app"},
-			"label": "label",
 		},
 	})
 }
@@ -282,9 +296,11 @@ func (cs *clientSuite) TestClientRemoveSlot(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"action": "remove-slot",
-		"slot": map[string]interface{}{
-			"snap": "snap",
-			"slot": "slot",
+		"slots": []interface{}{
+			map[string]interface{}{
+				"snap": "snap",
+				"slot": "slot",
+			},
 		},
 	})
 }

--- a/cmd/snap/cmd_add_plug_test.go
+++ b/cmd/snap/cmd_add_plug_test.go
@@ -61,17 +61,19 @@ func (s *SnapSuite) TestAddInterfaceExplicitEverything(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "add-plug",
-			"plug": map[string]interface{}{
-				"snap":      "producer",
-				"plug":      "plug",
-				"interface": "interface",
-				"attrs": map[string]interface{}{
-					"attr": "value",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap":      "producer",
+					"plug":      "plug",
+					"interface": "interface",
+					"attrs": map[string]interface{}{
+						"attr": "value",
+					},
+					"apps": []interface{}{
+						"meta/hooks/interfaces",
+					},
+					"label": "label",
 				},
-				"apps": []interface{}{
-					"meta/hooks/interfaces",
-				},
-				"label": "label",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/cmd/snap/cmd_add_slot_test.go
+++ b/cmd/snap/cmd_add_slot_test.go
@@ -61,17 +61,19 @@ func (s *SnapSuite) TestAddSlotExplicitEverything(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "add-slot",
-			"slot": map[string]interface{}{
-				"snap":      "consumer",
-				"slot":      "slot",
-				"interface": "interface",
-				"attrs": map[string]interface{}{
-					"attr": "value",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap":      "consumer",
+					"slot":      "slot",
+					"interface": "interface",
+					"attrs": map[string]interface{}{
+						"attr": "value",
+					},
+					"apps": []interface{}{
+						"my-app",
+					},
+					"label": "label",
 				},
-				"apps": []interface{}{
-					"my-app",
-				},
-				"label": "label",
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -66,13 +66,17 @@ func (s *SnapSuite) TestConnectExplicitEverything(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "connect",
-			"plug": map[string]interface{}{
-				"snap": "producer",
-				"plug": "plug",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap": "producer",
+					"plug": "plug",
+				},
 			},
-			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"slot": "slot",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap": "consumer",
+					"slot": "slot",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -88,13 +92,17 @@ func (s *SnapSuite) TestConnectExplicitPlugImplicitSlot(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "connect",
-			"plug": map[string]interface{}{
-				"snap": "producer",
-				"plug": "plug",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap": "producer",
+					"plug": "plug",
+				},
 			},
-			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"slot": "",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap": "consumer",
+					"slot": "",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -110,13 +118,17 @@ func (s *SnapSuite) TestConnectImplicitPlugExplicitSlot(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "connect",
-			"plug": map[string]interface{}{
-				"snap": "",
-				"plug": "plug",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap": "",
+					"plug": "plug",
+				},
 			},
-			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"slot": "slot",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap": "consumer",
+					"slot": "slot",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -132,13 +144,17 @@ func (s *SnapSuite) TestConnectImplicitPlugImplicitSlot(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "connect",
-			"plug": map[string]interface{}{
-				"snap": "",
-				"plug": "plug",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap": "",
+					"plug": "plug",
+				},
 			},
-			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"slot": "",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap": "consumer",
+					"slot": "",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -61,13 +61,17 @@ func (s *SnapSuite) TestDisconnectExplicitEverything(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "disconnect",
-			"plug": map[string]interface{}{
-				"snap": "producer",
-				"plug": "plug",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap": "producer",
+					"plug": "plug",
+				},
 			},
-			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"slot": "slot",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap": "consumer",
+					"slot": "slot",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -85,13 +89,17 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSlot(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "disconnect",
-			"plug": map[string]interface{}{
-				"snap": "",
-				"plug": "",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap": "",
+					"plug": "",
+				},
 			},
-			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"slot": "slot",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap": "consumer",
+					"slot": "slot",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)
@@ -109,13 +117,17 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnap(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "disconnect",
-			"plug": map[string]interface{}{
-				"snap": "",
-				"plug": "",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap": "",
+					"plug": "",
+				},
 			},
-			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"slot": "",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap": "consumer",
+					"slot": "",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/cmd/snap/cmd_remove_plug_test.go
+++ b/cmd/snap/cmd_remove_plug_test.go
@@ -56,9 +56,11 @@ func (s *SnapSuite) TestRemovePlug(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "remove-plug",
-			"plug": map[string]interface{}{
-				"snap": "producer",
-				"plug": "plug",
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"snap": "producer",
+					"plug": "plug",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/cmd/snap/cmd_remove_slot_test.go
+++ b/cmd/snap/cmd_remove_slot_test.go
@@ -55,9 +55,11 @@ func (s *SnapSuite) TestRemoveSlot(c *C) {
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
 		c.Check(DecodedRequestBody(c, r), DeepEquals, map[string]interface{}{
 			"action": "remove-slot",
-			"slot": map[string]interface{}{
-				"snap": "consumer",
-				"slot": "slot",
+			"slots": []interface{}{
+				map[string]interface{}{
+					"snap": "consumer",
+					"slot": "slot",
+				},
 			},
 		})
 		fmt.Fprintln(w, `{"type":"sync", "result":{}}`)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -947,10 +947,13 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 	if !c.d.enableInternalInterfaceActions && a.Action != "connect" && a.Action != "disconnect" {
 		return BadRequest("internal interface actions are disabled")
 	}
+	if len(a.Plugs) > 1 || len(a.Slots) > 1 {
+		return NotImplemented("many-to-many operations are not implemented")
+	}
 	switch a.Action {
 	case "connect":
-		if len(a.Plugs) != 1 || len(a.Slots) != 1 {
-			return BadRequest("many-to-many operations are not implemented")
+		if len(a.Plugs) == 0 || len(a.Slots) == 0 {
+			return BadRequest("at least one plug and slot is required")
 		}
 		err := c.d.interfaces.Connect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
 		if err != nil {
@@ -958,8 +961,8 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 		}
 		return SyncResponse(nil)
 	case "disconnect":
-		if len(a.Plugs) != 1 || len(a.Slots) != 1 {
-			return BadRequest("many-to-many operations are not implemented")
+		if len(a.Plugs) == 0 || len(a.Slots) == 0 {
+			return BadRequest("at least one plug and slot is required")
 		}
 		err := c.d.interfaces.Disconnect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
 		if err != nil {
@@ -967,8 +970,8 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 		}
 		return SyncResponse(nil)
 	case "add-plug":
-		if len(a.Plugs) != 1 {
-			return BadRequest("operating on multiple plugs is not implemented yet")
+		if len(a.Plugs) == 0 {
+			return BadRequest("at least one plug is required")
 		}
 		err := c.d.interfaces.AddPlug(&a.Plugs[0])
 		if err != nil {
@@ -979,8 +982,8 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 			Status: http.StatusCreated,
 		}
 	case "remove-plug":
-		if len(a.Plugs) != 1 {
-			return BadRequest("operating on multiple plugs is not implemented yet")
+		if len(a.Plugs) == 0 {
+			return BadRequest("at least one plug is required")
 		}
 		err := c.d.interfaces.RemovePlug(a.Plugs[0].Snap, a.Plugs[0].Name)
 		if err != nil {
@@ -988,8 +991,8 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 		}
 		return SyncResponse(nil)
 	case "add-slot":
-		if len(a.Slots) != 1 {
-			return BadRequest("operating on multiple slots is not implemented yet")
+		if len(a.Slots) == 0 {
+			return BadRequest("at least one slot is required")
 		}
 		err := c.d.interfaces.AddSlot(&a.Slots[0])
 		if err != nil {
@@ -1000,8 +1003,8 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 			Status: http.StatusCreated,
 		}
 	case "remove-slot":
-		if len(a.Slots) != 1 {
-			return BadRequest("operating on multiple slots is not implemented yet")
+		if len(a.Slots) == 0 {
+			return BadRequest("at least one slot is required")
 		}
 		err := c.d.interfaces.RemoveSlot(a.Slots[0].Snap, a.Slots[0].Name)
 		if err != nil {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -926,9 +926,9 @@ func getInterfaces(c *Command, r *http.Request) Response {
 
 // interfaceAction is an action performed on the interface system.
 type interfaceAction struct {
-	Action string          `json:"action"`
-	Plug   interfaces.Plug `json:"plug,omitempty"`
-	Slot   interfaces.Slot `json:"slot,omitempty"`
+	Action string            `json:"action"`
+	Plugs  []interfaces.Plug `json:"plugs,omitempty"`
+	Slots  []interfaces.Slot `json:"slots,omitempty"`
 }
 
 // changeInterfaces controls the interfaces system.
@@ -949,19 +949,28 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 	}
 	switch a.Action {
 	case "connect":
-		err := c.d.interfaces.Connect(a.Plug.Snap, a.Plug.Name, a.Slot.Snap, a.Slot.Name)
+		if len(a.Plugs) != 1 || len(a.Slots) != 1 {
+			return BadRequest("many-to-many operations are not implemented")
+		}
+		err := c.d.interfaces.Connect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
 		if err != nil {
 			return BadRequest("%v", err)
 		}
 		return SyncResponse(nil)
 	case "disconnect":
-		err := c.d.interfaces.Disconnect(a.Plug.Snap, a.Plug.Name, a.Slot.Snap, a.Slot.Name)
+		if len(a.Plugs) != 1 || len(a.Slots) != 1 {
+			return BadRequest("many-to-many operations are not implemented")
+		}
+		err := c.d.interfaces.Disconnect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
 		if err != nil {
 			return BadRequest("%v", err)
 		}
 		return SyncResponse(nil)
 	case "add-plug":
-		err := c.d.interfaces.AddPlug(&a.Plug)
+		if len(a.Plugs) != 1 {
+			return BadRequest("operating on multiple plugs is not implemented yet")
+		}
+		err := c.d.interfaces.AddPlug(&a.Plugs[0])
 		if err != nil {
 			return BadRequest("%v", err)
 		}
@@ -970,13 +979,19 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 			Status: http.StatusCreated,
 		}
 	case "remove-plug":
-		err := c.d.interfaces.RemovePlug(a.Plug.Snap, a.Plug.Name)
+		if len(a.Plugs) != 1 {
+			return BadRequest("operating on multiple plugs is not implemented yet")
+		}
+		err := c.d.interfaces.RemovePlug(a.Plugs[0].Snap, a.Plugs[0].Name)
 		if err != nil {
 			return BadRequest("%v", err)
 		}
 		return SyncResponse(nil)
 	case "add-slot":
-		err := c.d.interfaces.AddSlot(&a.Slot)
+		if len(a.Slots) != 1 {
+			return BadRequest("operating on multiple slots is not implemented yet")
+		}
+		err := c.d.interfaces.AddSlot(&a.Slots[0])
 		if err != nil {
 			return BadRequest("%v", err)
 		}
@@ -985,7 +1000,10 @@ func changeInterfaces(c *Command, r *http.Request) Response {
 			Status: http.StatusCreated,
 		}
 	case "remove-slot":
-		err := c.d.interfaces.RemoveSlot(a.Slot.Snap, a.Slot.Name)
+		if len(a.Slots) != 1 {
+			return BadRequest("operating on multiple slots is not implemented yet")
+		}
+		err := c.d.interfaces.RemoveSlot(a.Slots[0].Snap, a.Slots[0].Name)
 		if err != nil {
 			return BadRequest("%v", err)
 		}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1310,13 +1310,17 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "connect",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1362,13 +1366,17 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "other-interface"})
 	action := &interfaceAction{
 		Action: "connect",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1400,13 +1408,17 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "connect",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1438,13 +1450,17 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "connect",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1478,13 +1494,17 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1514,13 +1534,17 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1552,13 +1576,17 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1591,13 +1619,17 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1628,15 +1660,17 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plug: interfaces.Plug{
-			Snap:      "snap",
-			Name:      "plug",
-			Label:     "label",
-			Interface: "interface",
-			Attrs: map[string]interface{}{
-				"key": "value",
+		Plugs: []interfaces.Plug{
+			{
+				Snap:      "snap",
+				Name:      "plug",
+				Label:     "label",
+				Interface: "interface",
+				Attrs: map[string]interface{}{
+					"key": "value",
+				},
+				Apps: []string{"app"},
 			},
-			Apps: []string{"app"},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1656,7 +1690,7 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 		"status_code": 201.0,
 		"type":        "sync",
 	})
-	c.Check(d.interfaces.Plug("snap", "plug"), check.DeepEquals, &action.Plug)
+	c.Check(d.interfaces.Plug("snap", "plug"), check.DeepEquals, &action.Plugs[0])
 }
 
 func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
@@ -1667,15 +1701,17 @@ func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plug: interfaces.Plug{
-			Snap:      "producer",
-			Name:      "plug",
-			Label:     "label",
-			Interface: "interface",
-			Attrs: map[string]interface{}{
-				"key": "value",
+		Plugs: []interfaces.Plug{
+			{
+				Snap:      "producer",
+				Name:      "plug",
+				Label:     "label",
+				Interface: "interface",
+				Attrs: map[string]interface{}{
+					"key": "value",
+				},
+				Apps: []string{"app"},
 			},
-			Apps: []string{"app"},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1710,15 +1746,17 @@ func (s *apiSuite) TestAddPlugFailure(c *check.C) {
 	})
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plug: interfaces.Plug{
-			Snap:      "snap",
-			Name:      "plug",
-			Label:     "label",
-			Interface: "interface",
-			Attrs: map[string]interface{}{
-				"key": "value",
+		Plugs: []interfaces.Plug{
+			{
+				Snap:      "snap",
+				Name:      "plug",
+				Label:     "label",
+				Interface: "interface",
+				Attrs: map[string]interface{}{
+					"key": "value",
+				},
+				Apps: []string{"app"},
 			},
-			Apps: []string{"app"},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1749,9 +1787,11 @@ func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1781,9 +1821,11 @@ func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1816,9 +1858,11 @@ func (s *apiSuite) TestRemovePlugFailure(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plug: interfaces.Plug{
-			Snap: "producer",
-			Name: "plug",
+		Plugs: []interfaces.Plug{
+			{
+				Snap: "producer",
+				Name: "plug",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1848,15 +1892,17 @@ func (s *apiSuite) TestAddSlotSuccess(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slot: interfaces.Slot{
-			Snap:      "snap",
-			Name:      "slot",
-			Label:     "label",
-			Interface: "interface",
-			Attrs: map[string]interface{}{
-				"key": "value",
+		Slots: []interfaces.Slot{
+			{
+				Snap:      "snap",
+				Name:      "slot",
+				Label:     "label",
+				Interface: "interface",
+				Attrs: map[string]interface{}{
+					"key": "value",
+				},
+				Apps: []string{"app"},
 			},
-			Apps: []string{"app"},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1876,7 +1922,7 @@ func (s *apiSuite) TestAddSlotSuccess(c *check.C) {
 		"status_code": 201.0,
 		"type":        "sync",
 	})
-	c.Check(d.interfaces.Slot("snap", "slot"), check.DeepEquals, &action.Slot)
+	c.Check(d.interfaces.Slot("snap", "slot"), check.DeepEquals, &action.Slots[0])
 }
 
 func (s *apiSuite) TestAddSlotDisabled(c *check.C) {
@@ -1887,15 +1933,17 @@ func (s *apiSuite) TestAddSlotDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slot: interfaces.Slot{
-			Snap:      "consumer",
-			Name:      "slot",
-			Label:     "label",
-			Interface: "interface",
-			Attrs: map[string]interface{}{
-				"key": "value",
+		Slots: []interfaces.Slot{
+			{
+				Snap:      "consumer",
+				Name:      "slot",
+				Label:     "label",
+				Interface: "interface",
+				Attrs: map[string]interface{}{
+					"key": "value",
+				},
+				Apps: []string{"app"},
 			},
-			Apps: []string{"app"},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1930,15 +1978,17 @@ func (s *apiSuite) TestAddSlotFailure(c *check.C) {
 	})
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slot: interfaces.Slot{
-			Snap:      "snap",
-			Name:      "slot",
-			Label:     "label",
-			Interface: "interface",
-			Attrs: map[string]interface{}{
-				"key": "value",
+		Slots: []interfaces.Slot{
+			{
+				Snap:      "snap",
+				Name:      "slot",
+				Label:     "label",
+				Interface: "interface",
+				Attrs: map[string]interface{}{
+					"key": "value",
+				},
+				Apps: []string{"app"},
 			},
-			Apps: []string{"app"},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -1969,9 +2019,11 @@ func (s *apiSuite) TestRemoveSlotSuccess(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -2001,9 +2053,11 @@ func (s *apiSuite) TestRemoveSlotDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)
@@ -2036,9 +2090,11 @@ func (s *apiSuite) TestRemoveSlotFailure(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slot: interfaces.Slot{
-			Snap: "consumer",
-			Name: "slot",
+		Slots: []interfaces.Slot{
+			{
+				Snap: "consumer",
+				Name: "slot",
+			},
 		},
 	}
 	text, err := json.Marshal(action)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1310,18 +1310,8 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1366,18 +1356,8 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "other-interface"})
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1408,18 +1388,8 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1450,18 +1420,8 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1494,18 +1454,8 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1534,18 +1484,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1576,18 +1516,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1619,18 +1549,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1821,12 +1741,7 @@ func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1858,12 +1773,7 @@ func (s *apiSuite) TestRemovePlugFailure(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -2019,12 +1929,7 @@ func (s *apiSuite) TestRemoveSlotSuccess(c *check.C) {
 	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -2053,12 +1958,7 @@ func (s *apiSuite) TestRemoveSlotDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -2090,12 +1990,7 @@ func (s *apiSuite) TestRemoveSlotFailure(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots: []interfaces.Slot{
-			{
-				Snap: "consumer",
-				Name: "slot",
-			},
-		},
+		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1586,10 +1586,8 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 				Name:      "plug",
 				Label:     "label",
 				Interface: "interface",
-				Attrs: map[string]interface{}{
-					"key": "value",
-				},
-				Apps: []string{"app"},
+				Attrs:     map[string]interface{}{"key": "value"},
+				Apps:      []string{"app"},
 			},
 		},
 	}
@@ -1627,10 +1625,8 @@ func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
 				Name:      "plug",
 				Label:     "label",
 				Interface: "interface",
-				Attrs: map[string]interface{}{
-					"key": "value",
-				},
-				Apps: []string{"app"},
+				Attrs:     map[string]interface{}{"key": "value"},
+				Apps:      []string{"app"},
 			},
 		},
 	}
@@ -1672,10 +1668,8 @@ func (s *apiSuite) TestAddPlugFailure(c *check.C) {
 				Name:      "plug",
 				Label:     "label",
 				Interface: "interface",
-				Attrs: map[string]interface{}{
-					"key": "value",
-				},
-				Apps: []string{"app"},
+				Attrs:     map[string]interface{}{"key": "value"},
+				Apps:      []string{"app"},
 			},
 		},
 	}
@@ -1707,12 +1701,7 @@ func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs: []interfaces.Plug{
-			{
-				Snap: "producer",
-				Name: "plug",
-			},
-		},
+		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1808,10 +1797,8 @@ func (s *apiSuite) TestAddSlotSuccess(c *check.C) {
 				Name:      "slot",
 				Label:     "label",
 				Interface: "interface",
-				Attrs: map[string]interface{}{
-					"key": "value",
-				},
-				Apps: []string{"app"},
+				Attrs:     map[string]interface{}{"key": "value"},
+				Apps:      []string{"app"},
 			},
 		},
 	}
@@ -1849,10 +1836,8 @@ func (s *apiSuite) TestAddSlotDisabled(c *check.C) {
 				Name:      "slot",
 				Label:     "label",
 				Interface: "interface",
-				Attrs: map[string]interface{}{
-					"key": "value",
-				},
-				Apps: []string{"app"},
+				Attrs:     map[string]interface{}{"key": "value"},
+				Apps:      []string{"app"},
 			},
 		},
 	}
@@ -1894,10 +1879,8 @@ func (s *apiSuite) TestAddSlotFailure(c *check.C) {
 				Name:      "slot",
 				Label:     "label",
 				Interface: "interface",
-				Attrs: map[string]interface{}{
-					"key": "value",
-				},
-				Apps: []string{"app"},
+				Attrs:     map[string]interface{}{"key": "value"},
+				Apps:      []string{"app"},
 			},
 		},
 	}

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -119,7 +119,7 @@ by client implementations.
 
 kind               | value description
 -------------------|--------------------
-`license-required` | see “A note on licenses”, below
+`license-required` | see "A note on licenses", below
 
 ### Timestamps
 
@@ -332,7 +332,7 @@ field      | ignored except in action | description
 `action`   |                   | Required; a string, one of `install`, `update`, `remove`, `purge`, `activate`, `deactivate`, or `rollback`.
 `channel`  | `install` `update` | From which channel to pull the new package (and track henceforth). Channels are a means to discern the maturity of a package or the software it contains, although the exact meaning is left to the application developer. One of `edge`, `beta`, `candidate`, and `stable` which is the default.
 `leave_old`| `install` `update` `remove` | A boolean, equivalent to commandline's `--no-gc`. Default is false (do not leave old snaps around).
-`license`  | `install` `update` | A JSON object with `intro`, `license`, and `agreed` fields, the first two of which must match the license (see the section “A note on licenses”, below).
+`license`  | `install` `update` | A JSON object with `intro`, `license`, and `agreed` fields, the first two of which must match the license (see the section "A note on licenses", below).
 
 #### A note on licenses
 
@@ -561,7 +561,7 @@ Notes: user facing implementations in text form must show this data using yaml.
  "created_at": "1415639996123456",      // Creation timestamp
  "output": {},
  "resource": "/2.0/snaps/camlistore.sergiusens",
- "status": "running",                   // or “succeeded” or “failed”
+ "status": "running",                   // or "succeeded" or "failed"
  "updated_at": "1415639996451214"       // Last update timestamp
 }
 ```
@@ -628,24 +628,24 @@ Sample result:
 
 ```javascript
 {
-    “plugs”: [
+    "plugs": [
         {
-            “snap”:  "canonical-pi2",
-            “plug”:  "pin-13",
-            “interface”:  "bool-file",
-            “label”: "Pin 13",
-            “connections”: [
+            "snap":  "canonical-pi2",
+            "plug":  "pin-13",
+            "interface":  "bool-file",
+            "label": "Pin 13",
+            "connections": [
                 {"snap": "keyboard-lights", "slot": "capslock-led"}
             ]
         }
     ],
-    “slots”: [
+    "slots": [
         {
-            “snap”:  "keyboard-lights",
-            “slot”:  "capslock-led",
-            “interface”: "bool-file",
-            “label”: "Capslock indicator LED",
-            “connections”: [
+            "snap":  "keyboard-lights",
+            "slot":  "capslock-led",
+            "interface": "bool-file",
+            "label": "Capslock indicator LED",
+            "connections": [
                 {"snap": "canonical-pi2", "plug": "pin-13"}
             ]
         }
@@ -669,12 +669,12 @@ Sample input:
 
 ```javascript
 {
-    “action”: “connect”,
-    “plugs”: {
-        {“snap”: “canonical-pi2”,   “plug”: “pin-13”},
+    "action": "connect",
+    "plugs": {
+        {"snap": "canonical-pi2",   "plug": "pin-13"},
     },
-    “slots”: {
-        {“snap”: “keyboard-lights”, “slot”: “capslock-led”},
+    "slots": {
+        {"snap": "keyboard-lights", "slot": "capslock-led"},
     }
 }
 ```

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -670,7 +670,11 @@ Sample input:
 ```javascript
 {
     “action”: “connect”,
-    “plug”: {“snap”: “canonical-pi2”,   “plug”: “pin-13”},
-    “slot”: {“snap”: “keyboard-lights”, “slot”: “capslock-led”}
+    “plugs”: {
+        {“snap”: “canonical-pi2”,   “plug”: “pin-13”},
+    },
+    “slots”: {
+        {“snap”: “keyboard-lights”, “slot”: “capslock-led”},
+    }
 }
 ```

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -670,11 +670,7 @@ Sample input:
 ```javascript
 {
     "action": "connect",
-    "plugs": {
-        {"snap": "canonical-pi2",   "plug": "pin-13"},
-    },
-    "slots": {
-        {"snap": "keyboard-lights", "slot": "capslock-led"},
-    }
+    "plugs": {{"snap": "canonical-pi2",   "plug": "pin-13"}},
+    "slots": {{"snap": "keyboard-lights", "slot": "capslock-led"}}
 }
 ```


### PR DESCRIPTION
This patch changes the REST API for interacting with interfaces to
operate on lists of plugs and slots. In practice nothing changes but
this patch opens the avenue for connecting or disconnecting multiple
plugs and sockets in one call.

The connect/disconnect/{add,remove}-{plug,slot} actions are constrained
to one plug/slot. This restriction can be lifted later by another patch,
without any changes to the wire format.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>