### PR TITLE
daemon: maintain a daemon-wide overlord instance

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -39,11 +39,13 @@ import (
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/notifications"
 	"github.com/ubuntu-core/snappy/osutil"
+	"github.com/ubuntu-core/snappy/overlord"
 )
 
 // A Daemon listens for requests and routes them to the right command
 type Daemon struct {
 	sync.RWMutex // for concurrent access to the tasks map
+	overlord     *overlord.Overlord
 	tasks        map[string]*Task
 	listener     net.Listener
 	tomb         tomb.Tomb
@@ -264,6 +266,10 @@ func getTrustedAccountKey() string {
 
 // New Daemon
 func New() *Daemon {
+	ovld, err := overlord.New()
+	if err != nil {
+		panic(err.Error())
+	}
 	db, err := asserts.OpenSysDatabase(getTrustedAccountKey())
 	if err != nil {
 		panic(err.Error())
@@ -275,6 +281,7 @@ func New() *Daemon {
 		}
 	}
 	return &Daemon{
+		overlord:   ovld,
 		tasks:      make(map[string]*Task),
 		asserts:    db,
 		hub:        notifications.NewHub(),


### PR DESCRIPTION
This patch begins the path of overlord-izing the daemon and making
particular API requests happen through interactions with particular
managers.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>