### PR TITLE
Avoid more config checks base test

### DIFF
--- a/integration-tests/tests/base_test.go
+++ b/integration-tests/tests/base_test.go
@@ -65,13 +65,15 @@ func Test(t *testing.T) {
 		report.NewSubunitV2ParserReporter(&report.FileReporter{}))
 	runner.TestingT(t, output)
 
-	cfg, err := config.ReadConfig(config.DefaultFileName)
-	if err != nil {
-		t.Fatalf("Error reading config: %v", err)
-	}
+	if _, err := os.Stat(config.DefaultFileName); err == nil {
+		cfg, err := config.ReadConfig(config.DefaultFileName)
+		if err != nil {
+			t.Fatalf("Error reading config: %v", err)
+		}
 
-	if err := tearDownSnapd(cfg.FromBranch); err != nil {
-		t.Fatalf("Error stopping daemon: %v", err)
+		if err := tearDownSnapd(cfg.FromBranch); err != nil {
+			t.Fatalf("Error stopping daemon: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Similar to 0c0c8b67513a73b18980482c7abb1fb1a784a0f4 but also disables reading the config in another location so that check.list can function properly

Also needs f783769a44d75e42beeca8a990df388038241f93 to completely work