### PR TITLE
overlord/ifacestate: initial work on Connect

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"github.com/ubuntu-core/snappy/interfaces"
+)
+
+func (m *InterfaceManager) Repository() *interfaces.Repository {
+	return m.repo
+}
+
+func (m *InterfaceManager) Settle() {
+	m.runner.Settle()
+}

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -27,6 +27,6 @@ func (m *InterfaceManager) Repository() *interfaces.Repository {
 	return m.repo
 }
 
-func (m *InterfaceManager) Settle() {
-	m.runner.Settle()
+func (m *InterfaceManager) Wait() {
+	m.runner.Wait()
 }

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -24,6 +24,7 @@ package ifacestate
 import (
 	"fmt"
 
+	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/builtin"
 	"github.com/ubuntu-core/snappy/overlord/state"
@@ -46,8 +47,9 @@ func Manager() (*InterfaceManager, error) {
 // Connect initiates a change connecting an interface.
 //
 func Connect(change *state.Change, plugSnap, plugName, slotSnap, slotName string) error {
-	task := change.NewTask("connect", fmt.Sprintf("connect %s:%s to %s:%s",
-		plugSnap, plugName, slotSnap, slotName))
+	summary := fmt.Sprintf(i18n.G("Connecting %s:%s to %s:%s"),
+		plugSnap, plugName, slotSnap, slotName)
+	task := change.NewTask("connect", summary)
 	task.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
 	task.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plugName})
 	return nil

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -46,9 +46,6 @@ func Manager() (*InterfaceManager, error) {
 // Connect initiates a change connecting an interface.
 //
 func Connect(change *state.Change, plugSnap, plugName, slotSnap, slotName string) error {
-	change.State().Lock()
-	defer change.State().Unlock()
-
 	task := change.NewTask("connect", fmt.Sprintf("connect %s:%s to %s:%s",
 		plugSnap, plugName, slotSnap, slotName))
 	task.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
@@ -78,6 +75,9 @@ func (m *InterfaceManager) Init(s *state.State) error {
 }
 
 func (m *InterfaceManager) doConnect(task *state.Task) error {
+	task.State().Lock()
+	defer task.State().Unlock()
+
 	var slotRef interfaces.SlotRef
 	if err := task.Get("slot", &slotRef); err != nil {
 		return err
@@ -100,5 +100,6 @@ func (m *InterfaceManager) Ensure() error {
 
 // Stop implements StateManager.Stop.
 func (m *InterfaceManager) Stop() error {
+	m.runner.Stop()
 	return nil
 }

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -80,19 +80,15 @@ func (m *InterfaceManager) Init(s *state.State) error {
 func (m *InterfaceManager) doConnect(task *state.Task) error {
 	var slotRef interfaces.SlotRef
 	if err := task.Get("slot", &slotRef); err != nil {
-		task.SetStatus(state.ErrorStatus)
 		return err
 	}
 	var plugRef interfaces.PlugRef
 	if err := task.Get("plug", &plugRef); err != nil {
-		task.SetStatus(state.ErrorStatus)
 		return err
 	}
 	if err := m.repo.Connect(plugRef.Snap, plugRef.Name, slotRef.Snap, slotRef.Name); err != nil {
-		task.SetStatus(state.ErrorStatus)
 		return err
 	}
-	task.SetStatus(state.DoneStatus)
 	return nil
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -47,6 +47,9 @@ func Manager() (*InterfaceManager, error) {
 // Connect initiates a change connecting an interface.
 //
 func Connect(change *state.Change, plugSnap, plugName, slotSnap, slotName string) error {
+	// TODO: Store the intent-to-connect in the state so that we automatically
+	// try to reconnect on reboot (reconnection can fail or can connect with
+	// different parameters so we cannot store the actual connection details).
 	summary := fmt.Sprintf(i18n.G("Connecting %s:%s to %s:%s"),
 		plugSnap, plugName, slotSnap, slotName)
 	task := change.NewTask("connect", summary)

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -51,7 +51,7 @@ func Connect(change *state.Change, plugSnap, plugName, slotSnap, slotName string
 
 	task := change.NewTask("connect", fmt.Sprintf("connect %s:%s to %s:%s",
 		plugSnap, plugName, slotSnap, slotName))
-	task.Set("slot", interfaces.PlugRef{Snap: slotSnap, Name: slotName})
+	task.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
 	task.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plugName})
 	return nil
 }

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -85,6 +85,16 @@ func (s *interfaceManagerSuite) TestConnectAddsTask(c *C) {
 	c.Assert(slot.Name, Equals, "slot")
 }
 
+func (s *interfaceManagerSuite) TestConnectChangeCanBeMarshaled(c *C) {
+	s.state.Lock()
+	// NOTE: Unlock() marshals the change
+	defer s.state.Unlock()
+
+	change := s.state.NewChange("kind", "summary")
+	err := ifacestate.Connect(change, "consumer", "plug", "producer", "slot")
+	c.Assert(err, IsNil)
+}
+
 func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
 	repo := s.mgr.Repository()
 	err := repo.AddInterface(&interfaces.TestInterface{InterfaceName: "test"})

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -31,12 +31,6 @@ import (
 
 func TestInterfaceManager(t *testing.T) { TestingT(t) }
 
-type fakeBackend struct{}
-
-func (backend *fakeBackend) Checkpoint(data []byte) error {
-	return nil
-}
-
 type interfaceManagerSuite struct {
 	state *state.State
 	mgr   *ifacestate.InterfaceManager
@@ -45,7 +39,7 @@ type interfaceManagerSuite struct {
 var _ = Suite(&interfaceManagerSuite{})
 
 func (s *interfaceManagerSuite) SetUpTest(c *C) {
-	state := state.New(&fakeBackend{})
+	state := state.New(nil)
 	mgr, err := ifacestate.Manager()
 	c.Assert(err, IsNil)
 	err = mgr.Init(state)

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -79,16 +79,6 @@ func (s *interfaceManagerSuite) TestConnectAddsTask(c *C) {
 	c.Assert(slot.Name, Equals, "slot")
 }
 
-func (s *interfaceManagerSuite) TestConnectChangeCanBeMarshaled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	change := s.state.NewChange("kind", "summary")
-	// NOTE: Get() calls inside marshal arguments.
-	err := ifacestate.Connect(change, "consumer", "plug", "producer", "slot")
-	c.Assert(err, IsNil)
-}
-
 func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
 	repo := s.mgr.Repository()
 	err := repo.AddInterface(&interfaces.TestInterface{InterfaceName: "test"})

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -60,7 +60,7 @@ func (s *interfaceManagerSuite) TearDownTest(c *C) {
 
 func (s *interfaceManagerSuite) TestSmoke(c *C) {
 	s.mgr.Ensure()
-	s.mgr.Settle()
+	s.mgr.Wait()
 }
 
 func (s *interfaceManagerSuite) TestConnectAddsTask(c *C) {
@@ -101,7 +101,7 @@ func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
 	s.state.Unlock()
 
 	s.mgr.Ensure()
-	s.mgr.Settle()
+	s.mgr.Wait()
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -22,7 +22,106 @@ package ifacestate_test
 import (
 	"testing"
 
-	"gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/overlord/ifacestate"
+	"github.com/ubuntu-core/snappy/overlord/state"
 )
 
-func TestInterfaceManager(t *testing.T) { check.TestingT(t) }
+func TestInterfaceManager(t *testing.T) { TestingT(t) }
+
+type fakeBackend struct{}
+
+func (backend *fakeBackend) Checkpoint(data []byte) error {
+	return nil
+}
+
+type interfaceManagerSuite struct {
+	state *state.State
+	mgr   *ifacestate.InterfaceManager
+}
+
+var _ = Suite(&interfaceManagerSuite{})
+
+func (s *interfaceManagerSuite) SetUpTest(c *C) {
+	state := state.New(&fakeBackend{})
+	mgr, err := ifacestate.Manager()
+	c.Assert(err, IsNil)
+	err = mgr.Init(state)
+	c.Assert(err, IsNil)
+	s.state = state
+	s.mgr = mgr
+}
+
+func (s *interfaceManagerSuite) TearDownTest(c *C) {
+	s.mgr.Stop()
+}
+
+func (s *interfaceManagerSuite) TestSmoke(c *C) {
+	s.mgr.Ensure()
+	s.mgr.Settle()
+}
+
+func (s *interfaceManagerSuite) TestConnectAddsTask(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	change := s.state.NewChange("kind", "summary")
+	err := ifacestate.Connect(change, "consumer", "plug", "producer", "slot")
+	c.Assert(err, IsNil)
+	c.Assert(change.Tasks(), HasLen, 1)
+	task := change.Tasks()[0]
+	c.Assert(task.Kind(), Equals, "connect")
+	var plug interfaces.PlugRef
+	err = task.Get("plug", &plug)
+	c.Assert(err, IsNil)
+	c.Assert(plug.Snap, Equals, "consumer")
+	c.Assert(plug.Name, Equals, "plug")
+	var slot interfaces.SlotRef
+	err = task.Get("slot", &slot)
+	c.Assert(err, IsNil)
+	c.Assert(slot.Snap, Equals, "producer")
+	c.Assert(slot.Name, Equals, "slot")
+}
+
+func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
+	repo := s.mgr.Repository()
+	err := repo.AddInterface(&interfaces.TestInterface{InterfaceName: "test"})
+	c.Assert(err, IsNil)
+	err = repo.AddSlot(&interfaces.Slot{Snap: "producer", Name: "slot", Interface: "test"})
+	c.Assert(err, IsNil)
+	err = repo.AddPlug(&interfaces.Plug{Snap: "consumer", Name: "plug", Interface: "test"})
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	change := s.state.NewChange("kind", "summary")
+	err = ifacestate.Connect(change, "consumer", "plug", "producer", "slot")
+	c.Assert(err, IsNil)
+	s.state.Unlock()
+
+	s.mgr.Ensure()
+	s.mgr.Settle()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	task := change.Tasks()[0]
+	c.Check(task.Kind(), Equals, "connect")
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(change.Status(), Equals, state.DoneStatus)
+	c.Check(repo.Interfaces(), DeepEquals, &interfaces.Interfaces{
+		Slots: []*interfaces.Slot{{
+			Snap:        "producer",
+			Name:        "slot",
+			Interface:   "test",
+			Connections: []interfaces.PlugRef{{Snap: "consumer", Name: "plug"}},
+		}},
+		Plugs: []*interfaces.Plug{{
+			Snap:        "consumer",
+			Name:        "plug",
+			Interface:   "test",
+			Connections: []interfaces.SlotRef{{Snap: "producer", Name: "slot"}},
+		}},
+	})
+}

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -87,10 +87,10 @@ func (s *interfaceManagerSuite) TestConnectAddsTask(c *C) {
 
 func (s *interfaceManagerSuite) TestConnectChangeCanBeMarshaled(c *C) {
 	s.state.Lock()
-	// NOTE: Unlock() marshals the change
 	defer s.state.Unlock()
 
 	change := s.state.NewChange("kind", "summary")
+	// NOTE: Get() calls inside marshal arguments.
 	err := ifacestate.Connect(change, "consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
 }

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -164,7 +164,13 @@ func (r *TaskRunner) Wait() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for _, tb := range r.tombs {
-		tb.Wait()
+	for len(r.tombs) > 0 {
+		for id, t := range r.tombs {
+			r.mu.Unlock()
+			t.Wait()
+			r.mu.Lock()
+			delete(r.tombs, id)
+			break
+		}
 	}
 }

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -25,7 +25,7 @@ import (
 	"gopkg.in/tomb.v2"
 )
 
-// HandlerFunc is the type of function for the hanlders
+// HandlerFunc is the type of function for the handlers
 type HandlerFunc func(task *Task) error
 
 // TaskRunner controls the running of goroutines to execute known task kinds.

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -147,12 +147,8 @@ func (r *TaskRunner) Ensure() {
 	}
 }
 
-// Stop stops all concurrent activities and returns after that's done.
-// Note that Stop will lock the state.
+// Stop kills all concurrent activities and returns after that's done.
 func (r *TaskRunner) Stop() {
-	r.state.Lock()
-	defer r.state.Unlock()
-
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -163,13 +163,12 @@ func (r *TaskRunner) Stop() {
 	}
 }
 
-// Settle waits for all concurrent activities and returns after that's done.
-func (r *TaskRunner) Settle() {
+// Wait waits for all concurrent activities and returns after that's done.
+func (r *TaskRunner) Wait() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for id, tb := range r.tombs {
+	for _, tb := range r.tombs {
 		tb.Wait()
-		delete(r.tombs, id)
 	}
 }

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-03-14 14:48+0100\n"
+        "POT-Creation-Date: 2016-03-16 09:24+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -109,6 +109,10 @@ msgid   "Classic dimension is not enabled."
 msgstr  ""
 
 msgid   "Configures a package. The configuration is a YAML file, provided in the specified file which can be \"-\" for stdin. Output of the command is the current configuration, so running this command with no input file provides a snapshot of the app's current config."
+msgstr  ""
+
+#, c-format
+msgid   "Connecting %s:%s to %s:%s"
 msgstr  ""
 
 msgid   "Connects a plug to a slot"

--- a/update-pot
+++ b/update-pot
@@ -22,7 +22,7 @@ $GOPATH/bin/xgettext-go \
     --msgid-bugs-address=snappy-devel@lists.ubuntu.com \
     --keyword=i18n.G \
     --keyword-plural=i18n.DG \
-    $HERE/*/*.go $HERE/cmd/*/*.go
+    $(find $HERE -name "*.go")
 
 #xgettext -d snappy -o "$OUTPUT" --c++ --from-code=UTF-8 \
 #	--indent --add-comments=TRANSLATORS: --no-location --sort-output \


### PR DESCRIPTION
This patch adds initial work on implementing Connect().

So far everything is detached from the rest of the system (in
particular, there's a second interface repository that this Connect()
operates on.  As the code matures and takes shape it will take over and
replace the copy in the daemon package.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>