### PR TITLE
snappy: fix comments in generated application wrappers

### DIFF
--- a/snappy/binaries.go
+++ b/snappy/binaries.go
@@ -60,10 +60,10 @@ func generateSnapBinaryWrapper(app *AppYaml, pkgPath, aaProfile string, m *snapY
 	wrapperTemplate := `#!/bin/sh
 set -e
 
-# app info (deprecated)
+# snap info (deprecated)
 {{.OldAppVars}}
 
-# app info
+# snap info
 {{.NewAppVars}}
 
 if [ ! -d "$SNAP_USER_DATA" ]; then

--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -446,12 +446,12 @@ func (s *SnapTestSuite) TestClickCopyDataNoUserHomes(c *C) {
 const expectedWrapper = `#!/bin/sh
 set -e
 
-# app info (deprecated)
+# snap info (deprecated)
 export SNAP_APP_PATH="/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_APP_DATA_PATH="/var/lib/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_APP_USER_DATA_PATH="$HOME/snaps/pastebinit.mvo/1.4.0.0.1/"
 
-# app info
+# snap info
 export SNAP="/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_DATA="/var/lib/snaps/pastebinit.mvo/1.4.0.0.1/"
 export SNAP_NAME="pastebinit"
@@ -492,12 +492,12 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 const expectedFrameworkWrapper = `#!/bin/sh
 set -e
 
-# app info (deprecated)
+# snap info (deprecated)
 export SNAP_APP_PATH="/snaps/fmk/1.4.0.0.1/"
 export SNAP_APP_DATA_PATH="/var/lib/snaps/fmk/1.4.0.0.1/"
 export SNAP_APP_USER_DATA_PATH="$HOME/snaps/fmk/1.4.0.0.1/"
 
-# app info
+# snap info
 export SNAP="/snaps/fmk/1.4.0.0.1/"
 export SNAP_DATA="/var/lib/snaps/fmk/1.4.0.0.1/"
 export SNAP_NAME="fmk"


### PR DESCRIPTION
The comments used to refer to "app info" where they were really talking
about snap (package level) information.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>