### PR TITLE
overlord: simplify StateEngine and make it goroutine safe, no more Init in StateManager 

### DIFF
--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -32,13 +32,8 @@ import (
 type AssertManager struct{}
 
 // Manager returns a new assertion manager.
-func Manager() (*AssertManager, error) {
+func Manager(s *state.State) (*AssertManager, error) {
 	return &AssertManager{}, nil
-}
-
-// Init implements StateManager.Init.
-func (m *AssertManager) Init(s *state.State) error {
-	return nil
 }
 
 // Ensure implements StateManager.Ensure.

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -42,8 +42,23 @@ type InterfaceManager struct {
 }
 
 // Manager returns a new InterfaceManager.
-func Manager() (*InterfaceManager, error) {
-	return &InterfaceManager{}, nil
+func Manager(s *state.State) (*InterfaceManager, error) {
+	repo := interfaces.NewRepository()
+	for _, iface := range builtin.Interfaces() {
+		if err := repo.AddInterface(iface); err != nil {
+			return nil, err
+		}
+	}
+	runner := state.NewTaskRunner(s)
+	m := &InterfaceManager{
+		state:  s,
+		runner: runner,
+		repo:   repo,
+	}
+
+	runner.AddHandler("connect", m.doConnect)
+
+	return m, nil
 }
 
 // Connect initiates a change connecting an interface.
@@ -62,22 +77,6 @@ func Connect(change *state.Change, plugSnap, plugName, slotSnap, slotName string
 
 // Disconnect initiates a change disconnecting an interface.
 func (m *InterfaceManager) Disconnect(plugSnap, plugName, slotSnap, slotName string) error {
-	return nil
-}
-
-// Init implements StateManager.Init.
-func (m *InterfaceManager) Init(s *state.State) error {
-	repo := interfaces.NewRepository()
-	for _, iface := range builtin.Interfaces() {
-		if err := repo.AddInterface(iface); err != nil {
-			return err
-		}
-	}
-	runner := state.NewTaskRunner(s)
-	m.state = s
-	m.repo = repo
-	m.runner = runner
-	m.runner.AddHandler("connect", m.doConnect)
 	return nil
 }
 

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -40,9 +40,7 @@ var _ = Suite(&interfaceManagerSuite{})
 
 func (s *interfaceManagerSuite) SetUpTest(c *C) {
 	state := state.New(nil)
-	mgr, err := ifacestate.Manager()
-	c.Assert(err, IsNil)
-	err = mgr.Init(state)
+	mgr, err := ifacestate.Manager(state)
 	c.Assert(err, IsNil)
 	s.state = state
 	s.mgr = mgr

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -72,21 +72,21 @@ func New() (*Overlord, error) {
 
 	o.stateEng = NewStateEngine(s)
 
-	snapMgr, err := snapstate.Manager()
+	snapMgr, err := snapstate.Manager(s)
 	if err != nil {
 		return nil, err
 	}
 	o.snapMgr = snapMgr
 	o.stateEng.AddManager(o.snapMgr)
 
-	assertMgr, err := assertstate.Manager()
+	assertMgr, err := assertstate.Manager(s)
 	if err != nil {
 		return nil, err
 	}
 	o.assertMgr = assertMgr
 	o.stateEng.AddManager(o.assertMgr)
 
-	ifaceMgr, err := ifacestate.Manager()
+	ifaceMgr, err := ifacestate.Manager(s)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -98,11 +98,6 @@ type witnessManager struct {
 	ensureCallack  func(s *state.State) error
 }
 
-func (wm *witnessManager) Init(s *state.State) error {
-	wm.state = s
-	return nil
-}
-
 func (wm *witnessManager) Ensure() error {
 	if wm.expectedEnsure--; wm.expectedEnsure == 0 {
 		close(wm.ensureCalled)
@@ -137,6 +132,7 @@ func (ovs *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
 	c.Assert(err, IsNil)
 
 	witness := &witnessManager{
+		state:          o.StateEngine().State(),
 		expectedEnsure: 2,
 		ensureCalled:   make(chan struct{}),
 	}
@@ -164,6 +160,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBefore(c *C) {
 	c.Assert(err, IsNil)
 
 	witness := &witnessManager{
+		state:          o.StateEngine().State(),
 		expectedEnsure: 1,
 		ensureCalled:   make(chan struct{}),
 	}
@@ -194,6 +191,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeInEnsure(c *C) {
 	}
 
 	witness := &witnessManager{
+		state:          o.StateEngine().State(),
 		expectedEnsure: 2,
 		ensureCalled:   make(chan struct{}),
 		ensureCallack:  ensure,

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -64,8 +64,9 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.fakeBackend = &fakeSnappyBackend{}
 	s.state = state.New(nil)
 
-	s.snapmgr = &snapstate.SnapManager{}
-	s.snapmgr.Init(s.state)
+	var err error
+	s.snapmgr, err = snapstate.Manager(s.state)
+	c.Assert(err, IsNil)
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 }

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -101,6 +101,9 @@ func (se *StateEngine) AddManager(m StateManager) {
 func (se *StateEngine) Stop() {
 	se.mgrLock.Lock()
 	defer se.mgrLock.Unlock()
+	if se.stopped {
+		return
+	}
 	for _, m := range se.managers {
 		m.Stop()
 	}

--- a/overlord/stateengine_test.go
+++ b/overlord/stateengine_test.go
@@ -115,4 +115,7 @@ func (ses *stateEngineSuite) TestStop(c *C) {
 
 	se.Stop()
 	c.Check(calls, DeepEquals, []string{"stop:mgr1", "stop:mgr2"})
+
+	err := se.Ensure()
+	c.Check(err, ErrorMatches, "state engine already stopped")
 }

--- a/overlord/stateengine_test.go
+++ b/overlord/stateengine_test.go
@@ -115,6 +115,8 @@ func (ses *stateEngineSuite) TestStop(c *C) {
 
 	se.Stop()
 	c.Check(calls, DeepEquals, []string{"stop:mgr1", "stop:mgr2"})
+	se.Stop()
+	c.Check(calls, HasLen, 2)
 
 	err := se.Ensure()
 	c.Check(err, ErrorMatches, "state engine already stopped")


### PR DESCRIPTION
This simplifies StateEngine and makes it goroutine safe, there's no more Init in the StateManager interface, state should be passed to the constructors of the managers instead.