### PR TITLE
snap,snappy,systemd: change udev profile name, s/SNAP_ORIGIN/SNAP_DEVELOPER/, drop TMP* vars

### DIFF
--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -63,8 +63,6 @@ func GetBasicSnapEnvVars(desc interface{}) []string {
 	return fillSnapEnvVars(desc, []string{
 		"SNAP={{.AppPath}}",
 		"SNAP_DATA=/var/lib{{.AppPath}}",
-		"TMPDIR=/tmp/snaps/{{.UdevAppName}}/{{.Version}}/tmp",
-		"TEMPDIR=/tmp/snaps/{{.UdevAppName}}/{{.Version}}/tmp",
 		"SNAP_NAME={{.AppName}}",
 		"SNAP_VERSION={{.Version}}",
 		"SNAP_ORIGIN={{.Origin}}",
@@ -93,7 +91,6 @@ func GetDeprecatedBasicSnapEnvVars(desc interface{}) []string {
 		// SNAP_
 		"SNAP_APP_PATH={{.AppPath}}",
 		"SNAP_APP_DATA_PATH=/var/lib{{.AppPath}}",
-		"SNAP_APP_TMPDIR=/tmp/snaps/{{.UdevAppName}}/{{.Version}}/tmp",
 	})
 }
 

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -65,7 +65,7 @@ func GetBasicSnapEnvVars(desc interface{}) []string {
 		"SNAP_DATA=/var/lib{{.AppPath}}",
 		"SNAP_NAME={{.AppName}}",
 		"SNAP_VERSION={{.Version}}",
-		"SNAP_ORIGIN={{.Origin}}",
+		"SNAP_DEVELOPER={{.Origin}}",
 		"SNAP_ARCH={{.AppArch}}",
 	})
 }

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -66,7 +66,6 @@ func GetBasicSnapEnvVars(desc interface{}) []string {
 		"SNAP_NAME={{.AppName}}",
 		"SNAP_VERSION={{.Version}}",
 		"SNAP_ORIGIN={{.Origin}}",
-		"SNAP_DEVELOPER={{.UdevAppName}}",
 		"SNAP_ARCH={{.AppArch}}",
 	})
 }

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -66,7 +66,7 @@ func GetBasicSnapEnvVars(desc interface{}) []string {
 		"SNAP_NAME={{.AppName}}",
 		"SNAP_VERSION={{.Version}}",
 		"SNAP_ORIGIN={{.Origin}}",
-		"SNAP_FULLNAME={{.UdevAppName}}",
+		"SNAP_DEVELOPER={{.UdevAppName}}",
 		"SNAP_ARCH={{.AppArch}}",
 	})
 }

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -128,7 +128,7 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 	}
 
 	actualBinPath := binPathForBinary(pkgPath, app)
-	udevPartName := m.qualifiedName(origin)
+	udevAppName := app.qualifiedAppName(m, origin)
 
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("wrapper").Parse(wrapperTemplate))
@@ -149,7 +149,7 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 		AppArch:     arch.UbuntuArchitecture(),
 		AppPath:     pkgPath,
 		Version:     m.Version,
-		UdevAppName: udevPartName,
+		UdevAppName: udevAppName,
 		Origin:      origin,
 		Home:        "$HOME",
 		Target:      actualBinPath,
@@ -223,7 +223,7 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 	}
 
 	origin := originFromBasedir(baseDir)
-	udevPartName := m.qualifiedName(origin)
+	udevAppName := app.qualifiedAppName(m, origin)
 
 	desc := app.Description
 	if desc == "" {
@@ -251,7 +251,7 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 			IsFramework:    m.Type == snap.TypeFramework,
 			BusName:        app.BusName,
 			Type:           app.Daemon,
-			UdevAppName:    udevPartName,
+			UdevAppName:    udevAppName,
 			Socket:         app.Socket,
 			SocketFileName: socketFileName,
 			Restart:        app.RestartCond,

--- a/snappy/click.go
+++ b/snappy/click.go
@@ -222,7 +222,8 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 		return "", err
 	}
 
