### PR TITLE
asserts: add series to primary keys

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -50,7 +50,7 @@ var (
 	// XXX: is series actually part of the primary key?
 	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
-	SnapBuildType       = &AssertionType{"snap-build", []string{"snap-id", "snap-digest"}, assembleSnapBuild}
+	SnapBuildType       = &AssertionType{"snap-build", []string{"series", "snap-id", "snap-digest"}, assembleSnapBuild}
 	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}
 
 // ...

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -48,7 +48,7 @@ var (
 	DeviceSerialType = &AssertionType{"device-serial", []string{"brand-id", "model", "serial"}, assembleDeviceSerial}
 	IdentityType     = &AssertionType{"identity", []string{"account-id"}, assembleIdentity}
 	// XXX: is series actually part of the primary key?
-	ModelType           = &AssertionType{"model", []string{"brand-id", "model", "series"}, assembleModel}
+	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
 	SnapBuildType       = &AssertionType{"snap-build", []string{"snap-id", "snap-digest"}, assembleSnapBuild}
 	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -51,7 +51,7 @@ var (
 	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
 	SnapBuildType       = &AssertionType{"snap-build", []string{"series", "snap-id", "snap-digest"}, assembleSnapBuild}
-	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-id", "snap-digest"}, assembleSnapRevision}
+	SnapRevisionType    = &AssertionType{"snap-revision", []string{"series", "snap-id", "snap-digest"}, assembleSnapRevision}
 
 // ...
 )

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -44,10 +44,9 @@ type AssertionType struct {
 
 // Understood assertion types.
 var (
-	AccountKeyType   = &AssertionType{"account-key", []string{"account-id", "public-key-id"}, assembleAccountKey}
-	DeviceSerialType = &AssertionType{"device-serial", []string{"brand-id", "model", "serial"}, assembleDeviceSerial}
-	IdentityType     = &AssertionType{"identity", []string{"account-id"}, assembleIdentity}
-	// XXX: is series actually part of the primary key?
+	AccountKeyType      = &AssertionType{"account-key", []string{"account-id", "public-key-id"}, assembleAccountKey}
+	DeviceSerialType    = &AssertionType{"device-serial", []string{"brand-id", "model", "serial"}, assembleDeviceSerial}
+	IdentityType        = &AssertionType{"identity", []string{"account-id"}, assembleIdentity}
 	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
 	SnapBuildType       = &AssertionType{"snap-build", []string{"series", "snap-id", "snap-digest"}, assembleSnapBuild}

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -46,9 +46,9 @@ func (mods *modelSuite) SetUpSuite(c *C) {
 
 const modelExample = "type: model\n" +
 	"authority-id: brand-id1\n" +
+	"series: 16\n" +
 	"brand-id: brand-id1\n" +
 	"model: baz-3000\n" +
-	"series: 16\n" +
 	"os: core\n" +
 	"architecture: amd64\n" +
 	"gadget: brand-gadget\n" +
@@ -70,9 +70,9 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	model := a.(*asserts.Model)
 	c.Check(model.AuthorityID(), Equals, "brand-id1")
 	c.Check(model.Timestamp(), Equals, mods.ts)
+	c.Check(model.Series(), Equals, "16")
 	c.Check(model.BrandID(), Equals, "brand-id1")
 	c.Check(model.Model(), Equals, "baz-3000")
-	c.Check(model.Series(), Equals, "16")
 	c.Check(model.Class(), Equals, "fixed")
 	c.Check(model.OS(), Equals, "core")
 	c.Check(model.Architecture(), Equals, "amd64")
@@ -90,7 +90,7 @@ const (
 func (mods *modelSuite) TestDecodeInvalidMandatory(c *C) {
 	encoded := strings.Replace(modelExample, "TSLINE", mods.tsLine, 1)
 
-	mandatoryHeaders := []string{"brand-id", "model", "series", "os", "architecture", "gadget", "kernel", "store", "allowed-modes", "required-snaps", "class", "timestamp"}
+	mandatoryHeaders := []string{"series", "brand-id", "model", "os", "architecture", "gadget", "kernel", "store", "allowed-modes", "required-snaps", "class", "timestamp"}
 
 	for _, mandatory := range mandatoryHeaders {
 		invalid := strings.Replace(encoded, mandatory+":", "xyz:", 1)

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -165,6 +165,11 @@ type SnapRevision struct {
 	timestamp    time.Time
 }
 
+// Series returns the series of the snap submitted to the store.
+func (snaprev *SnapRevision) Series() string {
+	return snaprev.Header("series")
+}
+
 // SnapID returns the snap id of the snap.
 func (snaprev *SnapRevision) SnapID() string {
 	return snaprev.Header("snap-id")

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -165,7 +165,8 @@ type SnapRevision struct {
 	timestamp    time.Time
 }
 
-// Series returns the series of the snap submitted to the store.
+// Series returns the series of the snap submitted to and acknowledged by the
+// store.
 func (snaprev *SnapRevision) Series() string {
 	return snaprev.Header("series")
 }
@@ -175,8 +176,8 @@ func (snaprev *SnapRevision) SnapID() string {
 	return snaprev.Header("snap-id")
 }
 
-// SnapDigest returns the digest of the snap submitted to the store. The digest
-// is prefixed with the algorithm used to generate it.
+// SnapDigest returns the digest of the snap submitted to and acknowledged by
+// the store. The digest is prefixed with the algorithm used to generate it.
 func (snaprev *SnapRevision) SnapDigest() string {
 	return snaprev.Header("snap-digest")
 }

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -100,6 +100,11 @@ type SnapBuild struct {
 	timestamp time.Time
 }
 
+// Series returns the series for which the snap was built.
+func (snapbld *SnapBuild) Series() string {
+	return snapbld.Header("series")
+}
+
 // SnapID returns the snap id of the snap.
 func (snapbld *SnapBuild) SnapID() string {
 	return snapbld.Header("snap-id")

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -118,6 +118,7 @@ func (sbs *snapBuildSuite) SetUpSuite(c *C) {
 func (sbs *snapBuildSuite) TestDecodeOK(c *C) {
 	encoded := "type: snap-build\n" +
 		"authority-id: dev-id1\n" +
+		"series: 16\n" +
 		"snap-id: snap-id-1\n" +
 		"snap-digest: sha256 ...\n" +
 		"grade: stable\n" +
@@ -132,6 +133,7 @@ func (sbs *snapBuildSuite) TestDecodeOK(c *C) {
 	snapBuild := a.(*asserts.SnapBuild)
 	c.Check(snapBuild.AuthorityID(), Equals, "dev-id1")
 	c.Check(snapBuild.Timestamp(), Equals, sbs.ts)
+	c.Check(snapBuild.Series(), Equals, "16")
 	c.Check(snapBuild.SnapID(), Equals, "snap-id-1")
 	c.Check(snapBuild.SnapDigest(), Equals, "sha256 ...")
 	c.Check(snapBuild.SnapSize(), Equals, uint64(10000))
@@ -145,6 +147,7 @@ const (
 func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 	encoded := "type: snap-build\n" +
 		"authority-id: dev-id1\n" +
+		"series: 16\n" +
 		"snap-id: snap-id-1\n" +
 		"snap-digest: sha256 ...\n" +
 		"grade: stable\n" +
@@ -155,6 +158,7 @@ func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 		"openpgp c2ln"
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"series: 16\n", "", `"series" header is mandatory`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
 		{"grade: stable\n", "", `"grade" header is mandatory`},
@@ -224,6 +228,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheck(c *C) {
 
 	headers := map[string]string{
 		"authority-id": "dev-id1",
+		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-digest":  "sha256 ...",
 		"grade":        "devel",
@@ -242,6 +247,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 
 	headers := map[string]string{
 		"authority-id": "dev-id1",
+		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-digest":  "sha256 ...",
 		"grade":        "devel",

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -275,6 +275,7 @@ func (srs *snapRevSuite) SetUpSuite(c *C) {
 func (srs *snapRevSuite) makeValidEncoded() string {
 	return "type: snap-revision\n" +
 		"authority-id: store-id1\n" +
+		"series: 16\n" +
 		"snap-id: snap-id-1\n" +
 		"snap-digest: sha256 ...\n" +
 		"snap-revision: 1\n" +
@@ -290,6 +291,7 @@ func (srs *snapRevSuite) makeValidEncoded() string {
 func (srs *snapRevSuite) makeHeaders(overrides map[string]string) map[string]string {
 	headers := map[string]string{
 		"authority-id":  "store-id1",
+		"series":        "16",
 		"snap-id":       "snap-id-1",
 		"snap-digest":   "sha256 ...",
 		"snap-revision": "1",
@@ -312,6 +314,7 @@ func (srs *snapRevSuite) TestDecodeOK(c *C) {
 	snapRev := a.(*asserts.SnapRevision)
 	c.Check(snapRev.AuthorityID(), Equals, "store-id1")
 	c.Check(snapRev.Timestamp(), Equals, srs.ts)
+	c.Check(snapRev.Series(), Equals, "16")
 	c.Check(snapRev.SnapID(), Equals, "snap-id-1")
 	c.Check(snapRev.SnapDigest(), Equals, "sha256 ...")
 	c.Check(snapRev.SnapRevision(), Equals, uint64(1))
@@ -327,6 +330,7 @@ const (
 func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 	encoded := srs.makeValidEncoded()
 	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"series: 16\n", "", `"series" header is mandatory`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
 		{"snap-revision: 1\n", "", `"snap-revision" header is mandatory`},
@@ -378,6 +382,7 @@ func (srs *snapRevSuite) TestPrimaryKey(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = db.Find(asserts.SnapRevisionType, map[string]string{
+		"series":      "16",
 		"snap-id":     headers["snap-id"],
 		"snap-digest": headers["snap-digest"],
 	})

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -91,6 +91,7 @@ func (cs *clientSuite) TestClientAsserts(c *C) {
 	cs.header.Add("X-Ubuntu-Assertions-Count", "2")
 	cs.rsp = `type: snap-revision
 authority-id: store-id1
+series: 16
 snap-id: snap-id-1
 snap-digest: sha256 ...
 snap-revision: 1
@@ -104,6 +105,7 @@ openpgp ...
 
 type: snap-revision
 authority-id: store-id1
+series: 16
 snap-id: snap-id-2
 snap-digest: sha256 ...
 snap-revision: 1


### PR DESCRIPTION
Various changes to primary keys, all related to `series`:

* move series to to start of model's pk
* add series to start of snap-build's pk
* add series to start of snap-revision's pk