### PR TITLE
snappy: rename helloAppComposedName to helloSnapComposedName

### DIFF
--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -780,11 +780,11 @@ func (s *SnapTestSuite) TestAddPackageServicesStripsGlobalRootdir(c *C) {
 	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/etc/systemd/system/hello-app_svc1_1.10.service"))
 	c.Assert(err, IsNil)
 
-	baseDirWithoutRootPrefix := "/snaps/" + helloAppComposedName + "/1.10"
+	baseDirWithoutRootPrefix := "/snaps/" + helloSnapComposedName + "/1.10"
 	verbs := []string{"Start", "Stop", "StopPost"}
 	bins := []string{"hello", "goodbye", "missya"}
 	for i := range verbs {
-		expected := fmt.Sprintf("Exec%s=/usr/bin/ubuntu-core-launcher hello-app.svc1 %s_svc1_1.10 %s/bin/%s", verbs[i], helloAppComposedName, baseDirWithoutRootPrefix, bins[i])
+		expected := fmt.Sprintf("Exec%s=/usr/bin/ubuntu-core-launcher hello-app.svc1 %s_svc1_1.10 %s/bin/%s", verbs[i], helloSnapComposedName, baseDirWithoutRootPrefix, bins[i])
 		c.Check(string(content), Matches, "(?ms).*^"+regexp.QuoteMeta(expected)) // check.v1 adds ^ and $ around the regexp provided
 	}
 }

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -37,9 +37,9 @@ import (
 )
 
 const (
-	testOrigin           = "testspacethename"
-	fooComposedName      = "foo.testspacethename"
-	helloAppComposedName = "hello-app.testspacethename"
+	testOrigin            = "testspacethename"
+	fooComposedName       = "foo.testspacethename"
+	helloSnapComposedName = "hello-app.testspacethename"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -141,7 +141,7 @@ func (s *SnapTestSuite) TestLocalSnapSimple(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snap.Date(), Equals, st.ModTime())
 
-	c.Assert(snap.basedir, Equals, filepath.Join(s.tempdir, "snaps", helloAppComposedName, "1.10"))
+	c.Assert(snap.basedir, Equals, filepath.Join(s.tempdir, "snaps", helloSnapComposedName, "1.10"))
 	c.Assert(snap.InstalledSize(), Not(Equals), -1)
 }
 
@@ -841,7 +841,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(snap.Date(), Equals, st.ModTime())
 
-	c.Assert(snap.basedir, Equals, filepath.Join(s.tempdir, "snaps", helloAppComposedName, "1.10"))
+	c.Assert(snap.basedir, Equals, filepath.Join(s.tempdir, "snaps", helloSnapComposedName, "1.10"))
 	c.Assert(snap.InstalledSize(), Not(Equals), -1)
 }
 


### PR DESCRIPTION
This patch fixes leftover terminology from times when "app" was the
package. We call that snaps now and this patch just makes reading tests
easier and less confusing.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>