### PR TITLE
debian: add snap.8 manpage

### DIFF
--- a/cmd/snap/cmd_man.go
+++ b/cmd/snap/cmd_man.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"os"
+
+	"github.com/ubuntu-core/snappy/i18n"
+)
+
+type cmdMan struct{}
+
+var shortManHelp = i18n.G("produces manpage")
+var longManHelp = i18n.G("produces manpage")
+
+func init() {
+	addCommand("man", shortManHelp, longManHelp, func() interface{} {
+		return &cmdMan{}
+	})
+}
+
+func (*cmdMan) Execute([]string) error {
+	parser := Parser()
+	parser.WriteManPage(os.Stdout)
+
+	return nil
+}

--- a/cmd/snap/cmd_man.go
+++ b/cmd/snap/cmd_man.go
@@ -31,9 +31,10 @@ var shortManHelp = i18n.G("produces manpage")
 var longManHelp = i18n.G("produces manpage")
 
 func init() {
-	addCommand("man", shortManHelp, longManHelp, func() interface{} {
+	cmd := addCommand("man", shortManHelp, longManHelp, func() interface{} {
 		return &cmdMan{}
 	})
+	cmd.hidden = true
 }
 
 func (*cmdMan) Execute([]string) error {

--- a/debian/rules
+++ b/debian/rules
@@ -74,7 +74,7 @@ override_dh_auto_build:
 		GOPATH=${BUILDDIR} go generate ./i18n;\
 	fi;
 
-override_dh_auto_install: snappy.8
+override_dh_auto_install: snappy.8 snap.8
 	dh_auto_install -O--buildsystem=golang
 	# we do not need this in the package, its just needed during build
 	rm -rf ${CURDIR}/debian/tmp/usr/bin/xgettext-go
@@ -86,6 +86,9 @@ override_dh_auto_install: snappy.8
 snappy.8:
 	${BUILDDIR}/bin/snappy man > $@
 
+snap.8:
+	${BUILDDIR}/bin/snap man > $@
+
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=golang
-	rm -vf snappy.8
+	rm -vf snappy.8 snap.8

--- a/debian/ubuntu-snappy-cli.manpages
+++ b/debian/ubuntu-snappy-cli.manpages
@@ -1,1 +1,2 @@
 snappy.8
+snap.8


### PR DESCRIPTION
Add a (auto-generated) man page for snap (just like we do for snappy).