### PR TITLE
overlord: implement Overlord.Settle, chiefly for tests

### DIFF
--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -129,7 +129,7 @@ func (o *Overlord) ensureBefore(d time.Duration) {
 	o.ensureLock.Lock()
 	defer o.ensureLock.Unlock()
 	if o.ensureTimer == nil {
-		panic("cannot use EnsureBefore before Overlord.Run()")
+		panic("cannot use EnsureBefore before Overlord.Loop")
 	}
 	now := time.Now()
 	next := now.Add(d)

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -140,8 +140,8 @@ func (o *Overlord) ensureBefore(d time.Duration) {
 	}
 }
 
-// Run runs a loop to ensure the current state regularly through StateEngine Ensure().
-func (o *Overlord) Run() {
+// Loop runs a loop in a goroutine to ensure the current state regularly through StateEngine Ensure.
+func (o *Overlord) Loop() {
 	o.ensureTimerSetup()
 	o.loopTomb.Go(func() error {
 		for {
@@ -171,13 +171,13 @@ func (o *Overlord) Stop() error {
 // Settle runs first a state engine Ensure and then wait for activities to settle.
 // That's done by waiting for all managers activities to settle while
 // making sure no immediate further Ensure is scheduled. Chiefly for tests.
-// Cannot be used in conjuction with Run.
+// Cannot be used in conjuction with Loop.
 func (o *Overlord) Settle() {
 	func() {
 		o.ensureLock.Lock()
 		defer o.ensureLock.Unlock()
 		if o.ensureTimer != nil {
-			panic("cannot use Settle with an ensure loop (Overlord.Run)")
+			panic("cannot use Settle concurrently with other Settle or Loop calls")
 		}
 		o.ensureTimer = time.NewTimer(0)
 	}()

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -167,6 +167,30 @@ func (o *Overlord) Stop() error {
 	return err1
 }
 
+func (o *Overlord) syncEnsure() time.Time {
+	// XXX
+	o.stateEng.Ensure()
+	return time.Time{}
+}
+
+func (o *Overlord) noImmediateEnsure(longScheduledEnsureHorizon time.Time) (bool, time.Time) {
+	// XXX
+	time.Sleep(100 * time.Millisecond)
+	return true, time.Time{}
+}
+
+// Settle runs first a state engine Ensure and then wait for activities to settle.
+// That's done by waiting for all managers activities to settle while
+// making sure no immediate further Ensure is scheduled.
+func (o *Overlord) Settle() {
+	longScheduledEnsureHorizon := o.syncEnsure()
+	settled := false
+	for !settled {
+		o.stateEng.Wait()
+		settled, longScheduledEnsureHorizon = o.noImmediateEnsure(longScheduledEnsureHorizon)
+	}
+}
+
 // StateEngine returns the state engine used by the overlord.
 func (o *Overlord) StateEngine() *StateEngine {
 	return o.stateEng

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -45,11 +45,10 @@ var ensureInterval = 5 * time.Minute
 type Overlord struct {
 	stateEng *StateEngine
 	// ensure loop
-	loopTomb      *tomb.Tomb
-	ensureLock    sync.Mutex
-	ensureTimer   *time.Timer
-	ensureNext    time.Time
-	ensureRunning int
+	loopTomb    *tomb.Tomb
+	ensureLock  sync.Mutex
+	ensureTimer *time.Timer
+	ensureNext  time.Time
 	// managers
 	snapMgr   *snapstate.SnapManager
 	assertMgr *assertstate.AssertManager
@@ -118,31 +117,13 @@ func (o *Overlord) ensureTimerSetup() {
 	o.ensureNext = time.Now().Add(ensureInterval)
 }
 
-func (o *Overlord) syncEnsurePrep() time.Time {
+func (o *Overlord) ensureTimerReset() time.Time {
 	o.ensureLock.Lock()
 	defer o.ensureLock.Unlock()
 	now := time.Now()
 	o.ensureTimer.Reset(ensureInterval)
 	o.ensureNext = now.Add(ensureInterval)
-	o.ensureRunning++
 	return o.ensureNext
-}
-
-func (o *Overlord) syncEnsureDone() {
-	o.ensureLock.Lock()
-	defer o.ensureLock.Unlock()
-	o.ensureRunning--
-}
-
-func (o *Overlord) syncEnsure() time.Time {
-	next := o.syncEnsurePrep()
-	defer o.syncEnsureDone()
-	err := o.stateEng.Ensure()
-	if err != nil {
-		logger.Noticef("state engine ensure failed: %v", err)
-		// continue to the next Ensure() try for now
-	}
-	return next
 }
 
 func (o *Overlord) ensureBefore(d time.Duration) {
@@ -169,7 +150,12 @@ func (o *Overlord) Run() {
 				return nil
 			case <-o.ensureTimer.C:
 			}
-			o.syncEnsure()
+			o.ensureTimerReset()
+			err := o.stateEng.Ensure()
+			if err != nil {
+				logger.Noticef("state engine ensure failed: %v", err)
+				// continue to the next Ensure() try for now
+			}
 		}
 	})
 }
@@ -182,29 +168,33 @@ func (o *Overlord) Stop() error {
 	return err1
 }
 
-func (o *Overlord) noImmediateEnsure(longScheduledEnsureHorizon time.Time) bool {
-	o.ensureLock.Lock()
-	defer o.ensureLock.Unlock()
-	next1 := o.ensureNext
-	// something to do is scheduled earlier
-	if next1.Before(longScheduledEnsureHorizon) {
-		return false
-	}
-	if o.ensureRunning > 0 { // may be starting new goroutines right now
-		return false
-	}
-	return true
-}
-
 // Settle runs first a state engine Ensure and then wait for activities to settle.
 // That's done by waiting for all managers activities to settle while
 // making sure no immediate further Ensure is scheduled. Chiefly for tests.
+// Cannot be used in conjuction with Run.
 func (o *Overlord) Settle() {
-	longScheduledEnsureHorizon := o.syncEnsure()
-	settled := false
-	for !settled {
+	o.ensureLock.Lock()
+	if o.ensureTimer != nil {
+		panic("cannot use Settle with an ensure loop (Overlord.Run)")
+	}
+	o.ensureTimer = time.NewTimer(0)
+	defer func() {
+		o.ensureLock.Lock()
+		defer o.ensureLock.Unlock()
+		o.ensureTimer.Stop()
+		o.ensureTimer = nil
+	}()
+	o.ensureLock.Unlock()
+
+	done := false
+	for !done {
+		next := o.ensureTimerReset()
+		o.stateEng.Ensure()
+		// XXX return error
 		o.stateEng.Wait()
-		settled = o.noImmediateEnsure(longScheduledEnsureHorizon)
+		o.ensureLock.Lock()
+		done = o.ensureNext.Equal(next)
+		o.ensureLock.Unlock()
 	}
 }
 

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -356,7 +356,7 @@ func (ovs *overlordSuite) TestSettleChain(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (ovs *overlordSuite) TestExplicitEnsureBefore(c *C) {
+func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	restoreIntv := overlord.SetEnsureIntervalForTest(1 * time.Minute)
 	defer restoreIntv()
 	o, err := overlord.New()

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -298,8 +298,7 @@ func (ovs *overlordSuite) TestTrivialSettle(c *C) {
 	rm1 := newRunnerManager(s)
 	se.AddManager(rm1)
 
-	o.Run()
-	defer o.Stop()
+	defer o.StateEngine().Stop()
 
 	s.Lock()
 	defer s.Unlock()
@@ -330,8 +329,7 @@ func (ovs *overlordSuite) TestSettleChain(c *C) {
 	rm1 := newRunnerManager(s)
 	se.AddManager(rm1)
 
-	o.Run()
-	defer o.Stop()
+	defer o.StateEngine().Stop()
 
 	s.Lock()
 	defer s.Unlock()
@@ -375,8 +373,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 
 	se.AddManager(rm1)
 
-	o.Run()
-	defer o.Stop()
+	defer o.StateEngine().Stop()
 
 	s.Lock()
 	defer s.Unlock()

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -120,7 +120,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
 
-	o.Run()
+	o.Loop()
 
 	err = o.Stop()
 	c.Assert(err, IsNil)
@@ -139,7 +139,7 @@ func (ovs *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
 	}
 	o.StateEngine().AddManager(witness)
 
-	o.Run()
+	o.Loop()
 	defer o.Stop()
 
 	t0 := time.Now()
@@ -168,7 +168,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBefore(c *C) {
 	se := o.StateEngine()
 	se.AddManager(witness)
 
-	o.Run()
+	o.Loop()
 	defer o.Stop()
 
 	se.State().EnsureBefore(10 * time.Millisecond)
@@ -200,7 +200,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeInEnsure(c *C) {
 	se := o.StateEngine()
 	se.AddManager(witness)
 
-	o.Run()
+	o.Loop()
 	defer o.Stop()
 
 	se.State().EnsureBefore(0)

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ubuntu-core/snappy/logger"
+
 	"github.com/ubuntu-core/snappy/overlord/state"
 )
 
@@ -67,6 +69,14 @@ func (se *StateEngine) State() *state.State {
 	return se.state
 }
 
+type ensureError struct {
+	errs []error
+}
+
+func (e *ensureError) Error() string {
+	return fmt.Sprintf("state ensure errors: %v", e.errs)
+}
+
 // Ensure asks every manager to ensure that they are doing the necessary
 // work to put the current desired system state in place by calling their
 // respective Ensure methods.
@@ -81,11 +91,16 @@ func (se *StateEngine) Ensure() error {
 	if se.stopped {
 		return fmt.Errorf("state engine already stopped")
 	}
+	var errs []error
 	for _, m := range se.managers {
 		err := m.Ensure()
 		if err != nil {
-			return err
+			logger.Noticef("state ensure error: %v", err)
+			errs = append(errs, err)
 		}
+	}
+	if len(errs) != 0 {
+		return &ensureError{errs}
 	}
 	return nil
 }

--- a/overlord/stateengine.go
+++ b/overlord/stateengine.go
@@ -97,6 +97,18 @@ func (se *StateEngine) AddManager(m StateManager) {
 	se.managers = append(se.managers, m)
 }
 
+// Wait waits for all managers current activities.
+func (se *StateEngine) Wait() {
+	se.mgrLock.Lock()
+	defer se.mgrLock.Unlock()
+	if se.stopped {
+		return
+	}
+	for _, m := range se.managers {
+		m.Wait()
+	}
+}
+
 // Stop asks all managers to terminate activities running concurrently.
 func (se *StateEngine) Stop() {
 	se.mgrLock.Lock()

--- a/overlord/stateengine_test.go
+++ b/overlord/stateengine_test.go
@@ -97,8 +97,8 @@ func (ses *stateEngineSuite) TestEnsureError(c *C) {
 	se.AddManager(mgr2)
 
 	err := se.Ensure()
-	c.Check(err, Equals, err1)
-	c.Check(calls, DeepEquals, []string{"ensure:mgr1"})
+	c.Check(err.Error(), DeepEquals, "state ensure errors: [boom1 boom2]")
+	c.Check(calls, DeepEquals, []string{"ensure:mgr1", "ensure:mgr2"})
 }
 
 func (ses *stateEngineSuite) TestStop(c *C) {


### PR DESCRIPTION
Overlord.Settle runs first a state engine Ensure and then wait for activities to settle. That's done by waiting for all managers activities to settle while making sure no immediate further Ensure is scheduled. Chiefly for tests. 

This is chiefly for tests, it makes some simplifying assumptions and doesn't care if the waiting loop may busy loop sometimes. Cannot be used together with Overlord.Loop.

In the process:
* renamed Overlord.Run to Loop
* changed Ensure in StateEngine to bubble an error collecting all the errors for each manager Ensure