### PR TITLE
client,daemon,snappy,systemd: %s/\<ServiceName\>/AppName/g

### DIFF
--- a/client/services.go
+++ b/client/services.go
@@ -60,7 +60,7 @@ type ServiceStatus struct {
 	SubState        string `json:"sub_state"`
 	UnitFileState   string `json:"unit_file_state"`
 	SnapName        string `json:"snap_name"`
-	ServiceName     string `json:"service_name"`
+	AppName         string `json:"service_name"`
 }
 
 // Services returns the list of services belonging to an *active* Snap

--- a/client/services_test.go
+++ b/client/services_test.go
@@ -95,7 +95,7 @@ func (cs *clientSuite) TestClientServices(c *C) {
 				SubState:        "running",
 				UnitFileState:   "enabled",
 				SnapName:        "chatroom",
-				ServiceName:     "chatroom",
+				AppName:         "chatroom",
 			},
 		},
 	})

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -485,11 +485,11 @@ func snapService(c *Command, r *http.Request) Response {
 		}
 
 		for i := range status {
-			if desc, ok := appmap[status[i].ServiceName]; ok {
+			if desc, ok := appmap[status[i].AppName]; ok {
 				desc.Status = status[i]
 			} else {
 				// shouldn't really happen, but can't hurt
-				appmap[status[i].ServiceName] = &appDesc{Status: status[i]}
+				appmap[status[i].AppName] = &appDesc{Status: status[i]}
 			}
 		}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -914,7 +914,7 @@ func (s *apiSuite) TestSnapPutConfigNoConfig(c *check.C) {
 
 func (s *apiSuite) TestSnapServiceGet(c *check.C) {
 	findServices = func(string, string, progress.Meter) (snappy.ServiceActor, error) {
-		return &tSA{ssout: []*snappy.PackageServiceStatus{{ServiceName: "svc"}}}, nil
+		return &tSA{ssout: []*snappy.PackageServiceStatus{{AppName: "svc"}}}, nil
 	}
 
 	req, err := http.NewRequest("GET", "/2.0/snaps/foo.bar/services", nil)
@@ -935,12 +935,12 @@ func (s *apiSuite) TestSnapServiceGet(c *check.C) {
 	c.Assert(m["svc"], check.FitsTypeOf, new(appDesc))
 	c.Check(m["svc"].Op, check.Equals, "status")
 	c.Check(m["svc"].Spec, check.DeepEquals, &snappy.AppYaml{Name: "svc", Daemon: "forking", StopTimeout: timeout.DefaultTimeout})
-	c.Check(m["svc"].Status, check.DeepEquals, &snappy.PackageServiceStatus{ServiceName: "svc"})
+	c.Check(m["svc"].Status, check.DeepEquals, &snappy.PackageServiceStatus{AppName: "svc"})
 }
 
 func (s *apiSuite) TestSnapServicePut(c *check.C) {
 	findServices = func(string, string, progress.Meter) (snappy.ServiceActor, error) {
-		return &tSA{ssout: []*snappy.PackageServiceStatus{{ServiceName: "svc"}}}, nil
+		return &tSA{ssout: []*snappy.PackageServiceStatus{{AppName: "svc"}}}, nil
 	}
 
 	buf := bytes.NewBufferString(`{"action": "stop"}`)

--- a/snappy/service.go
+++ b/snappy/service.go
@@ -137,7 +137,7 @@ func (actor *serviceActor) Status() ([]string, error) {
 type PackageServiceStatus struct {
 	systemd.ServiceStatus
 	PackageName string `json:"package_name"`
-	ServiceName string `json:"service_name"`
+	AppName     string `json:"service_name"`
 }
 
 // ServiceStatus of all the found services.
@@ -153,7 +153,7 @@ func (actor *serviceActor) ServiceStatus() ([]*PackageServiceStatus, error) {
 		stati = append(stati, &PackageServiceStatus{
 			ServiceStatus: *status,
 			PackageName:   svc.m.Name,
-			ServiceName:   svc.svc.Name,
+			AppName:       svc.svc.Name,
 		})
 	}
 

--- a/snappy/service_test.go
+++ b/snappy/service_test.go
@@ -196,7 +196,7 @@ func (s *ServiceActorSuite) TestFindServicesFindsServices(c *C) {
 			UnitFileState:   "enabled",
 		},
 		PackageName: "hello-app",
-		ServiceName: "svc1",
+		AppName:     "svc1",
 	})
 
 	logs, err := actor.Logs()

--- a/snappy/services.go
+++ b/snappy/services.go
@@ -69,7 +69,7 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 	return systemd.New(dirs.GlobalRootDir, nil).GenServiceFile(
 		&systemd.ServiceDescription{
 			SnapName:       m.Name,
-			ServiceName:    app.Name,
+			AppName:        app.Name,
 			Version:        m.Version,
 			Description:    desc,
 			SnapPath:       baseDir,

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -155,7 +155,7 @@ func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) err
 // ServiceDescription describes a snappy systemd service
 type ServiceDescription struct {
 	SnapName        string
-	ServiceName     string
+	AppName         string
 	Version         string
 	Description     string
 	SnapPath        string
@@ -401,7 +401,7 @@ WantedBy={{.ServiceSystemdTarget}}
 		filepath.Join(desc.SnapPath, desc.Start),
 		filepath.Join(desc.SnapPath, desc.Stop),
 		filepath.Join(desc.SnapPath, desc.PostStop),
-		fmt.Sprintf("%s_%s_%s", desc.SnapName, desc.ServiceName, desc.Version),
+		fmt.Sprintf("%s_%s_%s", desc.SnapName, desc.AppName, desc.Version),
 		servicesSystemdTarget,
 		origin,
 		arch.UbuntuArchitecture(),

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -241,7 +241,7 @@ func (s *SystemdTestSuite) TestGenAppServiceFile(c *C) {
 
 	desc := &ServiceDescription{
 		SnapName:    "app",
-		ServiceName: "service",
+		AppName:     "service",
 		Version:     "1.0",
 		Description: "descr",
 		SnapPath:    "/apps/app.mvo/1.0/",
@@ -272,7 +272,7 @@ func (s *SystemdTestSuite) TestGenFmkServiceFile(c *C) {
 
 	desc := &ServiceDescription{
 		SnapName:    "app",
-		ServiceName: "service",
+		AppName:     "service",
 		Version:     "1.0",
 		Description: "descr",
 		SnapPath:    "/apps/app/1.0/",
@@ -293,7 +293,7 @@ func (s *SystemdTestSuite) TestGenServiceFileWithBusName(c *C) {
 
 	desc := &ServiceDescription{
 		SnapName:    "app",
-		ServiceName: "service",
+		AppName:     "service",
 		Version:     "1.0",
 		Description: "descr",
 		SnapPath:    "/apps/app.mvo/1.0/",


### PR DESCRIPTION
This patch changes service name into application name. This was
requested by Gustavo yesterday during a code review. I chose not to
change JSON serialization settings yet to minimize the affected code (so
on-the-wire protocol remains the same).

Wire changes will probably need some more work anyway (dashes-everywhere
initiative plus plenty of legacy terms in various places).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>