### PR TITLE
classic: send SIGINT instead of SIGSEGV when testing mountpoint

### DIFF
--- a/classic/helpers_test.go
+++ b/classic/helpers_test.go
@@ -73,10 +73,11 @@ func (t *HelpersTestSuite) TestMountpointReturnsUnexpectedString(c *C) {
 }
 
 func (t *HelpersTestSuite) TestIsMountedSignaled(c *C) {
-	t.makeMockMountpointCmd(c, "echo segfaulting;kill -SEGV $$")
+
+	t.makeMockMountpointCmd(c, "echo ctrl-c;kill -INT $$")
 
 	_, err := isMounted("/")
-	c.Assert(err, ErrorMatches, "(?m)got unexpected exit code.*: segfaulting$")
+	c.Assert(err, ErrorMatches, "(?m)got unexpected exit code.*: ctrl-c$")
 }
 
 func (t *HelpersTestSuite) TestIsMountedNoBinary(c *C) {


### PR DESCRIPTION
Trivial branch that changes the test in classic so that we not produce a leftover core file (thanks zyga)