### PR TITLE
overlord/state: introduce Task and Change.NewTask

### DIFF
--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -131,6 +131,8 @@ func (c *Change) NewTask(kind, summary string) *Task {
 	return t
 }
 
+// TODO: AddTask
+
 // Tasks returns all the tasks this state change depends on.
 func (c *Change) Tasks() []*Task {
 	c.state.ensureLocked()

--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -75,6 +75,9 @@ func (c *Change) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON makes Change a json.Unmarshaller
 func (c *Change) UnmarshalJSON(data []byte) error {
+	if c.state != nil {
+		c.state.ensureLocked()
+	}
 	var unmarshalled marshalledChange
 	err := json.Unmarshal(data, &unmarshalled)
 	if err != nil {

--- a/overlord/state/change_test.go
+++ b/overlord/state/change_test.go
@@ -72,3 +72,44 @@ func (cs *changeSuite) TestSetNeedsLock(c *C) {
 
 	c.Assert(func() { chg.Set("a", 1) }, PanicMatches, "internal error: accessing state without lock")
 }
+
+func (cs *changeSuite) TestNewTaskAndTasks(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("install", "...")
+
+	t1 := chg.NewTask("download", "1...")
+	t2 := chg.NewTask("verify", "2...")
+
+	tasks := chg.Tasks()
+	c.Check(tasks, HasLen, 2)
+
+	expected := map[string]*state.Task{
+		t1.ID(): t1,
+		t2.ID(): t2,
+	}
+
+	for _, t := range tasks {
+		c.Check(t, Equals, expected[t.ID()])
+	}
+}
+
+func (cs *changeSuite) TestNewTaskNeedsLocked(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install", "...")
+	st.Unlock()
+
+	c.Assert(func() { chg.NewTask("download", "...") }, PanicMatches, "internal error: accessing state without lock")
+}
+
+func (cs *changeSuite) TestTasksNeedsLocked(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install", "...")
+	st.Unlock()
+
+	c.Assert(func() { chg.Tasks() }, PanicMatches, "internal error: accessing state without lock")
+}

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -77,6 +77,7 @@ type State struct {
 	backend Backend
 	data    customData
 	changes map[string]*Change
+	tasks   map[string]*Task
 }
 
 // New returns a new empty state.
@@ -85,6 +86,7 @@ func New(backend Backend) *State {
 		backend: backend,
 		data:    make(customData),
 		changes: make(map[string]*Change),
+		tasks:   make(map[string]*Task),
 	}
 }
 

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -111,6 +111,7 @@ func (s *State) unlock() {
 type marshalledState struct {
 	Data    map[string]*json.RawMessage `json:"data"`
 	Changes map[string]*Change          `json:"changes"`
+	Tasks   map[string]*Task            `json:"tasks"`
 }
 
 // MarshalJSON makes State a json.Marshaller
@@ -119,6 +120,7 @@ func (s *State) MarshalJSON() ([]byte, error) {
 	return json.Marshal(marshalledState{
 		Data:    s.data,
 		Changes: s.changes,
+		Tasks:   s.tasks,
 	})
 }
 
@@ -132,7 +134,11 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	}
 	s.data = unmarshalled.Data
 	s.changes = unmarshalled.Changes
+	s.tasks = unmarshalled.Tasks
 	// backlink state again
+	for _, t := range s.tasks {
+		t.state = s
+	}
 	for _, chg := range s.changes {
 		chg.state = s
 	}

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -65,6 +65,9 @@ func (t *Task) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON makes Task a json.Unmarshaller
 func (t *Task) UnmarshalJSON(data []byte) error {
+	if t.state != nil {
+		t.state.ensureLocked()
+	}
 	var unmarshalled marshalledTask
 	err := json.Unmarshal(data, &unmarshalled)
 	if err != nil {

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package state
+
+import (
+//"encoding/json"
+)
+
+// Task represents an individual operation to be performed
+// for accomplishing one or more state changes.
+//
+// See Change for more details.
+type Task struct {
+	state   *State
+	id      string
+	kind    string
+	summary string
+	data    customData
+}
+
+func newTask(state *State, id, kind, summary string) *Task {
+	return &Task{
+		state:   state,
+		id:      id,
+		kind:    kind,
+		summary: summary,
+		data:    make(customData),
+	}
+}
+
+// ID returns the individual random key for this task.
+func (t *Task) ID() string {
+	return t.id
+}
+
+// Kind returns the nature of this task for managers to know how to handle it.
+func (t *Task) Kind() string {
+	return t.kind
+}
+
+// Summary returns a summary describing what the task is about.
+func (t *Task) Summary() string {
+	return t.summary
+}
+
+/*
+// Set associates value with key for future consulting by managers.
+// The provided value must properly marshal and unmarshal with encoding/json.
+func (t *Task) Set(key string, value interface{}) { ... }
+
+// Get unmarshals the stored value associated with the provided key
+// into the value parameter.
+func (t *Task) Get(key string, value interface{}) error { ... }
+*/

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package state_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/overlord/state"
+)
+
+type taskSuite struct{}
+
+var _ = Suite(&taskSuite{})
+
+func (ts *taskSuite) TestNewTask(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("install", "...")
+	t := chg.NewTask("download", "1...")
+
+	c.Check(t.Kind(), Equals, "download")
+	c.Check(t.Summary(), Equals, "1...")
+}
+
+func (ts *taskSuite) TestGetSet(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("install", "...")
+	t := chg.NewTask("download", "1...")
+
+	t.Set("a", 1)
+
+	var v int
+	err := t.Get("a", &v)
+	c.Assert(err, IsNil)
+	c.Check(v, Equals, 1)
+}
+
+func (ts *taskSuite) TestGetNeedsLock(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install", "...")
+	t := chg.NewTask("download", "1...")
+	st.Unlock()
+
+	var v int
+	c.Assert(func() { t.Get("a", &v) }, PanicMatches, "internal error: accessing state without lock")
+}
+
+func (ts *taskSuite) TestSetNeedsLock(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install", "...")
+	t := chg.NewTask("download", "1...")
+	st.Unlock()
+
+	c.Assert(func() { t.Set("a", 1) }, PanicMatches, "internal error: accessing state without lock")
+}


### PR DESCRIPTION
This introduces Task objects under Changes as per spec, to track tasks to complete a given Change; Task comes with basic properties and Set/Get for entries support, and marshalling support.

This also adds Change.NewTask to create Task objects.

SetStatus etc will come with a later branch.