### PR TITLE
many: selectively swap semantics of plugs and slots

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 )
 
-// Plug represents a capacity offered by a snap.
+// Plug represents the potential of a given snap to connect to a given plug.
 type Plug struct {
 	Snap        string                 `json:"snap"`
 	Name        string                 `json:"plug"`
@@ -41,7 +41,7 @@ type PlugRef struct {
 	Name string `json:"plug"`
 }
 
-// Slot represents the potential of a given snap to connect to a given plug.
+// Slot represents a capacity offered by a snap.
 type Slot struct {
 	Snap        string                 `json:"snap"`
 	Name        string                 `json:"slot"`

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 )
 
-// Plug represents the potential of a given snap to connect to a given plug.
+// Plug represents the potential of a given snap to connect to a slot.
 type Plug struct {
 	Snap        string                 `json:"snap"`
 	Name        string                 `json:"plug"`

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -29,7 +29,7 @@ import (
 type cmdInterfaces struct {
 	Interface   string `short:"i" description:"constrain listing to specific interfaces"`
 	Positionals struct {
-		Query SnapAndName `positional-arg-name:"<snap>:<plug or slot>" description:"snap or snap:name" skip-help:"true"`
+		Query SnapAndName `positional-arg-name:"<snap>:<slot or plug>" description:"snap or snap:name" skip-help:"true"`
 	} `positional-args:"true"`
 }
 
@@ -37,19 +37,19 @@ var shortInterfacesHelp = i18n.G("Lists interfaces in the system")
 var longInterfacesHelp = i18n.G(`
 The interfaces command lists interfaces available in the system.
 
-By default all plugs and slots, used and offered by all snaps, are displayed.
+By default all slots and plugs, used and offered by all snaps, are displayed.
  
-$ snap interfaces <snap>:<plug or slot>
+$ snap interfaces <snap>:<slot or plug>
 
-Lists only the specified plug or slot.
+Lists only the specified slot or plug.
 
 $ snap interfaces <snap>
 
-Lists the plugs offered and slots used by the specified snap.
+Lists the slots offered and plugs used by the specified snap.
 
 $ snap interfaces --i=<interface> [<snap>]
 
-Lists only plugs and slots of the specific interface.
+Lists only slots and plugs of the specific interface.
 `)
 
 func init() {
@@ -62,43 +62,8 @@ func (x *cmdInterfaces) Execute(args []string) error {
 	ifaces, err := Client().Interfaces()
 	if err == nil {
 		w := tabwriter.NewWriter(Stdout, 0, 4, 1, ' ', 0)
-		fmt.Fprintln(w, i18n.G("plug\tslot"))
+		fmt.Fprintln(w, i18n.G("slot\tplug"))
 		defer w.Flush()
-		for _, plug := range ifaces.Plugs {
-			if x.Positionals.Query.Snap != "" && x.Positionals.Query.Snap != plug.Snap {
-				continue
-			}
-			if x.Positionals.Query.Name != "" && x.Positionals.Query.Name != plug.Name {
-				continue
-			}
-			if x.Interface != "" && plug.Interface != x.Interface {
-				continue
-			}
-			// The OS snap (always ubuntu-core) is special and enable abbreviated
-			// display syntax on the plug-side of the connection.
-			if plug.Snap == "ubuntu-core" {
-				fmt.Fprintf(w, ":%s\t", plug.Name)
-			} else {
-				fmt.Fprintf(w, "%s:%s\t", plug.Snap, plug.Name)
-			}
-			for i := 0; i < len(plug.Connections); i++ {
-				if i > 0 {
-					fmt.Fprint(w, ",")
-				}
-				if plug.Connections[i].Name != plug.Name {
-					fmt.Fprintf(w, "%s:%s", plug.Connections[i].Snap, plug.Connections[i].Name)
-				} else {
-					fmt.Fprintf(w, "%s", plug.Connections[i].Snap)
-				}
-			}
-			// Display visual indicator for disconnected plugs
-			if len(plug.Connections) == 0 {
-				fmt.Fprint(w, "--")
-			}
-			fmt.Fprintf(w, "\n")
-		}
-		// Slots are treated differently. Since the loop above already printed each connected
-		// slot, the loop below focuses on printing just the disconnected slots.
 		for _, slot := range ifaces.Slots {
 			if x.Positionals.Query.Snap != "" && x.Positionals.Query.Snap != slot.Snap {
 				continue
@@ -109,9 +74,44 @@ func (x *cmdInterfaces) Execute(args []string) error {
 			if x.Interface != "" && slot.Interface != x.Interface {
 				continue
 			}
-			// Display visual indicator for disconnected slots.
+			// The OS snap (always ubuntu-core) is special and enable abbreviated
+			// display syntax on the slot-side of the connection.
+			if slot.Snap == "ubuntu-core" {
+				fmt.Fprintf(w, ":%s\t", slot.Name)
+			} else {
+				fmt.Fprintf(w, "%s:%s\t", slot.Snap, slot.Name)
+			}
+			for i := 0; i < len(slot.Connections); i++ {
+				if i > 0 {
+					fmt.Fprint(w, ",")
+				}
+				if slot.Connections[i].Name != slot.Name {
+					fmt.Fprintf(w, "%s:%s", slot.Connections[i].Snap, slot.Connections[i].Name)
+				} else {
+					fmt.Fprintf(w, "%s", slot.Connections[i].Snap)
+				}
+			}
+			// Display visual indicator for disconnected slots
 			if len(slot.Connections) == 0 {
-				fmt.Fprintf(w, "--\t%s:%s\n", slot.Snap, slot.Name)
+				fmt.Fprint(w, "--")
+			}
+			fmt.Fprintf(w, "\n")
+		}
+		// Plugs are treated differently. Since the loop above already printed each connected
+		// plug, the loop below focuses on printing just the disconnected plugs.
+		for _, plug := range ifaces.Plugs {
+			if x.Positionals.Query.Snap != "" && x.Positionals.Query.Snap != plug.Snap {
+				continue
+			}
+			if x.Positionals.Query.Name != "" && x.Positionals.Query.Name != plug.Name {
+				continue
+			}
+			if x.Interface != "" && plug.Interface != x.Interface {
+				continue
+			}
+			// Display visual indicator for disconnected plugs.
+			if len(plug.Connections) == 0 {
+				fmt.Fprintf(w, "--\t%s:%s\n", plug.Snap, plug.Name)
 			}
 		}
 	}

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -31,23 +31,23 @@ import (
 
 func (s *SnapSuite) TestInterfacesHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] interfaces [interfaces-OPTIONS] [<snap>:<plug or slot>]
+  snap.test [OPTIONS] interfaces [interfaces-OPTIONS] [<snap>:<slot or plug>]
 
 The interfaces command lists interfaces available in the system.
 
-By default all plugs and slots, used and offered by all snaps, are displayed.
+By default all slots and plugs, used and offered by all snaps, are displayed.
 
-$ snap interfaces <snap>:<plug or slot>
+$ snap interfaces <snap>:<slot or plug>
 
-Lists only the specified plug or slot.
+Lists only the specified slot or plug.
 
 $ snap interfaces <snap>
 
-Lists the plugs offered and slots used by the specified snap.
+Lists the slots offered and plugs used by the specified snap.
 
 $ snap interfaces --i=<interface> [<snap>]
 
-Lists only plugs and slots of the specific interface.
+Lists only slots and plugs of the specific interface.
 
 Help Options:
   -h, --help                       Show this help message
@@ -56,40 +56,11 @@ Help Options:
       -i=                          constrain listing to specific interfaces
 
 [interfaces command arguments]
-  <snap>:<plug or slot>:           snap or snap:name
+  <snap>:<slot or plug>:           snap or snap:name
 `
 	rest, err := Parser().ParseArgs([]string{"interfaces", "--help"})
 	c.Assert(err.Error(), Equals, msg)
 	c.Assert(rest, DeepEquals, []string{})
-}
-
-func (s *SnapSuite) TestInterfacesZeroPlugsOneSlot(c *C) {
-	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
-		body, err := ioutil.ReadAll(r.Body)
-		c.Check(err, IsNil)
-		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
-			"type": "sync",
-			"result": client.Interfaces{
-				Slots: []client.Slot{
-					{
-						Snap: "keyboard-lights",
-						Name: "capslock-led",
-					},
-				},
-			},
-		})
-	})
-	rest, err := Parser().ParseArgs([]string{"interfaces"})
-	c.Assert(err, IsNil)
-	c.Assert(rest, DeepEquals, []string{})
-	expectedStdout := "" +
-		"plug slot\n" +
-		"--   keyboard-lights:capslock-led\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
 }
 
 func (s *SnapSuite) TestInterfacesZeroSlotsOnePlug(c *C) {
@@ -104,6 +75,35 @@ func (s *SnapSuite) TestInterfacesZeroSlotsOnePlug(c *C) {
 			"result": client.Interfaces{
 				Plugs: []client.Plug{
 					{
+						Snap: "keyboard-lights",
+						Name: "capslock-led",
+					},
+				},
+			},
+		})
+	})
+	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	expectedStdout := "" +
+		"slot plug\n" +
+		"--   keyboard-lights:capslock-led\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestInterfacesZeroPlugsOneSlot(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
+		body, err := ioutil.ReadAll(r.Body)
+		c.Check(err, IsNil)
+		c.Check(body, DeepEquals, []byte{})
+		EncodeResponseBody(c, w, map[string]interface{}{
+			"type": "sync",
+			"result": client.Interfaces{
+				Slots: []client.Slot{
+					{
 						Snap:      "canonical-pi2",
 						Name:      "pin-13",
 						Interface: "bool-file",
@@ -117,13 +117,13 @@ func (s *SnapSuite) TestInterfacesZeroSlotsOnePlug(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
-		"plug                 slot\n" +
+		"slot                 plug\n" +
 		"canonical-pi2:pin-13 --\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestInterfacesOnePlugOneSlot(c *C) {
+func (s *SnapSuite) TestInterfacesOneSlotOnePlug(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
@@ -133,13 +133,13 @@ func (s *SnapSuite) TestInterfacesOnePlugOneSlot(c *C) {
 		EncodeResponseBody(c, w, map[string]interface{}{
 			"type": "sync",
 			"result": client.Interfaces{
-				Plugs: []client.Plug{
+				Slots: []client.Slot{
 					{
 						Snap:      "canonical-pi2",
 						Name:      "pin-13",
 						Interface: "bool-file",
 						Label:     "Pin 13",
-						Connections: []client.SlotRef{
+						Connections: []client.PlugRef{
 							{
 								Snap: "keyboard-lights",
 								Name: "capslock-led",
@@ -147,13 +147,13 @@ func (s *SnapSuite) TestInterfacesOnePlugOneSlot(c *C) {
 						},
 					},
 				},
-				Slots: []client.Slot{
+				Plugs: []client.Plug{
 					{
 						Snap:      "keyboard-lights",
 						Name:      "capslock-led",
 						Interface: "bool-file",
 						Label:     "Capslock indicator LED",
-						Connections: []client.PlugRef{
+						Connections: []client.SlotRef{
 							{
 								Snap: "canonical-pi2",
 								Name: "pin-13",
@@ -168,13 +168,13 @@ func (s *SnapSuite) TestInterfacesOnePlugOneSlot(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
-		"plug                 slot\n" +
+		"slot                 plug\n" +
 		"canonical-pi2:pin-13 keyboard-lights:capslock-led\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestInterfacesTwoSlots(c *C) {
+func (s *SnapSuite) TestInterfacesTwoPlugs(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
@@ -184,13 +184,13 @@ func (s *SnapSuite) TestInterfacesTwoSlots(c *C) {
 		EncodeResponseBody(c, w, map[string]interface{}{
 			"type": "sync",
 			"result": client.Interfaces{
-				Plugs: []client.Plug{
+				Slots: []client.Slot{
 					{
 						Snap:      "canonical-pi2",
 						Name:      "pin-13",
 						Interface: "bool-file",
 						Label:     "Pin 13",
-						Connections: []client.SlotRef{
+						Connections: []client.PlugRef{
 							{
 								Snap: "keyboard-lights",
 								Name: "capslock-led",
@@ -209,13 +209,13 @@ func (s *SnapSuite) TestInterfacesTwoSlots(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
-		"plug                 slot\n" +
+		"slot                 plug\n" +
 		"canonical-pi2:pin-13 keyboard-lights:capslock-led,keyboard-lights:scrollock-led\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestInterfacesSlotsWithCommonName(c *C) {
+func (s *SnapSuite) TestInterfacesPlugsWithCommonName(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
@@ -225,13 +225,13 @@ func (s *SnapSuite) TestInterfacesSlotsWithCommonName(c *C) {
 		EncodeResponseBody(c, w, map[string]interface{}{
 			"type": "sync",
 			"result": client.Interfaces{
-				Plugs: []client.Plug{
+				Slots: []client.Slot{
 					{
 						Snap:      "canonical-pi2",
 						Name:      "network-listening",
 						Interface: "network-listening",
 						Label:     "Ability to be a network service",
-						Connections: []client.SlotRef{
+						Connections: []client.PlugRef{
 							{
 								Snap: "paste-daemon",
 								Name: "network-listening",
@@ -243,13 +243,13 @@ func (s *SnapSuite) TestInterfacesSlotsWithCommonName(c *C) {
 						},
 					},
 				},
-				Slots: []client.Slot{
+				Plugs: []client.Plug{
 					{
 						Snap:      "paste-daemon",
 						Name:      "network-listening",
 						Interface: "network-listening",
 						Label:     "Ability to be a network service",
-						Connections: []client.PlugRef{
+						Connections: []client.SlotRef{
 							{
 								Snap: "canonical-pi2",
 								Name: "network-listening",
@@ -261,7 +261,7 @@ func (s *SnapSuite) TestInterfacesSlotsWithCommonName(c *C) {
 						Name:      "network-listening",
 						Interface: "network-listening",
 						Label:     "Ability to be a network service",
-						Connections: []client.PlugRef{
+						Connections: []client.SlotRef{
 							{
 								Snap: "canonical-pi2",
 								Name: "network-listening",
@@ -276,13 +276,13 @@ func (s *SnapSuite) TestInterfacesSlotsWithCommonName(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
-		"plug                            slot\n" +
+		"slot                            plug\n" +
 		"canonical-pi2:network-listening paste-daemon,time-daemon\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestInterfacesOsSnapPlugs(c *C) {
+func (s *SnapSuite) TestInterfacesOsSnapSlots(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
@@ -292,13 +292,13 @@ func (s *SnapSuite) TestInterfacesOsSnapPlugs(c *C) {
 		EncodeResponseBody(c, w, map[string]interface{}{
 			"type": "sync",
 			"result": client.Interfaces{
-				Plugs: []client.Plug{
+				Slots: []client.Slot{
 					{
 						Snap:      "ubuntu-core",
 						Name:      "network-listening",
 						Interface: "network-listening",
 						Label:     "Ability to be a network service",
-						Connections: []client.SlotRef{
+						Connections: []client.PlugRef{
 							{
 								Snap: "paste-daemon",
 								Name: "network-listening",
@@ -310,13 +310,13 @@ func (s *SnapSuite) TestInterfacesOsSnapPlugs(c *C) {
 						},
 					},
 				},
-				Slots: []client.Slot{
+				Plugs: []client.Plug{
 					{
 						Snap:      "paste-daemon",
 						Name:      "network-listening",
 						Interface: "network-listening",
 						Label:     "Ability to be a network service",
-						Connections: []client.PlugRef{
+						Connections: []client.SlotRef{
 							{
 								Snap: "ubuntu-core",
 								Name: "network-listening",
@@ -328,7 +328,7 @@ func (s *SnapSuite) TestInterfacesOsSnapPlugs(c *C) {
 						Name:      "network-listening",
 						Interface: "network-listening",
 						Label:     "Ability to be a network service",
-						Connections: []client.PlugRef{
+						Connections: []client.SlotRef{
 							{
 								Snap: "ubuntu-core",
 								Name: "network-listening",
@@ -343,13 +343,13 @@ func (s *SnapSuite) TestInterfacesOsSnapPlugs(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
-		"plug               slot\n" +
+		"slot               plug\n" +
 		":network-listening paste-daemon,time-daemon\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestInterfacesTwoPlugsAndFiltering(c *C) {
+func (s *SnapSuite) TestInterfacesTwoSlotsAndFiltering(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
@@ -359,13 +359,13 @@ func (s *SnapSuite) TestInterfacesTwoPlugsAndFiltering(c *C) {
 		EncodeResponseBody(c, w, map[string]interface{}{
 			"type": "sync",
 			"result": client.Interfaces{
-				Plugs: []client.Plug{
+				Slots: []client.Slot{
 					{
 						Snap:      "canonical-pi2",
 						Name:      "debug-console",
 						Interface: "serial-port",
 						Label:     "Serial port on the expansion header",
-						Connections: []client.SlotRef{
+						Connections: []client.PlugRef{
 							{
 								Snap: "ubuntu-core",
 								Name: "debug-console",
@@ -377,7 +377,7 @@ func (s *SnapSuite) TestInterfacesTwoPlugsAndFiltering(c *C) {
 						Name:      "pin-13",
 						Interface: "bool-file",
 						Label:     "Pin 13",
-						Connections: []client.SlotRef{
+						Connections: []client.PlugRef{
 							{
 								Snap: "keyboard-lights",
 								Name: "capslock-led",
@@ -392,7 +392,7 @@ func (s *SnapSuite) TestInterfacesTwoPlugsAndFiltering(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
-		"plug                        slot\n" +
+		"slot                        plug\n" +
 		"canonical-pi2:debug-console ubuntu-core\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
@@ -408,7 +408,7 @@ func (s *SnapSuite) TestInterfacesOfSpecificSnap(c *C) {
 		EncodeResponseBody(c, w, map[string]interface{}{
 			"type": "sync",
 			"result": client.Interfaces{
-				Plugs: []client.Plug{
+				Slots: []client.Slot{
 					{
 						Snap:      "cheese",
 						Name:      "photo-trigger",
@@ -435,14 +435,14 @@ func (s *SnapSuite) TestInterfacesOfSpecificSnap(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
-		"plug                 slot\n" +
+		"slot                 plug\n" +
 		"wake-up-alarm:toggle --\n" +
 		"wake-up-alarm:snooze --\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestInterfacesOfSpecificSnapAndPlug(c *C) {
+func (s *SnapSuite) TestInterfacesOfSpecificSnapAndSlot(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/2.0/interfaces")
@@ -452,7 +452,7 @@ func (s *SnapSuite) TestInterfacesOfSpecificSnapAndPlug(c *C) {
 		EncodeResponseBody(c, w, map[string]interface{}{
 			"type": "sync",
 			"result": client.Interfaces{
-				Plugs: []client.Plug{
+				Slots: []client.Slot{
 					{
 						Snap:      "cheese",
 						Name:      "photo-trigger",
@@ -479,7 +479,7 @@ func (s *SnapSuite) TestInterfacesOfSpecificSnapAndPlug(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
-		"plug                 slot\n" +
+		"slot                 plug\n" +
 		"wake-up-alarm:snooze --\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -628,25 +628,25 @@ Sample result:
 
 ```javascript
 {
-    "plugs": [
+    "slots": [
         {
             "snap":  "canonical-pi2",
-            "plug":  "pin-13",
+            "slot":  "pin-13",
             "interface":  "bool-file",
             "label": "Pin 13",
             "connections": [
-                {"snap": "keyboard-lights", "slot": "capslock-led"}
+                {"snap": "keyboard-lights", "plug": "capslock-led"}
             ]
         }
     ],
-    "slots": [
+    "plugs": [
         {
             "snap":  "keyboard-lights",
-            "slot":  "capslock-led",
+            "plug":  "capslock-led",
             "interface": "bool-file",
             "label": "Capslock indicator LED",
             "connections": [
-                {"snap": "canonical-pi2", "plug": "pin-13"}
+                {"snap": "canonical-pi2", "slot": "pin-13"}
             ]
         }
     ]
@@ -670,7 +670,7 @@ Sample input:
 ```javascript
 {
     "action": "connect",
-    "plugs": {{"snap": "canonical-pi2",   "plug": "pin-13"}},
-    "slots": {{"snap": "keyboard-lights", "slot": "capslock-led"}}
+    "slots": {{"snap": "canonical-pi2",   "plug": "pin-13"}},
+    "plugs": {{"snap": "keyboard-lights", "slot": "capslock-led"}}
 }
 ```

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -670,7 +670,7 @@ Sample input:
 ```javascript
 {
     "action": "connect",
-    "slots": {{"snap": "canonical-pi2",   "plug": "pin-13"}},
-    "plugs": {{"snap": "keyboard-lights", "slot": "capslock-led"}}
+    "slots": {{"snap": "canonical-pi2",   "slot": "pin-13"}},
+    "plugs": {{"snap": "keyboard-lights", "plug": "capslock-led"}}
 }
 ```

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -77,10 +77,10 @@ func (iface *BoolFileInterface) SanitizeSlot(plug *interfaces.Slot) error {
 	return nil
 }
 
-// PlugSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
+// SlotSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
 // Producers gain control over exporting, importing GPIOs as well as
 // controlling the direction of particular pins.
-func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	gpioSnippet := []byte(`
 /sys/class/gpio/export rw,
 /sys/class/gpio/unexport rw,
@@ -101,9 +101,9 @@ func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot 
 	}
 }
 
-// SlotSecuritySnippet returns the configuration snippet required to use a bool-file interface.
+// PlugSecuritySnippet returns the configuration snippet required to use a bool-file interface.
 // Consumers gain permission to read, write and lock the designated file.
-func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		// Allow write and lock on the file designated by the path.

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -77,10 +77,10 @@ func (iface *BoolFileInterface) SanitizeSlot(plug *interfaces.Slot) error {
 	return nil
 }
 
-// SlotSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
+// PlugSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
 // Producers gain control over exporting, importing GPIOs as well as
 // controlling the direction of particular pins.
-func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	gpioSnippet := []byte(`
 /sys/class/gpio/export rw,
 /sys/class/gpio/unexport rw,
@@ -101,9 +101,9 @@ func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot 
 	}
 }
 
-// PlugSecuritySnippet returns the configuration snippet required to use a bool-file interface.
+// SlotSecuritySnippet returns the configuration snippet required to use a bool-file interface.
 // Consumers gain permission to read, write and lock the designated file.
-func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		// Allow write and lock on the file designated by the path.

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -121,30 +121,30 @@ func (s *BoolFileInterfaceSuite) TestSanitizeSlot(c *C) {
 		`slot is not of interface "bool-file"`)
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetHandlesSymlinkErrors(c *C) {
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetHandlesSymlinkErrors(c *C) {
 	// Symbolic link traversal is handled correctly
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "", fmt.Errorf("broken symbolic link")
 	})
-	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, ErrorMatches, "cannot compute slot security snippet: broken symbolic link")
 	c.Assert(snippet, IsNil)
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetDereferencesSymlinks(c *C) {
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetDereferencesSymlinks(c *C) {
 	// Use a fake (successful) dereferencing function for the remainder of the test.
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "(dereferenced)" + path, nil
 	})
 	// Extra apparmor permission to access GPIO value
 	// The path uses dereferenced symbolic links.
-	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte(
 		"(dereferenced)/sys/class/gpio/gpio13/value rwk,\n"))
 	// Extra apparmor permission to access LED brightness.
 	// The path uses dereferenced symbolic links.
-	snippet, err = s.iface.SlotSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err = s.iface.PlugSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte(
 		"(dereferenced)/sys/class/leds/input27::capslock/brightness rwk,\n"))
@@ -157,63 +157,12 @@ func (s *BoolFileInterfaceSuite) TestSlotSecurityDoesNotContainPlugSecurity(c *C
 	})
 	var err error
 	var plugSnippet, slotSnippet []byte
-	slotSnippet, err = s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	slotSnippet, err = s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	plugSnippet, err = s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	plugSnippet, err = s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	// Ensure that we don't accidentally give plug-side permissions to slot-side.
 	c.Assert(bytes.Contains(slotSnippet, plugSnippet), Equals, false)
-}
-
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetPanicksOnUnsanitizedPlugs(c *C) {
-	// Unsanitized plugs should never be used and cause a panic.
-	c.Assert(func() {
-		s.iface.SlotSecuritySnippet(s.missingPathPlug, s.slot, interfaces.SecurityAppArmor)
-	}, PanicMatches, "plug is not sanitized")
-}
-
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetUnusedSecuritySystems(c *C) {
-	for _, plug := range []*interfaces.Plug{s.ledPlug, s.gpioPlug} {
-		// No extra seccomp permissions for slot
-		snippet, err := s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecuritySecComp)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra dbus permissions for slot
-		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityDBus)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra udev permissions for slot
-		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra udev permissions for slot
-		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// Other security types are not recognized
-		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, "foo")
-		c.Assert(err, ErrorMatches, `unknown security system`)
-		c.Assert(snippet, IsNil)
-	}
-}
-
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
-	// Extra apparmor permission to provide GPIOs
-	expectedGPIOSnippet := []byte(`
-/sys/class/gpio/export rw,
-/sys/class/gpio/unexport rw,
-/sys/class/gpio/gpio[0-9]+/direction rw,
-`)
-	snippet, err := s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedGPIOSnippet)
-}
-
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
-	// No extra apparmor permission to provide LEDs
-	snippet, err := s.iface.PlugSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
 }
 
 func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetPanicksOnUnsanitizedPlugs(c *C) {
@@ -225,20 +174,71 @@ func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetPanicksOnUnsanitizedPlug
 
 func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetUnusedSecuritySystems(c *C) {
 	for _, plug := range []*interfaces.Plug{s.ledPlug, s.gpioPlug} {
-		// No extra seccomp permissions for plug
+		// No extra seccomp permissions for slot
 		snippet, err := s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecuritySecComp)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra dbus permissions for plug
+		// No extra dbus permissions for slot
 		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityDBus)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra udev permissions for plug
+		// No extra udev permissions for slot
+		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for slot
 		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// Other security types are not recognized
 		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, "foo")
