### PR TITLE
interfaces: support permanent security snippets

### DIFF
--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -101,8 +101,8 @@ func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot 
 	}
 }
 
-// StaticSlotSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
-func (iface *BoolFileInterface) StaticSlotSecuritySnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+// PermanentSlotSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
+func (iface *BoolFileInterface) PermanentSlotSecuritySnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	// TODO: implement this for real
 	return nil, nil
 }
@@ -128,8 +128,8 @@ func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot 
 	}
 }
 
-// StaticPlugSecuritySnippet returns the configuration snippet required to use a bool-file interface.
-func (iface *BoolFileInterface) StaticPlugSecuritySnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+// PermanentPlugSecuritySnippet returns the configuration snippet required to use a bool-file interface.
+func (iface *BoolFileInterface) PermanentPlugSecuritySnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	// TODO: implement this for real
 	return nil, nil
 }

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -77,10 +77,10 @@ func (iface *BoolFileInterface) SanitizePlug(slot *interfaces.Plug) error {
 	return nil
 }
 
-// SlotSnippet returns the configuration snippet required to provide a bool-file interface.
+// ConnectedSlotSnippet returns the configuration snippet required to provide a bool-file interface.
 // Producers gain control over exporting, importing GPIOs as well as
 // controlling the direction of particular pins.
-func (iface *BoolFileInterface) SlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BoolFileInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	gpioSnippet := []byte(`
 /sys/class/gpio/export rw,
 /sys/class/gpio/unexport rw,
@@ -107,9 +107,9 @@ func (iface *BoolFileInterface) PermanentSlotSnippet(slot *interfaces.Slot, secu
 	return nil, nil
 }
 
-// PlugSnippet returns the configuration snippet required to use a bool-file interface.
+// ConnectedPlugSnippet returns the configuration snippet required to use a bool-file interface.
 // Consumers gain permission to read, write and lock the designated file.
-func (iface *BoolFileInterface) PlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BoolFileInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		// Allow write and lock on the file designated by the path.

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -101,6 +101,12 @@ func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot 
 	}
 }
 
+// StaticSlotSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
+func (iface *BoolFileInterface) StaticSlotSecuritySnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	// TODO: implement this for real
+	return nil, nil
+}
+
 // PlugSecuritySnippet returns the configuration snippet required to use a bool-file interface.
 // Consumers gain permission to read, write and lock the designated file.
 func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -120,6 +126,12 @@ func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot 
 	default:
 		return nil, interfaces.ErrUnknownSecurity
 	}
+}
+
+// StaticPlugSecuritySnippet returns the configuration snippet required to use a bool-file interface.
+func (iface *BoolFileInterface) StaticPlugSecuritySnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	// TODO: implement this for real
+	return nil, nil
 }
 
 func (iface *BoolFileInterface) dereferencedPath(slot *interfaces.Slot) (string, error) {

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -77,10 +77,10 @@ func (iface *BoolFileInterface) SanitizePlug(slot *interfaces.Plug) error {
 	return nil
 }
 
-// SlotSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
+// SlotSnippet returns the configuration snippet required to provide a bool-file interface.
 // Producers gain control over exporting, importing GPIOs as well as
 // controlling the direction of particular pins.
-func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BoolFileInterface) SlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	gpioSnippet := []byte(`
 /sys/class/gpio/export rw,
 /sys/class/gpio/unexport rw,
@@ -101,15 +101,15 @@ func (iface *BoolFileInterface) SlotSecuritySnippet(plug *interfaces.Plug, slot 
 	}
 }
 
-// PermanentSlotSecuritySnippet returns the configuration snippet required to provide a bool-file interface.
-func (iface *BoolFileInterface) PermanentSlotSecuritySnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+// PermanentSlotSnippet returns the configuration snippet required to provide a bool-file interface.
+func (iface *BoolFileInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	// TODO: implement this for real
 	return nil, nil
 }
 
-// PlugSecuritySnippet returns the configuration snippet required to use a bool-file interface.
+// PlugSnippet returns the configuration snippet required to use a bool-file interface.
 // Consumers gain permission to read, write and lock the designated file.
-func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BoolFileInterface) PlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		// Allow write and lock on the file designated by the path.
@@ -128,8 +128,8 @@ func (iface *BoolFileInterface) PlugSecuritySnippet(plug *interfaces.Plug, slot 
 	}
 }
 
-// PermanentPlugSecuritySnippet returns the configuration snippet required to use a bool-file interface.
-func (iface *BoolFileInterface) PermanentPlugSecuritySnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+// PermanentPlugSnippet returns the configuration snippet required to use a bool-file interface.
+func (iface *BoolFileInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	// TODO: implement this for real
 	return nil, nil
 }

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -121,30 +121,30 @@ func (s *BoolFileInterfaceSuite) TestSanitizePlug(c *C) {
 		`plug is not of interface "bool-file"`)
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetHandlesSymlinkErrors(c *C) {
+func (s *BoolFileInterfaceSuite) TestPlugSnippetHandlesSymlinkErrors(c *C) {
 	// Symbolic link traversal is handled correctly
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "", fmt.Errorf("broken symbolic link")
 	})
-	snippet, err := s.iface.PlugSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.PlugSnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, ErrorMatches, "cannot compute plug security snippet: broken symbolic link")
 	c.Assert(snippet, IsNil)
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetDereferencesSymlinks(c *C) {
+func (s *BoolFileInterfaceSuite) TestPlugSnippetDereferencesSymlinks(c *C) {
 	// Use a fake (successful) dereferencing function for the remainder of the test.
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "(dereferenced)" + path, nil
 	})
 	// Extra apparmor permission to access GPIO value
 	// The path uses dereferenced symbolic links.
-	snippet, err := s.iface.PlugSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.PlugSnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte(
 		"(dereferenced)/sys/class/gpio/gpio13/value rwk,\n"))
 	// Extra apparmor permission to access LED brightness.
 	// The path uses dereferenced symbolic links.
-	snippet, err = s.iface.PlugSecuritySnippet(s.plug, s.ledSlot, interfaces.SecurityAppArmor)
+	snippet, err = s.iface.PlugSnippet(s.plug, s.ledSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, []byte(
 		"(dereferenced)/sys/class/leds/input27::capslock/brightness rwk,\n"))
@@ -157,88 +157,88 @@ func (s *BoolFileInterfaceSuite) TestPlugSecurityDoesNotContainSlotSecurity(c *C
 	})
 	var err error
 	var slotSnippet, plugSnippet []byte
