### PR TITLE
debian: update versionized ubuntu-core-launcher dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -49,7 +49,7 @@ Description: System components for Ubuntu Core Snappy.
 Package: ubuntu-snappy-cli
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, lsb-release,
- squashfs-tools, ubuntu-core-launcher (>= 0.2.3),
+ squashfs-tools, ubuntu-core-launcher (>= 1.0.19),
  ubuntu-core-security-seccomp, ubuntu-core-security-apparmor,
  ubuntu-core-security-utils,
 Replaces: ubuntu-core-snappy (<< 0.2~ppa90)


### PR DESCRIPTION
The recent change to the way the launcher wrapper files are
generated will break the application launching if an older
version than 1.0.19 of ubuntu-core-launcher is installed.