### PR TITLE
asserts: remove account-id check during assembly (it's a pk so already checked)

### DIFF
--- a/asserts/identity.go
+++ b/asserts/identity.go
@@ -54,12 +54,7 @@ func (id *Identity) Timestamp() time.Time {
 }
 
 func assembleIdentity(assert assertionBase) (Assertion, error) {
-	_, err := checkMandatory(assert.headers, "account-id")
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = checkMandatory(assert.headers, "display-name")
+	_, err := checkMandatory(assert.headers, "display-name")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Small clean-up to remove unnecessary mandatory check. `account-id` is part of the primary key and PK headers are checked before assembly, so there's no need to check again. (No other assembly functions check PK headers.)