### PR TITLE
overlord: add first pass of the logic in StateEngine itself

### DIFF
--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ubuntu-core/snappy/overlord/assertstate"
 	"github.com/ubuntu-core/snappy/overlord/ifacestate"
 	"github.com/ubuntu-core/snappy/overlord/snapstate"
+	"github.com/ubuntu-core/snappy/overlord/state"
 )
 
 // Overlord is the central manager of a snappy system, keeping
@@ -40,7 +41,11 @@ type Overlord struct {
 func New() (*Overlord, error) {
 	o := &Overlord{}
 
-	o.stateEng = NewStateEngine()
+	// TODO: read it or create a fresh one and learn about the system
+	// current state
+	s := state.New(nil)
+
+	o.stateEng = NewStateEngine(s)
 
 	snapMgr, err := snapstate.Manager()
 	if err != nil {

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -41,4 +41,6 @@ func (os *overlordSuite) TestNew(c *C) {
 	c.Check(o.SnapManager(), NotNil)
 	c.Check(o.AssertManager(), NotNil)
 	c.Check(o.InterfaceManager(), NotNil)
+
+	c.Check(o.StateEngine(), NotNil)
 }

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -46,17 +46,22 @@ type StateManager interface {
 // by the individual managers registered. These managers must be able to
 // cope with Ensure calls in any order, coordinating among themselves
 // solely via the state.
-type StateEngine struct{}
+type StateEngine struct {
+	state    *state.State
+	managers []StateManager
+	inited   bool
+}
 
 // NewStateEngine returns a new state engine.
-// TODO: take or read a state somehow
-func NewStateEngine() *StateEngine {
-	return &StateEngine{}
+func NewStateEngine(s *state.State) *StateEngine {
+	return &StateEngine{
+		state: s,
+	}
 }
 
 // State returns the current system state.
 func (se *StateEngine) State() *state.State {
-	return nil
+	return se.state
 }
 
 // Ensure asks every manager to ensure that they are doing the necessary
@@ -68,15 +73,41 @@ func (se *StateEngine) State() *state.State {
 // must not perform long running activities during that operation, though.
 // These should be performed in properly tracked changes and tasks.
 func (se *StateEngine) Ensure() error {
+	if !se.inited {
+		for _, m := range se.managers {
+			err := m.Init(se.state)
+			if err != nil {
+				return err
+			}
+		}
+		se.inited = true
+	}
+
+	for _, m := range se.managers {
+		err := m.Ensure()
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
 // AddManager adds the provided manager to take part in state operations.
 func (se *StateEngine) AddManager(m StateManager) {
+	se.managers = append(se.managers, m)
 }
 
 // Stop asks all managers to terminate activities running concurrently.
 // It returns the first error found after all managers are stopped.
 func (se *StateEngine) Stop() error {
+	if se.inited {
+		for _, m := range se.managers {
+			err := m.Stop()
+			if err != nil {
+				return err
+			}
+		}
+		se.inited = false
+	}
 	return nil
 }

--- a/overlord/stateengine_test.go
+++ b/overlord/stateengine_test.go
@@ -1,0 +1,178 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/overlord"
+	"github.com/ubuntu-core/snappy/overlord/state"
+)
+
+type stateEngineSuite struct{}
+
+var _ = Suite(&stateEngineSuite{})
+
+func (ses *stateEngineSuite) TestNewAndState(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	c.Check(se.State(), Equals, s)
+}
+
+type fakeManager struct {
+	name                              string
+	state                             *state.State
+	calls                             *[]string
+	initError, ensureError, stopError error
+}
+
+func (fm *fakeManager) Init(s *state.State) error {
+	fm.state = s
+	*fm.calls = append(*fm.calls, "init:"+fm.name)
+	return fm.initError
+}
+
+func (fm *fakeManager) Ensure() error {
+	*fm.calls = append(*fm.calls, "ensure:"+fm.name)
+	return fm.ensureError
+}
+
+func (fm *fakeManager) Stop() error {
+	*fm.calls = append(*fm.calls, "stop:"+fm.name)
+	return fm.stopError
+}
+
+var _ overlord.StateManager = (*fakeManager)(nil)
+
+func (ses *stateEngineSuite) TestEnsure(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(calls, DeepEquals, []string{"init:mgr1", "init:mgr2", "ensure:mgr1", "ensure:mgr2"})
+	c.Check(mgr1.state, Equals, s)
+	c.Check(mgr2.state, Equals, s)
+
+	err = se.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(calls, DeepEquals, []string{"init:mgr1", "init:mgr2", "ensure:mgr1", "ensure:mgr2", "ensure:mgr1", "ensure:mgr2"})
+}
+
+func (ses *stateEngineSuite) TestEnsureInitError(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	err1 := errors.New("boom1")
+	err2 := errors.New("boom2")
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls, initError: err1}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls, initError: err2}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.Ensure()
+	c.Check(err, Equals, err1)
+	c.Check(calls, DeepEquals, []string{"init:mgr1"})
+}
+
+func (ses *stateEngineSuite) TestEnsureError(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	err1 := errors.New("boom1")
+	err2 := errors.New("boom2")
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls, ensureError: err1}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls, ensureError: err2}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.Ensure()
+	c.Check(err, Equals, err1)
+	c.Check(calls, DeepEquals, []string{"init:mgr1", "init:mgr2", "ensure:mgr1"})
+}
+
+func (ses *stateEngineSuite) TestStop(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(calls, HasLen, 4)
+
+	err = se.Stop()
+	c.Assert(err, IsNil)
+	c.Check(calls, DeepEquals, []string{"init:mgr1", "init:mgr2", "ensure:mgr1", "ensure:mgr2", "stop:mgr1", "stop:mgr2"})
+
+	err = se.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(calls, DeepEquals, []string{"init:mgr1", "init:mgr2", "ensure:mgr1", "ensure:mgr2", "stop:mgr1", "stop:mgr2", "init:mgr1", "init:mgr2", "ensure:mgr1", "ensure:mgr2"})
+}
+
+func (ses *stateEngineSuite) TestStopError(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	err1 := errors.New("boom1")
+	err2 := errors.New("boom2")
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls, stopError: err1}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls, stopError: err2}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(calls, HasLen, 4)
+
+	err = se.Stop()
+	c.Check(err, Equals, err1)
+	c.Check(calls, DeepEquals, []string{"init:mgr1", "init:mgr2", "ensure:mgr1", "ensure:mgr2", "stop:mgr1"})
+
+}


### PR DESCRIPTION
This adds the first pass of the logic of StateEngine that dispatches Ensure and Init and stopping to the state managers.