### PR TITLE
interfaces: add snap.yaml processing function

### DIFF
--- a/interfaces/yaml.go
+++ b/interfaces/yaml.go
@@ -1,0 +1,175 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type snapYaml struct {
+	Name     string                 `yaml:"name"`
+	RawPlugs map[string]interface{} `yaml:"plugs,omitempty"`
+	RawSlots map[string]interface{} `yaml:"slots,omitempty"`
+	RawApps  map[string]appYaml     `yaml:"apps,omitempty"`
+}
+
+type appYaml struct {
+	SlotNames []string `yaml:"slots,omitempty"`
+	PlugNames []string `yaml:"plugs,omitempty"`
+}
+
+// PlugsAndSlotsFromYaml parses the parts of snap.yaml relevant to interfaces
+// and returns plugs and slots found.
+func PlugsAndSlotsFromYaml(in []byte) ([]Plug, []Slot, error) {
+	var y snapYaml
+	if err := yaml.Unmarshal(in, &y); err != nil {
+		return nil, nil, err
+	}
+	// Collect top-level definitions of plugs
+	plugMap := make(map[string]*Plug)
+	for plugName, plugData := range y.RawPlugs {
+		iface, attrs, err := convertToSlotOrPlugData("plug", plugName, plugData)
+		if err != nil {
+			return nil, nil, err
+		}
+		plugMap[plugName] = &Plug{
+			Snap:      y.Name,
+			Name:      plugName,
+			Interface: iface,
+			Attrs:     attrs,
+		}
+	}
+	// Collect top-level definitions of slots
+	slotMap := make(map[string]*Slot)
+	for slotName, slotData := range y.RawSlots {
+		iface, attrs, err := convertToSlotOrPlugData("slot", slotName, slotData)
+		if err != nil {
+			return nil, nil, err
+		}
+		slotMap[slotName] = &Slot{
+			Snap:      y.Name,
+			Name:      slotName,
+			Interface: iface,
+			Attrs:     attrs,
+		}
+	}
+	// Collect app-level implicit definitions of plugs and slots
+	for _, app := range y.RawApps {
+		for _, plugName := range app.PlugNames {
+			if _, ok := plugMap[plugName]; !ok {
+				plugMap[plugName] = &Plug{
+					Snap:      y.Name,
+					Name:      plugName,
+					Interface: plugName,
+				}
+			}
+		}
+		for _, slotName := range app.SlotNames {
+			if _, ok := slotMap[slotName]; !ok {
+				slotMap[slotName] = &Slot{
+					Snap:      y.Name,
+					Name:      slotName,
+					Interface: slotName,
+				}
+			}
+		}
+	}
+	// Bind apps to plugs and slots
+	for appName, app := range y.RawApps {
+		for _, slotName := range app.SlotNames {
+			slot := slotMap[slotName]
+			slot.Apps = append(slot.Apps, appName)
+		}
+		for _, plugName := range app.PlugNames {
+			plug := plugMap[plugName]
+			plug.Apps = append(plug.Apps, appName)
+		}
+	}
+	// Bind unbound plugs and slots to all apps
+	for _, plug := range plugMap {
+		if len(plug.Apps) == 0 {
+			for appName := range y.RawApps {
+				plug.Apps = append(plug.Apps, appName)
+			}
+		}
+	}
+	for _, slot := range slotMap {
+		if len(slot.Apps) == 0 {
+			for appName := range y.RawApps {
+				slot.Apps = append(slot.Apps, appName)
+			}
+		}
+	}
+	// Flatten maps and return
+	var slots []Slot
+	for _, slot := range slotMap {
+		slots = append(slots, *slot)
+	}
+	var plugs []Plug
+	for _, plug := range plugMap {
+		plugs = append(plugs, *plug)
+	}
+	return plugs, slots, nil
+}
+
+func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (string, map[string]interface{}, error) {
+	switch data.(type) {
+	case map[interface{}]interface{}:
+		attrs := make(map[string]interface{})
+		iface := ""
+		for keyData, valueData := range data.(map[interface{}]interface{}) {
+			key, ok := keyData.(string)
+			if !ok {
+				return "", nil, fmt.Errorf("%s %q has attribute that is not a string (found %T)",
+					plugOrSlot, name, keyData)
+			}
+			if strings.HasPrefix(key, "$") {
+				return "", nil, fmt.Errorf("%s %q uses reserved attribute %q", plugOrSlot, name, key)
+			}
+			// XXX: perhaps we could special-case "label" the same way?
+			if key == "interface" {
+				value, ok := valueData.(string)
+				if !ok {
+					return "", nil, fmt.Errorf("interface name on %s %q is not a string (found %T)",
+						plugOrSlot, name, valueData)
+				}
+				iface = value
+			} else {
+				attrs[key] = valueData
+			}
+		}
+		if len(attrs) == 0 {
+			attrs = nil
+		}
+		if iface == "" {
+			return "", nil, fmt.Errorf("%s %q doesn't define interface name", plugOrSlot, name)
+		}
+		return iface, attrs, nil
+	case string:
+		return data.(string), nil, nil
+	case nil:
+		return name, nil, nil
+	default:
+		return "", nil, fmt.Errorf("%s %q has malformed definition (found %T)", plugOrSlot, name, data)
+	}
+}

