### PR TITLE
overlord/state: implement State.Tasks() and Task.HaltTasks()

### DIFF
--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -238,6 +238,16 @@ func (s *State) Changes() []*Change {
 	return res
 }
 
+// Tasks returns all tasks currently known to the state.
+func (s *State) Tasks() []*Task {
+	s.ensureLocked()
+	res := make([]*Task, 0, len(s.tasks))
+	for _, t := range s.tasks {
+		res = append(res, t)
+	}
+	return res
+}
+
 // ReadState returns the state deserialized from r.
 func ReadState(backend Backend, r io.Reader) (*State, error) {
 	s := new(State)

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -373,6 +373,8 @@ func (ss *stateSuite) TestNewTaskAndCheckpoint(c *C) {
 
 	task0_2 := tasks0[t2ID]
 	c.Check(task0_2.WaitTasks(), DeepEquals, []*state.Task{task0_1})
+
+	c.Check(task0_1.HaltTasks(), DeepEquals, []*state.Task{task0_2})
 }
 
 func (ss *stateSuite) TestEnsureBefore(c *C) {

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -397,6 +397,7 @@ func (ss *stateSuite) TestTasks(c *C) {
 	chg2 := st.NewChange("remove", "...")
 	t21 := chg2.NewTask("check", "...")
 	t22 := chg2.NewTask("rm", "...")
+	// TODO: chg1.AddTask(t22) when we have AddTask
 
 	tasks := st.Tasks()
 	c.Check(tasks, HasLen, 4)

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -201,7 +201,7 @@ func (t *Task) WaitTasks() []*Task {
 	return t.waitTasks.tasks(t.state)
 }
 
-// HaltTasks returns the list of tasks halted waiting for t.
+// HaltTasks returns the list of tasks registered to wait for t.
 func (t *Task) HaltTasks() []*Task {
 	t.state.ensureLocked()
 	return t.haltTasks.tasks(t.state)

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -43,6 +43,7 @@ type Task struct {
 	progress  progress
 	data      customData
 	waitTasks taskIDsSet
+	haltTasks taskIDsSet
 }
 
 func newTask(state *State, id, kind, summary string) *Task {
@@ -53,6 +54,7 @@ func newTask(state *State, id, kind, summary string) *Task {
 		summary:   summary,
 		data:      make(customData),
 		waitTasks: make(taskIDsSet),
+		haltTasks: make(taskIDsSet),
 	}
 }
 
@@ -64,6 +66,7 @@ type marshalledTask struct {
 	Progress  progress                    `json:"progress"`
 	Data      map[string]*json.RawMessage `json:"data"`
 	WaitTasks taskIDsSet                  `json:"wait-tasks"`
+	HaltTasks taskIDsSet                  `json:"halt-tasks"`
 }
 
 // MarshalJSON makes Task a json.Marshaller
@@ -77,6 +80,7 @@ func (t *Task) MarshalJSON() ([]byte, error) {
 		Progress:  t.progress,
 		Data:      t.data,
 		WaitTasks: t.waitTasks,
+		HaltTasks: t.haltTasks,
 	})
 }
 
@@ -97,6 +101,7 @@ func (t *Task) UnmarshalJSON(data []byte) error {
 	t.progress = unmarshalled.Progress
 	t.data = unmarshalled.Data
 	t.waitTasks = unmarshalled.WaitTasks
+	t.haltTasks = unmarshalled.HaltTasks
 	return nil
 }
 
@@ -187,10 +192,17 @@ func (t *Task) WaitFor(another *Task) {
 	t.state.ensureLocked()
 	t.status = WaitingStatus
 	t.waitTasks.add(another.ID())
+	another.haltTasks.add(t.id)
 }
 
 // WaitTasks returns the list of tasks registered for t to wait for.
 func (t *Task) WaitTasks() []*Task {
 	t.state.ensureLocked()
 	return t.waitTasks.tasks(t.state)
+}
+
+// HaltTasks returns the list of tasks halted waiting for t.
+func (t *Task) HaltTasks() []*Task {
+	t.state.ensureLocked()
+	return t.haltTasks.tasks(t.state)
 }

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -225,6 +225,8 @@ func (ts *taskSuite) TestTaskWaitFor(c *C) {
 
 	c.Assert(t2.WaitTasks(), DeepEquals, []*state.Task{t1})
 	c.Assert(t2.Status(), Equals, state.WaitingStatus)
+
+	c.Assert(t1.HaltTasks(), DeepEquals, []*state.Task{t2})
 }
 
 func (cs *taskSuite) TestWaitForNeedsLocked(c *C) {
@@ -246,4 +248,14 @@ func (cs *taskSuite) TestWaitTasksNeedsLocked(c *C) {
 	st.Unlock()
 
 	c.Assert(func() { t.WaitTasks() }, PanicMatches, "internal error: accessing state without lock")
+}
+
+func (cs *taskSuite) TestHaltTasksNeedsLocked(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install", "...")
+	t := chg.NewTask("download", "1...")
+	st.Unlock()
+
+	c.Assert(func() { t.HaltTasks() }, PanicMatches, "internal error: accessing state without lock")
 }


### PR DESCRIPTION
This implements State.Tasks() returning all known tasks and Task.HaltTasks() returning the tasks registered to wait on the receiver (symmetric to WaitTasks).