### PR TITLE
cmd: hide the snap experimental command

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -99,6 +99,7 @@ func Parser() *flags.Parser {
 	}
 	// Add the experimental command
 	experimentalCommand, err := parser.AddCommand("experimental", shortExperimentalHelp, longExperimentalHelp, &cmdExperimental{})
+	experimentalCommand.Hidden = true
 	if err != nil {
 		logger.Panicf("cannot add command %q: %v", "experimental", err)
 	}


### PR DESCRIPTION
Earlier we considered hiding the "snap experimental" command but we were blocked by older version of go-flags. With that issue out of the way we can now hide the command.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>