### PR TITLE
snappy,systemd: store Origin in ServiceDescription

### DIFF
--- a/snappy/services.go
+++ b/snappy/services.go
@@ -54,7 +54,8 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 		return "", err
 	}
 
-	udevPartName := m.qualifiedName(originFromBasedir(baseDir))
+	origin := originFromBasedir(baseDir)
+	udevPartName := m.qualifiedName(origin)
 
 	desc := app.Description
 	if desc == "" {
@@ -82,6 +83,7 @@ func generateSnapServicesFile(app *AppYaml, baseDir string, aaProfile string, m 
 			BusName:        app.BusName,
 			Type:           app.Daemon,
 			UdevAppName:    udevPartName,
+			Origin:         origin,
 			Socket:         app.Socket,
 			SocketFileName: socketFileName,
 			Restart:        app.RestartCond,

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -169,6 +169,7 @@ type ServiceDescription struct {
 	IsFramework     bool
 	BusName         string
 	UdevAppName     string
+	Origin          string
 	Socket          bool
 	SocketFileName  string
 	ListenStream    string
@@ -370,11 +371,6 @@ WantedBy={{.ServiceSystemdTarget}}
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("wrapper").Parse(serviceTemplate))
 
-	origin := ""
-	if len(desc.UdevAppName) > len(desc.SnapName) {
-		origin = desc.UdevAppName[len(desc.SnapName)+1:]
-	}
-
 	restartCond := desc.Restart.String()
 	if restartCond == "" {
 		restartCond = RestartOnFailure.String()
@@ -389,7 +385,6 @@ WantedBy={{.ServiceSystemdTarget}}
 		FullPathPostStop     string
 		AppTriple            string
 		ServiceSystemdTarget string
-		Origin               string
 		SnapArch             string
 		Home                 string
 		EnvVars              string
@@ -403,7 +398,6 @@ WantedBy={{.ServiceSystemdTarget}}
 		filepath.Join(desc.SnapPath, desc.PostStop),
 		fmt.Sprintf("%s_%s_%s", desc.SnapName, desc.AppName, desc.Version),
 		servicesSystemdTarget,
-		origin,
 		arch.UbuntuArchitecture(),
 		// systemd runs as PID 1 so %h will not work.
 		"/root",

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -251,6 +251,7 @@ func (s *SystemdTestSuite) TestGenAppServiceFile(c *C) {
 		StopTimeout: time.Duration(10 * time.Second),
 		AaProfile:   "aa-profile",
 		UdevAppName: "app.mvo",
+		Origin:      "mvo",
 		Type:        "simple",
 	}
 
@@ -304,6 +305,7 @@ func (s *SystemdTestSuite) TestGenServiceFileWithBusName(c *C) {
 		AaProfile:   "aa-profile",
 		BusName:     "foo.bar.baz",
 		UdevAppName: "app.mvo",
+		Origin:      "mvo",
 		Type:        "dbus",
 	}
 


### PR DESCRIPTION
This patch changes ServiceDescription to contain the Origin field. In
the past it was computed in a fragile way out of UdevAppName but with
this changing it makes sense to simplify everything by just having it
available directly.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>