-	udevPartName := m.qualifiedName(originFromBasedir(baseDir))
+	origin := originFromBasedir(baseDir)
+	udevPartName := m.qualifiedName(origin)
 
 	desc := app.Description
 	if desc == "" {
@@ -238,6 +239,7 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 		&systemd.ServiceDescription{
 			AppName:        m.Name,
 			ServiceName:    app.Name,
+			Origin:         origin,
 			Version:        m.Version,
 			Description:    desc,
 			AppPath:        baseDir,

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -449,14 +449,11 @@ set -e
 # app info (deprecated)
 export SNAP_APP_PATH="/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_APP_DATA_PATH="/var/lib/snaps/pastebinit.mvo/1.4.0.0.1/"
-export SNAP_APP_TMPDIR="/tmp/snaps/pastebinit.mvo/1.4.0.0.1/tmp"
 export SNAP_APP_USER_DATA_PATH="$HOME/snaps/pastebinit.mvo/1.4.0.0.1/"
 
 # app info
 export SNAP="/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_DATA="/var/lib/snaps/pastebinit.mvo/1.4.0.0.1/"
-export TMPDIR="/tmp/snaps/pastebinit.mvo/1.4.0.0.1/tmp"
-export TEMPDIR="/tmp/snaps/pastebinit.mvo/1.4.0.0.1/tmp"
 export SNAP_NAME="pastebinit"
 export SNAP_VERSION="1.4.0.0.1"
 export SNAP_ORIGIN="mvo"
@@ -839,7 +836,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher xkcd-webserver%s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo start
 Restart=on-failure
 WorkingDirectory=/snaps/xkcd-webserver%[2]s/0.3.4/
-Environment="SNAP_APP=xkcd-webserver_xkcd-webserver_0.3.4" "SNAP=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_DATA=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "TMPDIR=/tmp/snaps/xkcd-webserver%[2]s/0.3.4/tmp" "TEMPDIR=/tmp/snaps/xkcd-webserver%[2]s/0.3.4/tmp" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ORIGIN=%[3]s" "SNAP_FULLNAME=xkcd-webserver%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_PATH=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_DATA_PATH=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_TMPDIR=/tmp/snaps/xkcd-webserver%[2]s/0.3.4/tmp" "SNAP_APP_USER_DATA_PATH=/root/snaps/xkcd-webserver%[2]s/0.3.4/"
+Environment="SNAP_APP=xkcd-webserver_xkcd-webserver_0.3.4" "SNAP=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_DATA=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ORIGIN=%[3]s" "SNAP_FULLNAME=xkcd-webserver%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_PATH=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_DATA_PATH=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snaps/xkcd-webserver%[2]s/0.3.4/"
 ExecStop=/usr/bin/ubuntu-core-launcher xkcd-webserver%[2]s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher xkcd-webserver%[2]s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo post-stop
 TimeoutStopSec=30

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -457,7 +457,7 @@ export SNAP_DATA="/var/lib/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_NAME="pastebinit"
 export SNAP_VERSION="1.4.0.0.1"
 export SNAP_ORIGIN="mvo"
-export SNAP_FULLNAME="pastebinit.mvo"
+export SNAP_DEVELOPER="pastebinit.mvo"
 export SNAP_ARCH="%[1]s"
 export SNAP_USER_DATA="$HOME/snaps/pastebinit.mvo/1.4.0.0.1/"
 
@@ -836,7 +836,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher xkcd-webserver%s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo start
 Restart=on-failure
 WorkingDirectory=/snaps/xkcd-webserver%[2]s/0.3.4/
-Environment="SNAP_APP=xkcd-webserver_xkcd-webserver_0.3.4" "SNAP=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_DATA=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ORIGIN=%[3]s" "SNAP_FULLNAME=xkcd-webserver%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_PATH=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_DATA_PATH=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snaps/xkcd-webserver%[2]s/0.3.4/"
+Environment="SNAP_APP=xkcd-webserver_xkcd-webserver_0.3.4" "SNAP=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_DATA=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ORIGIN=%[3]s" "SNAP_DEVELOPER=xkcd-webserver%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_PATH=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_DATA_PATH=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snaps/xkcd-webserver%[2]s/0.3.4/"
 ExecStop=/usr/bin/ubuntu-core-launcher xkcd-webserver%[2]s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher xkcd-webserver%[2]s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo post-stop
 TimeoutStopSec=30

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -457,7 +457,6 @@ export SNAP_DATA="/var/lib/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_NAME="pastebinit"
 export SNAP_VERSION="1.4.0.0.1"
 export SNAP_ORIGIN="mvo"
-export SNAP_DEVELOPER="pastebinit.mvo"
 export SNAP_ARCH="%[1]s"
 export SNAP_USER_DATA="$HOME/snaps/pastebinit.mvo/1.4.0.0.1/"
 
@@ -836,7 +835,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher xkcd-webserver%s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo start
 Restart=on-failure
 WorkingDirectory=/snaps/xkcd-webserver%[2]s/0.3.4/
-Environment="SNAP_APP=xkcd-webserver_xkcd-webserver_0.3.4" "SNAP=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_DATA=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ORIGIN=%[3]s" "SNAP_DEVELOPER=xkcd-webserver%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_PATH=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_DATA_PATH=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snaps/xkcd-webserver%[2]s/0.3.4/"
+Environment="SNAP_APP=xkcd-webserver_xkcd-webserver_0.3.4" "SNAP=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_DATA=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ORIGIN=%[3]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_PATH=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_DATA_PATH=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snaps/xkcd-webserver%[2]s/0.3.4/"
 ExecStop=/usr/bin/ubuntu-core-launcher xkcd-webserver%[2]s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher xkcd-webserver%[2]s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo post-stop
 TimeoutStopSec=30

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -456,7 +456,7 @@ export SNAP="/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_DATA="/var/lib/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_NAME="pastebinit"
 export SNAP_VERSION="1.4.0.0.1"
-export SNAP_ORIGIN="mvo"
+export SNAP_DEVELOPER="mvo"
 export SNAP_ARCH="%[1]s"
 export SNAP_USER_DATA="$HOME/snaps/pastebinit.mvo/1.4.0.0.1/"
 
@@ -498,7 +498,7 @@ export SNAP="/snaps/fmk/1.4.0.0.1/"
 export SNAP_DATA="/var/lib/snaps/fmk/1.4.0.0.1/"
 export SNAP_NAME="fmk"
 export SNAP_VERSION="1.4.0.0.1"
-export SNAP_ORIGIN=""
+export SNAP_DEVELOPER=""
 export SNAP_ARCH="%[1]s"
 export SNAP_USER_DATA="$HOME/snaps/fmk/1.4.0.0.1/"
 
@@ -859,7 +859,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher xkcd-webserver.xkcd-webserver%s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo start
 Restart=on-failure
 WorkingDirectory=/snaps/xkcd-webserver%[2]s/0.3.4/
-Environment="SNAP_APP=xkcd-webserver_xkcd-webserver_0.3.4" "SNAP=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_DATA=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ORIGIN=%[3]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_PATH=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_DATA_PATH=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snaps/xkcd-webserver%[2]s/0.3.4/"
+Environment="SNAP_APP=xkcd-webserver_xkcd-webserver_0.3.4" "SNAP=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_DATA=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_DEVELOPER=%[3]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_PATH=/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_DATA_PATH=/var/lib/snaps/xkcd-webserver%[2]s/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snaps/xkcd-webserver%[2]s/0.3.4/"
 ExecStop=/usr/bin/ubuntu-core-launcher xkcd-webserver.xkcd-webserver%[2]s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher xkcd-webserver.xkcd-webserver%[2]s xkcd-webserver%[2]s_xkcd-webserver_0.3.4 /snaps/xkcd-webserver%[2]s/0.3.4/bin/foo post-stop
 TimeoutStopSec=30

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -68,6 +68,14 @@ type AppYaml struct {
 	SlotsRef []string `yaml:"slots"`
 }
 
+// qualifiedAppName returns the "full" application name, including the snap name and origin (except for frameworks).
+func (app *AppYaml) qualifiedAppName(s *snapYaml, origin string) string {
+	if s.Type == snap.TypeFramework || s.Type == snap.TypeGadget {
+		return fmt.Sprintf("%s.%s", s.Name, app.Name)
+	}
+	return fmt.Sprintf("%s.%s.%s", s.Name, app.Name, origin)
+}
+
 type plugYaml struct {
 	Interface           string `yaml:"interface"`
 	SecurityDefinitions `yaml:",inline"`

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -156,6 +156,7 @@ func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) err
 type ServiceDescription struct {
 	AppName         string
 	ServiceName     string
+	Origin          string
 	Version         string
 	Description     string
 	AppPath         string

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -371,11 +371,6 @@ WantedBy={{.ServiceSystemdTarget}}
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("wrapper").Parse(serviceTemplate))
 
-	origin := ""
-	if len(desc.UdevAppName) > len(desc.AppName) {
-		origin = desc.UdevAppName[len(desc.AppName)+1:]
-	}
-
 	restartCond := desc.Restart.String()
 	if restartCond == "" {
 		restartCond = RestartOnFailure.String()
@@ -404,7 +399,7 @@ WantedBy={{.ServiceSystemdTarget}}
 		filepath.Join(desc.AppPath, desc.PostStop),
 		fmt.Sprintf("%s_%s_%s", desc.AppName, desc.ServiceName, desc.Version),
 		servicesSystemdTarget,
-		origin,
+		desc.Origin,
 		arch.UbuntuArchitecture(),
 		// systemd runs as PID 1 so %h will not work.
 		"/root",

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -221,7 +221,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/start
 Restart=on-failure
 WorkingDirectory=/apps/app%[2]s/1.0/
-Environment="SNAP_APP=app_service_1.0" "SNAP=/apps/app%[2]s/1.0/" "SNAP_DATA=/var/lib/apps/app%[2]s/1.0/" "TMPDIR=/tmp/snaps/app%[2]s/1.0/tmp" "TEMPDIR=/tmp/snaps/app%[2]s/1.0/tmp" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ORIGIN=%[3]s" "SNAP_FULLNAME=app%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/apps/app%[2]s/1.0/" "SNAP_APP_PATH=/apps/app%[2]s/1.0/" "SNAP_APP_DATA_PATH=/var/lib/apps/app%[2]s/1.0/" "SNAP_APP_TMPDIR=/tmp/snaps/app%[2]s/1.0/tmp" "SNAP_APP_USER_DATA_PATH=/root/apps/app%[2]s/1.0/"
+Environment="SNAP_APP=app_service_1.0" "SNAP=/apps/app%[2]s/1.0/" "SNAP_DATA=/var/lib/apps/app%[2]s/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ORIGIN=%[3]s" "SNAP_FULLNAME=app%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/apps/app%[2]s/1.0/" "SNAP_APP_PATH=/apps/app%[2]s/1.0/" "SNAP_APP_DATA_PATH=/var/lib/apps/app%[2]s/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app%[2]s/1.0/"
 ExecStop=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/stop --post
 TimeoutStopSec=10

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -221,7 +221,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/start
 Restart=on-failure
 WorkingDirectory=/apps/app%[2]s/1.0/
-Environment="SNAP_APP=app_service_1.0" "SNAP=/apps/app%[2]s/1.0/" "SNAP_DATA=/var/lib/apps/app%[2]s/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ORIGIN=%[3]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/apps/app%[2]s/1.0/" "SNAP_APP_PATH=/apps/app%[2]s/1.0/" "SNAP_APP_DATA_PATH=/var/lib/apps/app%[2]s/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app%[2]s/1.0/"
+Environment="SNAP_APP=app_service_1.0" "SNAP=/apps/app%[2]s/1.0/" "SNAP_DATA=/var/lib/apps/app%[2]s/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_DEVELOPER=%[3]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/apps/app%[2]s/1.0/" "SNAP_APP_PATH=/apps/app%[2]s/1.0/" "SNAP_APP_DATA_PATH=/var/lib/apps/app%[2]s/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app%[2]s/1.0/"
 ExecStop=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/stop --post
 TimeoutStopSec=10

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -242,6 +242,7 @@ func (s *SystemdTestSuite) TestGenAppServiceFile(c *C) {
 	desc := &ServiceDescription{
 		AppName:     "app",
 		ServiceName: "service",
+		Origin:      "mvo",
 		Version:     "1.0",
 		Description: "descr",
 		AppPath:     "/apps/app.mvo/1.0/",
@@ -294,6 +295,7 @@ func (s *SystemdTestSuite) TestGenServiceFileWithBusName(c *C) {
 	desc := &ServiceDescription{
 		AppName:     "app",
 		ServiceName: "service",
+		Origin:      "mvo",
 		Version:     "1.0",
 		Description: "descr",
 		AppPath:     "/apps/app.mvo/1.0/",

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -221,7 +221,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/start
 Restart=on-failure
 WorkingDirectory=/apps/app%[2]s/1.0/
-Environment="SNAP_APP=app_service_1.0" "SNAP=/apps/app%[2]s/1.0/" "SNAP_DATA=/var/lib/apps/app%[2]s/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ORIGIN=%[3]s" "SNAP_DEVELOPER=app%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/apps/app%[2]s/1.0/" "SNAP_APP_PATH=/apps/app%[2]s/1.0/" "SNAP_APP_DATA_PATH=/var/lib/apps/app%[2]s/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app%[2]s/1.0/"
+Environment="SNAP_APP=app_service_1.0" "SNAP=/apps/app%[2]s/1.0/" "SNAP_DATA=/var/lib/apps/app%[2]s/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ORIGIN=%[3]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/apps/app%[2]s/1.0/" "SNAP_APP_PATH=/apps/app%[2]s/1.0/" "SNAP_APP_DATA_PATH=/var/lib/apps/app%[2]s/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app%[2]s/1.0/"
 ExecStop=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/stop --post
 TimeoutStopSec=10

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -221,7 +221,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/start
 Restart=on-failure
 WorkingDirectory=/apps/app%[2]s/1.0/
-Environment="SNAP_APP=app_service_1.0" "SNAP=/apps/app%[2]s/1.0/" "SNAP_DATA=/var/lib/apps/app%[2]s/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ORIGIN=%[3]s" "SNAP_FULLNAME=app%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/apps/app%[2]s/1.0/" "SNAP_APP_PATH=/apps/app%[2]s/1.0/" "SNAP_APP_DATA_PATH=/var/lib/apps/app%[2]s/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app%[2]s/1.0/"
+Environment="SNAP_APP=app_service_1.0" "SNAP=/apps/app%[2]s/1.0/" "SNAP_DATA=/var/lib/apps/app%[2]s/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ORIGIN=%[3]s" "SNAP_DEVELOPER=app%[2]s" "SNAP_ARCH=%[5]s" "SNAP_USER_DATA=/root/apps/app%[2]s/1.0/" "SNAP_APP_PATH=/apps/app%[2]s/1.0/" "SNAP_APP_DATA_PATH=/var/lib/apps/app%[2]s/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app%[2]s/1.0/"
 ExecStop=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher app%[2]s aa-profile /apps/app%[2]s/1.0/bin/stop --post
 TimeoutStopSec=10


### PR DESCRIPTION
This branch sets the stage for fixing the udev profile name to be application specific (so that we can have application specific device assignments). In the resulting discussion SNAP_ORIGIN was renamed to SNAP_DEVELOPER, SNAP_FULLNAME, SNAP_APP_TMPDIR, TMPDIR and TEMPDIR were discarded