### PR TITLE
interfaces: add SecurityTagForApp() and LauncherNameForApp()

### DIFF
--- a/interfaces/security.go
+++ b/interfaces/security.go
@@ -23,6 +23,17 @@ import (
 	"fmt"
 )
 
+// SecurityTagForApp returns the unified tag used for all security systems.
+//
+// In general, the tag has the form: "$snap.$app.snap". When both snap name and
+// app name are the same then the tag is simplified to just "$snap.snap".
+func SecurityTagForApp(snapName, appName string) string {
+	if appName == snapName {
+		return fmt.Sprintf("%s.snap", snapName)
+	}
+	return fmt.Sprintf("%s.%s.snap", snapName, appName)
+}
+
 // securityHelper is an interface for common aspects of generating security files.
 type securityHelper interface {
 	securitySystem() SecuritySystem

--- a/interfaces/security.go
+++ b/interfaces/security.go
@@ -23,11 +23,14 @@ import (
 	"fmt"
 )
 
-// LauncherNameForApp returns the launcher name for a given application.
+// WrapperNameForApp returns the name of the wrapper for a given application.
 //
-// In general, the launcher has the form: "$snap.$app". When both snap name and
+// A wrapper is a generated helper executable that assists in setting up
+// environment for running a particular application.
+//
+// In general, the wrapper has the form: "$snap.$app". When both snap name and
 // app name are the same then the tag is simplified to just "$snap".
-func LauncherNameForApp(snapName, appName string) string {
+func WrapperNameForApp(snapName, appName string) string {
 	if appName == snapName {
 		return snapName
 	}
@@ -39,7 +42,7 @@ func LauncherNameForApp(snapName, appName string) string {
 // In general, the tag has the form: "$snap.$app.snap". When both snap name and
 // app name are the same then the tag is simplified to just "$snap.snap".
 func SecurityTagForApp(snapName, appName string) string {
-	return fmt.Sprintf("%s.snap", LauncherNameForApp(snapName, appName))
+	return fmt.Sprintf("%s.snap", WrapperNameForApp(snapName, appName))
 }
 
 // securityHelper is an interface for common aspects of generating security files.

--- a/interfaces/security.go
+++ b/interfaces/security.go
@@ -23,15 +23,23 @@ import (
 	"fmt"
 )
 
+// LauncherNameForApp returns the launcher name for a given application.
+//
+// In general, the launcher has the form: "$snap.$app". When both snap name and
+// app name are the same then the tag is simplified to just "$snap".
+func LauncherNameForApp(snapName, appName string) string {
+	if appName == snapName {
+		return snapName
+	}
+	return fmt.Sprintf("%s.%s", snapName, appName)
+}
+
 // SecurityTagForApp returns the unified tag used for all security systems.
 //
 // In general, the tag has the form: "$snap.$app.snap". When both snap name and
 // app name are the same then the tag is simplified to just "$snap.snap".
 func SecurityTagForApp(snapName, appName string) string {
-	if appName == snapName {
-		return fmt.Sprintf("%s.snap", snapName)
-	}
-	return fmt.Sprintf("%s.%s.snap", snapName, appName)
+	return fmt.Sprintf("%s.snap", LauncherNameForApp(snapName, appName))
 }
 
 // securityHelper is an interface for common aspects of generating security files.

--- a/interfaces/security_test.go
+++ b/interfaces/security_test.go
@@ -61,6 +61,13 @@ func (s *SecuritySuite) prepareFixtureWithInterface(c *C, i Interface) {
 	c.Assert(err, IsNil)
 }
 
+// Tests for LauncherNameForApp()
+
+func (s *SecuritySuite) TestLauncherNameForApp(c *C) {
+	c.Assert(LauncherNameForApp("snap", "app"), Equals, "snap.app")
+	c.Assert(LauncherNameForApp("foo", "foo"), Equals, "foo")
+}
+
 // Tests for SecurityTagForApp()
 
 func (s *SecuritySuite) TestSecurityTagForApp(c *C) {

--- a/interfaces/security_test.go
+++ b/interfaces/security_test.go
@@ -61,6 +61,13 @@ func (s *SecuritySuite) prepareFixtureWithInterface(c *C, i Interface) {
 	c.Assert(err, IsNil)
 }
 
+// Tests for SecurityTagForApp()
+
+func (s *SecuritySuite) TestSecurityTagForApp(c *C) {
+	c.Assert(SecurityTagForApp("snap", "app"), Equals, "snap.app.snap")
+	c.Assert(SecurityTagForApp("foo", "foo"), Equals, "foo.snap")
+}
+
 // Tests for appArmor
 
 func (s *SecuritySuite) TestAppArmorPlugPermissions(c *C) {

--- a/interfaces/security_test.go
+++ b/interfaces/security_test.go
@@ -61,11 +61,11 @@ func (s *SecuritySuite) prepareFixtureWithInterface(c *C, i Interface) {
 	c.Assert(err, IsNil)
 }
 
-// Tests for LauncherNameForApp()
+// Tests for WrapperNameForApp()
 
-func (s *SecuritySuite) TestLauncherNameForApp(c *C) {
-	c.Assert(LauncherNameForApp("snap", "app"), Equals, "snap.app")
-	c.Assert(LauncherNameForApp("foo", "foo"), Equals, "foo")
+func (s *SecuritySuite) TestWrapperNameForApp(c *C) {
+	c.Assert(WrapperNameForApp("snap", "app"), Equals, "snap.app")
+	c.Assert(WrapperNameForApp("foo", "foo"), Equals, "foo")
 }
 
 // Tests for SecurityTagForApp()


### PR DESCRIPTION
This branch commences security cleanup in preparation for the switch to using interfaces.

As a first step I'm adding two functions:

SecurityTagForSnap() returns the unified security tag that is used for apparmor, seccomp, udev and dbus (or about to be used to be precise). It is simply "$snap.$app.snap" or "$snap.snap" in case application and snap name are the same.

WrapperNameForSnap() returns the name of the wrapper executable for a given application. Similarly it is simply "$snap.$app" or "$snap" in the case application and snap name are the same.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>