### PR TITLE
snappy: activate snaps on first boot

### DIFF
--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/progress"
-	"github.com/ubuntu-core/snappy/snap"
 
 	"gopkg.in/yaml.v2"
 )
@@ -130,9 +129,9 @@ var getActivator = func() activator {
 	return &Overlord{}
 }
 
-// enableSystemSnaps activates the installed kernel/os/gadget snaps
+// enableInstalledSnaps activates the installed preinstalled snaps
 // on the first boot
-func enableSystemSnaps() error {
+func enableInstalledSnaps() error {
 	repo := NewLocalSnapRepository()
 	all, err := repo.Installed()
 	if err != nil {
@@ -142,13 +141,10 @@ func enableSystemSnaps() error {
 	activator := getActivator()
 	pb := progress.MakeProgressBar()
 	for _, sn := range all {
-		switch sn.Type() {
-		case snap.TypeGadget, snap.TypeKernel, snap.TypeOS:
-			logger.Noticef("Acitvating %s", FullName(sn.Info()))
-			if err := activator.SetActive(sn, true, pb); err != nil {
-				// we don't want this to fail for now
-				logger.Noticef("failed to activate %s: %s", FullName(sn.Info()), err)
-			}
+		logger.Noticef("Acitvating %s", FullName(sn.Info()))
+		if err := activator.SetActive(sn, true, pb); err != nil {
+			// we don't want this to fail for now
+			logger.Noticef("failed to activate %s: %s", FullName(sn.Info()), err)
 		}
 	}
 
@@ -165,7 +161,7 @@ func FirstBoot() error {
 	defer stampFirstBoot()
 	defer enableFirstEther()
 
-	if err := enableSystemSnaps(); err != nil {
+	if err := enableInstalledSnaps(); err != nil {
 		return err
 	}
 

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -270,6 +270,6 @@ func (s *FirstBootTestSuite) TestSystemSnapsEnablesKernel(c *C) {
 	s.ensureSystemSnapIsEnabledOnFirstBoot(c, mockKernelYaml, true)
 }
 
-func (s *FirstBootTestSuite) TestSystemSnapsDoesNotEnableApps(c *C) {
-	s.ensureSystemSnapIsEnabledOnFirstBoot(c, "", false)
+func (s *FirstBootTestSuite) TestSystemSnapsDoesEnableApps(c *C) {
+	s.ensureSystemSnapIsEnabledOnFirstBoot(c, "", true)
 }


### PR DESCRIPTION
activate all pre-installed snaps on first boot to unblock image creation with webdm (this will be superseeded eventually by the ModelAssertion work).

This unblocks creating 16.04 images with ubuntu-device-flash that have e.g. webdm preinstalled.