### PR TITLE
integration-tests: avoid autopilot stop

### DIFF
--- a/integration-tests/tests/base_test.go
+++ b/integration-tests/tests/base_test.go
@@ -47,11 +47,13 @@ func init() {
 	// here by --fgimenez - 2015-10-15
 	wait.ForFunction(c, "regular", partition.Mode)
 
-	cli.ExecCommand(c, "sudo", "systemctl", "stop", "snappy-autopilot.timer")
-	cli.ExecCommand(c, "sudo", "systemctl", "disable", "snappy-autopilot.timer")
+	if _, err := os.Stat(config.DefaultFileName); err == nil {
+		cli.ExecCommand(c, "sudo", "systemctl", "stop", "snappy-autopilot.timer")
+		cli.ExecCommand(c, "sudo", "systemctl", "disable", "snappy-autopilot.timer")
 
-	cfg, err := config.ReadConfig(config.DefaultFileName)
-	if err == nil {
+		cfg, err := config.ReadConfig(config.DefaultFileName)
+		c.Assert(err, check.IsNil, check.Commentf("Error reading config: %v", err))
+
 		setUpSnapd(c, cfg.FromBranch)
 	}
 }


### PR DESCRIPTION
After 0c0c8b67513a73b18980482c7abb1fb1a784a0f4 running -check.list works better, but there's a delay because it unnecessarily stops/disables snappy-autopilot.timer when we are trying to list the tests and don't have a config file. This just skips that bit along with the previously skipped parts of init()