### PR TITLE
snappy: support generation of short binary names 

### DIFF
--- a/snappy/binaries.go
+++ b/snappy/binaries.go
@@ -30,14 +30,13 @@ import (
 	"github.com/ubuntu-core/snappy/arch"
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/osutil"
-	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snap/snapenv"
 )
 
 // generate the name
 func generateBinaryName(m *snapYaml, app *AppYaml) string {
 	var binName string
-	if m.Type == snap.TypeFramework {
+	if app.Name == m.Name {
 		binName = filepath.Base(app.Name)
 	} else {
 		binName = fmt.Sprintf("%s.%s", m.Name, filepath.Base(app.Name))

--- a/snappy/binaries_test.go
+++ b/snappy/binaries_test.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snappy
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/dirs"
+)
+
+type binariesTestSuite struct{}
+
+var _ = Suite(&binariesTestSuite{})
+
+func (s *SnapTestSuite) TestGenerateBinaryName(c *C) {
+	c.Check(generateBinaryName(&snapYaml{Name: "foo"}, &AppYaml{Name: "bar"}), Equals, filepath.Join(dirs.SnapBinariesDir, "foo.bar"))
+	c.Check(generateBinaryName(&snapYaml{Name: "foo"}, &AppYaml{Name: "foo"}), Equals, filepath.Join(dirs.SnapBinariesDir, "foo"))
+}


### PR DESCRIPTION
This branch modifies generateBinaryName to generate a short name if the appname and  the snapname match. This prepares the removal of frameworks.