### PR TITLE
interfaces/builtin: add "network" interface

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -25,6 +25,7 @@ import (
 
 var allInterfaces = []interfaces.Interface{
 	&BoolFileInterface{},
+	&NetworkInterface{},
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -33,4 +33,5 @@ var _ = Suite(&AllSuite{})
 func (s *AllSuite) TestInterfaces(c *C) {
 	all := builtin.Interfaces()
 	c.Check(all, Contains, &builtin.BoolFileInterface{})
+	c.Check(all, Contains, &builtin.NetworkInterface{})
 }

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -26,7 +26,7 @@ import (
 )
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network
-const connectedPlugAppArmorSnippet = `
+const connectedPlugAppArmor = `
 # Description: Can access the network as a client.
 # Usage: common
 #include <abstractions/nameservice>
@@ -36,7 +36,7 @@ const connectedPlugAppArmorSnippet = `
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/network
-const connectedPlugSecCompSnippet = `
+const connectedPlugSecComp = `
 # Description: Can access the network as a client.
 # Usage: common
 connect
@@ -120,9 +120,9 @@ func (iface *NetworkInterface) PermanentPlugSnippet(plug *interfaces.Plug, secur
 func (iface *NetworkInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
-		return []byte(connectedPlugAppArmorSnippet), nil
+		return []byte(connectedPlugAppArmor), nil
 	case interfaces.SecuritySecComp:
-		return []byte(connectedPlugSecCompSnippet), nil
+		return []byte(connectedPlugSecComp), nil
 	case interfaces.SecurityDBus, interfaces.SecurityUDev:
 		return nil, nil
 	default:

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -83,7 +83,7 @@ func (iface *NetworkInterface) SanitizeSlot(slot *interfaces.Slot) error {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	if slot.Snap != "ubuntu-core" {
-		return fmt.Errorf("slots using the network interface are reserved for ubuntu-core")
+		return fmt.Errorf("network slots are reserved for the operating system snap")
 	}
 	return nil
 }

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -1,0 +1,159 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/ubuntu-core/snappy/interfaces"
+)
+
+// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network
+const connectedPlugAppArmorSnippet = `
+# Description: Can access the network as a client.
+# Usage: common
+#include <abstractions/nameservice>
+#include <abstractions/ssl_certs>
+
+@{PROC}/sys/net/core/somaxconn r,
+`
+
+// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/network
+const connectedPlugSecCompSnippet = `
+# Description: Can access the network as a client.
+# Usage: common
+connect
+getpeername
+getsockname
+getsockopt
+recv
+recvfrom
+recvmmsg
+recvmsg
+send
+sendmmsg
+sendmsg
+sendto
+setsockopt
+shutdown
+
+# LP: #1446748 - limit this to AF_UNIX/AF_LOCAL and perhaps AF_NETLINK
+socket
+
+# This is an older interface and single entry point that can be used instead
+# of socket(), bind(), connect(), etc individually. While we could allow it,
+# we wouldn't be able to properly arg filter socketcall for AF_INET/AF_INET6
+# when LP: #1446748 is implemented.
+#socketcall
+`
+
+// NetworkInterface implements the "network" interface.
+//
+// Snaps that have a connected plug of this type can access the network as a
+// client. The OS snap will have the only slot of this type.
+//
+// Usage: common
+type NetworkInterface struct{}
+
+// Name returns the string "network".
+func (iface *NetworkInterface) Name() string {
+	return "network"
+}
+
+// SanitizeSlot checks and possibly modifies a slot.
+func (iface *NetworkInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
+	}
+	if slot.Snap != "ubuntu-core" {
+		return fmt.Errorf("slots using the network interface are reserved for ubuntu-core")
+	}
+	return nil
+}
+
+// SanitizePlug checks and possibly modifies a plug.
+func (iface *NetworkInterface) SanitizePlug(plug *interfaces.Plug) error {
+	if iface.Name() != plug.Interface {
+		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
+	}
+	// NOTE: currently we don't check anything on the plug side.
+	return nil
+}
+
+// PermanentPlugSnippet returns the snippet of text for the given security
+// system that is used during the whole lifetime of affected applications,
+// whether the plug is connected or not.
+//
+// Plugs don't get any permanent security snippets.
+func (iface *NetworkInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedPlugSnippet returns the snippet of text for the given security
+// system that is used by affected application, while a specific connection
+// between a plug and a slot exists.
+//
+// Connected plugs get the static seccomp and apparmor blobs defined at the top
+// of the file. They are not really connection specific in this case.
+func (iface *NetworkInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		return []byte(connectedPlugAppArmorSnippet), nil
+	case interfaces.SecuritySecComp:
+		return []byte(connectedPlugSecCompSnippet), nil
+	case interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// PermanentSlotSnippet returns the snippet of text for the given security
+// system that is used during the whole lifetime of affected applications,
+// whether the slot is connected or not.
+//
+// Slots don't get any permanent security snippets.
+func (iface *NetworkInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedSlotSnippet returns the snippet of text for the given security
+// system that is used by affected application, while a specific connection
+// between a plug and a slot exists.
+//
+// Slots don't get any per-connection security snippets.
+func (iface *NetworkInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -1,0 +1,126 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/interfaces/builtin"
+)
+
+type NetworkInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&NetworkInterfaceSuite{
+	iface: &builtin.NetworkInterface{},
+})
+
+func (s *NetworkInterfaceSuite) SetUpTest(c *C) {
+	s.slot = &interfaces.Slot{
+		Snap:      "ubuntu-core",
+		Name:      "network",
+		Interface: "network",
+	}
+	s.plug = &interfaces.Plug{
+		Snap:      "snap",
+		Name:      "network",
+		Interface: "network",
+	}
+}
+
+func (s *NetworkInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "network")
+}
+
+func (s *NetworkInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{
+		Snap:      "some-snap",
+		Name:      "network",
+		Interface: "network",
+	})
+	c.Assert(err, ErrorMatches, "slots using the network interface are reserved for ubuntu-core")
+}
+
+func (s *NetworkInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *NetworkInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{Interface: "other"}) },
+		PanicMatches, `slot is not of interface "network"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{Interface: "other"}) },
+		PanicMatches, `plug is not of interface "network"`)
+}
+
+func (s *NetworkInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *NetworkInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *NetworkInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -61,7 +61,7 @@ func (s *NetworkInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "network",
 		Interface: "network",
 	})
-	c.Assert(err, ErrorMatches, "slots using the network interface are reserved for ubuntu-core")
+	c.Assert(err, ErrorMatches, "network slots are reserved for the operating system snap")
 }
 
 func (s *NetworkInterfaceSuite) TestSanitizePlug(c *C) {


### PR DESCRIPTION
This patch adds the "network" snappy interface. This is somewhat
confusingly associated with the system of interfaces, not the system of
*network* interfaces.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>