### PR TITLE
snap,snappy,systemd: %s/\<AppArch\>/SnapArch/g

### DIFF
--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -67,7 +67,7 @@ func GetBasicSnapEnvVars(desc interface{}) []string {
 		"SNAP_VERSION={{.Version}}",
 		"SNAP_ORIGIN={{.Origin}}",
 		"SNAP_FULLNAME={{.UdevAppName}}",
-		"SNAP_ARCH={{.AppArch}}",
+		"SNAP_ARCH={{.SnapArch}}",
 	})
 }
 

--- a/snappy/binaries.go
+++ b/snappy/binaries.go
@@ -91,7 +91,7 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 	t := template.Must(template.New("wrapper").Parse(wrapperTemplate))
 	wrapperData := struct {
 		SnapName    string
-		AppArch     string
+		SnapArch    string
 		AppPath     string
 		Version     string
 		UdevAppName string
@@ -103,7 +103,7 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 		NewAppVars  string
 	}{
 		SnapName:    m.Name,
-		AppArch:     arch.UbuntuArchitecture(),
+		SnapArch:    arch.UbuntuArchitecture(),
 		AppPath:     pkgPath,
 		Version:     m.Version,
 		UdevAppName: udevPartName,

--- a/snappy/utils.go
+++ b/snappy/utils.go
@@ -52,7 +52,7 @@ func stripGlobalRootDirImpl(dir string) string {
 func makeSnapHookEnv(part *SnapPart) (env []string) {
 	desc := struct {
 		SnapName    string
-		AppArch     string
+		SnapArch    string
 		AppPath     string
 		Version     string
 		UdevAppName string

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -390,7 +390,7 @@ WantedBy={{.ServiceSystemdTarget}}
 		AppTriple            string
 		ServiceSystemdTarget string
 		Origin               string
-		AppArch              string
+		SnapArch             string
 		Home                 string
 		EnvVars              string
 		SocketFileName       string


### PR DESCRIPTION
This branch fixes another naming leftover from the era where "apps" were
the packages (now snaps). AppArch is the snap-wide architecture name,
not app-local architecture name.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>