### PR TITLE
debian: move snapd to /usr/lib/snappy/snapd

### DIFF
--- a/debian/ubuntu-snappy-cli.dirs
+++ b/debian/ubuntu-snappy-cli.dirs
@@ -1,1 +1,2 @@
-/var/lib/snappy/snaps 
+var/lib/snappy/snaps
+usr/lib

--- a/debian/ubuntu-snappy-cli.dirs
+++ b/debian/ubuntu-snappy-cli.dirs
@@ -1,2 +1,2 @@
 var/lib/snappy/snaps
-usr/lib
+usr/lib/snappy

--- a/debian/ubuntu-snappy-cli.install
+++ b/debian/ubuntu-snappy-cli.install
@@ -1,5 +1,5 @@
 /usr/bin/snap
-/usr/bin/snapd
+/usr/bin/snapd usr/lib/
 /usr/bin/snappy
 data/completion/snappy /usr/share/bash-completion/completions/
 # i18n stuff

--- a/debian/ubuntu-snappy-cli.install
+++ b/debian/ubuntu-snappy-cli.install
@@ -1,5 +1,5 @@
 /usr/bin/snap
-/usr/bin/snapd usr/lib/
+/usr/bin/snapd usr/lib/snappy/
 /usr/bin/snappy
 data/completion/snappy /usr/share/bash-completion/completions/
 # i18n stuff

--- a/debian/ubuntu-snappy.snapd.service
+++ b/debian/ubuntu-snappy.snapd.service
@@ -5,4 +5,4 @@ Before=ubuntu-snappy.frameworks-pre.target
 Requires=ubuntu-snappy.snapd.socket
 
 [Service]
-ExecStart=/usr/bin/snapd
+ExecStart=/usr/lib/snapd

--- a/debian/ubuntu-snappy.snapd.service
+++ b/debian/ubuntu-snappy.snapd.service
@@ -5,4 +5,4 @@ Before=ubuntu-snappy.frameworks-pre.target
 Requires=ubuntu-snappy.snapd.socket
 
 [Service]
-ExecStart=/usr/lib/snapd
+ExecStart=/usr/lib/snappy/snapd


### PR DESCRIPTION
Because `snapd` is only relevant as a daemon we move it to `/usr/lib/snappy` to avoid having it in PATH (and having to write a man-page for it ;)