-	plugSnippet, err = s.iface.PlugSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
+	plugSnippet, err = s.iface.PlugSnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	slotSnippet, err = s.iface.SlotSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
+	slotSnippet, err = s.iface.SlotSnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	// Ensure that we don't accidentally give slot-side permissions to plug-side.
 	c.Assert(bytes.Contains(plugSnippet, slotSnippet), Equals, false)
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetPanicksOnUnsanitizedSlots(c *C) {
+func (s *BoolFileInterfaceSuite) TestPlugSnippetPanicksOnUnsanitizedSlots(c *C) {
 	// Unsanitized slots should never be used and cause a panic.
 	c.Assert(func() {
-		s.iface.PlugSecuritySnippet(s.plug, s.missingPathSlot, interfaces.SecurityAppArmor)
+		s.iface.PlugSnippet(s.plug, s.missingPathSlot, interfaces.SecurityAppArmor)
 	}, PanicMatches, "slot is not sanitized")
 }
 
-func (s *BoolFileInterfaceSuite) TestPlugSecuritySnippetUnusedSecuritySystems(c *C) {
+func (s *BoolFileInterfaceSuite) TestPlugSnippetUnusedSecuritySystems(c *C) {
 	for _, slot := range []*interfaces.Slot{s.ledSlot, s.gpioSlot} {
 		// No extra seccomp permissions for plug
-		snippet, err := s.iface.PlugSecuritySnippet(s.plug, slot, interfaces.SecuritySecComp)
+		snippet, err := s.iface.PlugSnippet(s.plug, slot, interfaces.SecuritySecComp)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// No extra dbus permissions for plug
-		snippet, err = s.iface.PlugSecuritySnippet(s.plug, slot, interfaces.SecurityDBus)
+		snippet, err = s.iface.PlugSnippet(s.plug, slot, interfaces.SecurityDBus)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// No extra udev permissions for plug
-		snippet, err = s.iface.PlugSecuritySnippet(s.plug, slot, interfaces.SecurityUDev)
+		snippet, err = s.iface.PlugSnippet(s.plug, slot, interfaces.SecurityUDev)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// No extra udev permissions for plug
-		snippet, err = s.iface.PlugSecuritySnippet(s.plug, slot, interfaces.SecurityUDev)
+		snippet, err = s.iface.PlugSnippet(s.plug, slot, interfaces.SecurityUDev)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// Other security types are not recognized
-		snippet, err = s.iface.PlugSecuritySnippet(s.plug, slot, "foo")
+		snippet, err = s.iface.PlugSnippet(s.plug, slot, "foo")
 		c.Assert(err, ErrorMatches, `unknown security system`)
 		c.Assert(snippet, IsNil)
 	}
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
+func (s *BoolFileInterfaceSuite) TestSlotSnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
 	// Extra apparmor permission to provide GPIOs
 	expectedGPIOSnippet := []byte(`
 /sys/class/gpio/export rw,
 /sys/class/gpio/unexport rw,
 /sys/class/gpio/gpio[0-9]+/direction rw,
 `)
-	snippet, err := s.iface.SlotSecuritySnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.SlotSnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedGPIOSnippet)
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
+func (s *BoolFileInterfaceSuite) TestSlotSnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
 	// No extra apparmor permission to provide LEDs
-	snippet, err := s.iface.SlotSecuritySnippet(s.plug, s.ledSlot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.SlotSnippet(s.plug, s.ledSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetPanicksOnUnsanitizedSlots(c *C) {
+func (s *BoolFileInterfaceSuite) TestSlotSnippetPanicksOnUnsanitizedSlots(c *C) {
 	// Unsanitized slots should never be used and cause a panic.
 	c.Assert(func() {
-		s.iface.SlotSecuritySnippet(s.plug, s.missingPathSlot, interfaces.SecurityAppArmor)
+		s.iface.SlotSnippet(s.plug, s.missingPathSlot, interfaces.SecurityAppArmor)
 	}, PanicMatches, "slot is not sanitized")
 }
 
-func (s *BoolFileInterfaceSuite) TestSlotSecuritySnippetUnusedSecuritySystems(c *C) {
+func (s *BoolFileInterfaceSuite) TestSlotSnippetUnusedSecuritySystems(c *C) {
 	for _, slot := range []*interfaces.Slot{s.ledSlot, s.gpioSlot} {
 		// No extra seccomp permissions for slot
-		snippet, err := s.iface.SlotSecuritySnippet(s.plug, slot, interfaces.SecuritySecComp)
+		snippet, err := s.iface.SlotSnippet(s.plug, slot, interfaces.SecuritySecComp)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// No extra dbus permissions for slot
-		snippet, err = s.iface.SlotSecuritySnippet(s.plug, slot, interfaces.SecurityDBus)
+		snippet, err = s.iface.SlotSnippet(s.plug, slot, interfaces.SecurityDBus)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// No extra udev permissions for slot
-		snippet, err = s.iface.SlotSecuritySnippet(s.plug, slot, interfaces.SecurityUDev)
+		snippet, err = s.iface.SlotSnippet(s.plug, slot, interfaces.SecurityUDev)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
 		// Other security types are not recognized
-		snippet, err = s.iface.SlotSecuritySnippet(s.plug, slot, "foo")
+		snippet, err = s.iface.SlotSnippet(s.plug, slot, "foo")
 		c.Assert(err, ErrorMatches, `unknown security system`)
 		c.Assert(snippet, IsNil)
 	}

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -97,7 +97,7 @@ type Interface interface {
 	// another snap.
 	//
 	// The snippet should be specific to both the plug and the slot. If the
-	// slot is not necessary then consider using PermanentPlugSecutitySnippet()
+	// slot is not necessary then consider using PermanentPlugSecuritySnippet()
 	// instead.
 	//
 	// An empty snippet is returned when there are no additional permissions
@@ -125,7 +125,7 @@ type Interface interface {
 	// another snap.
 	//
 	// The snippet should be specific to both the plug and the slot, if the
-	// plug is not necessary then consider using PermanentSlotSecutitySnippet()
+	// plug is not necessary then consider using PermanentSlotSecuritySnippet()
 	// instead.
 	//
 	// An empty snippet is returned when there are no additional permissions

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -78,7 +78,7 @@ type Interface interface {
 	// SanitizeSlot checks if a slot is correct, altering if necessary.
 	SanitizeSlot(slot *Slot) error
 
-	// PermanentPlugSecuritySnippet returns permanent, plug-side security snippet.
+	// PermanentPlugSnippet returns permanent, plug-side security snippet.
 	//
 	// Permanent security snippet can be used to grant permissions to a snap that
 	// has a plug of a given interface even before the plug is connected to a
@@ -88,25 +88,25 @@ type Interface interface {
 	// that are required to implement this interface. ErrUnknownSecurity error
 	// is returned when the plug cannot deal with the requested security
 	// system.
-	PermanentPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
+	PermanentPlugSnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 
-	// PlugSecuritySnippet returns connection-specific, plug-side security snippet.
+	// PlugSnippet returns connection-specific, plug-side security snippet.
 	//
 	// Connection-specific security snippet can be used to grant permission to
 	// a snap that has a plug of a given interface connected to a slot in
 	// another snap.
 	//
 	// The snippet should be specific to both the plug and the slot. If the
-	// slot is not necessary then consider using PermanentPlugSecuritySnippet()
+	// slot is not necessary then consider using PermanentPlugSnippet()
 	// instead.
 	//
 	// An empty snippet is returned when there are no additional permissions
 	// that are required to implement this interface. ErrUnknownSecurity error
 	// is returned when the plug cannot deal with the requested security
 	// system.
-	PlugSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	PlugSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
-	// PermanentSlotSecuritySnippet returns permanent, slot-side security snippet.
+	// PermanentSlotSnippet returns permanent, slot-side security snippet.
 	//
 	// Permanent security snippet can be used to grant permissions to a snap that
 	// has a slot of a given interface even before the first connection to that
@@ -116,23 +116,23 @@ type Interface interface {
 	// that are required to implement this interface. ErrUnknownSecurity error
 	// is returned when the plug cannot deal with the requested security
 	// system.
-	PermanentSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	PermanentSlotSnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
-	// SlotSecuritySnippet returns connection-specific, slot-side security snippet.
+	// SlotSnippet returns connection-specific, slot-side security snippet.
 	//
 	// Connection-specific security snippet can be used to grant permission to
 	// a snap that has a slot of a given interface connected to a plug in
 	// another snap.
 	//
 	// The snippet should be specific to both the plug and the slot, if the
-	// plug is not necessary then consider using PermanentSlotSecuritySnippet()
+	// plug is not necessary then consider using PermanentSlotSnippet()
 	// instead.
 	//
 	// An empty snippet is returned when there are no additional permissions
 	// that are required to implement this interface. ErrUnknownSecurity error
 	// is returned when the plug cannot deal with the requested security
 	// system.
-	SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	SlotSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // SecuritySystem is a name of a security system.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -78,9 +78,9 @@ type Interface interface {
 	// SanitizeSlot checks if a slot is correct, altering if necessary.
 	SanitizeSlot(slot *Slot) error
 
-	// StaticPlugSecuritySnippet returns static, plug-side security snippet.
+	// PermanentPlugSecuritySnippet returns permanent, plug-side security snippet.
 	//
-	// Static security snippet can be used to grant permissions to a snap that
+	// Permanent security snippet can be used to grant permissions to a snap that
 	// has a plug of a given interface even before the plug is connected to a
 	// slot.
 	//
@@ -88,7 +88,7 @@ type Interface interface {
 	// that are required to implement this interface. ErrUnknownSecurity error
 	// is returned when the plug cannot deal with the requested security
 	// system.
-	StaticPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
+	PermanentPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 
 	// PlugSecuritySnippet returns connection-specific, plug-side security snippet.
 	//
@@ -97,7 +97,7 @@ type Interface interface {
 	// another snap.
 	//
 	// The snippet should be specific to both the plug and the slot. If the
-	// slot is not necessary then consider using StaticPlugSecutitySnippet()
+	// slot is not necessary then consider using PermanentPlugSecutitySnippet()
 	// instead.
 	//
 	// An empty snippet is returned when there are no additional permissions
@@ -106,9 +106,9 @@ type Interface interface {
 	// system.
 	PlugSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
-	// StaticSlotSecuritySnippet returns static, slot-side security snippet.
+	// PermanentSlotSecuritySnippet returns permanent, slot-side security snippet.
 	//
-	// Static security snippet can be used to grant permissions to a snap that
+	// Permanent security snippet can be used to grant permissions to a snap that
 	// has a slot of a given interface even before the first connection to that
 	// slot is made.
 	//
@@ -116,7 +116,7 @@ type Interface interface {
 	// that are required to implement this interface. ErrUnknownSecurity error
 	// is returned when the plug cannot deal with the requested security
 	// system.
-	StaticSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	PermanentSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
 	// SlotSecuritySnippet returns connection-specific, slot-side security snippet.
 	//
@@ -125,7 +125,7 @@ type Interface interface {
 	// another snap.
 	//
 	// The snippet should be specific to both the plug and the slot, if the
-	// plug is not necessary then consider using StaticSlotSecutitySnippet()
+	// plug is not necessary then consider using PermanentSlotSecutitySnippet()
 	// instead.
 	//
 	// An empty snippet is returned when there are no additional permissions

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -78,23 +78,61 @@ type Interface interface {
 	// SanitizeSlot checks if a slot is correct, altering if necessary.
 	SanitizeSlot(slot *Slot) error
 
-	// SlotSecuritySnippet returns the configuration snippet needed by the
-	// given security system to allow a snap to offer a slot of this interface.
+	// StaticPlugSecuritySnippet returns static, plug-side security snippet.
 	//
-	// An empty snippet is returned when the slot doesn't require anything
-	// from the security system to work, in addition to the default
-	// configuration.  ErrUnknownSecurity is returned when the slot cannot
-	// deal with the requested security system.
-	SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// Static security snippet can be used to grant permissions to a snap that
+	// has a plug of a given interface even before the plug is connected to a
+	// slot.
+	//
+	// An empty snippet is returned when there are no additional permissions
+	// that are required to implement this interface. ErrUnknownSecurity error
+	// is returned when the plug cannot deal with the requested security
+	// system.
+	StaticPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 
-	// PlugSecuritySnippet returns the configuration snippet needed by the
-	// given security system to allow a snap to use a slot of this interface.
+	// PlugSecuritySnippet returns connection-specific, plug-side security snippet.
 	//
-	// An empty snippet is returned when the plug doesn't require anything
-	// from the security system to work, in addition to the default
-	// configuration.  ErrUnknownSecurity is returned when the plug cannot
-	// deal with the requested security system.
+	// Connection-specific security snippet can be used to grant permission to
+	// a snap that has a plug of a given interface connected to a slot in
+	// another snap.
+	//
+	// The snippet should be specific to both the plug and the slot. If the
+	// slot is not necessary then consider using StaticPlugSecutitySnippet()
+	// instead.
+	//
+	// An empty snippet is returned when there are no additional permissions
+	// that are required to implement this interface. ErrUnknownSecurity error
+	// is returned when the plug cannot deal with the requested security
+	// system.
 	PlugSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+
+	// StaticSlotSecuritySnippet returns static, slot-side security snippet.
+	//
+	// Static security snippet can be used to grant permissions to a snap that
+	// has a slot of a given interface even before the first connection to that
+	// slot is made.
+	//
+	// An empty snippet is returned when there are no additional permissions
+	// that are required to implement this interface. ErrUnknownSecurity error
+	// is returned when the plug cannot deal with the requested security
+	// system.
+	StaticSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+
+	// SlotSecuritySnippet returns connection-specific, slot-side security snippet.
+	//
+	// Connection-specific security snippet can be used to grant permission to
+	// a snap that has a slot of a given interface connected to a plug in
+	// another snap.
+	//
+	// The snippet should be specific to both the plug and the slot, if the
+	// plug is not necessary then consider using StaticSlotSecutitySnippet()
+	// instead.
+	//
+	// An empty snippet is returned when there are no additional permissions
+	// that are required to implement this interface. ErrUnknownSecurity error
+	// is returned when the plug cannot deal with the requested security
+	// system.
+	SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // SecuritySystem is a name of a security system.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -90,7 +90,7 @@ type Interface interface {
 	// system.
 	PermanentPlugSnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 
-	// PlugSnippet returns connection-specific, plug-side security snippet.
+	// ConnectedPlugSnippet returns connection-specific, plug-side security snippet.
 	//
 	// Connection-specific security snippet can be used to grant permission to
 	// a snap that has a plug of a given interface connected to a slot in
@@ -104,7 +104,7 @@ type Interface interface {
 	// that are required to implement this interface. ErrUnknownSecurity error
 	// is returned when the plug cannot deal with the requested security
 	// system.
-	PlugSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	ConnectedPlugSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
 	// PermanentSlotSnippet returns permanent, slot-side security snippet.
 	//
@@ -118,7 +118,7 @@ type Interface interface {
 	// system.
 	PermanentSlotSnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
-	// SlotSnippet returns connection-specific, slot-side security snippet.
+	// ConnectedSlotSnippet returns connection-specific, slot-side security snippet.
 	//
 	// Connection-specific security snippet can be used to grant permission to
 	// a snap that has a slot of a given interface connected to a plug in
@@ -132,7 +132,7 @@ type Interface interface {
 	// that are required to implement this interface. ErrUnknownSecurity error
 	// is returned when the plug cannot deal with the requested security
 	// system.
-	SlotSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	ConnectedSlotSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // SecuritySystem is a name of a security system.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -78,7 +78,9 @@ type Interface interface {
 	// SanitizeSlot checks if a slot is correct, altering if necessary.
 	SanitizeSlot(slot *Slot) error
 
-	// PermanentPlugSnippet returns permanent, plug-side security snippet.
+	// PermanentPlugSnippet returns the snippet of text for the given security
+	// system that is used during the whole lifetime of affected applications,
+	// whether the plug is connected or not.
 	//
 	// Permanent security snippet can be used to grant permissions to a snap that
 	// has a plug of a given interface even before the plug is connected to a
@@ -90,7 +92,9 @@ type Interface interface {
 	// system.
 	PermanentPlugSnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 
-	// ConnectedPlugSnippet returns connection-specific, plug-side security snippet.
+	// ConnectedPlugSnippet returns the snippet of text for the given security
+	// system that is used by affected application, while a specific connection
+	// between a plug and a slot exists.
 	//
 	// Connection-specific security snippet can be used to grant permission to
 	// a snap that has a plug of a given interface connected to a slot in
@@ -106,7 +110,9 @@ type Interface interface {
 	// system.
 	ConnectedPlugSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
-	// PermanentSlotSnippet returns permanent, slot-side security snippet.
+	// PermanentSlotSnippet returns the snippet of text for the given security
+	// system that is used during the whole lifetime of affected applications,
+	// whether the slot is connected or not.
 	//
 	// Permanent security snippet can be used to grant permissions to a snap that
 	// has a slot of a given interface even before the first connection to that
@@ -118,7 +124,9 @@ type Interface interface {
 	// system.
 	PermanentSlotSnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
-	// ConnectedSlotSnippet returns connection-specific, slot-side security snippet.
+	// ConnectedSlotSnippet returns the snippet of text for the given security
+	// system that is used by affected application, while a specific connection
+	// between a plug and a slot exists.
 	//
 	// Connection-specific security snippet can be used to grant permission to
 	// a snap that has a slot of a given interface connected to a plug in

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -543,6 +543,17 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 	// Find all of the slots that affect this snap because of plug connection.
 	for _, slot := range r.slots[snapName] {
 		iface := r.ifaces[slot.Interface]
+		// Add the static snippet for the slot
+		snippet, err := iface.StaticSlotSecuritySnippet(slot, securitySystem)
+		if err != nil {
+			return nil, err
+		}
+		if snippet != nil {
+			for _, app := range slot.Apps {
+				snippets[app] = append(snippets[app], snippet)
+			}
+		}
+		// Add connection-specific snippet specific to each plug
 		for plug := range r.slotPlugs[slot] {
 			snippet, err := iface.SlotSecuritySnippet(plug, slot, securitySystem)
 			if err != nil {
@@ -559,6 +570,17 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 	// Find all of the plugs that affect this snap because of slot connection
 	for _, plug := range r.plugs[snapName] {
 		iface := r.ifaces[plug.Interface]
+		// Add the static snippet for the plug
+		snippet, err := iface.StaticPlugSecuritySnippet(plug, securitySystem)
+		if err != nil {
+			return nil, err
+		}
+		if snippet != nil {
+			for _, app := range plug.Apps {
+				snippets[app] = append(snippets[app], snippet)
+			}
+		}
+		// Add connection-specific snippet specific to each slot
 		for slot := range r.plugSlots[plug] {
 			snippet, err := iface.PlugSecuritySnippet(plug, slot, securitySystem)
 			if err != nil {

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -544,7 +544,7 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 	for _, slot := range r.slots[snapName] {
 		iface := r.ifaces[slot.Interface]
 		// Add the static snippet for the slot
-		snippet, err := iface.StaticSlotSecuritySnippet(slot, securitySystem)
+		snippet, err := iface.PermanentSlotSecuritySnippet(slot, securitySystem)
 		if err != nil {
 			return nil, err
 		}
@@ -571,7 +571,7 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 	for _, plug := range r.plugs[snapName] {
 		iface := r.ifaces[plug.Interface]
 		// Add the static snippet for the plug
-		snippet, err := iface.StaticPlugSecuritySnippet(plug, securitySystem)
+		snippet, err := iface.PermanentPlugSecuritySnippet(plug, securitySystem)
 		if err != nil {
 			return nil, err
 		}

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -542,9 +542,9 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 	var snippets = make(map[string][][]byte)
 	// Find all of the slots that affect this snap because of plug connection.
 	for _, slot := range r.slots[snapName] {
-		i := r.ifaces[slot.Interface]
+		iface := r.ifaces[slot.Interface]
 		for plug := range r.slotPlugs[slot] {
-			snippet, err := i.SlotSecuritySnippet(plug, slot, securitySystem)
+			snippet, err := iface.SlotSecuritySnippet(plug, slot, securitySystem)
 			if err != nil {
 				return nil, err
 			}
@@ -558,9 +558,9 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 	}
 	// Find all of the plugs that affect this snap because of slot connection
 	for _, plug := range r.plugs[snapName] {
-		i := r.ifaces[plug.Interface]
+		iface := r.ifaces[plug.Interface]
 		for slot := range r.plugSlots[plug] {
-			snippet, err := i.PlugSecuritySnippet(plug, slot, securitySystem)
+			snippet, err := iface.PlugSecuritySnippet(plug, slot, securitySystem)
 			if err != nil {
 				return nil, err
 			}

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -544,7 +544,7 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 	for _, slot := range r.slots[snapName] {
 		iface := r.ifaces[slot.Interface]
 		// Add the static snippet for the slot
-		snippet, err := iface.PermanentSlotSecuritySnippet(slot, securitySystem)
+		snippet, err := iface.PermanentSlotSnippet(slot, securitySystem)
 		if err != nil {
 			return nil, err
 		}
@@ -555,7 +555,7 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 		}
 		// Add connection-specific snippet specific to each plug
 		for plug := range r.slotPlugs[slot] {
-			snippet, err := iface.SlotSecuritySnippet(plug, slot, securitySystem)
+			snippet, err := iface.SlotSnippet(plug, slot, securitySystem)
 			if err != nil {
 				return nil, err
 			}
@@ -571,7 +571,7 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 	for _, plug := range r.plugs[snapName] {
 		iface := r.ifaces[plug.Interface]
 		// Add the static snippet for the plug
-		snippet, err := iface.PermanentPlugSecuritySnippet(plug, securitySystem)
+		snippet, err := iface.PermanentPlugSnippet(plug, securitySystem)
 		if err != nil {
 			return nil, err
 		}
@@ -582,7 +582,7 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 		}
 		// Add connection-specific snippet specific to each slot
 		for slot := range r.plugSlots[plug] {
-			snippet, err := iface.PlugSecuritySnippet(plug, slot, securitySystem)
+			snippet, err := iface.PlugSnippet(plug, slot, securitySystem)
 			if err != nil {
 				return nil, err
 			}

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -555,7 +555,7 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 		}
 		// Add connection-specific snippet specific to each plug
 		for plug := range r.slotPlugs[slot] {
-			snippet, err := iface.SlotSnippet(plug, slot, securitySystem)
+			snippet, err := iface.ConnectedSlotSnippet(plug, slot, securitySystem)
 			if err != nil {
 				return nil, err
 			}
@@ -582,7 +582,7 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 		}
 		// Add connection-specific snippet specific to each slot
 		for slot := range r.plugSlots[plug] {
-			snippet, err := iface.PlugSnippet(plug, slot, securitySystem)
+			snippet, err := iface.ConnectedPlugSnippet(plug, slot, securitySystem)
 			if err != nil {
 				return nil, err
 			}

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -849,7 +849,7 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 	const testSecurity SecuritySystem = "security"
 	iface := &TestInterface{
 		InterfaceName: "interface",
-		StaticPlugSecuritySnippetCallback: func(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
+		PermanentPlugSecuritySnippetCallback: func(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == testSecurity {
 				return []byte(`static plug snippet`), nil
 			}
@@ -861,7 +861,7 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 			}
 			return nil, ErrUnknownSecurity
 		},
-		StaticSlotSecuritySnippetCallback: func(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PermanentSlotSecuritySnippetCallback: func(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == testSecurity {
 				return []byte(`static slot snippet`), nil
 			}
@@ -940,14 +940,14 @@ func (s *RepositorySuite) TestSecuritySnippetsForSnapFailureWithConnectionSnippe
 	c.Check(snippets, IsNil)
 }
 
-func (s *RepositorySuite) TestSecuritySnippetsForSnapFailureWithStaticSnippets(c *C) {
+func (s *RepositorySuite) TestSecuritySnippetsForSnapFailureWithPermanentSnippets(c *C) {
 	var testSecurity SecuritySystem = "security"
 	iface := &TestInterface{
 		InterfaceName: "interface",
-		StaticSlotSecuritySnippetCallback: func(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PermanentSlotSecuritySnippetCallback: func(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			return nil, fmt.Errorf("cannot compute static snippet for consumer")
 		},
-		StaticPlugSecuritySnippetCallback: func(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
+		PermanentPlugSecuritySnippetCallback: func(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
 			return nil, fmt.Errorf("cannot compute static snippet for provider")
 		},
 	}

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -849,25 +849,25 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 	const testSecurity SecuritySystem = "security"
 	iface := &TestInterface{
 		InterfaceName: "interface",
-		PermanentPlugSecuritySnippetCallback: func(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
+		PermanentPlugSnippetCallback: func(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == testSecurity {
 				return []byte(`static plug snippet`), nil
 			}
 			return nil, ErrUnknownSecurity
 		},
-		PlugSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PlugSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == testSecurity {
 				return []byte(`connection-specific plug snippet`), nil
 			}
 			return nil, ErrUnknownSecurity
 		},
-		PermanentSlotSecuritySnippetCallback: func(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PermanentSlotSnippetCallback: func(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == testSecurity {
 				return []byte(`static slot snippet`), nil
 			}
 			return nil, ErrUnknownSecurity
 		},
-		SlotSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		SlotSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == testSecurity {
 				return []byte(`connection-specific slot snippet`), nil
 			}
@@ -919,10 +919,10 @@ func (s *RepositorySuite) TestSecuritySnippetsForSnapFailureWithConnectionSnippe
 	var testSecurity SecuritySystem = "security"
 	iface := &TestInterface{
 		InterfaceName: "interface",
-		SlotSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		SlotSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			return nil, fmt.Errorf("cannot compute snippet for consumer")
 		},
-		PlugSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PlugSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			return nil, fmt.Errorf("cannot compute snippet for provider")
 		},
 	}
@@ -944,10 +944,10 @@ func (s *RepositorySuite) TestSecuritySnippetsForSnapFailureWithPermanentSnippet
 	var testSecurity SecuritySystem = "security"
 	iface := &TestInterface{
 		InterfaceName: "interface",
-		PermanentSlotSecuritySnippetCallback: func(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PermanentSlotSnippetCallback: func(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			return nil, fmt.Errorf("cannot compute static snippet for consumer")
 		},
-		PermanentPlugSecuritySnippetCallback: func(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
+		PermanentPlugSnippetCallback: func(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
 			return nil, fmt.Errorf("cannot compute static snippet for provider")
 		},
 	}

--- a/interfaces/security_test.go
+++ b/interfaces/security_test.go
@@ -66,7 +66,7 @@ func (s *SecuritySuite) prepareFixtureWithInterface(c *C, i Interface) {
 func (s *SecuritySuite) TestAppArmorPlugPermissions(c *C) {
 	s.prepareFixtureWithInterface(c, &TestInterface{
 		InterfaceName: "interface",
-		PlugSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PlugSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == SecurityAppArmor {
 				return []byte("producer snippet\n"), nil
 			}
@@ -87,7 +87,7 @@ func (s *SecuritySuite) TestAppArmorPlugPermissions(c *C) {
 func (s *SecuritySuite) TestAppArmorSlotPermissions(c *C) {
 	s.prepareFixtureWithInterface(c, &TestInterface{
 		InterfaceName: "interface",
-		SlotSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		SlotSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == SecurityAppArmor {
 				return []byte("consumer snippet\n"), nil
 			}
@@ -110,7 +110,7 @@ func (s *SecuritySuite) TestAppArmorSlotPermissions(c *C) {
 func (s *SecuritySuite) TestSecCompPlugPermissions(c *C) {
 	s.prepareFixtureWithInterface(c, &TestInterface{
 		InterfaceName: "interface",
-		PlugSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PlugSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == SecuritySecComp {
 				return []byte("allow open\n"), nil
 			}
@@ -130,7 +130,7 @@ func (s *SecuritySuite) TestSecCompPlugPermissions(c *C) {
 func (s *SecuritySuite) TestSecCompSlotPermissions(c *C) {
 	s.prepareFixtureWithInterface(c, &TestInterface{
 		InterfaceName: "interface",
-		SlotSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		SlotSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == SecuritySecComp {
 				return []byte("deny kexec\n"), nil
 			}
@@ -152,7 +152,7 @@ func (s *SecuritySuite) TestSecCompSlotPermissions(c *C) {
 func (s *SecuritySuite) TestUdevPlugPermissions(c *C) {
 	s.prepareFixtureWithInterface(c, &TestInterface{
 		InterfaceName: "interface",
-		PlugSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PlugSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == SecurityUDev {
 				return []byte("...\n"), nil
 			}
@@ -170,7 +170,7 @@ func (s *SecuritySuite) TestUdevPlugPermissions(c *C) {
 func (s *SecuritySuite) TestUdevSlotPermissions(c *C) {
 	s.prepareFixtureWithInterface(c, &TestInterface{
 		InterfaceName: "interface",
-		SlotSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		SlotSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == SecurityUDev {
 				return []byte("...\n"), nil
 			}
@@ -190,7 +190,7 @@ func (s *SecuritySuite) TestUdevSlotPermissions(c *C) {
 func (s *SecuritySuite) TestDBusPlugPermissions(c *C) {
 	s.prepareFixtureWithInterface(c, &TestInterface{
 		InterfaceName: "interface",
-		PlugSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		PlugSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == SecurityDBus {
 				return []byte("...\n"), nil
 			}
@@ -214,7 +214,7 @@ func (s *SecuritySuite) TestDBusPlugPermissions(c *C) {
 func (s *SecuritySuite) TestDBusSlotPermissions(c *C) {
 	s.prepareFixtureWithInterface(c, &TestInterface{
 		InterfaceName: "interface",
-		SlotSecuritySnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+		SlotSnippetCallback: func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 			if securitySystem == SecurityDBus {
 				return []byte("...\n"), nil
 			}

--- a/interfaces/testtype.go
+++ b/interfaces/testtype.go
@@ -32,14 +32,14 @@ type TestInterface struct {
 	SanitizePlugCallback func(plug *Plug) error
 	// SanitizeSlotCallback is the callback invoked inside SanitizeSlot()
 	SanitizeSlotCallback func(slot *Slot) error
-	// SlotSecuritySnippetCallback is the callback invoked inside SlotSecuritySnippet()
-	SlotSecuritySnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
-	// PermanentSlotSecuritySnippetCallback is the callback invoked inside PermanentSlotSecuritySnippet()
-	PermanentSlotSecuritySnippetCallback func(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
-	// PlugSecuritySnippetCallback is the callback invoked inside PlugSecuritySnippet()
-	PlugSecuritySnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
-	// PermanentPlugSecuritySnippetCallback is the callback invoked inside PermanentPlugSecuritySnippet()
-	PermanentPlugSecuritySnippetCallback func(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
+	// SlotSnippetCallback is the callback invoked inside SlotSnippet()
+	SlotSnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// PermanentSlotSnippetCallback is the callback invoked inside PermanentSlotSnippet()
+	PermanentSlotSnippetCallback func(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// PlugSnippetCallback is the callback invoked inside PlugSnippet()
+	PlugSnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// PermanentPlugSnippetCallback is the callback invoked inside PermanentPlugSnippet()
+	PermanentPlugSnippetCallback func(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // String() returns the same value as Name().
@@ -74,38 +74,38 @@ func (t *TestInterface) SanitizeSlot(slot *Slot) error {
 	return nil
 }
 
-// PlugSecuritySnippet returns the configuration snippet "required" to offer a test plug.
+// PlugSnippet returns the configuration snippet "required" to offer a test plug.
 // Providers don't gain any extra permissions.
-func (t *TestInterface) PlugSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
-	if t.PlugSecuritySnippetCallback != nil {
-		return t.PlugSecuritySnippetCallback(plug, slot, securitySystem)
+func (t *TestInterface) PlugSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+	if t.PlugSnippetCallback != nil {
+		return t.PlugSnippetCallback(plug, slot, securitySystem)
 	}
 	return nil, nil
 }
 
-// PermanentPlugSecuritySnippet returns the configuration snippet "required" to offer a test plug.
+// PermanentPlugSnippet returns the configuration snippet "required" to offer a test plug.
 // Providers don't gain any extra permissions.
-func (t *TestInterface) PermanentPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
-	if t.PermanentPlugSecuritySnippetCallback != nil {
-		return t.PermanentPlugSecuritySnippetCallback(plug, securitySystem)
+func (t *TestInterface) PermanentPlugSnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
+	if t.PermanentPlugSnippetCallback != nil {
+		return t.PermanentPlugSnippetCallback(plug, securitySystem)
 	}
 	return nil, nil
 }
 
-// SlotSecuritySnippet returns the configuration snippet "required" to use a test plug.
+// SlotSnippet returns the configuration snippet "required" to use a test plug.
 // Consumers don't gain any extra permissions.
-func (t *TestInterface) SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
-	if t.SlotSecuritySnippetCallback != nil {
-		return t.SlotSecuritySnippetCallback(plug, slot, securitySystem)
+func (t *TestInterface) SlotSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+	if t.SlotSnippetCallback != nil {
+		return t.SlotSnippetCallback(plug, slot, securitySystem)
 	}
 	return nil, nil
 }
 
-// PermanentSlotSecuritySnippet returns the configuration snippet "required" to use a test plug.
+// PermanentSlotSnippet returns the configuration snippet "required" to use a test plug.
 // Consumers don't gain any extra permissions.
-func (t *TestInterface) PermanentSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
-	if t.PermanentSlotSecuritySnippetCallback != nil {
-		return t.PermanentSlotSecuritySnippetCallback(slot, securitySystem)
+func (t *TestInterface) PermanentSlotSnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+	if t.PermanentSlotSnippetCallback != nil {
+		return t.PermanentSlotSnippetCallback(slot, securitySystem)
 	}
 	return nil, nil
 }

--- a/interfaces/testtype.go
+++ b/interfaces/testtype.go
@@ -34,8 +34,12 @@ type TestInterface struct {
 	SanitizeSlotCallback func(slot *Slot) error
 	// SlotSecuritySnippetCallback is the callback invoked inside SlotSecuritySnippet()
 	SlotSecuritySnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// StaticSlotSecuritySnippetCallback is the callback invoked inside StaticSlotSecuritySnippet()
+	StaticSlotSecuritySnippetCallback func(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 	// PlugSecuritySnippetCallback is the callback invoked inside PlugSecuritySnippet()
 	PlugSecuritySnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// StaticPlugSecuritySnippetCallback is the callback invoked inside StaticPlugSecuritySnippet()
+	StaticPlugSecuritySnippetCallback func(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // String() returns the same value as Name().
@@ -79,11 +83,29 @@ func (t *TestInterface) PlugSecuritySnippet(plug *Plug, slot *Slot, securitySyst
 	return nil, nil
 }
 
+// StaticPlugSecuritySnippet returns the configuration snippet "required" to offer a test plug.
+// Providers don't gain any extra permissions.
+func (t *TestInterface) StaticPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
+	if t.StaticPlugSecuritySnippetCallback != nil {
+		return t.StaticPlugSecuritySnippetCallback(plug, securitySystem)
+	}
+	return nil, nil
+}
+
 // SlotSecuritySnippet returns the configuration snippet "required" to use a test plug.
 // Consumers don't gain any extra permissions.
 func (t *TestInterface) SlotSecuritySnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 	if t.SlotSecuritySnippetCallback != nil {
 		return t.SlotSecuritySnippetCallback(plug, slot, securitySystem)
+	}
+	return nil, nil
+}
+
+// StaticSlotSecuritySnippet returns the configuration snippet "required" to use a test plug.
+// Consumers don't gain any extra permissions.
+func (t *TestInterface) StaticSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+	if t.StaticSlotSecuritySnippetCallback != nil {
+		return t.StaticSlotSecuritySnippetCallback(slot, securitySystem)
 	}
 	return nil, nil
 }

--- a/interfaces/testtype.go
+++ b/interfaces/testtype.go
@@ -34,12 +34,12 @@ type TestInterface struct {
 	SanitizeSlotCallback func(slot *Slot) error
 	// SlotSecuritySnippetCallback is the callback invoked inside SlotSecuritySnippet()
 	SlotSecuritySnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
-	// StaticSlotSecuritySnippetCallback is the callback invoked inside StaticSlotSecuritySnippet()
-	StaticSlotSecuritySnippetCallback func(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
+	// PermanentSlotSecuritySnippetCallback is the callback invoked inside PermanentSlotSecuritySnippet()
+	PermanentSlotSecuritySnippetCallback func(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 	// PlugSecuritySnippetCallback is the callback invoked inside PlugSecuritySnippet()
 	PlugSecuritySnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
-	// StaticPlugSecuritySnippetCallback is the callback invoked inside StaticPlugSecuritySnippet()
-	StaticPlugSecuritySnippetCallback func(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
+	// PermanentPlugSecuritySnippetCallback is the callback invoked inside PermanentPlugSecuritySnippet()
+	PermanentPlugSecuritySnippetCallback func(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
 }
 
 // String() returns the same value as Name().
@@ -83,11 +83,11 @@ func (t *TestInterface) PlugSecuritySnippet(plug *Plug, slot *Slot, securitySyst
 	return nil, nil
 }
 
-// StaticPlugSecuritySnippet returns the configuration snippet "required" to offer a test plug.
+// PermanentPlugSecuritySnippet returns the configuration snippet "required" to offer a test plug.
 // Providers don't gain any extra permissions.
-func (t *TestInterface) StaticPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
-	if t.StaticPlugSecuritySnippetCallback != nil {
-		return t.StaticPlugSecuritySnippetCallback(plug, securitySystem)
+func (t *TestInterface) PermanentPlugSecuritySnippet(plug *Plug, securitySystem SecuritySystem) ([]byte, error) {
+	if t.PermanentPlugSecuritySnippetCallback != nil {
+		return t.PermanentPlugSecuritySnippetCallback(plug, securitySystem)
 	}
 	return nil, nil
 }
@@ -101,11 +101,11 @@ func (t *TestInterface) SlotSecuritySnippet(plug *Plug, slot *Slot, securitySyst
 	return nil, nil
 }
 
-// StaticSlotSecuritySnippet returns the configuration snippet "required" to use a test plug.
+// PermanentSlotSecuritySnippet returns the configuration snippet "required" to use a test plug.
 // Consumers don't gain any extra permissions.
-func (t *TestInterface) StaticSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
-	if t.StaticSlotSecuritySnippetCallback != nil {
-		return t.StaticSlotSecuritySnippetCallback(slot, securitySystem)
+func (t *TestInterface) PermanentSlotSecuritySnippet(slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+	if t.PermanentSlotSecuritySnippetCallback != nil {
+		return t.PermanentSlotSecuritySnippetCallback(slot, securitySystem)
 	}
 	return nil, nil
 }

--- a/interfaces/testtype.go
+++ b/interfaces/testtype.go
@@ -32,11 +32,11 @@ type TestInterface struct {
 	SanitizePlugCallback func(plug *Plug) error
 	// SanitizeSlotCallback is the callback invoked inside SanitizeSlot()
 	SanitizeSlotCallback func(slot *Slot) error
-	// SlotSnippetCallback is the callback invoked inside SlotSnippet()
+	// SlotSnippetCallback is the callback invoked inside ConnectedSlotSnippet()
 	SlotSnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 	// PermanentSlotSnippetCallback is the callback invoked inside PermanentSlotSnippet()
 	PermanentSlotSnippetCallback func(slot *Slot, securitySystem SecuritySystem) ([]byte, error)
-	// PlugSnippetCallback is the callback invoked inside PlugSnippet()
+	// PlugSnippetCallback is the callback invoked inside ConnectedPlugSnippet()
 	PlugSnippetCallback func(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 	// PermanentPlugSnippetCallback is the callback invoked inside PermanentPlugSnippet()
 	PermanentPlugSnippetCallback func(plug *Plug, securitySystem SecuritySystem) ([]byte, error)
@@ -74,9 +74,9 @@ func (t *TestInterface) SanitizeSlot(slot *Slot) error {
 	return nil
 }
 
-// PlugSnippet returns the configuration snippet "required" to offer a test plug.
+// ConnectedPlugSnippet returns the configuration snippet "required" to offer a test plug.
 // Providers don't gain any extra permissions.
-func (t *TestInterface) PlugSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+func (t *TestInterface) ConnectedPlugSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 	if t.PlugSnippetCallback != nil {
 		return t.PlugSnippetCallback(plug, slot, securitySystem)
 	}
@@ -92,9 +92,9 @@ func (t *TestInterface) PermanentPlugSnippet(plug *Plug, securitySystem Security
 	return nil, nil
 }
 
-// SlotSnippet returns the configuration snippet "required" to use a test plug.
+// ConnectedSlotSnippet returns the configuration snippet "required" to use a test plug.
 // Consumers don't gain any extra permissions.
-func (t *TestInterface) SlotSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
+func (t *TestInterface) ConnectedSlotSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error) {
 	if t.SlotSnippetCallback != nil {
 		return t.SlotSnippetCallback(plug, slot, securitySystem)
 	}

--- a/interfaces/testtype_test.go
+++ b/interfaces/testtype_test.go
@@ -108,16 +108,16 @@ func (s *TestInterfaceSuite) TestSanitizeSlotWrongInterface(c *C) {
 func (s *TestInterfaceSuite) TestPlugSnippet(c *C) {
 	plug := &Plug{Interface: "test"}
 	slot := &Slot{Interface: "test"}
-	snippet, err := s.i.PlugSnippet(plug, slot, SecurityAppArmor)
+	snippet, err := s.i.ConnectedPlugSnippet(plug, slot, SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.PlugSnippet(plug, slot, SecuritySecComp)
+	snippet, err = s.i.ConnectedPlugSnippet(plug, slot, SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.PlugSnippet(plug, slot, SecurityDBus)
+	snippet, err = s.i.ConnectedPlugSnippet(plug, slot, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.PlugSnippet(plug, slot, "foo")
+	snippet, err = s.i.ConnectedPlugSnippet(plug, slot, "foo")
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }
@@ -126,16 +126,16 @@ func (s *TestInterfaceSuite) TestPlugSnippet(c *C) {
 func (s *TestInterfaceSuite) TestSlotSnippet(c *C) {
 	plug := &Plug{Interface: "test"}
 	slot := &Slot{Interface: "test"}
-	snippet, err := s.i.SlotSnippet(plug, slot, SecurityAppArmor)
+	snippet, err := s.i.ConnectedSlotSnippet(plug, slot, SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.SlotSnippet(plug, slot, SecuritySecComp)
+	snippet, err = s.i.ConnectedSlotSnippet(plug, slot, SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.SlotSnippet(plug, slot, SecurityDBus)
+	snippet, err = s.i.ConnectedSlotSnippet(plug, slot, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.SlotSnippet(plug, slot, "foo")
+	snippet, err = s.i.ConnectedSlotSnippet(plug, slot, "foo")
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }

--- a/interfaces/testtype_test.go
+++ b/interfaces/testtype_test.go
@@ -105,37 +105,37 @@ func (s *TestInterfaceSuite) TestSanitizeSlotWrongInterface(c *C) {
 }
 
 // TestInterface hands out empty plug security snippets
-func (s *TestInterfaceSuite) TestPlugSecuritySnippet(c *C) {
+func (s *TestInterfaceSuite) TestPlugSnippet(c *C) {
 	plug := &Plug{Interface: "test"}
 	slot := &Slot{Interface: "test"}
-	snippet, err := s.i.PlugSecuritySnippet(plug, slot, SecurityAppArmor)
+	snippet, err := s.i.PlugSnippet(plug, slot, SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.PlugSecuritySnippet(plug, slot, SecuritySecComp)
+	snippet, err = s.i.PlugSnippet(plug, slot, SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.PlugSecuritySnippet(plug, slot, SecurityDBus)
+	snippet, err = s.i.PlugSnippet(plug, slot, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.PlugSecuritySnippet(plug, slot, "foo")
+	snippet, err = s.i.PlugSnippet(plug, slot, "foo")
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }
 
 // TestInterface hands out empty slot security snippets
-func (s *TestInterfaceSuite) TestSlotSecuritySnippet(c *C) {
+func (s *TestInterfaceSuite) TestSlotSnippet(c *C) {
 	plug := &Plug{Interface: "test"}
 	slot := &Slot{Interface: "test"}
-	snippet, err := s.i.SlotSecuritySnippet(plug, slot, SecurityAppArmor)
+	snippet, err := s.i.SlotSnippet(plug, slot, SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.SlotSecuritySnippet(plug, slot, SecuritySecComp)
+	snippet, err = s.i.SlotSnippet(plug, slot, SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.SlotSecuritySnippet(plug, slot, SecurityDBus)
+	snippet, err = s.i.SlotSnippet(plug, slot, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.SlotSecuritySnippet(plug, slot, "foo")
+	snippet, err = s.i.SlotSnippet(plug, slot, "foo")
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }


### PR DESCRIPTION
This branch changes the Interface interface to expose four security-related
methods. The methods are Connected{Slot,Plug}Snippet(), which replace the older
{Slot,Plug}SecuritySnippet(), and a pair of new Permanent{Slot,Plug}Snippet().

This change is driven by the realization that we can simplify security
and number of interfaces by disassociating some permissions from
established connections.

For example, a display server interface can now be just a single
interface rather than two. Consider this example:

    There's a Mir snap, with the "mir" slot.
    There's a xeyes snap with a "mir" plug.

The mir snap, simply because it has the mir slot gets to have access
to graphics cards and all the required machinery. Mir can start even
without xeyes running yet.

As a connection is made between xeyes and mir, a new set of permissions
are granted: Xeyes can now talk to mir socket.

The same example works with any managed, shared resource that the
managing snap needs to be able to control regardless of who is connected
at a particular moment.

This patch also changes test interface that is use for testing to
support the extra methods.
