### PR TITLE
integration-tests: always set env for snap tests

### DIFF
--- a/integration-tests/tests/base_test.go
+++ b/integration-tests/tests/base_test.go
@@ -53,7 +53,7 @@ func init() {
 	cfg, err := config.ReadConfig(config.DefaultFileName)
 	if err == nil {
 		if cfg.FromBranch {
-			setUpSnapdFromBranch(c)
+			setUpSnapd(c, cfg.FromBranch)
 		}
 	}
 }
@@ -70,25 +70,25 @@ func Test(t *testing.T) {
 		t.Fatalf("Error reading config: %v", err)
 	}
 
-	if cfg.FromBranch {
-		if err := tearDownSnapdFromBranch(); err != nil {
-			t.Fatalf("Error stopping daemon: %v", err)
-		}
+	if err := tearDownSnapd(cfg.FromBranch); err != nil {
+		t.Fatalf("Error stopping daemon: %v", err)
 	}
 }
 
-func setUpSnapdFromBranch(c *check.C) {
+func setUpSnapd(c *check.C, fromBranch bool) {
 	cli.ExecCommand(c, "sudo", "systemctl", "stop",
 		"ubuntu-snappy.snapd.service", "ubuntu-snappy.snapd.socket")
 
-	binPath, err := filepath.Abs("integration-tests/bin/snapd")
-	c.Assert(err, check.IsNil)
+	if fromBranch {
+		binPath, err := filepath.Abs("integration-tests/bin/snapd")
+		c.Assert(err, check.IsNil)
 
-	_, err = cli.ExecCommandErr("sudo", "mount", "-o", "bind",
-		binPath, "/usr/lib/snappy/snapd")
-	c.Assert(err, check.IsNil)
+		_, err = cli.ExecCommandErr("sudo", "mount", "-o", "bind",
+			binPath, "/usr/lib/snappy/snapd")
+		c.Assert(err, check.IsNil)
+	}
 
-	err = writeEnvConfig()
+	err := writeEnvConfig()
 	c.Assert(err, check.IsNil)
 
 	_, err = cli.ExecCommandErr("sudo", "systemctl", "daemon-reload")
@@ -98,7 +98,7 @@ func setUpSnapdFromBranch(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func tearDownSnapdFromBranch() error {
+func tearDownSnapd(fromBranch bool) error {
 	if _, err := cli.ExecCommandErr("sudo", "systemctl", "stop",
 		"ubuntu-snappy.snapd.service"); err != nil {
 		return err
@@ -108,8 +108,10 @@ func tearDownSnapdFromBranch() error {
 		return err
 	}
 
-	if _, err := cli.ExecCommandErr("sudo", "umount", "/usr/lib/snappy/snapd"); err != nil {
-		return err
+	if fromBranch {
+		if _, err := cli.ExecCommandErr("sudo", "umount", "/usr/lib/snappy/snapd"); err != nil {
+			return err
+		}
 	}
 
 	if _, err := cli.ExecCommandErr("sudo", "systemctl", "daemon-reload"); err != nil {


### PR DESCRIPTION
We are getting errors in the integration tests when not building the binary from branch (currently in the daily builds, soon in the gates) because of a missing environment variable needed for the `snap` binary tests (specifically `SNAPPY_TRUSTED_ACCOUNT_KEY`), this branch fixes it.