### PR TITLE
interfaces: add support for static security snippets

### DIFF
--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -49,7 +49,7 @@ Lists the slots offered and plugs used by the specified snap.
 
 $ snap interfaces --i=<interface> [<snap>]
 
-Lists only slots and plugs of the specific interface.
+Filters the complete output so only plugs and/or slots matching the provided details are listed.
 `)
 
 func init() {

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -47,7 +47,7 @@ Lists the slots offered and plugs used by the specified snap.
 
 $ snap interfaces --i=<interface> [<snap>]
 
-Lists only slots and plugs of the specific interface.
+Filters the complete output so only plugs and/or slots matching the provided details are listed.
 
 Help Options:
   -h, --help                       Show this help message

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -78,23 +78,61 @@ type Interface interface {
 	// SanitizeSlot checks if a slot is correct, altering if necessary.
 	SanitizeSlot(slot *Slot) error
 
-	// SlotSecuritySnippet returns the configuration snippet needed by the
-	// given security system to allow a snap to offer a slot of this interface.
+	// StaticPlugSecuritySnippet returns static, plug-side security snippet.
 	//
-	// An empty snippet is returned when the slot doesn't require anything
-	// from the security system to work, in addition to the default
-	// configuration.  ErrUnknownSecurity is returned when the slot cannot
-	// deal with the requested security system.
-	SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// Static security snippet can be used to grant permissions to a snap that
+	// has a plug of a given interface even before the plug is connected to a
+	// slot.
+	//
+	// An empty snippet is returned when there are no additional permissions
+	// that are required to implement this interface. ErrUnknownSecurity error
+	// is returned when the plug cannot deal with the requested security
+	// system.
+	StaticPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 
-	// PlugSecuritySnippet returns the configuration snippet needed by the
-	// given security system to allow a snap to use a slot of this interface.
+	// PlugSecuritySnippet returns connection-specific, plug-side security snippet.
 	//
-	// An empty snippet is returned when the plug doesn't require anything
-	// from the security system to work, in addition to the default
-	// configuration.  ErrUnknownSecurity is returned when the plug cannot
-	// deal with the requested security system.
+	// Connection-specific security snippet can be used to grant permission to
+	// a snap that has a plug of a given interface connected to a slot in
+	// another snap.
+	//
+	// The snippet should be specific to both the plug and the slot. If the
+	// slot is not necessary then consider using StaticPlugSecutitySnippet()
+	// instead.
+	//
+	// An empty snippet is returned when there are no additional permissions
+	// that are required to implement this interface. ErrUnknownSecurity error
+	// is returned when the plug cannot deal with the requested security
+	// system.
 	PlugSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+
+	// StaticSlotSecuritySnippet returns static, slot-side security snippet.
+	//
+	// Static security snippet can be used to grant permissions to a snap that
+	// has a slot of a given interface even before the first connection to that
+	// slot is made.
+	//
+	// An empty snippet is returned when there are no additional permissions
+	// that are required to implement this interface. ErrUnknownSecurity error
+	// is returned when the plug cannot deal with the requested security
+	// system.
+	StaticSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+
+	// SlotSecuritySnippet returns connection-specific, slot-side security snippet.
+	//
+	// Connection-specific security snippet can be used to grant permission to
+	// a snap that has a slot of a given interface connected to a plug in
+	// another snap.
+	//
+	// The snippet should be specific to both the plug and the slot, if the
+	// plug is not necessary then consider using StaticSlotSecutitySnippet()
+	// instead.
+	//
+	// An empty snippet is returned when there are no additional permissions
+	// that are required to implement this interface. ErrUnknownSecurity error
+	// is returned when the plug cannot deal with the requested security
+	// system.
+	SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // SecuritySystem is a name of a security system.

--- a/interfaces/testtype.go
+++ b/interfaces/testtype.go
@@ -34,8 +34,12 @@ type TestInterface struct {
 	SanitizeSlotCallback func(slot *Slot) error
 	// SlotSecuritySnippetCallback is the callback invoked inside SlotSecuritySnippet()
 	SlotSecuritySnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// StaticSlotSecuritySnippetCallback is the callback invoked inside StaticSlotSecuritySnippet()
+	StaticSlotSecuritySnippetCallback func(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 	// PlugSecuritySnippetCallback is the callback invoked inside PlugSecuritySnippet()
 	PlugSecuritySnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// StaticPlugSecuritySnippetCallback is the callback invoked inside StaticPlugSecuritySnippet()
+	StaticPlugSecuritySnippetCallback func(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // String() returns the same value as Name().
@@ -79,11 +83,29 @@ func (t *TestInterface) PlugSecuritySnippet(plug *Plug, slot *Slot, securitySyst
 	return nil, nil
 }
 
+// StaticPlugSecuritySnippet returns the configuration snippet "required" to offer a test plug.
+// Providers don't gain any extra permissions.
+func (t *TestInterface) StaticPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
+	if t.StaticPlugSecuritySnippetCallback != nil {
+		return t.StaticPlugSecuritySnippetCallback(plug, securitySystem)
+	}
+	return nil, nil
+}
+
 // SlotSecuritySnippet returns the configuration snippet "required" to use a test plug.
 // Consumers don't gain any extra permissions.
 func (t *TestInterface) SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 	if t.SlotSecuritySnippetCallback != nil {
 		return t.SlotSecuritySnippetCallback(plug, slot, securitySystem)
+	}
+	return nil, nil
+}
+
+// StaticSlotSecuritySnippet returns the configuration snippet "required" to use a test plug.
+// Consumers don't gain any extra permissions.
+func (t *TestInterface) StaticSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+	if t.StaticSlotSecuritySnippetCallback != nil {
+		return t.StaticSlotSecuritySnippetCallback(slot, securitySystem)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
interfaces: support static and connections-specific security snippets

This branch changes the Interface interface to expose four
security-related methods. In addition to existing SlotSecuritySnippet()
and PlugSecuritySnippet() there are now StaticSlotSecuritySnippet() and 
StaticPlugSecuritySnippet().

This change is driven by the realization that we can simplify security
and number of interfaces by disassociating some permissions from
established connections.

For example, a display server interface can now be just a single
interface rather than two. Consider this example:

1. There's a Mir snap, with the "mir" slot.
2. There's a xeyes snap with a "mir" plug.

The mir snap, simply because it has the mir *slot* gets to have access
to graphics cards and all the required machinery. Mir can start even
without xeyes running yet.

As a connection is made between xeyes and mir, a new set of permissions
are granted: Xeyes can now talk to mir socket.

The same example works with any managed, shared resource that the 
managing snap needs to be able to control regardless of who is connected
at a particular moment.

This patch also changes test interface that is use for testing to
support the extra methods.