### PR TITLE
asserts: add snap-size and remove snap-build from snap-revision

### DIFF
--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -156,6 +156,7 @@ func assembleSnapBuild(assert assertionBase) (Assertion, error) {
 // revision.
 type SnapRevision struct {
 	assertionBase
+	snapSize     uint64
 	snapRevision uint64
 	timestamp    time.Time
 }
@@ -171,14 +172,14 @@ func (snaprev *SnapRevision) SnapDigest() string {
 	return snaprev.Header("snap-digest")
 }
 
+// SnapSize returns the size in bytes of the snap submitted to the store.
+func (snaprev *SnapRevision) SnapSize() uint64 {
+	return snaprev.snapSize
+}
+
 // SnapRevision returns the revision of the snap-id assigned to this build.
 func (snaprev *SnapRevision) SnapRevision() uint64 {
 	return snaprev.snapRevision
-}
-
-// SnapBuild returns the digest of the associated snap-build.
-func (snaprev *SnapRevision) SnapBuild() string {
-	return snaprev.Header("snap-build")
 }
 
 // DeveloperID returns the id of the developer that submitted the snap build to
@@ -206,12 +207,12 @@ var _ consistencyChecker = (*SnapRevision)(nil)
 func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 	// TODO: more parsing/checking of snap-digest
 
-	snapRevision, err := checkUint(assert.headers, "snap-revision", 64)
+	snapSize, err := checkUint(assert.headers, "snap-size", 64)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = checkMandatory(assert.headers, "snap-build")
+	snapRevision, err := checkUint(assert.headers, "snap-revision", 64)
 	if err != nil {
 		return nil, err
 	}
@@ -228,6 +229,7 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 
 	return &SnapRevision{
 		assertionBase: assert,
+		snapSize:      snapSize,
 		snapRevision:  snapRevision,
 		timestamp:     timestamp,
 	}, nil

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -193,6 +193,14 @@ func (snaprev *SnapRevision) Timestamp() time.Time {
 	return snaprev.timestamp
 }
 
+// Implement further consistency checks.
+func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) error {
+	return nil
+}
+
+// sanity
+var _ consistencyChecker = (*SnapRevision)(nil)
+
 func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 	// TODO: more parsing/checking of snap-digest
 

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -152,8 +152,8 @@ func assembleSnapBuild(assert assertionBase) (Assertion, error) {
 }
 
 // SnapRevision holds a snap-revision assertion, which is a statement by the
-// store acknowledging the receipt of a snap build and labeling it with a snap
-// revision.
+// store acknowledging the receipt of a build of snap-id and labeling it with a
+// snap revision.
 type SnapRevision struct {
 	assertionBase
 	snapSize     uint64
@@ -177,13 +177,13 @@ func (snaprev *SnapRevision) SnapSize() uint64 {
 	return snaprev.snapSize
 }
 
-// SnapRevision returns the revision of the snap-id assigned to this build.
+// SnapRevision returns the revision assigned to this build of snap-id.
 func (snaprev *SnapRevision) SnapRevision() uint64 {
 	return snaprev.snapRevision
 }
 
-// DeveloperID returns the id of the developer that submitted the snap build to
-// the store.
+// DeveloperID returns the id of the developer that submitted this build of
+// snap-id.
 func (snaprev *SnapRevision) DeveloperID() string {
 	return snaprev.Header("developer-id")
 }

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -193,17 +193,6 @@ func (snaprev *SnapRevision) Timestamp() time.Time {
 	return snaprev.timestamp
 }
 
-// Implement further consistency checks.
-func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) error {
-	// TODO: check the associated snap-build exists.
-	// TODO: check the associated snap-build's digest.
-	// TODO: check developer-id matches snap-build's authority-id.
-	return nil
-}
-
-// sanity
-var _ consistencyChecker = (*SnapRevision)(nil)
-
 func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 	// TODO: more parsing/checking of snap-digest
 

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -152,7 +152,7 @@ func assembleSnapBuild(assert assertionBase) (Assertion, error) {
 }
 
 // SnapRevision holds a snap-revision assertion, which is a statement by the
