### PR TITLE
snappy: remove usage of snappy.Part from firstboot code

### DIFF
--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -49,7 +49,7 @@ func wrapConfig(pkgName string, conf interface{}) ([]byte, error) {
 	return yaml.Marshal(configWrap)
 }
 
-var newPartMap = newPartMapImpl
+var newSnapMap = newSnapMapImpl
 
 type configurator interface {
 	Configure(*Snap, []byte) ([]byte, error)
@@ -59,14 +59,14 @@ var newOverlord = func() configurator {
 	return (&Overlord{})
 }
 
-func newPartMapImpl() (map[string]Part, error) {
+func newSnapMapImpl() (map[string]*Snap, error) {
 	repo := NewLocalSnapRepository()
-	all, err := repo.All()
+	all, err := repo.AllSnaps()
 	if err != nil {
 		return nil, err
 	}
 
-	m := make(map[string]Part, 2*len(all))
+	m := make(map[string]*Snap, 2*len(all))
 	for _, part := range all {
 		m[FullName(part)] = part
 		m[BareName(part)] = part
@@ -83,28 +83,24 @@ func gadgetConfig() error {
 		return err
 	}
 
-	partMap, err := newPartMap()
+	snapMap, err := newSnapMap()
 	if err != nil {
 		return err
 	}
 
 	pb := progress.MakeProgressBar()
 	for _, pkgName := range gadget.Gadget.Software.BuiltIn {
-		part, ok := partMap[pkgName]
-		if !ok {
-			return errNoSnapToActivate
-		}
-		snap, ok := part.(*Snap)
+		snap, ok := snapMap[pkgName]
 		if !ok {
 			return errNoSnapToActivate
 		}
 		if err := snap.activate(false, pb); err != nil {
-			logger.Noticef("failed to activate %s: %s", FullName(part), err)
+			logger.Noticef("failed to activate %s: %s", fmt.Sprintf("%s.%s", snap.Name(), snap.Origin()), err)
 		}
 	}
 
 	for pkgName, conf := range gadget.Config {
-		snap, ok := partMap[pkgName]
+		snap, ok := snapMap[pkgName]
 		if !ok {
 			// We want to error early as this is a disparity and gadget snap
 			// packaging error.
@@ -117,7 +113,7 @@ func gadgetConfig() error {
 		}
 
 		overlord := newOverlord()
-		if _, err := overlord.Configure(snap.(*Snap), configData); err != nil {
+		if _, err := overlord.Configure(snap, configData); err != nil {
 			return err
 		}
 	}

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -48,8 +48,8 @@ type FirstBootTestSuite struct {
 	ifup         string
 	m            *snapYaml
 	e            error
-	partMap      map[string]Part
-	partMapErr   error
+	snapMap      map[string]*Snap
+	snapMapErr   error
 	verifyCmd    string
 	fakeOverlord *fakeOverlord
 }
@@ -85,7 +85,7 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	s.ifup = ifup
 	ifup = "/bin/true"
 	getGadget = s.getGadget
-	newPartMap = s.newPartMap
+	newSnapMap = s.newSnapMap
 	newOverlord = s.newOverlord
 	s.fakeOverlord = &fakeOverlord{
 		configs: map[string]string{},
@@ -93,8 +93,8 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 
 	s.m = nil
 	s.e = nil
-	s.partMap = nil
-	s.partMapErr = nil
+	s.snapMap = nil
+	s.snapMapErr = nil
 }
 
 func (s *FirstBootTestSuite) TearDownTest(c *C) {
@@ -102,15 +102,15 @@ func (s *FirstBootTestSuite) TearDownTest(c *C) {
 	ethdir = s.ethdir
 	ifup = s.ifup
 	getGadget = getGadgetImpl
-	newPartMap = newPartMapImpl
+	newSnapMap = newSnapMapImpl
 }
 
 func (s *FirstBootTestSuite) getGadget() (*snapYaml, error) {
 	return s.m, s.e
 }
 
-func (s *FirstBootTestSuite) newPartMap() (map[string]Part, error) {
-	return s.partMap, s.partMapErr
+func (s *FirstBootTestSuite) newSnapMap() (map[string]*Snap, error) {
+	return s.snapMap, s.snapMapErr
 }
 
 func (s *FirstBootTestSuite) newOverlord() configurator {
@@ -124,8 +124,8 @@ func (s *FirstBootTestSuite) newFakeApp() *Snap {
 			Type: snap.TypeApp,
 		},
 	}
-	s.partMap = make(map[string]Part)
-	s.partMap["myapp"] = &fakeMyApp
+	s.snapMap = make(map[string]*Snap)
+	s.snapMap["myapp"] = &fakeMyApp
 
 	return &fakeMyApp
 }
@@ -152,17 +152,17 @@ func (s *FirstBootTestSuite) TestSoftwareActivate(c *C) {
 
 	s.m = &snapYaml{Gadget: Gadget{Software: Software{BuiltIn: []string{name}}}}
 
-	all, err := NewLocalSnapRepository().All()
+	all, err := NewLocalSnapRepository().AllSnaps()
 	c.Check(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Check(all[0].Name(), Equals, name)
 	c.Check(all[0].IsInstalled(), Equals, true)
 	c.Check(all[0].IsActive(), Equals, false)
 
-	s.partMap = map[string]Part{name: all[0]}
+	s.snapMap = map[string]*Snap{name: all[0]}
 	c.Assert(FirstBoot(), IsNil)
 
-	all, err = NewLocalSnapRepository().All()
+	all, err = NewLocalSnapRepository().AllSnaps()
 	c.Check(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Check(all[0].Name(), Equals, name)

--- a/snappy/snap_local_repo.go
+++ b/snappy/snap_local_repo.go
@@ -56,9 +56,19 @@ func (s *SnapLocalRepository) All() ([]Part, error) {
 	return s.Installed()
 }
 
+// AllSnaps get all the snaps
+func (s *SnapLocalRepository) AllSnaps() ([]*Snap, error) {
+	globExpr := filepath.Join(s.path, "*", "*", "meta", "snap.yaml")
+	return s.snapsForGlobExpr(globExpr)
+}
+
 // Snaps gets all the snaps with the given name and origin
 func (s *SnapLocalRepository) Snaps(name, origin string) ([]*Snap, error) {
 	globExpr := filepath.Join(s.path, name+"."+origin, "*", "meta", "snap.yaml")
+	return s.snapsForGlobExpr(globExpr)
+}
+
+func (s *SnapLocalRepository) snapsForGlobExpr(globExpr string) ([]*Snap, error) {
 	parts, err := s.partsForGlobExpr(globExpr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Simple branch that works towards removing the usage of snappy.Part from the everything. This is the first part in firstboot.