### PR TITLE
overlord/state: improve TaskRunner dealing with status and errors, pass tombs to goroutines

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -24,6 +24,8 @@ package ifacestate
 import (
 	"fmt"
 
+	"gopkg.in/tomb.v2"
+
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/builtin"
@@ -79,7 +81,7 @@ func (m *InterfaceManager) Init(s *state.State) error {
 	return nil
 }
 
-func (m *InterfaceManager) doConnect(task *state.Task) error {
+func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 	task.State().Lock()
 	defer task.State().Unlock()
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -23,6 +23,8 @@ package snapstate
 import (
 	"fmt"
 
+	"gopkg.in/tomb.v2"
+
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/progress"
@@ -76,7 +78,7 @@ func Manager() (*SnapManager, error) {
 	return &SnapManager{}, nil
 }
 
-func (m *SnapManager) doInstallSnap(t *state.Task) error {
+func (m *SnapManager) doInstallSnap(t *state.Task, _ *tomb.Tomb) error {
 	var name, channel string
 	t.State().Lock()
 	if err := t.Get("name", &name); err != nil {
@@ -90,7 +92,7 @@ func (m *SnapManager) doInstallSnap(t *state.Task) error {
 	return err
 }
 
-func (m *SnapManager) doRemoveSnap(t *state.Task) error {
+func (m *SnapManager) doRemoveSnap(t *state.Task, _ *tomb.Tomb) error {
 	var name string
 	t.State().Lock()
 	if err := t.Get("name", &name); err != nil {

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -78,6 +78,7 @@ func (r *TaskRunner) run(fn HandlerFunc, task *Task) {
 		} else {
 			task.SetStatus(ErrorStatus)
 		}
+		// TODO: trigger ensure if we have halted
 
 		return err
 	})
@@ -118,7 +119,7 @@ func (r *TaskRunner) Ensure() {
 		tasks := chg.Tasks()
 		for _, t := range tasks {
 			// done or error are final, nothing to do
-			// TODO: actually for error progate to change and siblings
+			// TODO: actually for error progate to halted and their waited
 			status := t.Status()
 			if status == DoneStatus || status == ErrorStatus {
 				continue

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -115,8 +115,10 @@ func (r *TaskRunner) Ensure() {
 
 		tasks := chg.Tasks()
 		for _, t := range tasks {
-			// done, nothing to do
-			if t.Status() == DoneStatus {
+			// done or error are final, nothing to do
+			// TODO: actually for error progate to change and siblings
+			status := t.Status()
+			if status == DoneStatus || status == ErrorStatus {
 				continue
 			}
 

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -65,6 +65,7 @@ func (r *TaskRunner) Handlers() map[string]HandlerFunc {
 
 // run must be called with the state lock in place
 func (r *TaskRunner) run(fn HandlerFunc, task *Task) {
+	task.SetStatus(RunningStatus) // could have been set to waiting
 	r.tombs[task.ID()] = &tomb.Tomb{}
 	r.tombs[task.ID()].Go(func() error {
 		err := fn(task)

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -145,6 +145,7 @@ func (ts *taskRunnerSuite) TestErrorIsFinal(c *C) {
 	// ensure just kicks the go routine off
 	r.Ensure()
 	r.Wait()
+	// won't be restarted
 	r.Ensure()
 	r.Wait()
 

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -50,6 +50,9 @@ func (ts *taskRunnerSuite) TestEnsureTrivial(c *C) {
 	taskCompleted := sync.WaitGroup{}
 	r := state.NewTaskRunner(st)
 	fn := func(task *state.Task) error {
+		task.State().Lock()
+		defer task.State().Unlock()
+		c.Check(task.Status(), Equals, state.RunningStatus)
 		taskCompleted.Done()
 		return nil
 	}
@@ -78,6 +81,9 @@ func (ts *taskRunnerSuite) TestEnsureComplex(c *C) {
 
 	var ordering []string
 	fn := func(task *state.Task) error {
+		task.State().Lock()
+		defer task.State().Unlock()
+		c.Check(task.Status(), Equals, state.RunningStatus)
 		ordering = append(ordering, task.Kind())
 		return nil
 	}

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -21,7 +21,6 @@ package state_test
 
 import (
 	"sync"
-	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -62,6 +61,8 @@ func (ts *taskRunnerSuite) TestEnsureTrivial(c *C) {
 	taskCompleted.Add(1)
 	st.Unlock()
 
+	defer r.Stop()
+
 	// ensure just kicks the go routine off
 	r.Ensure()
 	taskCompleted.Wait()
@@ -83,6 +84,8 @@ func (ts *taskRunnerSuite) TestEnsureComplex(c *C) {
 	r.AddHandler("unpack", fn)
 	r.AddHandler("configure", fn)
 
+	defer r.Stop()
+
 	// run in a loop to ensure ordering is correct by pure chance
 	for i := 0; i < 100; i++ {
 		ordering = []string{}
@@ -98,10 +101,9 @@ func (ts *taskRunnerSuite) TestEnsureComplex(c *C) {
 		tConf.WaitFor(tUnp)
 		st.Unlock()
 
-		// ensure just kicks the go routine off
 		for len(ordering) < 3 {
 			r.Ensure()
-			time.Sleep(1 * time.Millisecond)
+			r.Wait()
 		}
 
 		c.Assert(ordering, DeepEquals, []string{"download", "unpack", "configure"})


### PR DESCRIPTION
This improves the situation around error handling and status setting in the taskrunner. Adds some related tests. Also starts passing tombs to started goroutines to support cancellation.