### PR TITLE
overlord/ifacestate: add intent-to-connect/disconnect

### DIFF
--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+func TestInterfaceManager(t *testing.T) { check.TestingT(t) }

--- a/overlord/ifacestate/intents.go
+++ b/overlord/ifacestate/intents.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"github.com/ubuntu-core/snappy/interfaces"
+)
+
+// Intent expresses persistent intent to connect or disconnect certain plug and
+// slot.  Intents are a part of the persistent state of the manager.
+type Intent struct {
+	Action string             `json:"action"`
+	Plug   interfaces.PlugRef `json:"plug"`
+	Slot   interfaces.SlotRef `json:"slot"`
+}
+
+const (
+	IntentConnect    = "connect"
+	IntentDisconnect = "disconnect"
+)

--- a/overlord/ifacestate/intents.go
+++ b/overlord/ifacestate/intents.go
@@ -32,6 +32,8 @@ type Intent struct {
 }
 
 const (
-	IntentConnect    = "connect"
+	// IntentConnect represents desire to connect a plug to a slot.
+	IntentConnect = "connect"
+	// IntentDisconnect represents desire to disconnect a plug from a slot.
 	IntentDisconnect = "disconnect"
 )

--- a/overlord/ifacestate/intents_test.go
+++ b/overlord/ifacestate/intents_test.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"encoding/json"
+
+	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/overlord/ifacestate"
+)
+
+type intentSuite struct {
+	intent ifacestate.Intent
+}
+
+var _ = check.Suite(&intentSuite{
+	intent: ifacestate.Intent{
+		Action: ifacestate.IntentConnect,
+		Plug:   interfaces.PlugRef{"snap", "plug"},
+		Slot:   interfaces.SlotRef{"snap", "slot"},
+	},
+})
+
+func (s *intentSuite) TestMarshallToJSON(c *check.C) {
+	data, err := json.Marshal(s.intent)
+	c.Assert(err, check.IsNil)
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.DeepEquals, map[string]interface{}{
+		"action": "connect",
+		"plug": map[string]interface{}{
+			"snap": "snap",
+			"plug": "plug",
+		},
+		"slot": map[string]interface{}{
+			"snap": "snap",
+			"slot": "slot",
+		},
+	})
+}
+
+func (s *intentSuite) TestMarshallFromJSON(c *check.C) {
+	data := []byte(`
+	{
+		"action": "connect",
+		"plug": { 
+			"snap": "snap",
+			"plug": "plug"
+		},
+		"slot": { 
+			"snap": "snap",
+			"slot": "slot"
+		}
+	}`)
+	var intent ifacestate.Intent
+	err := json.Unmarshal(data, &intent)
+	c.Assert(err, check.IsNil)
+	c.Check(intent, check.DeepEquals, s.intent)
+}


### PR DESCRIPTION
This branch adds the data structure used to represent a single intent, collection of which will be managed by the interface manager. On Connect/Disconnect we will create an appropriate intent and carry out the actions in Ensure().