-// store acknowledging the receipt of a build of snap-id and labeling it with a
+// store acknowledging the receipt of a build of a snap and labeling it with a
 // snap revision.
 type SnapRevision struct {
 	assertionBase
@@ -177,13 +177,13 @@ func (snaprev *SnapRevision) SnapSize() uint64 {
 	return snaprev.snapSize
 }
 
-// SnapRevision returns the revision assigned to this build of snap-id.
+// SnapRevision returns the revision assigned to this build of the snap.
 func (snaprev *SnapRevision) SnapRevision() uint64 {
 	return snaprev.snapRevision
 }
 
-// DeveloperID returns the id of the developer that submitted this build of
-// snap-id.
+// DeveloperID returns the id of the developer that submitted this build of the
+// snap.
 func (snaprev *SnapRevision) DeveloperID() string {
 	return snaprev.Header("developer-id")
 }

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -271,8 +271,8 @@ func (srs *snapRevSuite) makeValidEncoded() string {
 		"authority-id: store-id1\n" +
 		"snap-id: snap-id-1\n" +
 		"snap-digest: sha256 ...\n" +
+		"snap-size: 123\n" +
 		"snap-revision: 1\n" +
-		"snap-build: sha256 ...\n" +
 		"developer-id: dev-id1\n" +
 		"revision: 1\n" +
 		srs.tsLine +
@@ -286,8 +286,8 @@ func (srs *snapRevSuite) makeHeaders(overrides map[string]string) map[string]str
 		"authority-id":  "store-id1",
 		"snap-id":       "snap-id-1",
 		"snap-digest":   "sha256 ...",
+		"snap-size":     "123",
 		"snap-revision": "1",
-		"snap-build":    "sha256 ...",
 		"developer-id":  "dev-id1",
 		"revision":      "1",
 		"timestamp":     "2015-11-25T20:00:00Z",
@@ -308,8 +308,8 @@ func (srs *snapRevSuite) TestDecodeOK(c *C) {
 	c.Check(snapRev.Timestamp(), Equals, srs.ts)
 	c.Check(snapRev.SnapID(), Equals, "snap-id-1")
 	c.Check(snapRev.SnapDigest(), Equals, "sha256 ...")
+	c.Check(snapRev.SnapSize(), Equals, uint64(123))
 	c.Check(snapRev.SnapRevision(), Equals, uint64(1))
-	c.Check(snapRev.SnapBuild(), Equals, "sha256 ...")
 	c.Check(snapRev.DeveloperID(), Equals, "dev-id1")
 	c.Check(snapRev.Revision(), Equals, 1)
 }
@@ -323,10 +323,12 @@ func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
+		{"snap-size: 123\n", "", `"snap-size" header is mandatory`},
+		{"snap-size: 123\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},
+		{"snap-size: 123\n", "snap-size: zzz\n", `"snap-size" header is not an unsigned integer: zzz`},
 		{"snap-revision: 1\n", "", `"snap-revision" header is mandatory`},
 		{"snap-revision: 1\n", "snap-revision: -1\n", `"snap-revision" header is not an unsigned integer: -1`},
 		{"snap-revision: 1\n", "snap-revision: zzz\n", `"snap-revision" header is not an unsigned integer: zzz`},
-		{"snap-build: sha256 ...\n", "", `"snap-build" header is mandatory`},
 		{"developer-id: dev-id1\n", "", `"developer-id" header is mandatory`},
 		{srs.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -93,8 +93,8 @@ func (cs *clientSuite) TestClientAsserts(c *C) {
 authority-id: store-id1
 snap-id: snap-id-1
 snap-digest: sha256 ...
+snap-size: 123
 snap-revision: 1
-snap-build: sha256 ...
 developer-id: dev-id1
 revision: 1
 timestamp: 2015-11-25T20:00:00Z
@@ -106,8 +106,8 @@ type: snap-revision
 authority-id: store-id1
 snap-id: snap-id-2
 snap-digest: sha256 ...
+snap-size: 456
 snap-revision: 1
-snap-build: sha256 ...
 developer-id: dev-id1
 revision: 1
 timestamp: 2015-11-30T20:00:00Z


### PR DESCRIPTION
iirc, the snap-revision assertion was original tightly bound to the snap-build assertion by a combination of the snap-revision's header fields, one of which was called snap-build (really the digest of that assertion).

snap-revision's primary key was changed some time ago to uncouple it from the snap-build assertion. At that time, snap-revision's snap-build header became redundant and, more importantly, incorrect.

snap-size was added to snap-revision to give the assertion the same level of proof for the snap as snap-build has.