### PR TITLE
overlord/state: add propagation of ErrorStatus to waiting tasks in taskrunner

### DIFF
--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -88,11 +88,13 @@ func (r *TaskRunner) run(fn HandlerFunc, task *Task) {
 		halted := task.HaltTasks()
 		if err == nil {
 			task.SetStatus(DoneStatus)
+			if len(halted) > 0 {
+				// give a chance to taskrunners Ensure to start
+				// the waiting ones
+				r.state.EnsureBefore(0)
+			}
 		} else {
 			taskFail(task)
-		}
-		if len(halted) > 0 {
-			r.state.EnsureBefore(0)
 		}
 		return err
 	})

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -73,13 +73,15 @@ func (r *TaskRunner) run(fn HandlerFunc, task *Task) {
 
 		r.state.Lock()
 		defer r.state.Unlock()
+		halted := task.HaltTasks()
 		if err == nil {
 			task.SetStatus(DoneStatus)
 		} else {
 			task.SetStatus(ErrorStatus)
 		}
-		// TODO: trigger ensure if we have halted
-
+		if len(halted) > 0 {
+			r.state.EnsureBefore(0)
+		}
 		return err
 	})
 }

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -64,9 +64,9 @@ func (r *TaskRunner) Handlers() map[string]HandlerFunc {
 }
 
 // taskFail marks task t and all tasks waiting (directly and indirectly on it) as in ErrorStatus.
-func taskFail(t *Task) {
-	t.SetStatus(ErrorStatus)
-	mark := append([]*Task(nil), t.HaltTasks()...)
+func taskFail(task *Task) {
+	task.SetStatus(ErrorStatus)
+	mark := append([]*Task(nil), task.HaltTasks()...)
 	i := 0
 	for i < len(mark) {
 		t := mark[i]

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -65,12 +65,15 @@ func (r *TaskRunner) Handlers() map[string]HandlerFunc {
 
 // taskFail marks task t and all tasks waiting (directly and indirectly on it) as in ErrorStatus.
 func taskFail(t *Task) {
-	mark := make([]*Task, 1, 10)
-	mark[0] = t
+	t.SetStatus(ErrorStatus)
+	mark := append([]*Task(nil), t.HaltTasks()...)
 	i := 0
 	for i < len(mark) {
-		mark[i].SetStatus(ErrorStatus)
-		mark = append(mark, mark[i].HaltTasks()...)
+		t := mark[i]
+		if t.Status() == WaitingStatus {
+			t.SetStatus(ErrorStatus)
+			mark = append(mark, t.HaltTasks()...)
+		}
 		i++
 	}
 }

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -83,9 +83,7 @@ func (b *stateBackend) Checkpoint([]byte) error {
 }
 
 func (b *stateBackend) EnsureBefore(d time.Duration) {
-	go func() {
-		b.runner.Ensure()
-	}()
+	go b.runner.Ensure()
 }
 
 func (ts *taskRunnerSuite) TestEnsureComplex(c *C) {

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -74,22 +74,22 @@ func (ts *taskRunnerSuite) TestEnsureTrivial(c *C) {
 	taskCompleted.Wait()
 }
 
-type backend struct {
+type stateBackend struct {
 	runner *state.TaskRunner
 }
 
-func (b *backend) Checkpoint([]byte) error {
+func (b *stateBackend) Checkpoint([]byte) error {
 	return nil
 }
 
-func (b *backend) EnsureBefore(d time.Duration) {
+func (b *stateBackend) EnsureBefore(d time.Duration) {
 	go func() {
 		b.runner.Ensure()
 	}()
 }
 
 func (ts *taskRunnerSuite) TestEnsureComplex(c *C) {
-	b := &backend{}
+	b := &stateBackend{}
 	// we need state
 	st := state.New(b)
 


### PR DESCRIPTION
Also give a chance to start waiting goroutines automatically when the waited task is done.