+		c.Assert(err, ErrorMatches, `unknown security system`)
+		c.Assert(snippet, IsNil)
+	}
+}
+
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
+	// Extra apparmor permission to provide GPIOs
+	expectedGPIOSnippet := []byte(`
+/sys/class/gpio/export rw,
+/sys/class/gpio/unexport rw,
+/sys/class/gpio/gpio[0-9]+/direction rw,
+`)
+	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedGPIOSnippet)
+}
+
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
+	// No extra apparmor permission to provide LEDs
+	snippet, err := s.iface.SlotSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetPanicksOnUnsanitizedPlugs(c *C) {
+	// Unsanitized plugs should never be used and cause a panic.
+	c.Assert(func() {
+		s.iface.SlotSecuritySnippet(s.missingPathPlug, s.slot, interfaces.SecurityAppArmor)
+	}, PanicMatches, "plug is not sanitized")
+}
+
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetUnusedSecuritySystems(c *C) {
+	for _, plug := range []*interfaces.Plug{s.ledPlug, s.gpioPlug} {
+		// No extra seccomp permissions for plug
+		snippet, err := s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecuritySecComp)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra dbus permissions for plug
+		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityDBus)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for plug
+		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// Other security types are not recognized
+		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, "foo")
 		c.Assert(err, ErrorMatches, `unknown security system`)
 		c.Assert(snippet, IsNil)
 	}

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -38,50 +38,50 @@ func Test(t *testing.T) {
 type BoolFileInterfaceSuite struct {
 	testutil.BaseTest
 	iface             interfaces.Interface
-	gpioPlug          *interfaces.Plug
-	ledPlug           *interfaces.Plug
-	badPathPlug       *interfaces.Plug
-	parentDirPathPlug *interfaces.Plug
-	missingPathPlug   *interfaces.Plug
-	badInterfacePlug  *interfaces.Plug
-	slot              *interfaces.Slot
+	gpioSlot          *interfaces.Slot
+	ledSlot           *interfaces.Slot
+	badPathSlot       *interfaces.Slot
+	parentDirPathSlot *interfaces.Slot
+	missingPathSlot   *interfaces.Slot
 	badInterfaceSlot  *interfaces.Slot
+	plug              *interfaces.Plug
+	badInterfacePlug  *interfaces.Plug
 }
 
 var _ = Suite(&BoolFileInterfaceSuite{
 	iface: &builtin.BoolFileInterface{},
-	gpioPlug: &interfaces.Plug{
+	gpioSlot: &interfaces.Slot{
 		Interface: "bool-file",
 		Attrs: map[string]interface{}{
 			"path": "/sys/class/gpio/gpio13/value",
 		},
 	},
-	ledPlug: &interfaces.Plug{
+	ledSlot: &interfaces.Slot{
 		Interface: "bool-file",
 		Attrs: map[string]interface{}{
 			"path": "/sys/class/leds/input27::capslock/brightness",
 		},
 	},
-	missingPathPlug: &interfaces.Plug{
+	missingPathSlot: &interfaces.Slot{
 		Interface: "bool-file",
 	},
-	badPathPlug: &interfaces.Plug{
+	badPathSlot: &interfaces.Slot{
 		Interface: "bool-file",
 		Attrs:     map[string]interface{}{"path": "path"},
 	},
-	parentDirPathPlug: &interfaces.Plug{
+	parentDirPathSlot: &interfaces.Slot{
 		Interface: "bool-file",
 		Attrs: map[string]interface{}{
 			"path": "/sys/class/gpio/../value",
 		},
 	},
-	badInterfacePlug: &interfaces.Plug{
+	badInterfaceSlot: &interfaces.Slot{
 		Interface: "other-interface",
 	},
-	slot: &interfaces.Slot{
+	plug: &interfaces.Plug{
 		Interface: "bool-file",
 	},
-	badInterfaceSlot: &interfaces.Slot{
+	badInterfacePlug: &interfaces.Plug{
 		Interface: "other-interface",
 	},
 })
@@ -90,155 +90,155 @@ func (s *BoolFileInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "bool-file")
 }
 
-func (s *BoolFileInterfaceSuite) TestSanitizePlug(c *C) {
-	// Both LED and GPIO plugs are accepted
-	err := s.iface.SanitizePlug(s.ledPlug)
+func (s *BoolFileInterfaceSuite) TestSanitizeSlot(c *C) {
+	// Both LED and GPIO slots are accepted
+	err := s.iface.SanitizeSlot(s.ledSlot)
 	c.Assert(err, IsNil)
-	err = s.iface.SanitizePlug(s.gpioPlug)
+	err = s.iface.SanitizeSlot(s.gpioSlot)
 	c.Assert(err, IsNil)
-	// Plugs without the "path" attribute are rejected.
-	err = s.iface.SanitizePlug(s.missingPathPlug)
+	// Slots without the "path" attribute are rejected.
+	err = s.iface.SanitizeSlot(s.missingPathSlot)
 	c.Assert(err, ErrorMatches,
 		"bool-file must contain the path attribute")
-	// Plugs without the "path" attribute are rejected.
-	err = s.iface.SanitizePlug(s.parentDirPathPlug)
+	// Slots without the "path" attribute are rejected.
+	err = s.iface.SanitizeSlot(s.parentDirPathSlot)
 	c.Assert(err, ErrorMatches,
 		"bool-file can only point at LED brightness or GPIO value")
-	// Plugs with incorrect value of the "path" attribute are rejected.
-	err = s.iface.SanitizePlug(s.badPathPlug)
+	// Slots with incorrect value of the "path" attribute are rejected.
+	err = s.iface.SanitizeSlot(s.badPathSlot)
 	c.Assert(err, ErrorMatches,
 		"bool-file can only point at LED brightness or GPIO value")
-	// It is impossible to use "bool-file" interface to sanitize plugs with other interfaces.
-	c.Assert(func() { s.iface.SanitizePlug(s.badInterfacePlug) }, PanicMatches,
-		`plug is not of interface "bool-file"`)
-}
-
-func (s *BoolFileInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	// It is impossible to use "bool-file" interface to sanitize slots of different interface.
+	// It is impossible to use "bool-file" interface to sanitize slots with other interfaces.
 	c.Assert(func() { s.iface.SanitizeSlot(s.badInterfaceSlot) }, PanicMatches,
 		`slot is not of interface "bool-file"`)
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetHandlesSymlinkErrors(c *C) {
+func (s *BoolFileInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+	// It is impossible to use "bool-file" interface to sanitize plugs of different interface.
+	c.Assert(func() { s.iface.SanitizePlug(s.badInterfacePlug) }, PanicMatches,
+		`plug is not of interface "bool-file"`)
+}
+
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetHandlesSymlinkErrors(c *C) {
 	// Symbolic link traversal is handled correctly
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "", fmt.Errorf("broken symbolic link")
 	})
-	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, ErrorMatches, "cannot compute slot security snippet: broken symbolic link")
+	snippet, err := s.iface.PlugSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
+	c.Assert(err, ErrorMatches, "cannot compute plug security snippet: broken symbolic link")
 	c.Assert(snippet, IsNil)
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetDereferencesSymlinks(c *C) {
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetDereferencesSymlinks(c *C) {
 	// Use a fake (successful) dereferencing function for the remainder of the test.
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "(dereferenced)" + path, nil
 	})
 	// Extra apparmor permission to access GPIO value
 	// The path uses dereferenced symbolic links.
-	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.PlugSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte(
 		"(dereferenced)/sys/class/gpio/gpio13/value rwk,\n"))
 	// Extra apparmor permission to access LED brightness.
 	// The path uses dereferenced symbolic links.
-	snippet, err = s.iface.SlotSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err = s.iface.PlugSecuritySnippet(s.plug, s.ledSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte(
 		"(dereferenced)/sys/class/leds/input27::capslock/brightness rwk,\n"))
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecurityDoesNotContainPlugSecurity(c *C) {
+func (s *BoolFileInterfaceSuite) TestPlugSecurityDoesNotContainSlotSecurity(c *C) {
 	// Use a fake (successful) dereferencing function for the remainder of the test.
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return path, nil
 	})
 	var err error
-	var plugSnippet, slotSnippet []byte
-	slotSnippet, err = s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	var slotSnippet, plugSnippet []byte
+	plugSnippet, err = s.iface.PlugSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	plugSnippet, err = s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	slotSnippet, err = s.iface.SlotSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	// Ensure that we don't accidentally give plug-side permissions to slot-side.
-	c.Assert(bytes.Contains(slotSnippet, plugSnippet), Equals, false)
+	// Ensure that we don't accidentally give slot-side permissions to plug-side.
+	c.Assert(bytes.Contains(plugSnippet, slotSnippet), Equals, false)
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetPanicksOnUnsanitizedPlugs(c *C) {
-	// Unsanitized plugs should never be used and cause a panic.
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetPanicksOnUnsanitizedSlots(c *C) {
+	// Unsanitized slots should never be used and cause a panic.
 	c.Assert(func() {
-		s.iface.SlotSecuritySnippet(s.missingPathPlug, s.slot, interfaces.SecurityAppArmor)
-	}, PanicMatches, "plug is not sanitized")
+		s.iface.PlugSecuritySnippet(s.plug, s.missingPathSlot, interfaces.SecurityAppArmor)
+	}, PanicMatches, "slot is not sanitized")
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetUnusedSecuritySystems(c *C) {
-	for _, plug := range []*interfaces.Plug{s.ledPlug, s.gpioPlug} {
-		// No extra seccomp permissions for slot
-		snippet, err := s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecuritySecComp)
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetUnusedSecuritySystems(c *C) {
+	for _, slot := range []*interfaces.Slot{s.ledSlot, s.gpioSlot} {
+		// No extra seccomp permissions for plug
+		snippet, err := s.iface.PlugSecuritySnippet(s.plug, slot, interfaces.SecuritySecComp)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra dbus permissions for slot
-		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityDBus)
+		// No extra dbus permissions for plug
+		snippet, err = s.iface.PlugSecuritySnippet(s.plug, slot, interfaces.SecurityDBus)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra udev permissions for slot
-		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
+		// No extra udev permissions for plug
+		snippet, err = s.iface.PlugSecuritySnippet(s.plug, slot, interfaces.SecurityUDev)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra udev permissions for slot
-		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
+		// No extra udev permissions for plug
+		snippet, err = s.iface.PlugSecuritySnippet(s.plug, slot, interfaces.SecurityUDev)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// Other security types are not recognized
-		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, "foo")
+		snippet, err = s.iface.PlugSecuritySnippet(s.plug, slot, "foo")
 		c.Assert(err, ErrorMatches, `unknown security system`)
 		c.Assert(snippet, IsNil)
 	}
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
 	// Extra apparmor permission to provide GPIOs
 	expectedGPIOSnippet := []byte(`
 /sys/class/gpio/export rw,
 /sys/class/gpio/unexport rw,
 /sys/class/gpio/gpio[0-9]+/direction rw,
 `)
-	snippet, err := s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.SlotSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedGPIOSnippet)
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
 	// No extra apparmor permission to provide LEDs
-	snippet, err := s.iface.PlugSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.SlotSecuritySnippet(s.plug, s.ledSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetPanicksOnUnsanitizedPlugs(c *C) {
-	// Unsanitized plugs should never be used and cause a panic.
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetPanicksOnUnsanitizedSlots(c *C) {
+	// Unsanitized slots should never be used and cause a panic.
 	c.Assert(func() {
-		s.iface.PlugSecuritySnippet(s.missingPathPlug, s.slot, interfaces.SecurityAppArmor)
-	}, PanicMatches, "plug is not sanitized")
+		s.iface.SlotSecuritySnippet(s.plug, s.missingPathSlot, interfaces.SecurityAppArmor)
+	}, PanicMatches, "slot is not sanitized")
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetUnusedSecuritySystems(c *C) {
-	for _, plug := range []*interfaces.Plug{s.ledPlug, s.gpioPlug} {
-		// No extra seccomp permissions for plug
-		snippet, err := s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecuritySecComp)
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetUnusedSecuritySystems(c *C) {
+	for _, slot := range []*interfaces.Slot{s.ledSlot, s.gpioSlot} {
+		// No extra seccomp permissions for slot
+		snippet, err := s.iface.SlotSecuritySnippet(s.plug, slot, interfaces.SecuritySecComp)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra dbus permissions for plug
-		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityDBus)
+		// No extra dbus permissions for slot
+		snippet, err = s.iface.SlotSecuritySnippet(s.plug, slot, interfaces.SecurityDBus)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra udev permissions for plug
-		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
+		// No extra udev permissions for slot
+		snippet, err = s.iface.SlotSecuritySnippet(s.plug, slot, interfaces.SecurityUDev)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// Other security types are not recognized
-		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, "foo")
+		snippet, err = s.iface.SlotSecuritySnippet(s.plug, slot, "foo")
 		c.Assert(err, ErrorMatches, `unknown security system`)
 		c.Assert(snippet, IsNil)
 	}

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -121,30 +121,30 @@ func (s *BoolFileInterfaceSuite) TestSanitizeSlot(c *C) {
 		`slot is not of interface "bool-file"`)
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetHandlesSymlinkErrors(c *C) {
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetHandlesSymlinkErrors(c *C) {
 	// Symbolic link traversal is handled correctly
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "", fmt.Errorf("broken symbolic link")
 	})
-	snippet, err := s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, ErrorMatches, "cannot compute slot security snippet: broken symbolic link")
 	c.Assert(snippet, IsNil)
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetDereferencesSymlinks(c *C) {
+func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetDereferencesSymlinks(c *C) {
 	// Use a fake (successful) dereferencing function for the remainder of the test.
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "(dereferenced)" + path, nil
 	})
 	// Extra apparmor permission to access GPIO value
 	// The path uses dereferenced symbolic links.
-	snippet, err := s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte(
 		"(dereferenced)/sys/class/gpio/gpio13/value rwk,\n"))
 	// Extra apparmor permission to access LED brightness.
 	// The path uses dereferenced symbolic links.
-	snippet, err = s.iface.PlugSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err = s.iface.SlotSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte(
 		"(dereferenced)/sys/class/leds/input27::capslock/brightness rwk,\n"))
@@ -157,63 +157,12 @@ func (s *BoolFileInterfaceSuite) TestSlotSecurityDoesNotContainPlugSecurity(c *C
 	})
 	var err error
 	var plugSnippet, slotSnippet []byte
-	slotSnippet, err = s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	slotSnippet, err = s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	plugSnippet, err = s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	plugSnippet, err = s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	// Ensure that we don't accidentally give plug-side permissions to slot-side.
 	c.Assert(bytes.Contains(slotSnippet, plugSnippet), Equals, false)
-}
-
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetPanicksOnUnsanitizedPlugs(c *C) {
-	// Unsanitized plugs should never be used and cause a panic.
-	c.Assert(func() {
-		s.iface.PlugSecuritySnippet(s.missingPathPlug, s.slot, interfaces.SecurityAppArmor)
-	}, PanicMatches, "plug is not sanitized")
-}
-
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetUnusedSecuritySystems(c *C) {
-	for _, plug := range []*interfaces.Plug{s.ledPlug, s.gpioPlug} {
-		// No extra seccomp permissions for slot
-		snippet, err := s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecuritySecComp)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra dbus permissions for slot
-		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityDBus)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra udev permissions for slot
-		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra udev permissions for slot
-		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// Other security types are not recognized
-		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, "foo")
-		c.Assert(err, ErrorMatches, `unknown security system`)
-		c.Assert(snippet, IsNil)
-	}
-}
-
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
-	// Extra apparmor permission to provide GPIOs
-	expectedGPIOSnippet := []byte(`
-/sys/class/gpio/export rw,
-/sys/class/gpio/unexport rw,
-/sys/class/gpio/gpio[0-9]+/direction rw,
-`)
-	snippet, err := s.iface.SlotSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedGPIOSnippet)
-}
-
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
-	// No extra apparmor permission to provide LEDs
-	snippet, err := s.iface.SlotSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
 }
 
 func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetPanicksOnUnsanitizedPlugs(c *C) {
@@ -225,20 +174,71 @@ func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetPanicksOnUnsanitizedPlug
 
 func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetUnusedSecuritySystems(c *C) {
 	for _, plug := range []*interfaces.Plug{s.ledPlug, s.gpioPlug} {
-		// No extra seccomp permissions for plug
+		// No extra seccomp permissions for slot
 		snippet, err := s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecuritySecComp)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra dbus permissions for plug
+		// No extra dbus permissions for slot
 		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityDBus)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
-		// No extra udev permissions for plug
+		// No extra udev permissions for slot
+		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for slot
 		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// Other security types are not recognized
 		snippet, err = s.iface.SlotSecuritySnippet(plug, s.slot, "foo")
+		c.Assert(err, ErrorMatches, `unknown security system`)
+		c.Assert(snippet, IsNil)
+	}
+}
+
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
+	// Extra apparmor permission to provide GPIOs
+	expectedGPIOSnippet := []byte(`
+/sys/class/gpio/export rw,
+/sys/class/gpio/unexport rw,
+/sys/class/gpio/gpio[0-9]+/direction rw,
+`)
+	snippet, err := s.iface.PlugSecuritySnippet(s.gpioPlug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedGPIOSnippet)
+}
+
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
+	// No extra apparmor permission to provide LEDs
+	snippet, err := s.iface.PlugSecuritySnippet(s.ledPlug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetPanicksOnUnsanitizedPlugs(c *C) {
+	// Unsanitized plugs should never be used and cause a panic.
+	c.Assert(func() {
+		s.iface.PlugSecuritySnippet(s.missingPathPlug, s.slot, interfaces.SecurityAppArmor)
+	}, PanicMatches, "plug is not sanitized")
+}
+
+func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetUnusedSecuritySystems(c *C) {
+	for _, plug := range []*interfaces.Plug{s.ledPlug, s.gpioPlug} {
+		// No extra seccomp permissions for plug
+		snippet, err := s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecuritySecComp)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra dbus permissions for plug
+		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityDBus)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for plug
+		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// Other security types are not recognized
+		snippet, err = s.iface.PlugSecuritySnippet(plug, s.slot, "foo")
 		c.Assert(err, ErrorMatches, `unknown security system`)
 		c.Assert(snippet, IsNil)
 	}

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -25,7 +25,7 @@ import (
 	"regexp"
 )
 
