### PR TITLE
client, cmd, daemon, snap, snappy: add buy command

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -29,16 +29,17 @@ import (
 // Snap holds the data for a snap as obtained from snapd.
 type Snap struct {
 	// XXX: actually add summary to the REST api when the store provides it
-	Summary       string `json:"summary"`
-	Description   string `json:"description"`
-	DownloadSize  int64  `json:"download_size"`
-	Icon          string `json:"icon"`
-	InstalledSize int64  `json:"installed_size"`
-	Name          string `json:"name"`
-	Developer     string `json:"developer"`
-	Status        string `json:"status"`
-	Type          string `json:"type"`
-	Version       string `json:"version"`
+	Summary       string  `json:"summary"`
+	Description   string  `json:"description"`
+	DownloadSize  int64   `json:"download_size"`
+	Icon          string  `json:"icon"`
+	InstalledSize int64   `json:"installed_size"`
+	Name          string  `json:"name"`
+	Developer     string  `json:"developer"`
+	Status        string  `json:"status"`
+	Type          string  `json:"type"`
+	Version       string  `json:"version"`
+	Price         float64 `json:"price"`
 }
 
 // SnapFilter is used to filter snaps by source, name and/or type

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -104,3 +104,12 @@ func (client *Client) DeactivateSnap(name string) (string, error) {
 
 	return client.doAsync("POST", path, nil, body)
 }
+
+// BuySnap purcahses the snap with the given name, returning the UUID
+// of the background operation upon success.
+func (client *Client) BuySnap(name string) (string, error) {
+	path := fmt.Sprintf("/2.0/snaps/%s", name)
+	body := strings.NewReader(`{"action":"buy"}`)
+
+	return client.doAsync("POST", path, nil, body)
+}

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -77,7 +77,7 @@ func (x *cmdFind) Execute([]string) error {
 	w := tabwriter.NewWriter(Stdout, 5, 3, 1, ' ', 0)
 	defer w.Flush()
 
-	fmt.Fprintln(w, i18n.G("Name\tVersion\tPrice\tSummary"))
+	fmt.Fprintln(w, i18n.G("Name\tVersion\tPrice\tStatus\tSummary"))
 
 	for _, name := range names {
 		snap := snaps[name]
@@ -87,7 +87,7 @@ func (x *cmdFind) Execute([]string) error {
 		} else {
 			price = i18n.G("free")
 		}
-		fmt.Fprintf(w, "%s\t%s\t%v\t%s\n", name, snap.Version, price, snap.Summary)
+		fmt.Fprintf(w, "%s\t%s\t%v\t%s\t%s\n", name, snap.Version, price, snap.Status, snap.Summary)
 	}
 
 	return nil

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -77,11 +77,17 @@ func (x *cmdFind) Execute([]string) error {
 	w := tabwriter.NewWriter(Stdout, 5, 3, 1, ' ', 0)
 	defer w.Flush()
 
-	fmt.Fprintln(w, i18n.G("Name\tVersion\tSummary"))
+	fmt.Fprintln(w, i18n.G("Name\tVersion\tPrice\tSummary"))
 
 	for _, name := range names {
 		snap := snaps[name]
-		fmt.Fprintf(w, "%s\t%s\t%s\n", name, snap.Version, snap.Summary)
+		var price string
+		if snap.Price > 0 {
+			price = fmt.Sprintf("%v", snap.Price)
+		} else {
+			price = "free"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%v\t%s\n", name, snap.Version, price, snap.Summary)
 	}
 
 	return nil

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -85,7 +85,7 @@ func (x *cmdFind) Execute([]string) error {
 		if snap.Price > 0 {
 			price = fmt.Sprintf("%v", snap.Price)
 		} else {
-			price = "free"
+			price = i18n.G("free")
 		}
 		fmt.Fprintf(w, "%s\t%s\t%v\t%s\n", name, snap.Version, price, snap.Summary)
 	}

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -52,6 +52,7 @@ var (
 	shortRollbackHelp   = i18n.G("Rollback a snap to its previous known-good version")
 	shortActivateHelp   = i18n.G("Activate a snap that is installed but inactive")
 	shortDeactivateHelp = i18n.G("Deactivate an installed active snap")
+	shortBuyHelp        = i18n.G("Buy a paid snap")
 )
 
 var longInstallHelp = i18n.G(`
@@ -87,6 +88,10 @@ var longDeactivateHelp = i18n.G(`
 The deactivate command deactivates an installed, active snap.
 
 Snaps that are not active don't have their apps available for use.
+`)
+
+var longBuyHelp = i18n.G(`
+The buy command purchases a paid snap.
 `)
 
 type cmdOp struct {
@@ -162,6 +167,7 @@ func init() {
 			{"activate", shortActivateHelp, longActivateHelp, (*client.Client).ActivateSnap},
 			{"deactivate", shortDeactivateHelp, longDeactivateHelp, (*client.Client).DeactivateSnap},
 		*/
+		{"buy", shortBuyHelp, longBuyHelp, (*client.Client).BuySnap},
 	} {
 		op := s.op
 		addCommand(s.name, s.short, s.long, func() flags.Commander { return &cmdOp{op: op} })

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -623,6 +623,10 @@ func (inst *snapInstruction) deactivate() interface{} {
 	return waitChange(chg)
 }
 
+func (inst *snapInstruction) buy() interface{} {
+	return snappy.Buy(inst.pkg, inst)
+}
+
 func (inst *snapInstruction) dispatch() func() interface{} {
 	switch inst.Action {
 	case "install":
@@ -637,6 +641,8 @@ func (inst *snapInstruction) dispatch() func() interface{} {
 		return inst.activate
 	case "deactivate":
 		return inst.deactivate
+	case "buy":
+		return inst.buy
 	default:
 		return nil
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -241,6 +241,7 @@ func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {
 			"update_available":   "v2",
 			"rollback_available": "v0",
 			"channel":            "stable",
+			"price":              float64(0),
 		},
 	}
 

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -73,12 +73,15 @@ func mapSnap(localSnaps []*snappy.Snap, remoteSnap *snap.Info) map[string]interf
 		panic("no localSnaps & remoteSnap is nil -- how did i even get here")
 	}
 
-	status := "not installed"
+	status := "available"
 	installedSize := int64(-1)
 	downloadSize := int64(-1)
 	price := float64(-1)
 
 	if remoteSnap != nil {
+		if remoteSnap.RequiresPurchase {
+			status = "priced"
+		}
 		price = remoteSnap.Price
 	}
 
@@ -88,8 +91,6 @@ func mapSnap(localSnaps []*snappy.Snap, remoteSnap *snap.Info) map[string]interf
 			status = "active"
 		} else if localSnap.IsInstalled() {
 			status = "installed"
-		} else {
-			status = "removed"
 		}
 	} else if remoteSnap == nil {
 		panic("unable to load a valid snap")

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -76,6 +76,11 @@ func mapSnap(localSnaps []*snappy.Snap, remoteSnap *snap.Info) map[string]interf
 	status := "not installed"
 	installedSize := int64(-1)
 	downloadSize := int64(-1)
+	price := float64(-1)
+
+	if remoteSnap != nil {
+		price = remoteSnap.Price
+	}
 
 	idx, localSnap := bestSnap(localSnaps)
 	if localSnap != nil {
@@ -151,6 +156,7 @@ func mapSnap(localSnaps []*snappy.Snap, remoteSnap *snap.Info) map[string]interf
 		"description":    description,
 		"installed_size": installedSize,
 		"download_size":  downloadSize,
+		"price":          price,
 	}
 
 	if localSnap != nil {

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -189,7 +189,7 @@ Sample result:
       "developer": "chipaca",
       "price": 2.99,
       "resource": "/v2/snaps/http",
-      "status": "active",
+      "status": "priced",
       "type": "app",
       "version": "3.1",
       "channel": "stable"
@@ -223,8 +223,8 @@ Sample result:
 
 #### Fields
 * `snaps`
-    * `status`: can be either `not installed`, `installed`, `active` (i.e. is
-      current).
+    * `status`: may transition as `available` => `installed` => `active`. For paid snaps,
+      the initial state is `priced` and once bought it becomes `available`.
     * `name`: the snap name.
     * `version`: a string representing the version.
     * `icon`: a url to the snap icon, possibly relative to this server.

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -187,6 +187,7 @@ Sample result:
       "installed_size": 1821897,
       "name": "http",
       "developer": "chipaca",
+      "price": 2.99,
       "resource": "/v2/snaps/http",
       "status": "active",
       "type": "app",
@@ -238,6 +239,7 @@ Sample result:
       be rolled back to the version specified as a value to this entry.
     * `update_available`: if present and not empty, it means the snap can be
       updated to the version specified as a value to this entry.
+    * `price`: 0 means free, >0 implies a cost in the currently selected currency
     * `channel`: which channel the package is currently tracking.
 * `paging`
     * `count`: the number of snaps on this page

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -312,7 +312,7 @@ See `sources` for `/v2/snaps`.
 
 ### POST
 
-* Description: install, update, remove, activate, deactivate,
+* Description: Install, update, remove, activate, deactivate,
   rollback or buy the snap
 * Access: trusted
 * Operation: async

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -312,8 +312,8 @@ See `sources` for `/v2/snaps`.
 
 ### POST
 
-* Description: Install, update, remove, activate, deactivate, or
-  rollback the snap
+* Description: install, update, remove, activate, deactivate,
+  rollback or buy the snap
 * Access: trusted
 * Operation: async
 * Return: background operation or standard error
@@ -330,7 +330,7 @@ See `sources` for `/v2/snaps`.
 
 field      | ignored except in action | description
 -----------|-------------------|------------
-`action`   |                   | Required; a string, one of `install`, `update`, `remove`, `activate`, `deactivate`, or `rollback`.
+`action`   |                   | Required; a string, one of `install`, `update`, `remove`, `activate`, `deactivate`, `rollback`, or `buy`.
 `channel`  | `install` `update` | From which channel to pull the new package (and track henceforth). Channels are a means to discern the maturity of a package or the software it contains, although the exact meaning is left to the application developer. One of `edge`, `beta`, `candidate`, and `stable` which is the default.
 `leave_old`| `install` `update` `remove` | A boolean, equivalent to commandline's `--no-gc`. Default is false (do not leave old snaps around).
 `license`  | `install` `update` | A JSON object with `intro`, `license`, and `agreed` fields, the first two of which must match the license (see the section "A note on licenses", below).

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -38,7 +38,7 @@ func (s *searchSuite) TestSearchMustPrintMatch(c *check.C) {
 
 	// XXX: Summary is empty atm, waiting for store support
 	expected := "(?ms)" +
-		"Name +Version +Price +Summary *\n" +
+		"Name +Version +Price +Status +Summary *\n" +
 		".*" +
 		"^hello-world +.* *\n" +
 		".*"

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -38,7 +38,7 @@ func (s *searchSuite) TestSearchMustPrintMatch(c *check.C) {
 
 	// XXX: Summary is empty atm, waiting for store support
 	expected := "(?ms)" +
-		"Name +Version +Summary *\n" +
+		"Name +Version +Price +Summary *\n" +
 		".*" +
 		"^hello-world +.* *\n" +
 		".*"

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-09 09:25+0200\n"
+        "POT-Creation-Date: 2016-04-08 15:37+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -249,7 +249,7 @@ msgstr  ""
 msgid   "Name\tDate\tVersion\tDeveloper\t"
 msgstr  ""
 
-msgid   "Name\tVersion\tSummary"
+msgid   "Name\tVersion\tPrice\tSummary"
 msgstr  ""
 
 #. TRANSLATORS: the %s is a pkgname
@@ -656,4 +656,3 @@ msgstr  ""
 #, c-format
 msgid   "version: %s\n"
 msgstr  ""
-

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -249,7 +249,7 @@ msgstr  ""
 msgid   "Name\tDate\tVersion\tDeveloper\t"
 msgstr  ""
 
-msgid   "Name\tVersion\tPrice\tSummary"
+msgid   "Name\tVersion\tPrice\tStatus\tSummary"
 msgstr  ""
 
 #. TRANSLATORS: the %s is a pkgname

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -619,6 +619,9 @@ msgstr  ""
 msgid   "data-size: %s\n"
 msgstr  ""
 
+msgid   "free"
+msgstr  ""
+
 #. TRANSLATORS: the %s is a date
 #. TRANSLATORS: the %s is a date
 #, c-format

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -89,6 +89,9 @@ msgstr  ""
 msgid   "Builds a snap package"
 msgstr  ""
 
+msgid   "Buy a paid snap"
+msgstr  ""
+
 msgid   "Classic dimension destroyed on this snappy system."
 msgstr  ""
 
@@ -476,6 +479,10 @@ msgid   "\n"
         "The activate command activates an installed but inactive snap.\n"
         "\n"
         "Snaps that are not active don't have their apps available for use.\n"
+msgstr  ""
+
+msgid   "\n"
+        "The buy command purchases a paid snap.\n"
 msgstr  ""
 
 msgid   "\n"

--- a/snap/info.go
+++ b/snap/info.go
@@ -69,6 +69,7 @@ type Info struct {
 	AnonDownloadURL string
 	DownloadURL     string
 	Price           float64
+	RequiresPurchase bool
 }
 
 // Name returns the blessed name for the snap.

--- a/snap/info.go
+++ b/snap/info.go
@@ -68,6 +68,7 @@ type Info struct {
 
 	AnonDownloadURL string
 	DownloadURL     string
+	Price           float64
 }
 
 // Name returns the blessed name for the snap.

--- a/snappy/buy.go
+++ b/snappy/buy.go
@@ -1,0 +1,31 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snappy
+
+import (
+	"github.com/ubuntu-core/snappy/progress"
+)
+
+// Buy the given snap name.
+func Buy(fullName string, meter progress.Meter) error {
+	mStore := NewConfiguredUbuntuStoreSnapRepository()
+	_, err := mStore.Buy(fullName, meter)
+	return err
+}

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -265,10 +265,18 @@ func (s *SnapTestSuite) TestUpdate(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
+	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "[]") // no purchases
+	}))
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+
 	dlURL = mockServer.URL + "/dl"
 	iconURL = mockServer.URL + "/icon"
 
 	s.storeCfg.DetailsURI, err = url.Parse(mockServer.URL + "/details/")
+	c.Assert(err, IsNil)
+	s.storeCfg.PurchasesURI, err = url.Parse(mockPurchasesServer.URL + "/click/purchases/")
 	c.Assert(err, IsNil)
 
 	// bulk

--- a/store/auth.go
+++ b/store/auth.go
@@ -162,6 +162,13 @@ func ReadStoreToken() (*StoreToken, error) {
 	return &readStoreToken, nil
 }
 
+// DeleteStoreToken deletes the currently stored store token, i.e. it logs the user out
+func DeleteStoreToken() {
+	targetFile := storeTokenFilename()
+	// We don't care if the remove fails
+	os.Remove(targetFile)
+}
+
 // RequestPackageAccessMacaroon requests a macaroon for accessing package data from the ubuntu store.
 func RequestPackageAccessMacaroon() (string, error) {
 	const errorPrefix = "cannot get package access macaroon from store: "

--- a/store/details.go
+++ b/store/details.go
@@ -38,6 +38,7 @@ type snapDetails struct {
 	IconURL         string             `json:"icon_url"`
 	LastUpdated     string             `json:"last_updated,omitempty"`
 	Name            string             `json:"package_name"`
+	FullName        string             `json:"name"`
 	Prices          map[string]float64 `json:"prices,omitempty"`
 	Publisher       string             `json:"publisher,omitempty"`
 	RatingsAverage  float64            `json:"ratings_average,omitempty"`
@@ -50,4 +51,42 @@ type snapDetails struct {
 	// FIXME: the store should return "developer" to us instead of
 	//        origin
 	Developer string `json:"origin" yaml:"origin"`
+}
+
+/*
+A Purchase encapsulates the purchase data sent to us from the software center agent.
+
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+[
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "com.ubuntu.developer.dev.appname",
+    "refundable_until": "2015-07-15 18:46:21",
+    "state": "Complete"
+  },
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "com.ubuntu.developer.dev.appname",
+    "item_sku": "item-1-sku",
+    "purchase_id": "1",
+    "refundable_until": null,
+    "state": "Complete"
+  },
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "com.ubuntu.developer.dev.otherapp",
+    "refundable_until": "2015-07-17 11:33:29",
+    "state": "Complete"
+  }
+]
+*/
+type Purchase struct {
+	OpenID          string `json:"open_id"`
+	PackageName     string `json:"package_name"`
+	RefundableUntil string `json:"refundable_until"`
+	State           string `json:"state"`
+	ItemSKU         string `json:"item_sku,omitempty"`
+	PurchaseID      string `json:"purchase_id,omitempty"`
 }

--- a/store/details.go
+++ b/store/details.go
@@ -92,8 +92,7 @@ type Purchase struct {
 }
 
 /*
-PurchaseInstruction encapsulates the data that must be sent
-in order to make a purchase from the store.
+PurchaseInstruction encapsulates the data that must be sent in order to make a purchase from the store.
 */
 type PurchaseInstruction struct {
 	DeviceID  string  `json:"device_id,omitempty"`

--- a/store/details.go
+++ b/store/details.go
@@ -90,3 +90,25 @@ type Purchase struct {
 	ItemSKU         string `json:"item_sku,omitempty"`
 	PurchaseID      string `json:"purchase_id,omitempty"`
 }
+
+/*
+PurchaseInstruction encapsulates the data that must be sent
+in order to make a purchase from the store.
+*/
+type PurchaseInstruction struct {
+	DeviceID  string  `json:"device_id,omitempty"`
+	Name      string  `json:"name"`
+	ItemSKU   string  `json:"item_sku,omitempty"`
+	Amount    float64 `json:"amount,omitempty"`
+	Currency  string  `json:"currency,omitempty"`
+	BackendID string  `json:"backend_id,omitempty"`
+	MethodID  int64   `json:"method_id,omitempty"`
+}
+
+/*
+AuthError contains the reason behind an authentication failure
+*/
+type AuthError struct {
+	Threshold int64  `json:"threshold"`
+	Error     string `json:"error"`
+}

--- a/store/errors.go
+++ b/store/errors.go
@@ -38,6 +38,9 @@ var (
 
 	// ErrInvalidCredentials is returned on login error
 	ErrInvalidCredentials = errors.New("invalid credentials")
+
+	// ErrScaAuthFailed is returned when purchase server authorization fails
+	ErrScaAuthFailed = errors.New("invalid store token")
 )
 
 // ErrDownload represents a download error

--- a/store/errors.go
+++ b/store/errors.go
@@ -41,6 +41,9 @@ var (
 
 	// ErrScaAuthFailed is returned when purchase server authorization fails
 	ErrScaAuthFailed = errors.New("invalid store token")
+
+	// ErrTokenNeedsRefresh is returned when the store token has expired, and needs refreshing
+	ErrTokenNeedsRefresh = errors.New("store token needs refresh")
 )
 
 // ErrDownload represents a download error

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -301,10 +301,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string) (*snap.Info, erro
 func getSuggestedCurrency(h *http.Header) string {
 	s := h.Get("X-Suggested-Currency")
 	if s == "" {
-		s = os.Getenv("U1_SEARCH_CURRENCY")
-		if s == "" {
-			s = "USD"
-		}
+		s = "USD"
 	}
 	return s
 }

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -596,7 +596,8 @@ var download = func(name string, w io.Writer, req *http.Request, pbar progress.M
 	return err
 }
 
-// Buy the specified snap using the default currency and payment method
+// Buy the specified snap using the default currency and payment method.
+// Returns the state of the purchase: Complete, Cancelled or Pending.
 func (s *SnapUbuntuStoreRepository) Buy(name string, inter progress.Meter) (string, error) {
 	client := &http.Client{}
 

--- a/store/snap_remote_repo_test.go
+++ b/store/snap_remote_repo_test.go
@@ -40,6 +40,13 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
+func newEmptyPurchasesServer(c *C) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, Equals, "/click/purchases/")
+		io.WriteString(w, "[]")
+	}))
+}
+
 type remoteRepoTestSuite struct {
 	store *SnapUbuntuStoreRepository
 
@@ -59,6 +66,7 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 
 func (t *remoteRepoTestSuite) TearDownTest(c *C) {
 	download = t.origDownloadFunc
+	DeleteStoreToken()
 }
 
 func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
@@ -262,7 +270,47 @@ const MockDetailsJSON = `{
 }
 `
 
+/* acquired via https://myapps.developer.ubuntu.com/docs/api/click-purchases.html
+ */
+const MockPurchasesJSON = `[
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "8nzc1x4iim2xj1g2ul64.chipaca",
+    "refundable_until": "2015-07-15 18:46:21",
+    "state": "Complete"
+  },
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "8nzc1x4iim2xj1g2ul64.chipaca",
+    "item_sku": "item-1-sku",
+    "purchase_id": "1",
+    "refundable_until": null,
+    "state": "Complete"
+  },
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "com.ubuntu.developer.dev.otherapp",
+    "refundable_until": "2015-07-17 11:33:29",
+    "state": "Complete"
+  }
+]
+`
+
+/* acquired via https://myapps.developer.ubuntu.com/docs/api/click-purchases.html
+ */
+const MockPurchaseJSON = `{
+  "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+  "package_name": "8nzc1x4iim2xj1g2ul64.chipaca",
+  "refundable_until": "2015-07-15 18:46:21",
+  "state": "Complete"
+}
+`
+
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
+	mockStoreToken := StoreToken{TokenName: "meep"}
+	err := WriteStoreToken(mockStoreToken)
+	c.Assert(err, IsNil)
+
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// no store ID by default
 		storeID := r.Header.Get("X-Ubuntu-Store")
@@ -279,11 +327,22 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	var err error
+	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, Equals, fmt.Sprintf("/click/purchases/%s.%s/", funkyAppName, funkyAppDeveloper))
+		c.Check(r.URL.Query().Get("include_item_purchases"), Equals, "true")
+		io.WriteString(w, MockPurchasesJSON)
+	}))
+
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+
 	detailsURI, err := url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
+	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/click/purchases/")
+	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		DetailsURI: detailsURI,
+		DetailsURI:   detailsURI,
+		PurchasesURI: purchasesURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
 	c.Assert(repo, NotNil)
@@ -300,6 +359,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(result.Description(), Equals, "Returns for store credit only.\nThis is a simple hello world example.")
 	c.Check(result.Summary(), Equals, "hello world example")
 	c.Check(result.Price, Equals, float64(1.23))
+	c.Check(result.RequiresPurchase, Equals, false) // this app has been purchased, according to the mock
 }
 
 const MockNoDetailsJSON = `{"errors": ["No such package"], "result": "error"}`
@@ -314,11 +374,22 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
+	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, Equals, "/click/purchases/no-such-pkg/")
+		c.Check(r.URL.Query().Get("include_item_purchases"), Equals, "true")
+		io.WriteString(w, MockPurchasesJSON)
+	}))
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+
 	var err error
 	detailsURI, err := url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
+	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/click/purchases/")
+	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		DetailsURI: detailsURI,
+		DetailsURI:   detailsURI,
+		PurchasesURI: purchasesURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
 	c.Assert(repo, NotNil)
@@ -391,11 +462,18 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFind(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
+	mockPurchasesServer := newEmptyPurchasesServer(c)
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+
 	var err error
 	searchURI, err := url.Parse(mockServer.URL)
 	c.Assert(err, IsNil)
+	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/click/purchases/")
+	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI: searchURI,
+		SearchURI:    searchURI,
+		PurchasesURI: purchasesURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
 	c.Assert(repo, NotNil)
@@ -439,11 +517,18 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdates(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
+	mockPurchasesServer := newEmptyPurchasesServer(c)
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+
 	var err error
 	bulkURI, err := url.Parse(mockServer.URL + "/updates/")
 	c.Assert(err, IsNil)
+	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/click/purchases/")
+	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		BulkURI: bulkURI,
+		BulkURI:      bulkURI,
+		PurchasesURI: purchasesURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
 	c.Assert(repo, NotNil)

--- a/store/snap_remote_repo_test.go
+++ b/store/snap_remote_repo_test.go
@@ -235,7 +235,7 @@ const MockDetailsJSON = `{
     "origin": "chipaca",
     "package_name": "8nzc1x4iim2xj1g2ul64",
     "price": 0.0,
-    "prices": {},
+    "prices": {"GBP": 1.23, "USD": 4.56},
     "publisher": "John Lenton",
     "ratings_average": 0.0,
     "release": [
@@ -269,6 +269,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 		c.Check(storeID, Equals, "")
 
 		c.Check(r.URL.Path, Equals, fmt.Sprintf("/details/%s.%s/edge", funkyAppName, funkyAppDeveloper))
+
+		w.Header().Set("X-Suggested-Currency", "GBP")
+		w.WriteHeader(http.StatusOK)
+
 		io.WriteString(w, MockDetailsJSON)
 	}))
 
@@ -295,6 +299,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(result.Channel, Equals, "edge")
 	c.Check(result.Description(), Equals, "Returns for store credit only.\nThis is a simple hello world example.")
 	c.Check(result.Summary(), Equals, "hello world example")
+	c.Check(result.Price, Equals, float64(1.23))
 }
 
 const MockNoDetailsJSON = `{"errors": ["No such package"], "result": "error"}`
@@ -353,7 +358,7 @@ const MockSearchJSON = `{
                 "last_updated": "2015-04-15T18:30:16Z",
                 "origin": "chipaca",
                 "package_name": "8nzc1x4iim2xj1g2ul64",
-                "prices": {},
+                "prices": {"GBP": 1.23, "USD": 4.56},
                 "publisher": "John Lenton",
                 "ratings_average": 0.0,
                 "revision": 7,


### PR DESCRIPTION
Add buy command to perform basic purchasing of snaps.
Improve error handling around expired tokens.