### PR TITLE
overlord: introduce an ensure loop with Run() and Stop() on Overlord

### DIFF
--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -24,8 +24,10 @@ import (
 )
 
 // SetEnsureIntervalForTest let's change overlord ensure interval for tests.
-func SetEnsureIntervalForTest(d time.Duration) time.Duration {
+func SetEnsureIntervalForTest(d time.Duration) (restore func()) {
 	prev := ensureInterval
 	ensureInterval = d
-	return prev
+	return func() {
+		ensureInterval = prev
+	}
 }

--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -1,0 +1,31 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord
+
+import (
+	"time"
+)
+
+// SetEnsureIntervalForTest let's change overlord ensure interval for tests.
+func SetEnsureIntervalForTest(d time.Duration) time.Duration {
+	prev := ensureInterval
+	ensureInterval = d
+	return prev
+}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -125,8 +125,12 @@ func (o *Overlord) Run() {
 // Stop stops the ensure loop and the managers under the StateEngine.
 func (o *Overlord) Stop() error {
 	o.loopTomb.Kill(nil)
-	o.loopTomb.Wait()
-	return o.stateEng.Stop()
+	err1 := o.loopTomb.Wait()
+	err2 := o.stateEng.Stop()
+	if err1 != nil {
+		return err1
+	}
+	return err2
 }
 
 // StateEngine returns the state engine used by the overlord.

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -114,7 +114,8 @@ func (o *Overlord) Run() {
 			}
 			err := o.stateEng.Ensure()
 			if err != nil {
-				logger.Panicf("state engine ensure failed not recoverably: %v", err)
+				logger.Noticef("state engine ensure failed: %v", err)
+				// continue to the next Ensure() try for now
 			}
 			timer.Reset(intv)
 		}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -105,18 +105,18 @@ func loadState(backend state.Backend) (*state.State, error) {
 func (o *Overlord) Run() {
 	intv := ensureInterval
 	o.loopTomb.Go(func() error {
-		tim := time.NewTimer(intv)
+		timer := time.NewTimer(intv)
 		for {
 			select {
 			case <-o.loopTomb.Dying():
 				return nil
-			case <-tim.C:
+			case <-timer.C:
 			}
 			err := o.stateEng.Ensure()
 			if err != nil {
 				logger.Panicf("state engine ensure failed not recoverably: %v", err)
 			}
-			tim.Reset(intv)
+			timer.Reset(intv)
 		}
 	})
 }

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -125,11 +125,8 @@ func (o *Overlord) Run() {
 // Stop stops the ensure loop and the managers under the StateEngine.
 func (o *Overlord) Stop() error {
 	o.loopTomb.Kill(nil)
-	err := o.stateEng.Stop()
-	if err != nil {
-		return err
-	}
-	return o.loopTomb.Wait()
+	o.loopTomb.Wait()
+	return o.stateEng.Stop()
 }
 
 // StateEngine returns the state engine used by the overlord.

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -37,7 +37,7 @@ import (
 	"github.com/ubuntu-core/snappy/overlord/state"
 )
 
-var ensureInterval = 3 * time.Second
+var ensureInterval = 5 * time.Second
 
 // Overlord is the central manager of a snappy system, keeping
 // track of all available state managers and related helpers.
@@ -105,19 +105,19 @@ func loadState(backend state.Backend) (*state.State, error) {
 func (o *Overlord) Run() {
 	intv := ensureInterval
 	o.loopTomb.Go(func() error {
-		timer := time.NewTimer(intv)
+		tick := time.NewTicker(intv)
+		defer tick.Stop()
 		for {
 			select {
 			case <-o.loopTomb.Dying():
 				return nil
-			case <-timer.C:
+			case <-tick.C:
 			}
 			err := o.stateEng.Ensure()
 			if err != nil {
 				logger.Noticef("state engine ensure failed: %v", err)
 				// continue to the next Ensure() try for now
 			}
-			timer.Reset(intv)
 		}
 	})
 }

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -22,7 +22,9 @@ package overlord_test
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -83,4 +85,30 @@ func (os *overlordSuite) TestNewWithInvalidState(c *C) {
 
 	_, err = overlord.New()
 	c.Assert(err, ErrorMatches, "EOF")
+}
+
+func (os *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
+	prevInterval := overlord.SetEnsureIntervalForTest(10 * time.Millisecond)
+	defer overlord.SetEnsureIntervalForTest(prevInterval)
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+
+	calls := []string{}
+
+	witness := &fakeManager{name: "witness", calls: &calls}
+	o.StateEngine().AddManager(witness)
+
+	o.Run()
+	time.Sleep(30 * time.Millisecond)
+	err = o.Stop()
+	c.Assert(err, IsNil)
+
+	ensureCalls := 0
+	for _, call := range calls {
+		if strings.HasPrefix(call, "ensure:") {
+			ensureCalls++
+		}
+	}
+
+	c.Check(ensureCalls >= 2, Equals, true)
 }

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -88,8 +88,8 @@ func (os *overlordSuite) TestNewWithInvalidState(c *C) {
 }
 
 func (os *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
-	prevInterval := overlord.SetEnsureIntervalForTest(10 * time.Millisecond)
-	defer overlord.SetEnsureIntervalForTest(prevInterval)
+	restoreIntv := overlord.SetEnsureIntervalForTest(10 * time.Millisecond)
+	defer restoreIntv()
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
This introduces Overlord.Run() and Overlord.Stop() to run and control a loop that will ensure current state regularly by calling state engine Ensure.