### PR TITLE
asserts: add series everywhere

### DIFF
--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -67,6 +67,7 @@ func (aks *accountKeySuite) SetUpSuite(c *C) {
 func (aks *accountKeySuite) TestDecodeOK(c *C) {
 	encoded := "type: account-key\n" +
 		"authority-id: canonical\n" +
+		"series: 16\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
 		"public-key-fingerprint: " + aks.fp + "\n" +
@@ -79,6 +80,7 @@ func (aks *accountKeySuite) TestDecodeOK(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.AccountKeyType)
 	accKey := a.(*asserts.AccountKey)
+	c.Check(accKey.Series(), Equals, "16")
 	c.Check(accKey.AccountID(), Equals, "acc-id1")
 	c.Check(accKey.PublicKeyFingerprint(), Equals, aks.fp)
 	c.Check(accKey.PublicKeyID(), Equals, aks.keyid)
@@ -93,6 +95,7 @@ const (
 func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 	encoded := "type: account-key\n" +
 		"authority-id: canonical\n" +
+		"series: 16\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
 		"public-key-fingerprint: " + aks.fp + "\n" +
@@ -103,6 +106,7 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 		"openpgp c2ln"
 
 	invalidHeaderTests := []struct{ original, invalid, expectedErr string }{
+		{"series: 16\n", "", `"series" header is mandatory`},
 		{"account-id: acc-id1\n", "", `"account-id" header is mandatory`},
 		{aks.sinceLine, "", `"since" header is mandatory`},
 		{aks.untilLine, "", `"until" header is mandatory`},
@@ -122,6 +126,7 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 func (aks *accountKeySuite) TestDecodeInvalidPublicKey(c *C) {
 	headers := "type: account-key\n" +
 		"authority-id: canonical\n" +
+		"series: 16\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
 		"public-key-fingerprint: " + aks.fp + "\n" +
@@ -150,6 +155,7 @@ func (aks *accountKeySuite) TestDecodeInvalidPublicKey(c *C) {
 func (aks *accountKeySuite) TestDecodeFingerprintMismatch(c *C) {
 	invalid := "type: account-key\n" +
 		"authority-id: canonical\n" +
+		"series: 16\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
 		"public-key-fingerprint: 00\n" +
@@ -166,6 +172,7 @@ func (aks *accountKeySuite) TestDecodeFingerprintMismatch(c *C) {
 func (aks *accountKeySuite) TestDecodeKeyIDMismatch(c *C) {
 	invalid := "type: account-key\n" +
 		"authority-id: canonical\n" +
+		"series: 16\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: aa\n" +
 		"public-key-fingerprint: " + aks.fp + "\n" +
@@ -200,6 +207,7 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 
 	headers := map[string]string{
 		"authority-id":           "canonical",
+		"series":                 "16",
 		"account-id":             "acc-id1",
 		"public-key-id":          aks.keyid,
 		"public-key-fingerprint": aks.fp,
@@ -220,6 +228,7 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 
 	headers := map[string]string{
 		"authority-id":           "canonical",
+		"series":                 "16",
 		"account-id":             "acc-id1",
 		"public-key-id":          aks.keyid,
 		"public-key-fingerprint": aks.fp,
@@ -235,6 +244,7 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	c.Assert(err, IsNil)
 
 	found, err := db.Find(asserts.AccountKeyType, map[string]string{
+		"series":        "16",
 		"account-id":    "acc-id1",
 		"public-key-id": aks.keyid,
 	})
@@ -246,6 +256,7 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 func (aks *accountKeySuite) TestPublicKeyIsValidAt(c *C) {
 	encoded := "type: account-key\n" +
 		"authority-id: canonical\n" +
+		"series: 16\n" +
 		"account-id: acc-id1\n" +
 		"public-key-id: " + aks.keyid + "\n" +
 		"public-key-fingerprint: " + aks.fp + "\n" +

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -50,7 +50,7 @@ var (
 	// XXX: is series actually part of the primary key?
 	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
-	SnapBuildType       = &AssertionType{"snap-build", []string{"snap-id", "snap-digest"}, assembleSnapBuild}
+	SnapBuildType       = &AssertionType{"snap-build", []string{"series", "snap-id", "snap-digest"}, assembleSnapBuild}
 	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}
 
 // ...

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -51,7 +51,7 @@ var (
 	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
 	SnapBuildType       = &AssertionType{"snap-build", []string{"series", "snap-id", "snap-digest"}, assembleSnapBuild}
-	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}
+	SnapRevisionType    = &AssertionType{"snap-revision", []string{"series", "snap-id", "snap-digest"}, assembleSnapRevision}
 
 // ...
 )

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -44,7 +44,7 @@ type AssertionType struct {
 
 // Understood assertion types.
 var (
-	AccountKeyType   = &AssertionType{"account-key", []string{"account-id", "public-key-id"}, assembleAccountKey}
+	AccountKeyType   = &AssertionType{"account-key", []string{"series", "account-id", "public-key-id"}, assembleAccountKey}
 	DeviceSerialType = &AssertionType{"device-serial", []string{"brand-id", "model", "serial"}, assembleDeviceSerial}
 	IdentityType     = &AssertionType{"identity", []string{"series", "account-id"}, assembleIdentity}
 	// XXX: is series actually part of the primary key?

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -479,11 +479,6 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 		return nil, fmt.Errorf("assertion body length and declared body-length don't match: %v != %v", len(body), length)
 	}
 
-	// TODO(matt): uncomment this once all assertions include `series`
-	//if _, err := checkMandatory(headers, "series"); err != nil {
-	//	return nil, fmt.Errorf("assertion: %v", err)
-	//}
-
 	if _, err := checkMandatory(headers, "authority-id"); err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
 	}
@@ -502,6 +497,12 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 			return nil, fmt.Errorf("assertion %s: %v", assertType.Name, err)
 		}
 	}
+
+	// TODO(matt): consider uncommenting this once all assertions include
+	// `series`, just in case it's not in the primary key. Needs a test.
+	//if _, err := checkMandatory(headers, "series"); err != nil {
+	//	return nil, fmt.Errorf("assertion: %v", err)
+	//}
 
 	revision, err := checkRevision(headers)
 	if err != nil {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -45,7 +45,7 @@ type AssertionType struct {
 // Understood assertion types.
 var (
 	AccountKeyType   = &AssertionType{"account-key", []string{"series", "account-id", "public-key-id"}, assembleAccountKey}
-	DeviceSerialType = &AssertionType{"device-serial", []string{"brand-id", "model", "serial"}, assembleDeviceSerial}
+	DeviceSerialType = &AssertionType{"device-serial", []string{"series", "brand-id", "model", "serial"}, assembleDeviceSerial}
 	IdentityType     = &AssertionType{"identity", []string{"series", "account-id"}, assembleIdentity}
 	// XXX: is series actually part of the primary key?
 	ModelType           = &AssertionType{"model", []string{"brand-id", "model", "series"}, assembleModel}

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -48,7 +48,7 @@ var (
 	DeviceSerialType = &AssertionType{"device-serial", []string{"series", "brand-id", "model", "serial"}, assembleDeviceSerial}
 	IdentityType     = &AssertionType{"identity", []string{"series", "account-id"}, assembleIdentity}
 	// XXX: is series actually part of the primary key?
-	ModelType           = &AssertionType{"model", []string{"brand-id", "model", "series"}, assembleModel}
+	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
 	SnapBuildType       = &AssertionType{"snap-build", []string{"snap-id", "snap-digest"}, assembleSnapBuild}
 	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -79,6 +79,8 @@ type Assertion interface {
 	Revision() int
 	// AuthorityID returns the authority that signed this assertion
 	AuthorityID() string
+	// Series return the series of the assertion.
+	Series() string
 
 	// Header retrieves the header with name
 	Header(name string) string
@@ -122,6 +124,11 @@ func (ab *assertionBase) Revision() int {
 // AuthorityID returns the authority-id a.k.a the signer id of the assertion.
 func (ab *assertionBase) AuthorityID() string {
 	return ab.headers["authority-id"]
+}
+
+// Series return the series of the assertion.
+func (ab *assertionBase) Series() string {
+	return ab.Header("series")
 }
 
 // Header returns the value of an header by name.
@@ -472,6 +479,11 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 	if length != len(body) {
 		return nil, fmt.Errorf("assertion body length and declared body-length don't match: %v != %v", len(body), length)
 	}
+
+	// TODO(matt): uncomment this once all assertions include `series`
+	//if _, err := checkMandatory(headers, "series"); err != nil {
+	//	return nil, fmt.Errorf("assertion: %v", err)
+	//}
 
 	if _, err := checkMandatory(headers, "authority-id"); err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -46,7 +46,7 @@ type AssertionType struct {
 var (
 	AccountKeyType   = &AssertionType{"account-key", []string{"account-id", "public-key-id"}, assembleAccountKey}
 	DeviceSerialType = &AssertionType{"device-serial", []string{"brand-id", "model", "serial"}, assembleDeviceSerial}
-	IdentityType     = &AssertionType{"identity", []string{"account-id"}, assembleIdentity}
+	IdentityType     = &AssertionType{"identity", []string{"series", "account-id"}, assembleIdentity}
 	// XXX: is series actually part of the primary key?
 	ModelType           = &AssertionType{"model", []string{"brand-id", "model", "series"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -44,10 +44,9 @@ type AssertionType struct {
 
 // Understood assertion types.
 var (
-	AccountKeyType   = &AssertionType{"account-key", []string{"series", "account-id", "public-key-id"}, assembleAccountKey}
-	DeviceSerialType = &AssertionType{"device-serial", []string{"series", "brand-id", "model", "serial"}, assembleDeviceSerial}
-	IdentityType     = &AssertionType{"identity", []string{"series", "account-id"}, assembleIdentity}
-	// XXX: is series actually part of the primary key?
+	AccountKeyType      = &AssertionType{"account-key", []string{"series", "account-id", "public-key-id"}, assembleAccountKey}
+	DeviceSerialType    = &AssertionType{"device-serial", []string{"series", "brand-id", "model", "serial"}, assembleDeviceSerial}
+	IdentityType        = &AssertionType{"identity", []string{"series", "account-id"}, assembleIdentity}
 	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
 	SnapBuildType       = &AssertionType{"snap-build", []string{"series", "snap-id", "snap-digest"}, assembleSnapBuild}

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -44,6 +44,7 @@ func (as *assertsSuite) TestUnknown(c *C) {
 
 const exampleEmptyBodyAllDefaults = "type: test-only\n" +
 	"authority-id: auth-id1\n" +
+	"series: 16\n" +
 	"primary-key: abc" +
 	"\n\n" +
 	"openpgp c2ln"
@@ -62,6 +63,7 @@ func (as *assertsSuite) TestDecodeEmptyBodyAllDefaults(c *C) {
 
 const exampleEmptyBody2NlNl = "type: test-only\n" +
 	"authority-id: auth-id1\n" +
+	"series: 16\n" +
 	"primary-key: xyz\n" +
 	"revision: 0\n" +
 	"body-length: 0" +
@@ -79,6 +81,7 @@ func (as *assertsSuite) TestDecodeEmptyBodyNormalize2NlNl(c *C) {
 
 const exampleBodyAndExtraHeaders = "type: test-only\n" +
 	"authority-id: auth-id2\n" +
+	"series: 16\n" +
 	"primary-key: abc\n" +
 	"revision: 5\n" +
 	"header1: value1\n" +
@@ -104,6 +107,7 @@ func (as *assertsSuite) TestDecodeWithABodyAndExtraHeaders(c *C) {
 func (as *assertsSuite) TestDecodeGetSignatureBits(c *C) {
 	content := "type: test-only\n" +
 		"authority-id: auth-id1\n" +
+		"series: 16\n" +
 		"primary-key: xyz\n" +
 		"revision: 5\n" +
 		"header1: value1\n" +
@@ -147,6 +151,7 @@ func (as *assertsSuite) TestDecodeHeaderParsingErrors(c *C) {
 func (as *assertsSuite) TestDecodeInvalid(c *C) {
 	encoded := "type: test-only\n" +
 		"authority-id: auth-id\n" +
+		"series: 16\n" +
 		"primary-key: abc\n" +
 		"revision: 0\n" +
 		"body-length: 5" +
@@ -320,6 +325,7 @@ func (as *assertsSuite) TestDecoderSignatureTooBig(c *C) {
 func (as *assertsSuite) TestEncode(c *C) {
 	encoded := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
+		"series: 16\n" +
 		"primary-key: xyz\n" +
 		"revision: 5\n" +
 		"header1: value1\n" +
@@ -337,6 +343,7 @@ func (as *assertsSuite) TestEncode(c *C) {
 func (as *assertsSuite) TestEncoderOK(c *C) {
 	encoded := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
+		"series: 16\n" +
 		"primary-key: xyzyz\n" +
 		"revision: 5\n" +
 		"header1: value1\n" +
@@ -366,6 +373,7 @@ func (as *assertsSuite) TestEncoderOK(c *C) {
 func (as *assertsSuite) TestEncoderSingleDecodeOK(c *C) {
 	encoded := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
+		"series: 16\n" +
 		"primary-key: abc\n" +
 		"revision: 5\n" +
 		"header1: value1\n" +
@@ -392,6 +400,7 @@ func (as *assertsSuite) TestEncoderSingleDecodeOK(c *C) {
 func (as *assertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 	headers := map[string]string{
 		"authority-id": "auth-id1",
+		"series":       "16",
 		"primary-key":  "0",
 	}
 	a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, asserts.OpenPGPPrivateKey(testPrivKey1))
@@ -404,6 +413,7 @@ func (as *assertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 	headers := map[string]string{
 		"authority-id": "auth-id1",
+		"series":       "16",
 		"primary-key":  "0",
 	}
 	body := []byte("THE-BODY")
@@ -419,6 +429,7 @@ func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 func (as *assertsSuite) TestSignFormatSanitySupportMultilineHeaderValues(c *C) {
 	headers := map[string]string{
 		"authority-id": "auth-id1",
+		"series":       "16",
 		"primary-key":  "0",
 	}
 
@@ -450,6 +461,7 @@ func (as *assertsSuite) TestSignFormatSanitySupportMultilineHeaderValues(c *C) {
 func (as *assertsSuite) TestHeaders(c *C) {
 	encoded := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
+		"series: 16\n" +
 		"primary-key: abc\n" +
 		"revision: 5\n" +
 		"header1: value1\n" +
@@ -465,6 +477,7 @@ func (as *assertsSuite) TestHeaders(c *C) {
 	c.Check(hs, DeepEquals, map[string]string{
 		"type":         "test-only",
 		"authority-id": "auth-id2",
+		"series":       "16",
 		"primary-key":  "abc",
 		"revision":     "5",
 		"header1":      "value1",
@@ -476,6 +489,7 @@ func (as *assertsSuite) TestHeaders(c *C) {
 func (as *assertsSuite) TestHeadersReturnsCopy(c *C) {
 	encoded := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
+		"series: 16\n" +
 		"primary-key: xyz\n" +
 		"revision: 5\n" +
 		"header1: value1\n" +
@@ -496,6 +510,7 @@ func (as *assertsSuite) TestHeadersReturnsCopy(c *C) {
 func (as *assertsSuite) TestAssembleRoundtrip(c *C) {
 	encoded := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
+		"series: 16\n" +
 		"primary-key: abc\n" +
 		"revision: 5\n" +
 		"header1: value1\n" +

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -218,8 +218,8 @@ func (db *Database) Sign(assertType *AssertionType, headers map[string]string, b
 }
 
 // findAccountKey finds an AccountKey exactly by account id and key id.
-func (db *Database) findAccountKey(authorityID, keyID string) (*AccountKey, error) {
-	key := []string{authorityID, keyID}
+func (db *Database) findAccountKey(series string, authorityID, keyID string) (*AccountKey, error) {
+	key := []string{series, authorityID, keyID}
 	// consider trusted account keys then disk stored account keys
 	for _, bs := range db.backstores {
 		a, err := bs.Get(AccountKeyType, key)
@@ -241,7 +241,7 @@ func (db *Database) Check(assert Assertion) error {
 		return err
 	}
 	// TODO: later may need to consider type of assert to find candidate keys
-	accKey, err := db.findAccountKey(assert.AuthorityID(), sig.KeyID())
+	accKey, err := db.findAccountKey(assert.Series(), assert.AuthorityID(), sig.KeyID())
 	if err == ErrNotFound {
 		return fmt.Errorf("no matching public key %q for signature by %q", sig.KeyID(), assert.AuthorityID())
 	}

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -168,6 +168,7 @@ func (chks *checkSuite) SetUpTest(c *C) {
 
 	headers := map[string]string{
 		"authority-id": "canonical",
+		"series":       "16",
 		"primary-key":  "0",
 	}
 	chks.a, err = asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, asserts.OpenPGPPrivateKey(testPrivKey0))
@@ -276,6 +277,7 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 func (safs *signAddFindSuite) TestSign(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
+		"series":       "16",
 		"primary-key":  "a",
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
@@ -366,6 +368,7 @@ func (safs *signAddFindSuite) TestSignAssemblerError(c *C) {
 func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
+		"series":       "16",
 		"primary-key":  "a",
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
@@ -402,6 +405,7 @@ func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 func (safs *signAddFindSuite) TestFindNotFound(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
+		"series":       "16",
 		"primary-key":  "a",
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
@@ -434,6 +438,7 @@ func (safs *signAddFindSuite) TestFindPrimaryLeftOut(c *C) {
 func (safs *signAddFindSuite) TestFindMany(c *C) {
 	headers := map[string]string{
 		"authority-id": "canonical",
+		"series":       "16",
 		"primary-key":  "a",
 		"other":        "other-x",
 	}
@@ -444,6 +449,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 
 	headers = map[string]string{
 		"authority-id": "canonical",
+		"series":       "16",
 		"primary-key":  "b",
 		"other":        "other-y",
 	}
@@ -454,6 +460,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 
 	headers = map[string]string{
 		"authority-id": "canonical",
+		"series":       "16",
 		"primary-key":  "c",
 		"other":        "other-x",
 	}
@@ -505,6 +512,7 @@ func (safs *signAddFindSuite) TestFindFindsTrustedAccountKeys(c *C) {
 	now := time.Now().UTC()
 	headers := map[string]string{
 		"authority-id":           "canonical",
+		"series":                 "16",
 		"account-id":             "acc-id1",
 		"public-key-id":          pk1.PublicKey().ID(),
 		"public-key-fingerprint": pk1.PublicKey().Fingerprint(),
@@ -519,6 +527,7 @@ func (safs *signAddFindSuite) TestFindFindsTrustedAccountKeys(c *C) {
 
 	// find the trusted key as well
 	tKey, err := safs.db.Find(asserts.AccountKeyType, map[string]string{
+		"series":        "16",
 		"account-id":    "canonical",
 		"public-key-id": safs.signingKeyID,
 	})
@@ -542,6 +551,7 @@ func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithTrus
 	now := time.Now().UTC()
 	headers := map[string]string{
 		"authority-id":           "canonical",
+		"series":                 "16",
 		"account-id":             "canonical",
 		"public-key-id":          safs.signingKeyID,
 		"public-key-fingerprint": pubKey0.Fingerprint(),

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -46,9 +46,9 @@ func (mods *modelSuite) SetUpSuite(c *C) {
 
 const modelExample = "type: model\n" +
 	"authority-id: brand-id1\n" +
+	"series: 16\n" +
 	"brand-id: brand-id1\n" +
 	"model: baz-3000\n" +
-	"series: 16\n" +
 	"os: core\n" +
 	"architecture: amd64\n" +
 	"gadget: brand-gadget\n" +
@@ -70,9 +70,9 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	model := a.(*asserts.Model)
 	c.Check(model.AuthorityID(), Equals, "brand-id1")
 	c.Check(model.Timestamp(), Equals, mods.ts)
+	c.Check(model.Series(), Equals, "16")
 	c.Check(model.BrandID(), Equals, "brand-id1")
 	c.Check(model.Model(), Equals, "baz-3000")
-	c.Check(model.Series(), Equals, "16")
 	c.Check(model.Class(), Equals, "fixed")
 	c.Check(model.OS(), Equals, "core")
 	c.Check(model.Architecture(), Equals, "amd64")
@@ -90,7 +90,7 @@ const (
 func (mods *modelSuite) TestDecodeInvalidMandatory(c *C) {
 	encoded := strings.Replace(modelExample, "TSLINE", mods.tsLine, 1)
 
-	mandatoryHeaders := []string{"brand-id", "model", "series", "os", "architecture", "gadget", "kernel", "store", "allowed-modes", "required-snaps", "class", "timestamp"}
+	mandatoryHeaders := []string{"series", "brand-id", "model", "os", "architecture", "gadget", "kernel", "store", "allowed-modes", "required-snaps", "class", "timestamp"}
 
 	for _, mandatory := range mandatoryHeaders {
 		invalid := strings.Replace(encoded, mandatory+":", "xyz:", 1)

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -165,6 +165,7 @@ func (dss *deviceSerialSuite) SetUpSuite(c *C) {
 
 const deviceSerialExample = "type: device-serial\n" +
 	"authority-id: canonical\n" +
+	"series: 16\n" +
 	"brand-id: brand-id1\n" +
 	"model: baz-3000\n" +
 	"serial: 2700\n" +
@@ -184,6 +185,7 @@ func (dss *deviceSerialSuite) TestDecodeOK(c *C) {
 	deviceSerial := a.(*asserts.DeviceSerial)
 	c.Check(deviceSerial.AuthorityID(), Equals, "canonical")
 	c.Check(deviceSerial.Timestamp(), Equals, dss.ts)
+	c.Check(deviceSerial.Series(), Equals, "16")
 	c.Check(deviceSerial.BrandID(), Equals, "brand-id1")
 	c.Check(deviceSerial.Model(), Equals, "baz-3000")
 	c.Check(deviceSerial.Serial(), Equals, "2700")
@@ -198,6 +200,7 @@ func (dss *deviceSerialSuite) TestDecodeInvalid(c *C) {
 	encoded := strings.Replace(deviceSerialExample, "TSLINE", dss.tsLine, 1)
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"series: 16\n", "", `"series" header is mandatory`},
 		{"serial: 2700\n", "", `"serial" header is mandatory`},
 		{"device-key:\n DEVICEKEY\n", "", `"device-key" header is mandatory`},
 		{"device-key:\n DEVICEKEY\n", "device-key: openpgp ZZZ\n", `public key: could not decode base64 data:.*`},

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -92,7 +92,7 @@ func assembleTestOnly(assert assertionBase) (Assertion, error) {
 	return &TestOnly{assert}, nil
 }
 
-var TestOnlyType = &AssertionType{"test-only", []string{"primary-key"}, assembleTestOnly}
+var TestOnlyType = &AssertionType{"test-only", []string{"series", "primary-key"}, assembleTestOnly}
 
 type TestOnly2 struct {
 	assertionBase
@@ -102,7 +102,7 @@ func assembleTestOnly2(assert assertionBase) (Assertion, error) {
 	return &TestOnly2{assert}, nil
 }
 
-var TestOnly2Type = &AssertionType{"test-only-2", []string{"pk1", "pk2"}, assembleTestOnly2}
+var TestOnly2Type = &AssertionType{"test-only-2", []string{"series", "pk1", "pk2"}, assembleTestOnly2}
 
 func init() {
 	typeRegistry[TestOnlyType.Name] = TestOnlyType

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -59,6 +59,7 @@ func makeAccountKeyForTest(authorityID string, pubKey *packet.PublicKey, validYe
 		assertionBase: assertionBase{
 			headers: map[string]string{
 				"authority-id":  authorityID,
+				"series":        "16",
 				"account-id":    authorityID,
 				"public-key-id": openPGPPubKey.ID(),
 			},

--- a/asserts/identity.go
+++ b/asserts/identity.go
@@ -33,7 +33,12 @@ type Identity struct {
 	timestamp time.Time
 }
 
-// AccountID returns the account-id of the identit.
+// Series return the series of the identity assertion.
+func (id *Identity) Series() string {
+	return id.Header("series")
+}
+
+// AccountID returns the account-id of the identity.
 func (id *Identity) AccountID() string {
 	return id.Header("account-id")
 }

--- a/asserts/identity.go
+++ b/asserts/identity.go
@@ -33,11 +33,6 @@ type Identity struct {
 	timestamp time.Time
 }
 
-// Series return the series of the identity assertion.
-func (id *Identity) Series() string {
-	return id.Header("series")
-}
-
 // AccountID returns the account-id of the identity.
 func (id *Identity) AccountID() string {
 	return id.Header("account-id")

--- a/asserts/identity_test.go
+++ b/asserts/identity_test.go
@@ -44,6 +44,7 @@ func (ids *identitySuite) SetUpSuite(c *C) {
 
 const identityExample = "type: identity\n" +
 	"authority-id: canonical\n" +
+	"series: 16\n" +
 	"account-id: abc-123\n" +
 	"display-name: Display Name\n" +
 	"validation: certified\n" +
@@ -60,6 +61,7 @@ func (ids *identitySuite) TestDecodeOK(c *C) {
 	identity := a.(*asserts.Identity)
 	c.Check(identity.AuthorityID(), Equals, "canonical")
 	c.Check(identity.Timestamp(), Equals, ids.ts)
+	c.Check(identity.Series(), Equals, "16")
 	c.Check(identity.AccountID(), Equals, "abc-123")
 	c.Check(identity.DisplayName(), Equals, "Display Name")
 	c.Check(identity.IsCertified(), Equals, true)
@@ -98,6 +100,7 @@ func (ids *identitySuite) TestDecodeInvalid(c *C) {
 	encoded := strings.Replace(identityExample, "TSLINE", ids.tsLine, 1)
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"series: 16\n", "", `"series" header is mandatory`},
 		{"account-id: abc-123\n", "", `"account-id" header is mandatory`},
 		{"display-name: Display Name\n", "", `"display-name" header is mandatory`},
 		{"validation: certified\n", "", `"validation" header is mandatory`},

--- a/asserts/membackstore_test.go
+++ b/asserts/membackstore_test.go
@@ -37,6 +37,7 @@ func (mbss *memBackstoreSuite) SetUpTest(c *C) {
 
 	encoded := "type: test-only\n" +
 		"authority-id: auth-id1\n" +
+		"series: 16\n" +
 		"primary-key: foo" +
 		"\n\n" +
 		"openpgp c2ln"
@@ -49,7 +50,7 @@ func (mbss *memBackstoreSuite) TestPutAndGet(c *C) {
 	err := mbss.bs.Put(asserts.TestOnlyType, mbss.a)
 	c.Assert(err, IsNil)
 
-	a, err := mbss.bs.Get(asserts.TestOnlyType, []string{"foo"})
+	a, err := mbss.bs.Get(asserts.TestOnlyType, []string{"16", "foo"})
 	c.Assert(err, IsNil)
 
 	c.Check(a, Equals, mbss.a)
@@ -79,6 +80,7 @@ func (mbss *memBackstoreSuite) TestPutNotNewer(c *C) {
 func (mbss *memBackstoreSuite) TestSearch(c *C) {
 	encoded := "type: test-only\n" +
 		"authority-id: auth-id1\n" +
+		"series: 16\n" +
 		"primary-key: one\n" +
 		"other: other1" +
 		"\n\n" +
@@ -88,6 +90,7 @@ func (mbss *memBackstoreSuite) TestSearch(c *C) {
 
 	encoded = "type: test-only\n" +
 		"authority-id: auth-id1\n" +
+		"series: 16\n" +
 		"primary-key: two\n" +
 		"other: other2" +
 		"\n\n" +
@@ -138,6 +141,7 @@ func (mbss *memBackstoreSuite) TestSearch(c *C) {
 func (mbss *memBackstoreSuite) TestSearch2Levels(c *C) {
 	encoded := "type: test-only-2\n" +
 		"authority-id: auth-id1\n" +
+		"series: 16\n" +
 		"pk1: a\n" +
 		"pk2: x" +
 		"\n\n" +
@@ -147,6 +151,7 @@ func (mbss *memBackstoreSuite) TestSearch2Levels(c *C) {
 
 	encoded = "type: test-only-2\n" +
 		"authority-id: auth-id1\n" +
+		"series: 16\n" +
 		"pk1: b\n" +
 		"pk2: x" +
 		"\n\n" +

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -118,6 +118,7 @@ func (sbs *snapBuildSuite) SetUpSuite(c *C) {
 func (sbs *snapBuildSuite) TestDecodeOK(c *C) {
 	encoded := "type: snap-build\n" +
 		"authority-id: dev-id1\n" +
+		"series: 16\n" +
 		"snap-id: snap-id-1\n" +
 		"snap-digest: sha256 ...\n" +
 		"grade: stable\n" +
@@ -145,6 +146,7 @@ const (
 func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 	encoded := "type: snap-build\n" +
 		"authority-id: dev-id1\n" +
+		"series: 16\n" +
 		"snap-id: snap-id-1\n" +
 		"snap-digest: sha256 ...\n" +
 		"grade: stable\n" +
@@ -155,6 +157,7 @@ func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 		"openpgp c2ln"
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"series: 16\n", "", `"series" header is mandatory`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
 		{"grade: stable\n", "", `"grade" header is mandatory`},

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -193,6 +193,7 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 
 	headers := map[string]string{
 		"authority-id":           "canonical",
+		"series":                 "16",
 		"account-id":             accountID,
 		"public-key-id":          accKeyID,
 		"public-key-fingerprint": accFingerp,
@@ -224,6 +225,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheck(c *C) {
 
 	headers := map[string]string{
 		"authority-id": "dev-id1",
+		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-digest":  "sha256 ...",
 		"grade":        "devel",
@@ -242,6 +244,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 
 	headers := map[string]string{
 		"authority-id": "dev-id1",
+		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-digest":  "sha256 ...",
 		"grade":        "devel",
@@ -284,6 +287,7 @@ func (srs *snapRevSuite) makeValidEncoded() string {
 func (srs *snapRevSuite) makeHeaders(overrides map[string]string) map[string]string {
 	headers := map[string]string{
 		"authority-id":  "store-id1",
+		"series":        "16",
 		"snap-id":       "snap-id-1",
 		"snap-digest":   "sha256 ...",
 		"snap-revision": "1",

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -275,6 +275,7 @@ func (srs *snapRevSuite) SetUpSuite(c *C) {
 func (srs *snapRevSuite) makeValidEncoded() string {
 	return "type: snap-revision\n" +
 		"authority-id: store-id1\n" +
+		"series: 16\n" +
 		"snap-id: snap-id-1\n" +
 		"snap-digest: sha256 ...\n" +
 		"snap-revision: 1\n" +
@@ -313,6 +314,7 @@ func (srs *snapRevSuite) TestDecodeOK(c *C) {
 	snapRev := a.(*asserts.SnapRevision)
 	c.Check(snapRev.AuthorityID(), Equals, "store-id1")
 	c.Check(snapRev.Timestamp(), Equals, srs.ts)
+	c.Check(snapRev.Series(), Equals, "16")
 	c.Check(snapRev.SnapID(), Equals, "snap-id-1")
 	c.Check(snapRev.SnapDigest(), Equals, "sha256 ...")
 	c.Check(snapRev.SnapRevision(), Equals, uint64(1))
@@ -328,6 +330,7 @@ const (
 func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 	encoded := srs.makeValidEncoded()
 	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"series: 16\n", "", `"series" header is mandatory`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
 		{"snap-revision: 1\n", "", `"snap-revision" header is mandatory`},
@@ -379,6 +382,7 @@ func (srs *snapRevSuite) TestPrimaryKey(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = db.Find(asserts.SnapRevisionType, map[string]string{
+		"series":      "16",
 		"snap-id":     headers["snap-id"],
 		"snap-digest": headers["snap-digest"],
 	})

--- a/asserts/sysdb_test.go
+++ b/asserts/sysdb_test.go
@@ -47,6 +47,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 	// self-signed
 	headers := map[string]string{
 		"authority-id":           "canonical",
+		"series":                 "16",
 		"account-id":             "canonical",
 		"public-key-id":          trustedPubKey.ID(),
 		"public-key-fingerprint": trustedPubKey.Fingerprint(),
@@ -68,6 +69,7 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 
 	headers = map[string]string{
 		"authority-id": "canonical",
+		"series":       "16",
 		"primary-key":  "0",
 	}
 	sdbs.probeAssert, err = asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, pk)

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -91,6 +91,7 @@ func (cs *clientSuite) TestClientAsserts(c *C) {
 	cs.header.Add("X-Ubuntu-Assertions-Count", "2")
 	cs.rsp = `type: snap-revision
 authority-id: store-id1
+series: 16
 snap-id: snap-id-1
 snap-digest: sha256 ...
 snap-revision: 1
@@ -104,6 +105,7 @@ openpgp ...
 
 type: snap-revision
 authority-id: store-id1
+series: 16
 snap-id: snap-id-2
 snap-digest: sha256 ...
 snap-revision: 1

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2107,45 +2107,39 @@ const (
 	testTrustedKey = `type: account-key
 authority-id: can0nical
 account-id: can0nical
-public-key-id: 844efa9730eec4be
-public-key-fingerprint: 716ff3cec4b9364a2bd930dc844efa9730eec4be
+public-key-id: 33f5d7e5d273dfad
+public-key-fingerprint: 851fa8363c79cc0cd1c73a1833f5d7e5d273dfad
+series: 16
 since: 2016-01-14T15:00:00Z
 until: 2023-01-14T15:00:00Z
-body-length: 376
+body-length: 372
 
-openpgp xsBNBFaXv40BCADIlqLKFZaPaoe4TNLQv77vh4JWTlt7Z3IN2ducNqfg50q5mnkyUD2D
-SckvsMy1440+a0Z83m/A7aPaO1JkLpMGfLr23VLyKCaAe0k6hg69/6aEfXhfy0yYvEOgGcBiX+fN
-T6tqdRCsd+08LtisjYez7iJvmVwQ/syeduoTU4EiSVO1zlgc3eeq3TFyvcN0E1EsZ/7l2A33amTo
-mtAPVyQsa1B+lTeaUgwuPBWV0oTuYcUSfYsmmsXEKx/PnzkliicnrC9QZ5CcisskVve3QwPAuLUz
-2nV7/6vSRF22T4cUPF4QntjZBB6xjopdDH6wQsKyzLTTRak74moWksx8MEmVABEBAAE=
+openpgp xsBNBFbgGZ8BCADFFgoCtakq1BXe5pv8JIb0NjoK7zcMMkntUDZyhqfkETt9RQjvkg+6ve7uiCQtioOM5yep1E534dK6VZxxsnGbfoAbO/2dm6rzckv0mTumU5Z8/E36hDz7/bZIG+h8A72kfOd39TfO7RydX6WHao0dB8oyh0Ct/Jj08wioeLhNb7mDKxZoLxuRpNiRB/wBImpYULcBV4BTJj1BoReAjXGef72NhgaO95S+6gqhcC0Pp6eN6vqwUH9RFYFkMf76qvHCyQculBq8FjG+6EyVKCpeXdYN2LzsACKFn2wtY/xXzSqTeTnFHPTA6K4Ch3Flr5kPbKvvnna4n3Rgnjwm+ixPABEBAAE=
 
-openpgp wsBcBAABCAAQBQJWl8DiCRCETvqXMO7EvgAAhjkIAEoINWjQkujtx/TFYsKh0yYcQSpT
-v8O83mLRP7Ty+mH99uQ0/DbeQ1hM5st8cFgzU8SzlDCh6BUMnAl/bR/hhibFD40CBLd13kDXl1aN
-APybmSYoDVRQPAPop44UF0aCrTIw4Xds3E56d2Rsn+CkNML03kRc/i0Q53uYzZwxXVnzW/gVOXDL
-u/IZtjeo3KsB645MVEUxJLQmjlgMOwMvCHJgWhSvZOuf7wC0soBCN9Ufa/0M/PZFXzzn8LpjKVrX
-iDXhV7cY5PceG8ZV7Duo1JadOCzpkOHmai4DcrN7ZeY8bJnuNjOwvTLkrouw9xci4IxpPDRu0T/i
-K9qaJtUo4cA=`
+openpgp wsBcBAABCAAQBQJW4BpqCRAz9dfl0nPfrQAAZ/UIAB0XvtB+EUIfz1v6YD1PfFEDxHGX
+Ja4bqr0ik3GYuPF6JrNfe+MkoBFs4rKD5XHhWym4GIukCrrBCuHZ0TaEdu8+uihEEChkJ99j8e33
+Rkho+N90LgVUrdnSqepVVXWFLMTIEmeG+/diPfDsBSoKP72faoPQAOFgZd2r3grjaemOCoyJR5gN
+H2Lkzm+DKgzzoQzQfT4ctvu+oju0aygr6UmZTzoRLj8qqOK1f49p4BPK4D+9PQv0D4Se5VMyLv0+
+Glwd4qQJK12Dzkg1cnj8x7aQT98DwhxkrsIcKveSJIhlkK4Y/1vczWxLtQkSg50AHe0AhOvumtkp
+e6Fkj0oQztA=`
 	testAccKey = `type: account-key
 authority-id: can0nical
 account-id: developer1
-public-key-id: adea89b00094c337
-public-key-fingerprint: 5fa7b16ad5e8c8810d5a0686adea89b00094c337
+public-key-id: 37df895cebe1b232
+public-key-fingerprint: fbb515beda3687d1ce0d09d237df895cebe1b232
+series: 16
 since: 2016-01-14T15:00:00Z
 until: 2023-01-14T15:00:00Z
-body-length: 376
+body-length: 372
 
-openpgp xsBNBFaXv5MBCACkK//qNb3UwRtDviGcCSEi8Z6d5OXok3yilQmEh0LuW6DyP9sVpm08
-Vb1LGewOa5dThWGX4XKRBI/jCUnjCJQ6v15lLwHe1N7MJQ58DUxKqWFMV9yn4RcDPk6LqoFpPGdR
-rbp9Ivo3PqJRMyD0wuJk9RhbaGZmILcL//BLgomE9NgQdAfZbiEnGxtkqAjeVtBtcJIj5TnCC658
-ZCqwugQeO9iJuIn3GosYvvTB6tReq6GP6b4dqvoi7SqxHVhtt2zD4Y6FUZIVmvZK0qwkV0gua2az
-LzPOeoVcU1AEl7HVeBk7G6GiT5jx+CjjoGa0j22LdJB9S3JXHtGYk5p9CAwhABEBAAE=
+openpgp xsBNBFbgGogBCADDJ9unqpn1SKEFaCNsI3NmyFKzNcIAd5SI88ttO+PsOpCtjoJTvKt+ss9n5lCRsGmtdhiTo/VMktL8A+sgErDDZ3XUy5wFmFlRFqnkskf6TGFRPskth6whNcxIQ/EiRuPUM7/HXTKO4CBBVlJLuriNY5qF8W/0mGlgPXrGGo8uqaCOKFjcZpbLZAmeoW5Mgl2as12v718atvwzhT/vUYJqfmu5Fd+Z5gcWm/7+uPu4LAPRR/gR0k31AYyw3zksQfrH4E+vPcp5UYS4INxF+M7v8oB4IhuLRrsaPXe2d2x7y1d28IGtmDgGkoBUBFHu7vrdFdEJA0g2luCceorAkvUvABEBAAE=
 
-openpgp wsBcBAABCAAQBQJWl8HNCRCETvqXMO7EvgAAeuAIABn/1i8qGyaIhxOWE2cHIPYW3hq2
-PWpq7qrPN5Dbp/00xrTvc6tvMQWsXlMrAsYuq3sBCxUp3JRp9XhGiQeJtb8ft10g3+3J7e8OGHjl
-CfXJ3A5el8Xxp5qkFywCsLdJgNtF6+uSQ4dO8SrAwzkM7c3JzntxdiFOjDLUSyZ+rXL42jdRagTY
-8bcZfb47vd68Hyz3EvSvJuHSDbcNSTd3B832cimpfq5vJ7FoDrchVn3sg+3IwekuPhG3LQn5BVtc
-0ontHd+V1GaandhqBaDA01cGZN0gnqv2Haogt0P/h3nZZZJ1nTW5PLC6hs8TZdBdl3Lel8yAHD5L
-ZF5jSvRDLgI=`
+openpgp wsBcBAABCAAQBQJW4BroCRAz9dfl0nPfrQAA6pgIAE8roGlbt02xEUoQbyhn9MOQyMck
+Dnivwb7b7iFz6TeZ/EMpFhytjxdxzOZcNrEoamC1eTN7XophsAXXtknyNtUmqijT8VB81xtKm2v4
+0pVlNaoe1g3bUppnHGJrmoFMvaP0djNv46YVfpyt5eBGfdvGCJDiAtT40FDNs8LbGHJ33Nha3SyB
+8nyC07DzpWzbajO3if+7QgbtRGubEoAEsGy7tZY9jqy0QsFfXspe3bfZf9NnEtQ/F14k15RnbN1Y
++A886r+LC0o7fUR1YGQAfUf3CuvoHbYY1wVR+uNfiauh0Re10aQ1Ubg1zq62MR+5pIo6Sj6fma43
+gnXtE+RRd3o=`
 )
 
 func (s *apiSuite) TestAssertOK(c *check.C) {
@@ -2164,8 +2158,9 @@ func (s *apiSuite) TestAssertOK(c *check.C) {
 	c.Check(rsp.Status, check.Equals, http.StatusOK)
 	// Verify (internal)
 	_, err = d.asserts.Find(asserts.AccountKeyType, map[string]string{
+		"series":        "16",
 		"account-id":    "developer1",
-		"public-key-id": "adea89b00094c337",
+		"public-key-id": "37df895cebe1b232",
 	})
 	c.Check(err, check.IsNil)
 }


### PR DESCRIPTION
Add/move `series` header to all assertion types, and make `series` the first part of the primary key. Fix fallout in other snappy packages.