### PR TITLE
snappy: replace "hello-app" with "hello-snap"

### DIFF
--- a/snappy/click_test.go
+++ b/snappy/click_test.go
@@ -777,14 +777,14 @@ func (s *SnapTestSuite) TestAddPackageServicesStripsGlobalRootdir(c *C) {
 	err = addPackageServices(m, baseDir, false, nil)
 	c.Assert(err, IsNil)
 
-	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/etc/systemd/system/hello-app_svc1_1.10.service"))
+	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/etc/systemd/system/hello-snap_svc1_1.10.service"))
 	c.Assert(err, IsNil)
 
 	baseDirWithoutRootPrefix := "/snaps/" + helloSnapComposedName + "/1.10"
 	verbs := []string{"Start", "Stop", "StopPost"}
 	bins := []string{"hello", "goodbye", "missya"}
 	for i := range verbs {
-		expected := fmt.Sprintf("Exec%s=/usr/bin/ubuntu-core-launcher hello-app.svc1 %s_svc1_1.10 %s/bin/%s", verbs[i], helloSnapComposedName, baseDirWithoutRootPrefix, bins[i])
+		expected := fmt.Sprintf("Exec%s=/usr/bin/ubuntu-core-launcher hello-snap.svc1 %s_svc1_1.10 %s/bin/%s", verbs[i], helloSnapComposedName, baseDirWithoutRootPrefix, bins[i])
 		c.Check(string(content), Matches, "(?ms).*^"+regexp.QuoteMeta(expected)) // check.v1 adds ^ and $ around the regexp provided
 	}
 }
