### PR TITLE
interfaces/buitlin: add network-bind interface, simplify work required to add more

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -25,7 +25,7 @@ import (
 
 var allInterfaces = []interfaces.Interface{
 	&BoolFileInterface{},
-	&NetworkInterface{},
+	NewNetworkInterface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -26,6 +26,7 @@ import (
 var allInterfaces = []interfaces.Interface{
 	&BoolFileInterface{},
 	NewNetworkInterface(),
+	NewNetworkBindInterface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -34,4 +34,5 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	all := builtin.Interfaces()
 	c.Check(all, Contains, &builtin.BoolFileInterface{})
 	c.Check(all, DeepContains, builtin.NewNetworkInterface())
+	c.Check(all, DeepContains, builtin.NewNetworkBindInterface())
 }

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -33,5 +33,5 @@ var _ = Suite(&AllSuite{})
 func (s *AllSuite) TestInterfaces(c *C) {
 	all := builtin.Interfaces()
 	c.Check(all, Contains, &builtin.BoolFileInterface{})
-	c.Check(all, Contains, &builtin.NetworkInterface{})
+	c.Check(all, DeepContains, builtin.NewNetworkInterface())
 }

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/ubuntu-core/snappy/interfaces"
+)
+
+// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network-bind
+const networkBindConnectedPlugAppArmor = `
+# Description: Can access the network as a server.
+# Usage: common
+#include <abstractions/nameservice>
+#include <abstractions/ssl_certs>
+
+# These probably shouldn't be something that apps should use, but this offers
+# no information disclosure since the files are in the read-only part of the
+# system.
+/etc/hosts.deny r,
+/etc/hosts.allow r,
+
+@{PROC}/sys/net/core/somaxconn r,
+@{PROC}/sys/net/ipv4/ip_local_port_range r,
+
+# LP: #1496906: java apps need these for some reason and they leak the IPv6 IP
+# addresses and routes. Until we find another way to handle them (see the bug
+# for some options), we need to allow them to avoid developer confusion.
+@{PROC}/@{pid}/net/if_inet6 r,
+@{PROC}/@{pid}/net/ipv6_route r,
+
+# java apps request this but seem to work fine without it. Netlink sockets
+# are used to talk to kernel subsystems though and since apps run as root,
+# allowing blanket access needs to be carefully considered. Kernel capabilities
+# checks (which apparmor mediates) *should* be enough to keep abuse down,
+# however Linux capabilities can be quite broad and there have been CVEs in
+# this area. The issue is complicated because reservied policy groups like
+# 'network-admin' and 'network-firewall' have legitimate use for this rule,
+# however a network facing server shouldn't typically be running with these
+# policy groups. For now, explicitly deny to silence the denial. LP: #1499897
+deny network netlink dgram,
+`
+
+// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/network-bind
+const networkBindConnectedPlugSecComp = `
+# Description: Can access the network as a server.
+# Usage: common
+accept
+accept4
+bind
+connect
+getpeername
+getsockname
+getsockopt
+listen
+recv
+recvfrom
+recvmmsg
+recvmsg
+send
+sendmmsg
+sendmsg
+sendto
+setsockopt
+shutdown
+
+# LP: #1446748 - limit this to AF_INET/AF_INET6
+socket
+
+# This is an older interface and single entry point that can be used instead
+# of socket(), bind(), connect(), etc individually. While we could allow it,
+# we wouldn't be able to properly arg filter socketcall for AF_INET/AF_INET6
+# when LP: #1446748 is implemented.
+#socketcall
+`
+
+// NewNetworkBindInterface returns a new "network-bind" interface.
+func NewNetworkBindInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "network-bind",
+		connectedPlugAppArmor: networkBindConnectedPlugAppArmor,
+		connectedPlugSecComp:  networkBindConnectedPlugSecComp,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -1,0 +1,126 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/interfaces/builtin"
+)
+
+type NetworkBindInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&NetworkBindInterfaceSuite{
+	iface: builtin.NewNetworkBindInterface(),
+})
+
+func (s *NetworkBindInterfaceSuite) SetUpTest(c *C) {
+	s.slot = &interfaces.Slot{
+		Snap:      "ubuntu-core",
+		Name:      "network-bind",
+		Interface: "network-bind",
+	}
+	s.plug = &interfaces.Plug{
+		Snap:      "snap",
+		Name:      "network-bind",
+		Interface: "network-bind",
+	}
+}
+
+func (s *NetworkBindInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "network-bind")
+}
+
+func (s *NetworkBindInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{
+		Snap:      "some-snap",
+		Name:      "network-bind",
+		Interface: "network-bind",
+	})
+	c.Assert(err, ErrorMatches, "network-bind slots are reserved for the operating system snap")
+}
+
+func (s *NetworkBindInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *NetworkBindInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{Interface: "other"}) },
+		PanicMatches, `slot is not of interface "network-bind"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{Interface: "other"}) },
+		PanicMatches, `plug is not of interface "network-bind"`)
+}
+
+func (s *NetworkBindInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *NetworkBindInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *NetworkBindInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -33,7 +33,7 @@ type NetworkInterfaceSuite struct {
 }
 
 var _ = Suite(&NetworkInterfaceSuite{
-	iface: &builtin.NetworkInterface{},
+	iface: builtin.NewNetworkInterface(),
 })
 
 func (s *NetworkInterfaceSuite) SetUpTest(c *C) {


### PR DESCRIPTION
This branch add another interface from the list planned for 16.04. In addition in makes crating similar interfaces very easy.