-// Plug represents a capacity offered by a snap.
+// Plug represents the potential of a given snap to connect to a plug.
 type Plug struct {
 	Snap        string                 `json:"snap"`
 	Name        string                 `json:"plug"`
@@ -42,7 +42,7 @@ type PlugRef struct {
 	Name string `json:"plug"`
 }
 
-// Slot represents the potential of a given snap to connect to a plug.
+// Slot represents a capacity offered by a snap.
 type Slot struct {
 	Snap        string                 `json:"snap"`
 	Name        string                 `json:"slot"`
@@ -78,23 +78,23 @@ type Interface interface {
 	// SanitizeSlot checks if a slot is correct, altering if necessary.
 	SanitizeSlot(slot *Slot) error
 
+	// SlotSecuritySnippet returns the configuration snippet needed by the
+	// given security system to allow a snap to offer a slot of this interface.
+	//
+	// An empty snippet is returned when the slot doesn't require anything
+	// from the security system to work, in addition to the default
+	// configuration.  ErrUnknownSecurity is returned when the slot cannot
+	// deal with the requested security system.
+	SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+
 	// PlugSecuritySnippet returns the configuration snippet needed by the
-	// given security system to allow a snap to offer a plug of this interface.
+	// given security system to allow a snap to use a slot of this interface.
 	//
 	// An empty snippet is returned when the plug doesn't require anything
 	// from the security system to work, in addition to the default
 	// configuration.  ErrUnknownSecurity is returned when the plug cannot
 	// deal with the requested security system.
 	PlugSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
-
-	// SlotSecuritySnippet returns the configuration snippet needed by the
-	// given security system to allow a snap to use a plug of this interface.
-	//
-	// An empty snippet is returned when the plug doesn't require anything
-	// from the security system to work, in addition to the default
-	// configuration.  ErrUnknownSecurity is returned when the plug cannot
-	// deal with the requested security system.
-	SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // SecuritySystem is a name of a security system.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -25,7 +25,7 @@ import (
 	"regexp"
 )
 
-// Plug represents the potential of a given snap to connect to a plug.
+// Plug represents the potential of a given snap to connect to a slot.
 type Plug struct {
 	Snap        string                 `json:"snap"`
 	Name        string                 `json:"plug"`

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-03-01 12:16+0100\n"
+        "POT-Creation-Date: 2016-03-04 12:01+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -513,19 +513,19 @@ msgstr  ""
 msgid   "\n"
         "The interfaces command lists interfaces available in the system.\n"
         "\n"
-        "By default all plugs and slots, used and offered by all snaps, are displayed.\n"
+        "By default all slots and plugs, used and offered by all snaps, are displayed.\n"
         " \n"
-        "$ snap interfaces <snap>:<plug or slot>\n"
+        "$ snap interfaces <snap>:<slot or plug>\n"
         "\n"
-        "Lists only the specified plug or slot.\n"
+        "Lists only the specified slot or plug.\n"
         "\n"
         "$ snap interfaces <snap>\n"
         "\n"
-        "Lists the plugs offered and slots used by the specified snap.\n"
+        "Lists the slots offered and plugs used by the specified snap.\n"
         "\n"
         "$ snap interfaces --i=<interface> [<snap>]\n"
         "\n"
-        "Lists only plugs and slots of the specific interface.\n"
+        "Lists only slots and plugs of the specific interface.\n"
 msgstr  ""
 
 msgid   "\n"
@@ -615,15 +615,15 @@ msgstr  ""
 msgid   "package name is required"
 msgstr  ""
 
-msgid   "plug\tslot"
-msgstr  ""
-
 msgid   "produces manpage"
 msgstr  ""
 
 #. TRANSLATORS: the %s release string
 #, c-format
 msgid   "release: %s\n"
+msgstr  ""
+
+msgid   "slot\tplug"
 msgstr  ""
 
 #. TRANSLATORS: the first %s is the package name, the second is the service name; the %v is the error

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -81,13 +81,13 @@ func verifyAppYaml(app *AppYaml) error {
 	return verifyStructStringsAgainstWhitelist(*app, servicesBinariesStringsWhitelist)
 }
 
-func verifySlotYaml(slot *slotYaml) error {
-	if err := verifyStructStringsAgainstWhitelist(*slot, servicesBinariesStringsWhitelist); err != nil {
+func verifyPlugYaml(plug *plugYaml) error {
+	if err := verifyStructStringsAgainstWhitelist(*plug, servicesBinariesStringsWhitelist); err != nil {
 		return err
 	}
 
-	if slot.Interface != "old-security" {
-		return fmt.Errorf("can not use interface %q, only `old-security` supported", slot.Interface)
+	if plug.Interface != "old-security" {
+		return fmt.Errorf("can not use interface %q, only `old-security` supported", plug.Interface)
 	}
 
 	return nil

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -986,12 +986,12 @@ func (s *SnapTestSuite) TestBinariesWhitelistSimple(c *C) {
 }
 
 func (s *SnapTestSuite) TestUsesWhitelistSimple(c *C) {
-	c.Check(verifySlotYaml(&slotYaml{
+	c.Check(verifyPlugYaml(&plugYaml{
 		Interface: "old-security",
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityTemplate: "foo"},
 	}), IsNil)
-	c.Check(verifySlotYaml(&slotYaml{
+	c.Check(verifyPlugYaml(&plugYaml{
 		Interface: "old-security",
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityPolicy: &SecurityPolicyDefinition{
@@ -1007,18 +1007,18 @@ func (s *SnapTestSuite) TestBinariesWhitelistIllegal(c *C) {
 }
 
 func (s *SnapTestSuite) TestWrongType(c *C) {
-	c.Check(verifySlotYaml(&slotYaml{
+	c.Check(verifyPlugYaml(&plugYaml{
 		Interface: "some-interface",
 	}), ErrorMatches, ".*can not use interface.* only `old-security` supported")
 }
 
 func (s *SnapTestSuite) TestUsesWhitelistIllegal(c *C) {
-	c.Check(verifySlotYaml(&slotYaml{
+	c.Check(verifyPlugYaml(&plugYaml{
 		Interface: "old-security",
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityTemplate: "x\n"},
 	}), ErrorMatches, ".*contains illegal.*")
-	c.Check(verifySlotYaml(&slotYaml{
+	c.Check(verifyPlugYaml(&plugYaml{
 		Interface: "old-security",
 		SecurityDefinitions: SecurityDefinitions{
 			SecurityPolicy: &SecurityPolicyDefinition{

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -742,19 +742,19 @@ func hasConfig(baseDir string) bool {
 	return osutil.FileExists(filepath.Join(baseDir, "meta", "hooks", "config"))
 }
 
-func findSlotForApp(m *snapYaml, app *AppYaml) (*slotYaml, error) {
-	if len(app.SlotsRef) == 0 {
+func findPlugForApp(m *snapYaml, app *AppYaml) (*plugYaml, error) {
+	if len(app.PlugsRef) == 0 {
 		return nil, nil
 	}
-	if len(app.SlotsRef) != 1 {
-		return nil, fmt.Errorf("only a single slot is supported, %d found", len(app.SlotsRef))
+	if len(app.PlugsRef) != 1 {
+		return nil, fmt.Errorf("only a single plug is supported, %d found", len(app.PlugsRef))
 	}
 
-	slot, ok := m.Slots[app.SlotsRef[0]]
+	plug, ok := m.Plugs[app.PlugsRef[0]]
 	if !ok {
-		return nil, fmt.Errorf("can not find slot %q", app.SlotsRef[0])
+		return nil, fmt.Errorf("can not find plug %q", app.PlugsRef[0])
 	}
-	return slot, nil
+	return plug, nil
 }
 
 func generatePolicy(m *snapYaml, baseDir string) error {
@@ -769,20 +769,20 @@ func generatePolicy(m *snapYaml, baseDir string) error {
 	}
 
 	for _, app := range m.Apps {
-		slot, err := findSlotForApp(m, app)
+		plug, err := findPlugForApp(m, app)
 		if err != nil {
 			return err
 		}
 
-		// if no slot is specified, use the defaultSecurityPolicy
-		if slot == nil {
+		// if no plug is specified, use the defaultSecurityPolicy
+		if plug == nil {
 			if err = defaultSecurityPolicy.generatePolicyForServiceBinary(m, app.Name, baseDir); err != nil {
 				logger.Noticef("Failed to generate policy for app %s: %v", app.Name, err)
 			}
 			continue
 		}
 
-		err = slot.generatePolicyForServiceBinary(m, app.Name, baseDir)
+		err = plug.generatePolicyForServiceBinary(m, app.Name, baseDir)
 		if err != nil {
 			foundError = err
 			logger.Noticef("Failed to generate policy for service %s: %v", app.Name, err)
@@ -872,15 +872,15 @@ func CompareGeneratePolicyFromFile(fn string) error {
 	baseDir := filepath.Dir(filepath.Dir(fn))
 
 	for _, app := range m.Apps {
-		slot, err := findSlotForApp(m, app)
+		plug, err := findPlugForApp(m, app)
 		if err != nil {
 			return err
 		}
-		if slot == nil {
+		if plug == nil {
 			continue
 		}
 
-		p, err := slot.generatePolicyForServiceBinaryResult(m, app.Name, baseDir)
+		p, err := plug.generatePolicyForServiceBinaryResult(m, app.Name, baseDir)
 		// FIXME: use apparmor_profile -p on both AppArmor profiles
 		if err != nil {
 			// FIXME: what to do here?

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -603,11 +603,11 @@ vendor: someone
 version: 1.0
 apps:
  binary1:
-   slots: [binary1]
+   plugs: [binary1]
  service1:
-   slots: [service1]
+   plugs: [service1]
    daemon: forking
-slots:
+plugs:
  binary1:
   interface: old-security
   caps: []
@@ -822,8 +822,8 @@ vendor: someone
 version: 1.0
 apps:
  binary1:
-   slots: [binary1]
-slots:
+   plugs: [binary1]
+plugs:
  binary1:
    interface: old-security
    caps: []
@@ -1034,44 +1034,44 @@ version: 123456789
 
 }
 
-func (a *SecurityTestSuite) TestFindSlotForAppEmpty(c *C) {
+func (a *SecurityTestSuite) TestFindPlugForAppEmpty(c *C) {
 	app := &AppYaml{}
 	m := &snapYaml{}
-	slot, err := findSlotForApp(m, app)
+	plug, err := findPlugForApp(m, app)
 	c.Check(err, IsNil)
-	c.Check(slot, IsNil)
+	c.Check(plug, IsNil)
 }
 
-func (a *SecurityTestSuite) TestFindSlotlForAppTooMany(c *C) {
+func (a *SecurityTestSuite) TestFindPluglForAppTooMany(c *C) {
 	app := &AppYaml{
-		SlotsRef: []string{"one", "two"},
+		PlugsRef: []string{"one", "two"},
 	}
 	m := &snapYaml{}
-	slot, err := findSlotForApp(m, app)
-	c.Check(slot, IsNil)
-	c.Check(err, ErrorMatches, "only a single slot is supported, 2 found")
+	plug, err := findPlugForApp(m, app)
+	c.Check(plug, IsNil)
+	c.Check(err, ErrorMatches, "only a single plug is supported, 2 found")
 }
 
-func (a *SecurityTestSuite) TestFindSlotForAppNotFound(c *C) {
+func (a *SecurityTestSuite) TestFindPlugForAppNotFound(c *C) {
 	app := &AppYaml{
-		SlotsRef: []string{"not-there"},
+		PlugsRef: []string{"not-there"},
 	}
 	m := &snapYaml{}
-	slot, err := findSlotForApp(m, app)
-	c.Check(slot, IsNil)
-	c.Check(err, ErrorMatches, `can not find slot "not-there"`)
+	plug, err := findPlugForApp(m, app)
+	c.Check(plug, IsNil)
+	c.Check(err, ErrorMatches, `can not find plug "not-there"`)
 }
 
-func (a *SecurityTestSuite) TestFindSlotFinds(c *C) {
+func (a *SecurityTestSuite) TestFindPlugFinds(c *C) {
 	app := &AppYaml{
-		SlotsRef: []string{"slot"},
+		PlugsRef: []string{"plug"},
 	}
 	m := &snapYaml{
-		Slots: map[string]*slotYaml{
-			"slot": &slotYaml{Interface: "some-type"},
+		Plugs: map[string]*plugYaml{
+			"plug": &plugYaml{Interface: "some-type"},
 		},
 	}
-	slot, err := findSlotForApp(m, app)
+	plug, err := findPlugForApp(m, app)
 	c.Check(err, IsNil)
-	c.Check(slot.Interface, Equals, "some-type")
+	c.Check(plug.Interface, Equals, "some-type")
 }

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -426,18 +426,18 @@ func (s *SnapPart) CanInstall(allowGadget bool, inter interacter) error {
 func (s *SnapPart) RequestSecurityPolicyUpdate(policies, templates map[string]bool) error {
 	var foundError error
 	for name, app := range s.Apps() {
-		slot, err := findSlotForApp(s.m, app)
+		plug, err := findPlugForApp(s.m, app)
 		if err != nil {
-			logger.Noticef("Failed to find slot for %s: %v", name, err)
+			logger.Noticef("Failed to find plug for %s: %v", name, err)
 			foundError = err
 			continue
 		}
-		if slot == nil {
+		if plug == nil {
 			continue
 		}
 
-		if slot.NeedsAppArmorUpdate(policies, templates) {
-			err := slot.generatePolicyForServiceBinary(s.m, name, s.basedir)
+		if plug.NeedsAppArmorUpdate(policies, templates) {
+			err := plug.generatePolicyForServiceBinary(s.m, name, s.basedir)
 			if err != nil {
 				logger.Noticef("Failed to regenerate policy for %s: %v", name, err)
 				foundError = err

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -68,7 +68,7 @@ type AppYaml struct {
 	SlotsRef []string `yaml:"slots"`
 }
 
-type slotYaml struct {
+type plugYaml struct {
 	Interface           string `yaml:"interface"`
 	SecurityDefinitions `yaml:",inline"`
 }
@@ -93,8 +93,8 @@ type snapYaml struct {
 	// Apps can be both binary or service
 	Apps map[string]*AppYaml `yaml:"apps,omitempty"`
 
-	// Slots maps the used "interfaces" to the apps
-	Slots map[string]*slotYaml `yaml:"slots,omitempty"`
+	// Plugs maps the used "interfaces" to the apps
+	Plugs map[string]*plugYaml `yaml:"plugs,omitempty"`
 
 	// FIXME: clarify those
 
@@ -151,9 +151,9 @@ func validateSnapYamlData(file string, yamlData []byte, m *snapYaml) error {
 		}
 	}
 
-	// check for "slots"
-	for _, slots := range m.Slots {
-		if err := verifySlotYaml(slots); err != nil {
+	// check for "plugs"
+	for _, plugs := range m.Plugs {
+		if err := verifyPlugYaml(plugs); err != nil {
 			return err
 		}
 	}
@@ -179,9 +179,9 @@ func parseSnapYamlData(yamlData []byte, hasConfig bool) (*snapYaml, error) {
 		app.Name = name
 	}
 
-	for name, slot := range m.Slots {
-		if slot.Interface == "" {
-			slot.Interface = name
+	for name, plug := range m.Plugs {
+		if plug.Interface == "" {
+			plug.Interface = name
 		}
 	}
 

--- a/snappy/snap_yaml_test.go
+++ b/snappy/snap_yaml_test.go
@@ -31,11 +31,11 @@ var _ = Suite(&snapYamlTestSuite{})
 func (s *snapYamlTestSuite) TestParseYamlSetsTypeInUsesFromName(c *C) {
 	snapYaml := []byte(`name: foo
 version: 1.0
-slots:
+plugs:
  old-security:
   caps: []
 `)
 	sy, err := parseSnapYamlData(snapYaml, false)
 	c.Assert(err, IsNil)
-	sy.Slots["old-security"].Interface = "old-security"
+	sy.Plugs["old-security"].Interface = "old-security"
 }

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -376,9 +376,9 @@ version: 1.10
 apps:
  some-binary:
   command: some-binary
-  slots: [some-binary]
+  plugs: [some-binary]
 
-slots:
+plugs:
  some-binary:
   interface: old-security
   security-template: not-there

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -976,15 +976,15 @@ apps:
  testme:
    command: bin/testme
    description: "testme client"
-   slots: [testme]
+   plugs: [testme]
  testme-override:
    command: bin/testme-override
-   slots: [testme-override]
+   plugs: [testme-override]
  testme-policy:
    command: bin/testme-policy
-   slots: [testme-policy]
+   plugs: [testme-policy]
 
-slots:
+plugs:
  testme:
    interface: old-security
    caps:
@@ -1010,20 +1010,20 @@ func (s *SnapTestSuite) TestSnapYamlSecurityBinaryParsing(c *C) {
 
 	c.Assert(m.Apps["testme"].Name, Equals, "testme")
 	c.Assert(m.Apps["testme"].Command, Equals, "bin/testme")
-	c.Assert(m.Slots["testme"].SecurityCaps, HasLen, 1)
-	c.Assert(m.Slots["testme"].SecurityCaps[0], Equals, "foo_group")
-	c.Assert(m.Slots["testme"].SecurityTemplate, Equals, "foo_template")
+	c.Assert(m.Plugs["testme"].SecurityCaps, HasLen, 1)
+	c.Assert(m.Plugs["testme"].SecurityCaps[0], Equals, "foo_group")
+	c.Assert(m.Plugs["testme"].SecurityTemplate, Equals, "foo_template")
 
 	c.Assert(m.Apps["testme-override"].Name, Equals, "testme-override")
 	c.Assert(m.Apps["testme-override"].Command, Equals, "bin/testme-override")
-	c.Assert(m.Slots["testme-override"].SecurityCaps, HasLen, 0)
-	c.Assert(m.Slots["testme-override"].SecurityOverride.ReadPaths[0], Equals, "/foo")
-	c.Assert(m.Slots["testme-override"].SecurityOverride.Syscalls[0], Equals, "bar")
+	c.Assert(m.Plugs["testme-override"].SecurityCaps, HasLen, 0)
+	c.Assert(m.Plugs["testme-override"].SecurityOverride.ReadPaths[0], Equals, "/foo")
+	c.Assert(m.Plugs["testme-override"].SecurityOverride.Syscalls[0], Equals, "bar")
 
 	c.Assert(m.Apps["testme-policy"].Name, Equals, "testme-policy")
 	c.Assert(m.Apps["testme-policy"].Command, Equals, "bin/testme-policy")
-	c.Assert(m.Slots["testme-policy"].SecurityCaps, HasLen, 0)
-	c.Assert(m.Slots["testme-policy"].SecurityPolicy.AppArmor, Equals, "meta/testme-policy.profile")
+	c.Assert(m.Plugs["testme-policy"].SecurityCaps, HasLen, 0)
+	c.Assert(m.Plugs["testme-policy"].SecurityPolicy.AppArmor, Equals, "meta/testme-policy.profile")
 }
 
 var securityServiceSnapYaml = []byte(`name: test-snap
@@ -1034,9 +1034,9 @@ apps:
    daemon: forking
    stop-command: bin/testme-service.stop
    description: "testme service"
-   slots: [testme-service]
+   plugs: [testme-service]
 
-slots:
+plugs:
  testme-service:
    interface: old-security
    caps:
@@ -1052,10 +1052,10 @@ func (s *SnapTestSuite) TestSnapYamlSecurityServiceParsing(c *C) {
 	c.Assert(m.Apps["testme-service"].Name, Equals, "testme-service")
 	c.Assert(m.Apps["testme-service"].Command, Equals, "bin/testme-service.start")
 	c.Assert(m.Apps["testme-service"].Stop, Equals, "bin/testme-service.stop")
-	c.Assert(m.Slots["testme-service"].SecurityCaps, HasLen, 2)
-	c.Assert(m.Slots["testme-service"].SecurityCaps[0], Equals, "network-client")
-	c.Assert(m.Slots["testme-service"].SecurityCaps[1], Equals, "foo_group")
-	c.Assert(m.Slots["testme-service"].SecurityTemplate, Equals, "foo_template")
+	c.Assert(m.Plugs["testme-service"].SecurityCaps, HasLen, 2)
+	c.Assert(m.Plugs["testme-service"].SecurityCaps[0], Equals, "network-client")
+	c.Assert(m.Plugs["testme-service"].SecurityCaps[1], Equals, "foo_group")
+	c.Assert(m.Plugs["testme-service"].SecurityTemplate, Equals, "foo_template")
 }
 
 func (s *SnapTestSuite) TestDetectsAlreadyInstalled(c *C) {
@@ -1264,15 +1264,15 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateService(c *C) {
 	// if one of the services needs updating, it's updated and returned
 	svc := &AppYaml{
 		Name:     "svc",
-		SlotsRef: []string{"svc"},
+		PlugsRef: []string{"svc"},
 	}
 	part := &SnapPart{
 		m: &snapYaml{
 			Name:    "part",
 			Apps:    map[string]*AppYaml{"svc": svc},
 			Version: "42",
-			Slots: map[string]*slotYaml{
-				"svc": &slotYaml{
+			Plugs: map[string]*plugYaml{
+				"svc": &plugYaml{
 					SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"},
 				},
 			},
@@ -1288,15 +1288,15 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateBinary(c *C) {
 	// if one of the binaries needs updating, the part needs updating
 	bin := &AppYaml{
 		Name:     "echo",
-		SlotsRef: []string{"echo"},
+		PlugsRef: []string{"echo"},
 	}
 	part := &SnapPart{
 		m: &snapYaml{
 			Name:    "part",
 			Apps:    map[string]*AppYaml{"echo": bin},
 			Version: "42",
-			Slots: map[string]*slotYaml{
-				"echo": &slotYaml{
+			Plugs: map[string]*plugYaml{
+				"echo": &plugYaml{
 					SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"},
 				},
 			},
@@ -1311,11 +1311,11 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateBinary(c *C) {
 func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateNothing(c *C) {
 	svc := &AppYaml{
 		Name:     "svc",
-		SlotsRef: []string{"svc"},
+		PlugsRef: []string{"svc"},
 	}
 	bin := &AppYaml{
 		Name:     "echo",
-		SlotsRef: []string{"echo"},
+		PlugsRef: []string{"echo"},
 	}
 	part := &SnapPart{
 		m: &snapYaml{
@@ -1324,11 +1324,11 @@ func (s *SnapTestSuite) TestRequestSecurityPolicyUpdateNothing(c *C) {
 				"echo": bin,
 			},
 			Version: "42",
-			Slots: map[string]*slotYaml{
-				"svc": &slotYaml{
+			Plugs: map[string]*plugYaml{
+				"svc": &plugYaml{
 					SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"},
 				},
-				"echo": &slotYaml{
+				"echo": &plugYaml{
 					SecurityDefinitions: SecurityDefinitions{SecurityTemplate: "foo"},
 				},
 			},


### PR DESCRIPTION
This branch swaps Plugs and Slots around. Unlike a naive approach that would do this globally, the change is applied only to specific places because, ironically, some places already had the "plug connects to slot" order without us noticing.

Most notably the ``snappy`` package now applies ``old-security`` on the ``plug`` (not on the slot)``.
In the ``client`` and ``interfaces`` package only comments  are moved around since the representation of both types was symmetrical.

The biggest change was in the ``snap interfaces`` command where the order of displaying the elements was fully swapped so that the *slot* side is printed in the first column and all the *plugs* are printed in the second column.

For reference, "old-security" interface has to be specified under *plugs* now.