### PR TITLE
 snappy: pass AppName to generateSnapBinaryWrapper

### DIFF
--- a/snappy/binaries.go
+++ b/snappy/binaries.go
@@ -91,6 +91,7 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 	t := template.Must(template.New("wrapper").Parse(wrapperTemplate))
 	wrapperData := struct {
 		SnapName    string
+		AppName     string
 		SnapArch    string
 		SnapPath    string
 		Version     string
@@ -103,6 +104,7 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 		NewAppVars  string
 	}{
 		SnapName:    m.Name,
+		AppName:     app.Name,
 		SnapArch:    arch.UbuntuArchitecture(),
 		SnapPath:    pkgPath,
 		Version:     m.Version,

--- a/snappy/binaries.go
+++ b/snappy/binaries.go
@@ -71,6 +71,10 @@ if [ ! -d "$SNAP_USER_DATA" ]; then
 fi
 export HOME="$SNAP_USER_DATA"
 
+# Snap name is: {{.SnapName}}
+# App name is: {{.AppName}}
+# Developer name is: {{.Origin}}
+
 # export old pwd
 export SNAP_OLD_PWD="$(pwd)"
 cd $SNAP_DATA

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -466,6 +466,10 @@ if [ ! -d "$SNAP_USER_DATA" ]; then
 fi
 export HOME="$SNAP_USER_DATA"
 
+# Snap name is: pastebinit
+# App name is: pastebinit
+# Developer name is: mvo
+
 # export old pwd
 export SNAP_OLD_PWD="$(pwd)"
 cd $SNAP_DATA
@@ -508,6 +512,10 @@ if [ ! -d "$SNAP_USER_DATA" ]; then
    mkdir -p "$SNAP_USER_DATA"
 fi
 export HOME="$SNAP_USER_DATA"
+
+# Snap name is: fmk
+# App name is: echo
+# Developer name is: 
 
 # export old pwd
 export SNAP_OLD_PWD="$(pwd)"


### PR DESCRIPTION
This branch passes application (executable) name to the application
wrapper generator function. This will be soon required as input to the
new, simplified ubuntu-core-launcher.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>