### PR TITLE
snappy: tidy field names in securityAppID

### DIFF
--- a/snappy/security.go
+++ b/snappy/security.go
@@ -340,10 +340,10 @@ func getSecurityProfile(m *snapYaml, appName, baseDir string) (string, error) {
 }
 
 type securityAppID struct {
-	AppID   string
-	Pkgname string
-	Appname string
-	Version string
+	AppID    string
+	SnapName string
+	Appname  string
+	Version  string
 }
 
 func newAppID(appID string) (*securityAppID, error) {
@@ -352,10 +352,10 @@ func newAppID(appID string) (*securityAppID, error) {
 		return nil, errInvalidAppID
 	}
 	id := securityAppID{
-		AppID:   appID,
-		Pkgname: tmp[0],
-		Appname: tmp[1],
-		Version: tmp[2],
+		AppID:    appID,
+		SnapName: tmp[0],
+		Appname:  tmp[1],
+		Version:  tmp[2],
 	}
 	return &id, nil
 }
@@ -371,7 +371,7 @@ func (sa *securityAppID) appArmorVars() string {
 @{APP_VERSION}="%s"
 @{INSTALL_DIR}="{/snaps,/gadget}"
 # Deprecated:
-@{CLICK_DIR}="{/snaps,/gadget}"`, sa.Appname, dbusPath(sa.AppID), dbusPath(sa.Pkgname), sa.Pkgname, sa.Version)
+@{CLICK_DIR}="{/snaps,/gadget}"`, sa.Appname, dbusPath(sa.AppID), dbusPath(sa.SnapName), sa.SnapName, sa.Version)
 	return aavars
 }
 
@@ -820,7 +820,7 @@ func regeneratePolicyForSnap(snapname string) error {
 		}
 		if appID.Version != appliedVersion {
 			// FIXME: dirs.SnapSnapsDir is too simple, gadget
-			fn := filepath.Join(dirs.SnapSnapsDir, appID.Pkgname, appID.Version, "meta", "snap.yaml")
+			fn := filepath.Join(dirs.SnapSnapsDir, appID.SnapName, appID.Version, "meta", "snap.yaml")
 			if !osutil.FileExists(fn) {
 				continue
 			}

--- a/snappy/security.go
+++ b/snappy/security.go
@@ -342,7 +342,7 @@ func getSecurityProfile(m *snapYaml, appName, baseDir string) (string, error) {
 type securityAppID struct {
 	AppID    string
 	SnapName string
-	Appname  string
+	AppName  string
 	Version  string
 }
 
@@ -354,7 +354,7 @@ func newAppID(appID string) (*securityAppID, error) {
 	id := securityAppID{
 		AppID:    appID,
 		SnapName: tmp[0],
-		Appname:  tmp[1],
+		AppName:  tmp[1],
 		Version:  tmp[2],
 	}
 	return &id, nil
@@ -371,7 +371,7 @@ func (sa *securityAppID) appArmorVars() string {
 @{APP_VERSION}="%s"
 @{INSTALL_DIR}="{/snaps,/gadget}"
 # Deprecated:
-@{CLICK_DIR}="{/snaps,/gadget}"`, sa.Appname, dbusPath(sa.AppID), dbusPath(sa.SnapName), sa.SnapName, sa.Version)
+@{CLICK_DIR}="{/snaps,/gadget}"`, sa.AppName, dbusPath(sa.AppID), dbusPath(sa.SnapName), sa.SnapName, sa.Version)
 	return aavars
 }
 

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -217,10 +217,10 @@ func (a *SecurityTestSuite) TestSecurityFindCapsMultipleErrorHandling(c *C) {
 
 func (a *SecurityTestSuite) TestSecurityGetAppArmorVars(c *C) {
 	appID := &securityAppID{
-		Appname: "foo",
-		Version: "1.0",
-		AppID:   "id",
-		Pkgname: "pkgname",
+		Appname:  "foo",
+		Version:  "1.0",
+		AppID:    "id",
+		SnapName: "pkgname",
 	}
 	c.Assert(appID.appArmorVars(), Equals, `
 # Specified profile variables
@@ -355,8 +355,8 @@ func (a *SecurityTestSuite) TestSecurityGenAppArmorTemplatePolicy(c *C) {
 		Version: "1.0",
 	}
 	appid := &securityAppID{
-		Pkgname: "foo",
-		Version: "1.0",
+		SnapName: "foo",
+		Version:  "1.0",
 	}
 	template := "mock-template"
 	caps := []string{"cap1"}
@@ -405,8 +405,8 @@ func (a *SecurityTestSuite) TestSecurityGenSeccompTemplatedPolicy(c *C) {
 		Version: "1.0",
 	}
 	appid := &securityAppID{
-		Pkgname: "foo",
-		Version: "1.0",
+		SnapName: "foo",
+		Version:  "1.0",
 	}
 	template := "mock-template"
 	caps := []string{"cap1"}
@@ -467,9 +467,9 @@ func (a *SecurityTestSuite) TestSecurityGetApparmorCustomPolicy(c *C) {
 		Version: "1.0",
 	}
 	appid := &securityAppID{
-		AppID:   "foo_bar_1.0",
-		Pkgname: "foo",
-		Version: "1.0",
+		AppID:    "foo_bar_1.0",
+		SnapName: "foo",
+		Version:  "1.0",
 	}
 	customPolicy := filepath.Join(c.MkDir(), "foo")
 	err := ioutil.WriteFile(customPolicy, []byte(aaCustomPolicy), 0644)
@@ -498,10 +498,10 @@ func (a *SecurityTestSuite) TestSecurityGetAppID(c *C) {
 	id, err := newAppID("pkg_app_1.0")
 	c.Assert(err, IsNil)
 	c.Assert(id, DeepEquals, &securityAppID{
-		AppID:   "pkg_app_1.0",
-		Pkgname: "pkg",
-		Appname: "app",
-		Version: "1.0",
+		AppID:    "pkg_app_1.0",
+		SnapName: "pkg",
+		Appname:  "app",
+		Version:  "1.0",
 	})
 }
 
@@ -804,8 +804,8 @@ func (a *SecurityTestSuite) TestSecurityGenerateCustomPolicyAdditionalIsConsider
 		Version: "1.0",
 	}
 	appid := &securityAppID{
-		Pkgname: "foo",
-		Version: "1.0",
+		SnapName: "foo",
+		Version:  "1.0",
 	}
 	fn := makeCustomAppArmorPolicy(c)
 

--- a/snappy/security_test.go
+++ b/snappy/security_test.go
@@ -217,7 +217,7 @@ func (a *SecurityTestSuite) TestSecurityFindCapsMultipleErrorHandling(c *C) {
 
 func (a *SecurityTestSuite) TestSecurityGetAppArmorVars(c *C) {
 	appID := &securityAppID{
-		Appname:  "foo",
+		AppName:  "foo",
 		Version:  "1.0",
 		AppID:    "id",
 		SnapName: "pkgname",
@@ -500,7 +500,7 @@ func (a *SecurityTestSuite) TestSecurityGetAppID(c *C) {
 	c.Assert(id, DeepEquals, &securityAppID{
 		AppID:    "pkg_app_1.0",
 		SnapName: "pkg",
-		Appname:  "app",
+		AppName:  "app",
 		Version:  "1.0",
 	})
 }


### PR DESCRIPTION
This branch does two trivial renames:
  - securityAppID.Appname to AppName
  - securityAppID.Pkgname to SnapName

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>