--- a/interfaces/yaml_test.go
+++ b/interfaces/yaml_test.go
@@ -1,0 +1,482 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/interfaces"
+)
+
+type YamlSuite struct{}
+
+var _ = Suite(&YamlSuite{})
+
+func (s *YamlSuite) TestUnmarshalGarbage(c *C) {
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`"`))
+	c.Assert(err, ErrorMatches, "yaml: found unexpected end of stream")
+}
+
+func (s *YamlSuite) TestUnmarshalEmpty(c *C) {
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(``))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, HasLen, 0)
+	c.Assert(slots, HasLen, 0)
+}
+
+// Tests focusing on plugs
+
+func (s *YamlSuite) TestUnmarshalStandaloneImplicitPlug(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    network-client:
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, DeepEquals, []interfaces.Plug{
+		{
+			Snap:      "snap",
+			Name:      "network-client",
+			Interface: "network-client",
+		},
+	})
+	c.Assert(slots, HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneAbbreviatedPlug(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net: network-client
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, DeepEquals, []interfaces.Plug{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+		},
+	})
+	c.Assert(slots, HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneMinimalisticPlug(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net:
+        interface: network-client
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, DeepEquals, []interfaces.Plug{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+		},
+	})
+	c.Assert(slots, HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneCompletePlug(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net:
+        interface: network-client
+        ipv6-aware: true
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, DeepEquals, []interfaces.Plug{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+			Attrs:     map[string]interface{}{"ipv6-aware": true},
+		},
+	})
+	c.Assert(slots, HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalLastPlugDefinitionWins(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net:
+        interface: network-client
+        attr: 1
+    net:
+        interface: network-client
+        attr: 2
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, DeepEquals, []interfaces.Plug{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+			Attrs:     map[string]interface{}{"attr": 2},
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalPlugsExplicitlyDefinedImplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    network-client:
+apps:
+    app:
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, DeepEquals, []interfaces.Plug{
+		{
+			Snap:      "snap",
+			Name:      "network-client",
+			Interface: "network-client",
+			Apps:      []string{"app"},
+		},
+	})
+	c.Assert(slots, HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalPlugsExplicitlyDefinedExplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net: network-client
+apps:
+    app:
+        plugs: ["net"]
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, DeepEquals, []interfaces.Plug{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+			Apps:      []string{"app"},
+		},
+	})
+	c.Assert(slots, HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalPlugsImplicitlyDefinedExplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+apps:
+    app:
+        plugs: ["network-client"]
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, DeepEquals, []interfaces.Plug{
+		{
+			Snap:      "snap",
+			Name:      "network-client",
+			Interface: "network-client",
+			Apps:      []string{"app"},
+		},
+	})
+	c.Assert(slots, HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithoutInterfaceName(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net:
+        ipv6-aware: true
+`))
+	c.Assert(err, ErrorMatches, `plug "net" doesn't define interface name`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithNonStringInterfaceName(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net:
+        interface: 1.0
+        ipv6-aware: true
+`))
+	c.Assert(err, ErrorMatches, `interface name on plug "net" is not a string \(found float64\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithNonStringAttributes(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net:
+        1: ok
+`))
+	c.Assert(err, ErrorMatches, `plug "net" has attribute that is not a string \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithUnexpectedType(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    net: 5
+`))
+	c.Assert(err, ErrorMatches, `plug "net" has malformed definition \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalReservedPlugAttribute(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+plugs:
+    serial:
+        interface: serial-port
+        $baud-rate: [9600]
+`))
+	c.Assert(err, ErrorMatches, `plug "serial" uses reserved attribute "\$baud-rate"`)
+}
+
+// Tests focusing on slots
+
+func (s *YamlSuite) TestUnmarshalStandaloneImplicitSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    network-client:
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, HasLen, 0)
+	c.Assert(slots, DeepEquals, []interfaces.Slot{
+		{
+			Snap:      "snap",
+			Name:      "network-client",
+			Interface: "network-client",
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneAbbreviatedSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net: network-client
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, HasLen, 0)
+	c.Assert(slots, DeepEquals, []interfaces.Slot{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneMinimalisticSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net:
+        interface: network-client
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, HasLen, 0)
+	c.Assert(slots, DeepEquals, []interfaces.Slot{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneCompleteSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net:
+        interface: network-client
+        ipv6-aware: true
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, HasLen, 0)
+	c.Assert(slots, DeepEquals, []interfaces.Slot{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+			Attrs:     map[string]interface{}{"ipv6-aware": true},
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalLastSlotDefinitionWins(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net:
+        interface: network-client
+        attr: 1
+    net:
+        interface: network-client
+        attr: 2
+`))
+	c.Assert(err, IsNil)
+	c.Assert(slots, DeepEquals, []interfaces.Slot{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+			Attrs:     map[string]interface{}{"attr": 2},
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalSlotsExplicitlyDefinedImplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    network-client:
+apps:
+    app:
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, HasLen, 0)
+	c.Assert(slots, DeepEquals, []interfaces.Slot{
+		{
+			Snap:      "snap",
+			Name:      "network-client",
+			Interface: "network-client",
+			Apps:      []string{"app"},
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalSlotsExplicitlyDefinedExplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net: network-client
+apps:
+    app:
+        slots: ["net"]
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, HasLen, 0)
+	c.Assert(slots, DeepEquals, []interfaces.Slot{
+		{
+			Snap:      "snap",
+			Name:      "net",
+			Interface: "network-client",
+			Apps:      []string{"app"},
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalSlotsImplicitlyDefinedExplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	plugs, slots, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+apps:
+    app:
+        slots: ["network-client"]
+`))
+	c.Assert(err, IsNil)
+	c.Assert(plugs, HasLen, 0)
+	c.Assert(slots, DeepEquals, []interfaces.Slot{
+		{
+			Snap:      "snap",
+			Name:      "network-client",
+			Interface: "network-client",
+			Apps:      []string{"app"},
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithoutInterfaceName(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net:
+        ipv6-aware: true
+`))
+	c.Assert(err, ErrorMatches, `slot "net" doesn't define interface name`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringInterfaceName(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net:
+        interface: 1.0
+        ipv6-aware: true
+`))
+	c.Assert(err, ErrorMatches, `interface name on slot "net" is not a string \(found float64\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringAttributes(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net:
+        1: ok
+`))
+	c.Assert(err, ErrorMatches, `slot "net" has attribute that is not a string \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithUnexpectedType(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    net: 5
+`))
+	c.Assert(err, ErrorMatches, `slot "net" has malformed definition \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalReservedSlotAttribute(c *C) {
+	// NOTE: yaml content cannot use tabs, intent the section with spaces.
+	_, _, err := interfaces.PlugsAndSlotsFromYaml([]byte(`
+name: snap
+slots:
+    serial:
+        interface: serial-port
+        $baud-rate: [9600]
+`))
+	c.Assert(err, ErrorMatches, `slot "serial" uses reserved attribute "\$baud-rate"`)
+}


### PR DESCRIPTION
This patch adds a function that converts a snap.yaml into a list of
plugs and slots. The function follows all of the details mentioned in
the specification of interfaces.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>