### PR TITLE
interfaces: move naming functions to dedicated file

### DIFF
--- a/interfaces/naming.go
+++ b/interfaces/naming.go
@@ -1,0 +1,46 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"fmt"
+)
+
+// WrapperNameForApp returns the name of the wrapper for a given application.
+//
+// A wrapper is a generated helper executable that assists in setting up
+// environment for running a particular application.
+//
+// In general, the wrapper has the form: "$snap.$app". When both snap name and
+// app name are the same then the tag is simplified to just "$snap".
+func WrapperNameForApp(snapName, appName string) string {
+	if appName == snapName {
+		return snapName
+	}
+	return fmt.Sprintf("%s.%s", snapName, appName)
+}
+
+// SecurityTagForApp returns the unified tag used for all security systems.
+//
+// In general, the tag has the form: "$snap.$app.snap". When both snap name and
+// app name are the same then the tag is simplified to just "$snap.snap".
+func SecurityTagForApp(snapName, appName string) string {
+	return fmt.Sprintf("%s.snap", WrapperNameForApp(snapName, appName))
+}

--- a/interfaces/naming_test.go
+++ b/interfaces/naming_test.go
@@ -1,0 +1,44 @@
+// -*- Mote: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	. "github.com/ubuntu-core/snappy/interfaces"
+)
+
+type NamingSuite struct{}
+
+var _ = Suite(&NamingSuite{})
+
+// Tests for WrapperNameForApp()
+
+func (s *NamingSuite) TestWrapperNameForApp(c *C) {
+	c.Assert(WrapperNameForApp("snap", "app"), Equals, "snap.app")
+	c.Assert(WrapperNameForApp("foo", "foo"), Equals, "foo")
+}
+
+// Tests for SecurityTagForApp()
+
+func (s *NamingSuite) TestSecurityTagForApp(c *C) {
+	c.Assert(SecurityTagForApp("snap", "app"), Equals, "snap.app.snap")
+	c.Assert(SecurityTagForApp("foo", "foo"), Equals, "foo.snap")
+}

--- a/interfaces/security.go
+++ b/interfaces/security.go
@@ -25,28 +25,6 @@ import (
 	"strings"
 )
 
-// WrapperNameForApp returns the name of the wrapper for a given application.
-//
-// A wrapper is a generated helper executable that assists in setting up
-// environment for running a particular application.
-//
-// In general, the wrapper has the form: "$snap.$app". When both snap name and
-// app name are the same then the tag is simplified to just "$snap".
-func WrapperNameForApp(snapName, appName string) string {
-	if appName == snapName {
-		return snapName
-	}
-	return fmt.Sprintf("%s.%s", snapName, appName)
-}
-
-// SecurityTagForApp returns the unified tag used for all security systems.
-//
-// In general, the tag has the form: "$snap.$app.snap". When both snap name and
-// app name are the same then the tag is simplified to just "$snap.snap".
-func SecurityTagForApp(snapName, appName string) string {
-	return fmt.Sprintf("%s.snap", WrapperNameForApp(snapName, appName))
-}
-
 // securityHelper is an interface for common aspects of generating security files.
 type securityHelper interface {
 	securitySystem() SecuritySystem

--- a/interfaces/security_test.go
+++ b/interfaces/security_test.go
@@ -78,20 +78,6 @@ func (s *SecuritySuite) prepareFixtureWithInterface(c *C, i Interface) {
 	c.Assert(err, IsNil)
 }
 
-// Tests for WrapperNameForApp()
-
-func (s *SecuritySuite) TestWrapperNameForApp(c *C) {
-	c.Assert(WrapperNameForApp("snap", "app"), Equals, "snap.app")
-	c.Assert(WrapperNameForApp("foo", "foo"), Equals, "foo")
-}
-
-// Tests for SecurityTagForApp()
-
-func (s *SecuritySuite) TestSecurityTagForApp(c *C) {
-	c.Assert(SecurityTagForApp("snap", "app"), Equals, "snap.app.snap")
-	c.Assert(SecurityTagForApp("foo", "foo"), Equals, "foo.snap")
-}
-
 // Tests for appArmor
 
 func (s *SecuritySuite) TestAppArmorPlugPermissions(c *C) {


### PR DESCRIPTION
This patch moves functions related to naming things to a dedicated file
in anticipation of unification and simplification of the agreement with
the security team.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>