@@ -846,12 +846,12 @@ func (s *SnapTestSuite) TestAddPackageBinariesStripsGlobalRootdir(c *C) {
 	err = addPackageBinaries(m, baseDir)
 	c.Assert(err, IsNil)
 
-	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/snaps/bin/hello-app.hello"))
+	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/snaps/bin/hello-snap.hello"))
 	c.Assert(err, IsNil)
 
 	needle := `
 cd $SNAP_DATA
-ubuntu-core-launcher hello-app.hello hello-app.testspacethename_hello_1.10 /snaps/hello-app.testspacethename/1.10/bin/hello "$@"
+ubuntu-core-launcher hello-snap.hello hello-snap.testspacethename_hello_1.10 /snaps/hello-snap.testspacethename/1.10/bin/hello "$@"
 `
 	c.Assert(string(content), Matches, "(?ms).*"+regexp.QuoteMeta(needle)+".*")
 }

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -39,7 +39,7 @@ import (
 const (
 	testOrigin            = "testspacethename"
 	fooComposedName       = "foo.testspacethename"
-	helloSnapComposedName = "hello-app.testspacethename"
+	helloSnapComposedName = "hello-snap.testspacethename"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -55,7 +55,7 @@ func init() {
 // makeInstalledMockSnap creates a installed mock snap without any
 // content other than the meta data
 func makeInstalledMockSnap(tempdir, snapYamlContent string) (yamlFile string, err error) {
-	const packageHello = `name: hello-app
+	const packageHello = `name: hello-snap
 version: 1.10
 apps:
  hello:
@@ -85,19 +85,19 @@ apps:
 		return "", err
 	}
 
-	if err := addMockDefaultApparmorProfile("hello-app_hello_1.10"); err != nil {
+	if err := addMockDefaultApparmorProfile("hello-snap_hello_1.10"); err != nil {
 		return "", err
 	}
 
-	if err := addMockDefaultApparmorProfile("hello-app_svc1_1.10"); err != nil {
+	if err := addMockDefaultApparmorProfile("hello-snap_svc1_1.10"); err != nil {
 		return "", err
 	}
 
-	if err := addMockDefaultSeccompProfile("hello-app_hello_1.10"); err != nil {
+	if err := addMockDefaultSeccompProfile("hello-snap_hello_1.10"); err != nil {
 		return "", err
 	}
 
-	if err := addMockDefaultSeccompProfile("hello-app_svc1_1.10"); err != nil {
+	if err := addMockDefaultSeccompProfile("hello-snap_svc1_1.10"); err != nil {
 		return "", err
 	}
 

--- a/snappy/hwaccess_test.go
+++ b/snappy/hwaccess_test.go
@@ -42,9 +42,9 @@ func (s *SnapTestSuite) TestAddHWAccessSimple(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
 	regenerateAppArmorRulesWasCalled := mockRegenerateAppArmorRules()
 
-	err := AddHWAccess("hello-app", "/dev/ttyUSB0")
+	err := AddHWAccess("hello-snap", "/dev/ttyUSB0")
 	c.Assert(err, IsNil)
-	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-app.hwaccess.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-snap.hwaccess.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert("\n"+string(content), Equals, `
 read-paths:
@@ -60,7 +60,7 @@ func (s *SnapTestSuite) TestAddHWAccessInvalidDevice(c *C) {
 	regenerateAppArmorRulesWasCalled := mockRegenerateAppArmorRules()
 	makeInstalledMockSnap(s.tempdir, "")
 
-	err := AddHWAccess("hello-app", "ttyUSB0")
+	err := AddHWAccess("hello-snap", "ttyUSB0")
 	c.Assert(err, Equals, ErrInvalidHWDevice)
 	c.Assert(*regenerateAppArmorRulesWasCalled, Equals, false)
 }
@@ -68,12 +68,12 @@ func (s *SnapTestSuite) TestAddHWAccessInvalidDevice(c *C) {
 func (s *SnapTestSuite) TestAddHWAccessMultiplePaths(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
 
-	err := AddHWAccess("hello-app", "/dev/ttyUSB0")
+	err := AddHWAccess("hello-snap", "/dev/ttyUSB0")
 	c.Assert(err, IsNil)
-	err = AddHWAccess("hello-app", "/sys/devices/gpio1")
+	err = AddHWAccess("hello-snap", "/sys/devices/gpio1")
 	c.Assert(err, IsNil)
 
-	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-app.hwaccess.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-snap.hwaccess.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert("\n"+string(content), Equals, `
 read-paths:
@@ -88,12 +88,12 @@ write-paths:
 func (s *SnapTestSuite) TestAddHWAccessAddSameDeviceTwice(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
 
-	err := AddHWAccess("hello-app", "/dev/ttyUSB0")
+	err := AddHWAccess("hello-snap", "/dev/ttyUSB0")
 	c.Assert(err, IsNil)
-	err = AddHWAccess("hello-app", "/dev/ttyUSB0")
+	err = AddHWAccess("hello-snap", "/dev/ttyUSB0")
 	c.Assert(err, Equals, ErrHWAccessAlreadyAdded)
 
-	writePaths, err := ListHWAccess("hello-app")
+	writePaths, err := ListHWAccess("hello-snap")
 	c.Assert(err, IsNil)
 	c.Assert(writePaths, DeepEquals, []string{"/dev/ttyUSB0"})
 }
@@ -117,52 +117,52 @@ func (s *SnapTestSuite) TestAddHWAccessIllegalPackage(c *C) {
 func (s *SnapTestSuite) TestListHWAccessNoAdditionalAccess(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
 
-	writePaths, err := ListHWAccess("hello-app")
+	writePaths, err := ListHWAccess("hello-snap")
 	c.Assert(err, IsNil)
 	c.Assert(writePaths, HasLen, 0)
 }
 
 func (s *SnapTestSuite) TestListHWAccess(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
-	err := AddHWAccess("hello-app", "/dev/ttyUSB0")
+	err := AddHWAccess("hello-snap", "/dev/ttyUSB0")
 	c.Assert(err, IsNil)
 
-	err = AddHWAccess("hello-app", "/sys/devices/gpio1")
+	err = AddHWAccess("hello-snap", "/sys/devices/gpio1")
 	c.Assert(err, IsNil)
 
-	err = AddHWAccess("hello-app", "/sys/class/gpio/export")
+	err = AddHWAccess("hello-snap", "/sys/class/gpio/export")
 	c.Assert(err, IsNil)
 
-	err = AddHWAccess("hello-app", "/sys/class/gpio/unexport")
+	err = AddHWAccess("hello-snap", "/sys/class/gpio/unexport")
 	c.Assert(err, IsNil)
 
-	writePaths, err := ListHWAccess("hello-app")
+	writePaths, err := ListHWAccess("hello-snap")
 	c.Assert(writePaths, DeepEquals, []string{"/dev/ttyUSB0", "/sys/devices/gpio1", "/sys/class/gpio/export", "/sys/class/gpio/unexport"})
 }
 
 func (s *SnapTestSuite) TestRemoveHWAccessInvalidDevice(c *C) {
-	err := RemoveHWAccess("hello-app", "meep")
+	err := RemoveHWAccess("hello-snap", "meep")
 	c.Assert(err, Equals, ErrInvalidHWDevice)
 }
 
 func (s *SnapTestSuite) TestRemoveHWAccess(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
-	err := AddHWAccess("hello-app", "/dev/ttyUSB0")
+	err := AddHWAccess("hello-snap", "/dev/ttyUSB0")
 
 	// check that the udev rules file got created
-	udevRulesFilename := "70-snappy_hwassign_hello-app.rules"
+	udevRulesFilename := "70-snappy_hwassign_hello-snap.rules"
 	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapUdevRulesDir, udevRulesFilename)), Equals, true)
 
-	writePaths, err := ListHWAccess("hello-app")
+	writePaths, err := ListHWAccess("hello-snap")
 	c.Assert(err, IsNil)
 	c.Assert(writePaths, DeepEquals, []string{"/dev/ttyUSB0"})
 
 	regenerateAppArmorRulesWasCalled := mockRegenerateAppArmorRules()
-	err = RemoveHWAccess("hello-app", "/dev/ttyUSB0")
+	err = RemoveHWAccess("hello-snap", "/dev/ttyUSB0")
 	c.Assert(err, IsNil)
 	c.Assert(*regenerateAppArmorRulesWasCalled, Equals, true)
 
-	writePaths, err = ListHWAccess("hello-app")
+	writePaths, err = ListHWAccess("hello-snap")
 	c.Assert(err, IsNil)
 	c.Assert(writePaths, HasLen, 0)
 
@@ -170,7 +170,7 @@ func (s *SnapTestSuite) TestRemoveHWAccess(c *C) {
 	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapUdevRulesDir, udevRulesFilename)), Equals, false)
 
 	// check the json.additional got cleaned out
-	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-app.hwaccess.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-snap.hwaccess.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert(string(content), Equals, "{}\n")
 }
@@ -179,14 +179,14 @@ func (s *SnapTestSuite) TestRemoveHWAccessMultipleDevices(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
 
 	// setup
-	err := AddHWAccess("hello-app", "/dev/bar")
-	AddHWAccess("hello-app", "/dev/bar*")
+	err := AddHWAccess("hello-snap", "/dev/bar")
+	AddHWAccess("hello-snap", "/dev/bar*")
 	// ensure its there
-	writePaths, _ := ListHWAccess("hello-app")
+	writePaths, _ := ListHWAccess("hello-snap")
 	c.Assert(writePaths, DeepEquals, []string{"/dev/bar", "/dev/bar*"})
 
 	// check the file only lists udevReadGlob once
-	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-app.hwaccess.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-snap.hwaccess.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert("\n"+string(content), Equals, `
 read-paths:
@@ -197,24 +197,24 @@ write-paths:
 `)
 
 	// check the udev rule file contains all the rules
-	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapUdevRulesDir, "70-snappy_hwassign_hello-app.rules"))
+	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapUdevRulesDir, "70-snappy_hwassign_hello-snap.rules"))
 	c.Assert(err, IsNil)
 	c.Assert(string(content), Equals,
-		`KERNEL=="bar", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-app.hello"
-KERNEL=="bar", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-app.svc1"
-KERNEL=="bar*", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-app.hello"
-KERNEL=="bar*", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-app.svc1"
+		`KERNEL=="bar", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-snap.hello"
+KERNEL=="bar", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-snap.svc1"
+KERNEL=="bar*", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-snap.hello"
+KERNEL=="bar*", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-snap.svc1"
 `)
 	// remove
-	err = RemoveHWAccess("hello-app", "/dev/bar")
+	err = RemoveHWAccess("hello-snap", "/dev/bar")
 	c.Assert(err, IsNil)
 
 	// ensure the right thing was removed
-	writePaths, _ = ListHWAccess("hello-app")
+	writePaths, _ = ListHWAccess("hello-snap")
 	c.Assert(writePaths, DeepEquals, []string{"/dev/bar*"})
 
 	// check udevReadGlob is still there
-	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-app.hwaccess.yaml"))
+	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-snap.hwaccess.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert("\n"+string(content), Equals, `
 read-paths:
@@ -223,11 +223,11 @@ write-paths:
 - /dev/bar*
 `)
 	// check the udevReadGlob Udev rule is still there
-	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapUdevRulesDir, "70-snappy_hwassign_hello-app.rules"))
+	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapUdevRulesDir, "70-snappy_hwassign_hello-snap.rules"))
 	c.Assert(err, IsNil)
 	c.Assert(string(content), Equals,
-		`KERNEL=="bar*", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-app.hello"
-KERNEL=="bar*", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-app.svc1"
+		`KERNEL=="bar*", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-snap.hello"
+KERNEL=="bar*", TAG:="snappy-assign", ENV{SNAPPY_APP}:="hello-snap.svc1"
 `)
 }
 
@@ -249,11 +249,11 @@ func (s *SnapTestSuite) TestRemoveHWAccessFail(c *C) {
 	runUdevAdm = makeRunUdevAdmMock(&runUdevAdmCalls)
 
 	makeInstalledMockSnap(s.tempdir, "")
-	err := AddHWAccess("hello-app", "/dev/ttyUSB0")
+	err := AddHWAccess("hello-snap", "/dev/ttyUSB0")
 	c.Assert(err, IsNil)
 
 	regenerateAppArmorRulesWasCalled := mockRegenerateAppArmorRules()
-	err = RemoveHWAccess("hello-app", "/dev/something")
+	err = RemoveHWAccess("hello-snap", "/dev/something")
 	c.Assert(err, Equals, ErrHWAccessRemoveNotFound)
 	c.Assert(*regenerateAppArmorRulesWasCalled, Equals, false)
 	verifyUdevAdmActivateRules(c, runUdevAdmCalls)
@@ -285,15 +285,15 @@ apps:
 func (s *SnapTestSuite) TestRemoveAllHWAccess(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
 
-	err := AddHWAccess("hello-app", "/dev/ttyUSB0")
+	err := AddHWAccess("hello-snap", "/dev/ttyUSB0")
 	c.Assert(err, IsNil)
 
 	regenerateAppArmorRulesWasCalled := mockRegenerateAppArmorRules()
 	c.Check(*regenerateAppArmorRulesWasCalled, Equals, false)
-	c.Check(RemoveAllHWAccess("hello-app"), IsNil)
+	c.Check(RemoveAllHWAccess("hello-snap"), IsNil)
 
 	c.Check(osutil.FileExists(filepath.Join(dirs.SnapUdevRulesDir, "70-snappy_hwassign_foo-app.rules")), Equals, false)
-	c.Check(osutil.FileExists(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-app.hwaccess.yaml")), Equals, false)
+	c.Check(osutil.FileExists(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-snap.hwaccess.yaml")), Equals, false)
 	c.Check(*regenerateAppArmorRulesWasCalled, Equals, true)
 }
 
@@ -301,12 +301,12 @@ func (s *SnapTestSuite) TestAddSysDevice(c *C) {
 	makeInstalledMockSnap(s.tempdir, "")
 	regenerateAppArmorRulesWasCalled := mockRegenerateAppArmorRules()
 
-	err := AddHWAccess("hello-app", "/sys/devices/foo1")
+	err := AddHWAccess("hello-snap", "/sys/devices/foo1")
 	c.Assert(err, IsNil)
-	err = AddHWAccess("hello-app", "/sys/class/gpio/foo2")
+	err = AddHWAccess("hello-snap", "/sys/class/gpio/foo2")
 	c.Assert(err, IsNil)
 
-	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-app.hwaccess.yaml"))
+	content, err := ioutil.ReadFile(filepath.Join(dirs.SnapAppArmorAdditionalDir, "hello-snap.hwaccess.yaml"))
 	c.Assert(err, IsNil)
 	c.Assert("\n"+string(content), Equals, `
 read-paths:
@@ -316,7 +316,7 @@ write-paths:
 - /sys/class/gpio/foo2
 `)
 	// ensure that no udev rule has been generated
-	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapUdevRulesDir, "70-snappy_hwassign_hello-app.rules"))
+	content, err = ioutil.ReadFile(filepath.Join(dirs.SnapUdevRulesDir, "70-snappy_hwassign_hello-snap.rules"))
 	c.Assert(content, IsNil)
 
 	// ensure the regenerate code was called

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -199,20 +199,20 @@ func (s *SnapTestSuite) TestInstallAppPackageNameFails(c *C) {
 	pkgdir := filepath.Dir(filepath.Dir(yamlFile))
 
 	c.Assert(os.MkdirAll(filepath.Join(pkgdir, ".click", "info"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(pkgdir, ".click", "info", "hello-app.manifest"), []byte(`{"name": "hello-app"}`), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(pkgdir, ".click", "info", "hello-snap.manifest"), []byte(`{"name": "hello-snap"}`), 0644), IsNil)
 	ag := &progress.NullProgress{}
 	part, err := NewInstalledSnapPart(yamlFile, "potato")
 	c.Assert(err, IsNil)
 	c.Assert(part.activate(true, ag), IsNil)
-	current := ActiveSnapByName("hello-app")
+	current := ActiveSnapByName("hello-snap")
 	c.Assert(current, NotNil)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/details/hello-app.potato/ch":
+		case "/details/hello-snap.potato/ch":
 			io.WriteString(w, `{
 "origin": "potato",
-"package_name": "hello-app",
+"package_name": "hello-snap",
 "version": "2",
 "anon_download_url": "blah"
 }`)
@@ -227,7 +227,7 @@ func (s *SnapTestSuite) TestInstallAppPackageNameFails(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	_, err = Install("hello-app.potato", "ch", 0, ag)
+	_, err = Install("hello-snap.potato", "ch", 0, ag)
 	c.Assert(err, ErrorMatches, ".*"+ErrPackageNameAlreadyInstalled.Error())
 }
 

--- a/snappy/overlord_test.go
+++ b/snappy/overlord_test.go
@@ -34,7 +34,7 @@ func (o *overlordTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 }
 
-var helloAppYaml = `name: hello-app
+var helloAppYaml = `name: hello-snap
 version: 1.0
 `
 
@@ -46,5 +46,5 @@ func (o *overlordTestSuite) TestInstalled(c *C) {
 	installed, err := overlord.Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
-	c.Assert(installed[0].Name(), Equals, "hello-app")
+	c.Assert(installed[0].Name(), Equals, "hello-snap")
 }

--- a/snappy/parts_test.go
+++ b/snappy/parts_test.go
@@ -128,9 +128,9 @@ func (s *SnapTestSuite) TestFindSnapsByNameFound(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
 
-	parts := FindSnapsByName("hello-app", installed)
+	parts := FindSnapsByName("hello-snap", installed)
 	c.Assert(parts, HasLen, 1)
-	c.Assert(parts[0].Name(), Equals, "hello-app")
+	c.Assert(parts[0].Name(), Equals, "hello-snap")
 }
 
 func (s *SnapTestSuite) TestFindSnapsByNameWithOrigin(c *C) {
@@ -140,9 +140,9 @@ func (s *SnapTestSuite) TestFindSnapsByNameWithOrigin(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
 
-	parts := FindSnapsByName("hello-app."+testOrigin, installed)
+	parts := FindSnapsByName("hello-snap."+testOrigin, installed)
 	c.Assert(parts, HasLen, 1)
-	c.Assert(parts[0].Name(), Equals, "hello-app")
+	c.Assert(parts[0].Name(), Equals, "hello-snap")
 }
 
 func (s *SnapTestSuite) TestFindSnapsByNameWithOriginNotThere(c *C) {
@@ -152,19 +152,19 @@ func (s *SnapTestSuite) TestFindSnapsByNameWithOriginNotThere(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
 
-	parts := FindSnapsByName("hello-app.otherns", installed)
+	parts := FindSnapsByName("hello-snap.otherns", installed)
 	c.Assert(parts, HasLen, 0)
 }
 
 func (s *SnapTestSuite) TestPackageNameInstalled(c *C) {
-	c.Check(PackageNameActive("hello-app"), Equals, false)
+	c.Check(PackageNameActive("hello-snap"), Equals, false)
 
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, "")
 	c.Assert(err, IsNil)
 	pkgdir := filepath.Dir(filepath.Dir(yamlFile))
 
 	c.Assert(os.MkdirAll(filepath.Join(pkgdir, ".click", "info"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(pkgdir, ".click", "info", "hello-app.manifest"), []byte(`{"name": "hello-app"}`), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(pkgdir, ".click", "info", "hello-snap.manifest"), []byte(`{"name": "hello-snap"}`), 0644), IsNil)
 	ag := &progress.NullProgress{}
 
 	part, err := NewInstalledSnapPart(yamlFile, testOrigin)
@@ -172,9 +172,9 @@ func (s *SnapTestSuite) TestPackageNameInstalled(c *C) {
 
 	c.Assert(part.activate(true, ag), IsNil)
 
-	c.Check(PackageNameActive("hello-app"), Equals, true)
+	c.Check(PackageNameActive("hello-snap"), Equals, true)
 	c.Assert(part.deactivate(true, ag), IsNil)
-	c.Check(PackageNameActive("hello-app"), Equals, false)
+	c.Check(PackageNameActive("hello-snap"), Equals, false)
 }
 
 func (s *SnapTestSuite) TestFindSnapsByNameAndVersion(c *C) {
@@ -183,20 +183,20 @@ func (s *SnapTestSuite) TestFindSnapsByNameAndVersion(c *C) {
 	installed, err := repo.Installed()
 	c.Assert(err, IsNil)
 
-	parts := FindSnapsByNameAndVersion("hello-app."+testOrigin, "1.10", installed)
+	parts := FindSnapsByNameAndVersion("hello-snap."+testOrigin, "1.10", installed)
 	c.Check(parts, HasLen, 1)
 	parts = FindSnapsByNameAndVersion("bad-app."+testOrigin, "1.10", installed)
 	c.Check(parts, HasLen, 0)
-	parts = FindSnapsByNameAndVersion("hello-app.badOrigin", "1.10", installed)
+	parts = FindSnapsByNameAndVersion("hello-snap.badOrigin", "1.10", installed)
 	c.Check(parts, HasLen, 0)
-	parts = FindSnapsByNameAndVersion("hello-app."+testOrigin, "2.20", installed)
+	parts = FindSnapsByNameAndVersion("hello-snap."+testOrigin, "2.20", installed)
 	c.Check(parts, HasLen, 0)
 
-	parts = FindSnapsByNameAndVersion("hello-app", "1.10", installed)
+	parts = FindSnapsByNameAndVersion("hello-snap", "1.10", installed)
 	c.Check(parts, HasLen, 1)
 	parts = FindSnapsByNameAndVersion("bad-app", "1.10", installed)
 	c.Check(parts, HasLen, 0)
-	parts = FindSnapsByNameAndVersion("hello-app", "2.20", installed)
+	parts = FindSnapsByNameAndVersion("hello-snap", "2.20", installed)
 	c.Check(parts, HasLen, 0)
 }
 

--- a/snappy/purge_test.go
+++ b/snappy/purge_test.go
@@ -76,8 +76,8 @@ func (s *purgeSuite) mkpkg(c *C, args ...string) (dataDirs []string, part *SnapP
 	default:
 		panic("dunno what to do with args")
 	}
-	app := "hello-app." + testOrigin
-	yaml := "version: 1.0\nname: hello-app\nversion: " + version + "\n" + extra
+	app := "hello-snap." + testOrigin
+	yaml := "version: 1.0\nname: hello-snap\nversion: " + version + "\n" + extra
 	yamlFile, err := makeInstalledMockSnap(s.tempdir, yaml)
 	c.Assert(err, IsNil)
 
@@ -106,7 +106,7 @@ func (s *purgeSuite) TestPurgeActiveRaisesError(c *C) {
 	_, part := s.mkpkg(c)
 	c.Assert(part.activate(true, inter), IsNil)
 
-	err := Purge("hello-app", 0, inter)
+	err := Purge("hello-snap", 0, inter)
 	c.Check(err, Equals, ErrStillActive)
 	c.Check(inter.notified, HasLen, 0)
 }
@@ -115,7 +115,7 @@ func (s *purgeSuite) TestPurgeInactiveOK(c *C) {
 	inter := &MockProgressMeter{}
 	ddirs, _ := s.mkpkg(c)
 
-	err := Purge("hello-app", 0, inter)
+	err := Purge("hello-snap", 0, inter)
 	c.Check(err, IsNil)
 
 	for _, ddir := range ddirs {
@@ -135,7 +135,7 @@ func (s *purgeSuite) TestPurgeActiveExplicitOK(c *C) {
 		c.Assert(os.Mkdir(canary, 0755), IsNil)
 	}
 
-	err := Purge("hello-app", DoPurgeActive, inter)
+	err := Purge("hello-snap", DoPurgeActive, inter)
 	c.Check(err, IsNil)
 
 	for _, ddir := range ddirs {
@@ -164,7 +164,7 @@ func (s *purgeSuite) TestPurgeActiveRestartServices(c *C) {
 		return []byte("ActiveState=inactive\n"), nil
 	}
 
-	err := Purge("hello-app", DoPurgeActive, inter)
+	err := Purge("hello-snap", DoPurgeActive, inter)
 	c.Check(err, IsNil)
 	for _, ddir := range ddirs {
 		c.Check(osutil.FileExists(filepath.Join(ddir, "canary")), Equals, false)
@@ -183,7 +183,7 @@ func (s *purgeSuite) TestPurgeMultiOK(c *C) {
 	ddirs0, _ := s.mkpkg(c, "v0")
 	ddirs1, _ := s.mkpkg(c, "v1")
 
-	err := Purge("hello-app", 0, inter)
+	err := Purge("hello-snap", 0, inter)
 	c.Check(err, IsNil)
 
 	for _, ddir := range ddirs0 {
@@ -214,7 +214,7 @@ func (s *purgeSuite) TestPurgeMultiContinuesOnFail(c *C) {
 	}
 	defer func() { remove = removeSnapData }()
 
-	err := Purge("hello-app", 0, inter)
+	err := Purge("hello-snap", 0, inter)
 	c.Check(err, Equals, anError)
 	c.Check(count, Equals, 6)
 	for _, ddir := range ddirs0 {
@@ -241,7 +241,7 @@ func (s *purgeSuite) TestPurgeRemovedWorks(c *C) {
 		c.Check(osutil.FileExists(ddir), Equals, true)
 	}
 
-	err = Purge("hello-app", 0, inter)
+	err = Purge("hello-snap", 0, inter)
 	c.Check(err, IsNil)
 	for _, ddir := range ddirs {
 		c.Check(osutil.FileExists(ddir), Equals, false)

--- a/snappy/service_test.go
+++ b/snappy/service_test.go
@@ -82,7 +82,7 @@ func (s *ServiceActorSuite) SetUpTest(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system/multi-user.target.wants"), 0755), IsNil)
 	systemd.SystemctlCmd = s.myRun
 	systemd.JournalctlCmd = s.myJctl
-	_, err := makeInstalledMockSnap(dirs.GlobalRootDir, `name: hello-app
+	_, err := makeInstalledMockSnap(dirs.GlobalRootDir, `name: hello-snap
 version: 1.09
 apps:
  svc1:
@@ -92,7 +92,7 @@ apps:
    command: something
 `)
 	c.Assert(err, IsNil)
-	f, err := makeInstalledMockSnap(dirs.GlobalRootDir, `name: hello-app
+	f, err := makeInstalledMockSnap(dirs.GlobalRootDir, `name: hello-snap
 version: 1.10
 apps:
  svc1:
@@ -131,7 +131,7 @@ func (s *ServiceActorSuite) TestFindServicesNoPackagesNoPattern(c *C) {
 }
 
 func (s *ServiceActorSuite) TestFindServicesNoServices(c *C) {
-	_, err := FindServices("hello-app", "notfound", s.pb)
+	_, err := FindServices("hello-snap", "notfound", s.pb)
 	c.Check(err, Equals, ErrServiceNotFound)
 }
 
@@ -182,20 +182,20 @@ func (s *ServiceActorSuite) TestFindServicesFindsServices(c *C) {
 	status, err := actor.Status()
 	c.Check(err, IsNil)
 	c.Assert(status, HasLen, 1)
-	c.Check(status[0], Equals, "hello-app\tsvc1\tenabled; loaded; active (running)")
+	c.Check(status[0], Equals, "hello-snap\tsvc1\tenabled; loaded; active (running)")
 
 	stobj, err := actor.ServiceStatus()
 	c.Check(err, IsNil)
 	c.Assert(stobj, HasLen, 1)
 	c.Check(stobj[0], DeepEquals, &PackageServiceStatus{
 		ServiceStatus: systemd.ServiceStatus{
-			ServiceFileName: "hello-app_svc1_1.10.service",
+			ServiceFileName: "hello-snap_svc1_1.10.service",
 			LoadState:       "loaded",
 			ActiveState:     "active",
 			SubState:        "running",
 			UnitFileState:   "enabled",
 		},
-		PackageName: "hello-app",
+		PackageName: "hello-snap",
 		AppName:     "svc1",
 	})
 
@@ -239,6 +239,6 @@ func (s *ServiceActorSuite) TestFindServicesReportsErrors(c *C) {
 }
 
 func (s *ServiceActorSuite) TestFindServicesIgnoresForegroundApps(c *C) {
-	_, err := FindServices("hello-app", "non-svc2", s.pb)
+	_, err := FindServices("hello-snap", "non-svc2", s.pb)
 	c.Check(err, Equals, ErrServiceNotFound)
 }

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -96,7 +96,7 @@ func (s *SquashfsTestSuite) TearDownTest(c *C) {
 
 var _ = Suite(&SquashfsTestSuite{})
 
-const packageHello = `name: hello-app
+const packageHello = `name: hello-snap
 version: 1.10
 `
 
@@ -115,14 +115,14 @@ func (s *SquashfsTestSuite) TestInstallViaSquashfsWorks(c *C) {
 	c.Assert(err, IsNil)
 
 	// after install the blob is in the right dir
-	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-app.origin_1.10.snap")), Equals, true)
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-snap.origin_1.10.snap")), Equals, true)
 
 	// ensure the right unit is created
-	mup := systemd.MountUnitPath("/snaps/hello-app.origin/1.10", "mount")
+	mup := systemd.MountUnitPath("/snaps/hello-snap.origin/1.10", "mount")
 	content, err := ioutil.ReadFile(mup)
 	c.Assert(err, IsNil)
-	c.Assert(string(content), Matches, "(?ms).*^Where=/snaps/hello-app.origin/1.10")
-	c.Assert(string(content), Matches, "(?ms).*^What=/var/lib/snappy/snaps/hello-app.origin_1.10.snap")
+	c.Assert(string(content), Matches, "(?ms).*^Where=/snaps/hello-snap.origin/1.10")
+	c.Assert(string(content), Matches, "(?ms).*^What=/var/lib/snappy/snaps/hello-snap.origin_1.10.snap")
 }
 
 func (s *SquashfsTestSuite) TestAddSquashfsMount(c *C) {
@@ -171,7 +171,7 @@ func (s *SquashfsTestSuite) TestRemoveViaSquashfsWorks(c *C) {
 	c.Assert(err, IsNil)
 
 	// after install the blob is in the right dir
-	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-app.origin_1.10.snap")), Equals, true)
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-snap.origin_1.10.snap")), Equals, true)
 
 	// now remove and ensure its gone
 	part, err := NewSnapFile(snapFile, "origin", true)
@@ -179,7 +179,7 @@ func (s *SquashfsTestSuite) TestRemoveViaSquashfsWorks(c *C) {
 	installedPart, err := newSnapPartFromYaml(filepath.Join(part.instdir, "meta", "package.yaml"), part.origin, part.m)
 	err = (&Overlord{}).Uninstall(installedPart, &MockProgressMeter{})
 	c.Assert(err, IsNil)
-	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-app.origin_1.10.snap")), Equals, false)
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-snap.origin_1.10.snap")), Equals, false)
 
 }
 

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -126,7 +126,7 @@ func (s *SnapTestSuite) TestLocalSnapSimple(c *C) {
 	snap, err := NewInstalledSnapPart(snapYaml, testOrigin)
 	c.Assert(err, IsNil)
 	c.Assert(snap, NotNil)
-	c.Check(snap.Name(), Equals, "hello-app")
+	c.Check(snap.Name(), Equals, "hello-snap")
 	c.Check(snap.Version(), Equals, "1.10")
 	c.Check(snap.IsActive(), Equals, false)
 	c.Check(snap.Description(), Equals, "Hello")
@@ -193,7 +193,7 @@ func (s *SnapTestSuite) TestLocalSnapRepositorySimple(c *C) {
 	installed, err := snap.Installed()
 	c.Assert(err, IsNil)
 	c.Assert(installed, HasLen, 1)
-	c.Assert(installed[0].Name(), Equals, "hello-app")
+	c.Assert(installed[0].Name(), Equals, "hello-snap")
 	c.Assert(installed[0].Version(), Equals, "1.10")
 }
 
@@ -681,7 +681,7 @@ func (s *SnapTestSuite) TestMakeConfigEnv(c *C) {
 	// regular env is unaltered
 	c.Assert(envMap["PATH"], Equals, os.Getenv("PATH"))
 	// SNAP_* is overriden
-	c.Assert(envMap["SNAP_NAME"], Equals, "hello-app")
+	c.Assert(envMap["SNAP_NAME"], Equals, "hello-snap")
 	c.Assert(envMap["SNAP_VERSION"], Equals, "1.10")
 	c.Check(envMap["LC_ALL"], Equals, "C.UTF-8")
 }
@@ -779,7 +779,7 @@ apps:
 }
 
 func (s *SnapTestSuite) TestErrorOnUnsupportedArchitecture(c *C) {
-	const packageHello = `name: hello-app
+	const packageHello = `name: hello-snap
 version: 1.10
 architectures:
     - yadayada
@@ -793,7 +793,7 @@ architectures:
 }
 
 func (s *SnapTestSuite) TestServicesWithPorts(c *C) {
-	const packageHello = `name: hello-app
+	const packageHello = `name: hello-snap
 version: 1.10
 apps:
  hello:
@@ -822,7 +822,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(snap, NotNil)
 
-	c.Assert(snap.Name(), Equals, "hello-app")
+	c.Assert(snap.Name(), Equals, "hello-snap")
 	c.Assert(snap.Origin(), Equals, testOrigin)
 	c.Assert(snap.Version(), Equals, "1.10")
 	c.Assert(snap.IsActive(), Equals, false)
@@ -949,7 +949,7 @@ gadget:
     id: my-store
   software:
     built-in:
-      - hello-app
+      - hello-snap
 type: gadget
 `)
 	c.Assert(err, IsNil)
@@ -965,7 +965,7 @@ type: gadget
 	c.Assert(r, NotNil)
 	installed, err := r.Installed()
 	c.Assert(err, IsNil)
-	parts := FindSnapsByName("hello-app", installed)
+	parts := FindSnapsByName("hello-snap", installed)
 	c.Assert(parts, HasLen, 1)
 	c.Check(s.overlord.Uninstall(parts[0].(*SnapPart), p), Equals, ErrPackageNotRemovable)
 }


### PR DESCRIPTION
A lot of the test code used "hello-app" to refer to the package name
because it originated in the era when "apps" were packages. This patch
corrects that to "hello-snap" so that test are less confusing and more
consistent.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>