### PR TITLE
snap: expand snap.yaml parsing to cover plugs, slots and apps

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -58,28 +58,8 @@ type SlotInfo struct {
 type AppInfo struct {
 	Snap *Info
 
-	Name string
-
-	// TODO: rest of the app fields
-
-	plugs []string
-	slots []string
-}
-
-// Plugs returns all of the plugs bound to this application.
-func (app *AppInfo) Plugs() []*PlugInfo {
-	plugs := make([]*PlugInfo, 0, len(app.plugs))
-	for _, name := range app.plugs {
-		plugs = append(plugs, app.Snap.Plugs[name])
-	}
-	return plugs
-}
-
-// Slots returns all of the slots bound to this application.
-func (app *AppInfo) Slots() []*SlotInfo {
-	slots := make([]*SlotInfo, 0, len(app.slots))
-	for _, name := range app.slots {
-		slots = append(slots, app.Snap.Slots[name])
-	}
-	return slots
+	Name    string
+	Command string
+	Plugs   map[string]*PlugInfo
+	Slots   map[string]*SlotInfo
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -40,17 +40,7 @@ type PlugInfo struct {
 	Interface string
 	Attrs     map[string]interface{}
 	Label     string
-
-	apps []string
-}
-
-// Apps returns all applications bound to this plug.
-func (plug *PlugInfo) Apps() []*AppInfo {
-	apps := make([]*AppInfo, 0, len(plug.apps))
-	for _, name := range plug.apps {
-		apps = append(apps, plug.Snap.Apps[name])
-	}
-	return apps
+	Apps      map[string]*AppInfo
 }
 
 // SlotInfo provides information about a slot.
@@ -61,17 +51,7 @@ type SlotInfo struct {
 	Interface string
 	Attrs     map[string]interface{}
 	Label     string
-
-	apps []string
-}
-
-// Apps returns all applications bound to this slot.
-func (slot *SlotInfo) Apps() []*AppInfo {
-	apps := make([]*AppInfo, 0, len(slot.apps))
-	for _, name := range slot.apps {
-		apps = append(apps, slot.Snap.Apps[name])
-	}
-	return apps
+	Apps      map[string]*AppInfo
 }
 
 // AppInfo provides information about a plug.

--- a/snap/info.go
+++ b/snap/info.go
@@ -27,4 +27,79 @@ type Info struct {
 	Type        Type
 	Channel     string
 	Description string
+	Apps        map[string]*AppInfo
+	Plugs       map[string]*PlugInfo
+	Slots       map[string]*SlotInfo
+}
+
+// PlugInfo provides information about a plug.
+type PlugInfo struct {
+	Snap *Info
+
+	Name      string
+	Interface string
+	Attrs     map[string]interface{}
+	Label     string
+
+	apps []string
+}
+
+// Apps returns all applications bound to this plug.
+func (plug *PlugInfo) Apps() []*AppInfo {
+	apps := make([]*AppInfo, 0, len(plug.apps))
+	for _, name := range plug.apps {
+		apps = append(apps, plug.Snap.Apps[name])
+	}
+	return apps
+}
+
+// SlotInfo provides information about a slot.
+type SlotInfo struct {
+	Snap *Info
+
+	Name      string
+	Interface string
+	Attrs     map[string]interface{}
+	Label     string
+
+	apps []string
+}
+
+// Apps returns all applications bound to this slot.
+func (slot *SlotInfo) Apps() []*AppInfo {
+	apps := make([]*AppInfo, 0, len(slot.apps))
+	for _, name := range slot.apps {
+		apps = append(apps, slot.Snap.Apps[name])
+	}
+	return apps
+}
+
+// AppInfo provides information about a plug.
+type AppInfo struct {
+	Snap *Info
+
+	Name string
+
+	// TODO: rest of the app fields
+
+	plugs []string
+	slots []string
+}
+
+// Plugs returns all of the plugs bound to this application.
+func (app *AppInfo) Plugs() []*PlugInfo {
+	plugs := make([]*PlugInfo, 0, len(app.plugs))
+	for _, name := range app.plugs {
+		plugs = append(plugs, app.Snap.Plugs[name])
+	}
+	return plugs
+}
+
+// Slots returns all of the slots bound to this application.
+func (app *AppInfo) Slots() []*SlotInfo {
+	slots := make([]*SlotInfo, 0, len(app.slots))
+	for _, name := range app.slots {
+		slots = append(slots, app.Snap.Slots[name])
+	}
+	return slots
 }

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -178,6 +178,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 }
 
 func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface string, attrs map[string]interface{}, err error) {
+	iface = name
 	switch data.(type) {
 	case map[interface{}]interface{}:
 		for keyData, valueData := range data.(map[interface{}]interface{}) {
@@ -203,9 +204,6 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface s
 				}
 				attrs[key] = valueData
 			}
-		}
-		if iface == "" {
-			return "", nil, fmt.Errorf("%s %q doesn't define interface name", plugOrSlot, name)
 		}
 		return iface, attrs, nil
 	case string:

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -87,6 +87,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 			Name:      name,
 			Interface: iface,
 			Attrs:     attrs,
+			Apps:      make(map[string]*AppInfo),
 		}
 	}
 	// Collect top-level definitions of slots
@@ -100,6 +101,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 			Name:      name,
 			Interface: iface,
 			Attrs:     attrs,
+			Apps:      make(map[string]*AppInfo),
 		}
 	}
 	// Collect definitions of apps
@@ -119,6 +121,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 					Snap:      snap,
 					Name:      name,
 					Interface: name,
+					Apps:      make(map[string]*AppInfo),
 				}
 			}
 		}
@@ -128,6 +131,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 					Snap:      snap,
 					Name:      name,
 					Interface: name,
+					Apps:      make(map[string]*AppInfo),
 				}
 			}
 		}
@@ -135,26 +139,24 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	// Bind apps to plugs and slots
 	for appName, app := range y.RawApps {
 		for _, slotName := range app.SlotNames {
-			slot := snap.Slots[slotName]
-			slot.apps = append(slot.apps, appName)
+			snap.Slots[slotName].Apps[appName] = snap.Apps[appName]
 		}
 		for _, plugName := range app.PlugNames {
-			plug := snap.Plugs[plugName]
-			plug.apps = append(plug.apps, appName)
+			snap.Plugs[plugName].Apps[appName] = snap.Apps[appName]
 		}
 	}
 	// Bind unbound plugs and slots to all apps
 	for _, plug := range snap.Plugs {
-		if len(plug.apps) == 0 {
+		if len(plug.Apps) == 0 {
 			for name := range y.RawApps {
-				plug.apps = append(plug.apps, name)
+				plug.Apps[name] = snap.Apps[name]
 			}
 		}
 	}
 	for _, slot := range snap.Slots {
-		if len(slot.apps) == 0 {
+		if len(slot.Apps) == 0 {
 			for name := range y.RawApps {
-				slot.apps = append(slot.apps, name)
+				slot.Apps[name] = snap.Apps[name]
 			}
 		}
 	}

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -180,6 +180,10 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface string, attrs map[string]interface{}, err error) {
 	iface = name
 	switch data.(type) {
+	case string:
+		return data.(string), nil, nil
+	case nil:
+		return name, nil, nil
 	case map[interface{}]interface{}:
 		for keyData, valueData := range data.(map[interface{}]interface{}) {
 			key, ok := keyData.(string)
@@ -206,10 +210,6 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface s
 			}
 		}
 		return iface, attrs, nil
-	case string:
-		return data.(string), nil, nil
-	case nil:
-		return name, nil, nil
 	default:
 		return "", nil, fmt.Errorf("%s %q has malformed definition (found %T)", plugOrSlot, name, data)
 	}

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -33,9 +33,9 @@ type snapYaml struct {
 	Type        Type                   `yaml:"type"`
 	Channel     string                 `yaml:"channel"`
 	Description string                 `yaml:"description"`
-	RawPlugs    map[string]interface{} `yaml:"plugs,omitempty"`
-	RawSlots    map[string]interface{} `yaml:"slots,omitempty"`
-	RawApps     map[string]appYaml     `yaml:"apps,omitempty"`
+	Plugs       map[string]interface{} `yaml:"plugs,omitempty"`
+	Slots       map[string]interface{} `yaml:"slots,omitempty"`
+	Apps        map[string]appYaml     `yaml:"apps,omitempty"`
 }
 
 type plugYaml struct {
@@ -77,7 +77,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		Slots:       make(map[string]*SlotInfo),
 	}
 	// Collect top-level definitions of plugs
-	for name, data := range y.RawPlugs {
+	for name, data := range y.Plugs {
 		iface, attrs, err := convertToSlotOrPlugData("plug", name, data)
 		if err != nil {
 			return nil, err
@@ -91,7 +91,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		}
 	}
 	// Collect top-level definitions of slots
-	for name, data := range y.RawSlots {
+	for name, data := range y.Slots {
 		iface, attrs, err := convertToSlotOrPlugData("slot", name, data)
 		if err != nil {
 			return nil, err
@@ -105,7 +105,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		}
 	}
 	// Collect definitions of apps
-	for name, app := range y.RawApps {
+	for name, app := range y.Apps {
 		snap.Apps[name] = &AppInfo{
 			Snap:  snap,
 			Name:  name,
@@ -114,7 +114,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		}
 	}
 	// Collect app-level implicit definitions of plugs and slots
-	for _, app := range y.RawApps {
+	for _, app := range y.Apps {
 		for _, name := range app.PlugNames {
 			if _, ok := snap.Plugs[name]; !ok {
 				snap.Plugs[name] = &PlugInfo{
@@ -137,7 +137,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		}
 	}
 	// Bind apps to plugs and slots
-	for appName, app := range y.RawApps {
+	for appName, app := range y.Apps {
 		for _, slotName := range app.SlotNames {
 			snap.Slots[slotName].Apps[appName] = snap.Apps[appName]
 		}
@@ -148,29 +148,29 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	// Bind unbound plugs and slots to all apps
 	for _, plug := range snap.Plugs {
 		if len(plug.Apps) == 0 {
-			for name := range y.RawApps {
+			for name := range y.Apps {
 				plug.Apps[name] = snap.Apps[name]
 			}
 		}
 	}
 	for _, slot := range snap.Slots {
 		if len(slot.Apps) == 0 {
-			for name := range y.RawApps {
+			for name := range y.Apps {
 				slot.Apps[name] = snap.Apps[name]
 			}
 		}
 	}
 	// Bind unbound apps to all plugs and slots
 	for _, app := range snap.Apps {
-		// NOTE: This used RawPlugs and RawSlots so that implicitly defined
+		// NOTE: This used Plugs and Slots so that implicitly defined
 		// (non-top-level) plugs and slots don't get bound here.
 		if len(app.plugs) == 0 {
-			for name := range y.RawPlugs {
+			for name := range y.Plugs {
 				app.plugs = append(app.plugs, name)
 			}
 		}
 		if len(app.slots) == 0 {
-			for name := range y.RawSlots {
+			for name := range y.Slots {
 				app.slots = append(app.slots, name)
 			}
 		}

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -175,11 +175,9 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	return snap, nil
 }
 
-func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (string, map[string]interface{}, error) {
+func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface string, attrs map[string]interface{}, err error) {
 	switch data.(type) {
 	case map[interface{}]interface{}:
-		attrs := make(map[string]interface{})
-		iface := ""
 		for keyData, valueData := range data.(map[interface{}]interface{}) {
 			key, ok := keyData.(string)
 			if !ok {
@@ -198,11 +196,11 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (string,
 				}
 				iface = value
 			} else {
+				if attrs == nil {
+					attrs = make(map[string]interface{})
+				}
 				attrs[key] = valueData
 			}
-		}
-		if len(attrs) == 0 {
-			attrs = nil
 		}
 		if iface == "" {
 			return "", nil, fmt.Errorf("%s %q doesn't define interface name", plugOrSlot, name)

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -21,18 +21,200 @@ package snap
 
 import (
 	"fmt"
+	"strings"
+
 	"gopkg.in/yaml.v2"
 )
 
+type snapYaml struct {
+	Name        string                 `yaml:"name"`
+	Developer   string                 `yaml:"developer"`
+	Version     string                 `yaml:"version"`
+	Type        Type                   `yaml:"type"`
+	Channel     string                 `yaml:"channel"`
+	Description string                 `yaml:"description"`
+	RawPlugs    map[string]interface{} `yaml:"plugs,omitempty"`
+	RawSlots    map[string]interface{} `yaml:"slots,omitempty"`
+	RawApps     map[string]appYaml     `yaml:"apps,omitempty"`
+}
+
+type plugYaml struct {
+	Interface string                 `yaml:"interface"`
+	Attrs     map[string]interface{} `yaml:"attrs,omitempty"`
+	Apps      []string               `yaml:"apps,omitempty"`
+	Label     string                 `yaml:"label"`
+}
+
+type slotYaml struct {
+	Interface string                 `yaml:"interface"`
+	Attrs     map[string]interface{} `yaml:"attrs,omitempty"`
+	Apps      []string               `yaml:"apps,omitempty"`
+	Label     string                 `yaml:"label"`
+}
+
+type appYaml struct {
+	SlotNames []string `yaml:"slots,omitempty"`
+	PlugNames []string `yaml:"plugs,omitempty"`
+}
+
 // InfoFromSnapYaml creates a new info based on the given snap.yaml data
 func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
-	var s Info
-	err := yaml.Unmarshal(yamlData, &s)
+	var y snapYaml
+	err := yaml.Unmarshal(yamlData, &y)
 	if err != nil {
 		return nil, fmt.Errorf("info failed to parse: %s", err)
 	}
-
+	// Construct snap skeleton, without apps, plugs and slots
+	snap := &Info{
+		Name:        y.Name,
+		Developer:   y.Developer,
+		Version:     y.Version,
+		Type:        y.Type,
+		Channel:     y.Channel,
+		Description: y.Description,
+		Apps:        make(map[string]*AppInfo),
+		Plugs:       make(map[string]*PlugInfo),
+		Slots:       make(map[string]*SlotInfo),
+	}
+	// Collect top-level definitions of plugs
+	for name, data := range y.RawPlugs {
+		iface, attrs, err := convertToSlotOrPlugData("plug", name, data)
+		if err != nil {
+			return nil, err
+		}
+		snap.Plugs[name] = &PlugInfo{
+			Snap:      snap,
+			Name:      name,
+			Interface: iface,
+			Attrs:     attrs,
+		}
+	}
+	// Collect top-level definitions of slots
+	for name, data := range y.RawSlots {
+		iface, attrs, err := convertToSlotOrPlugData("slot", name, data)
+		if err != nil {
+			return nil, err
+		}
+		snap.Slots[name] = &SlotInfo{
+			Snap:      snap,
+			Name:      name,
+			Interface: iface,
+			Attrs:     attrs,
+		}
+	}
+	// Collect definitions of apps
+	for name, app := range y.RawApps {
+		snap.Apps[name] = &AppInfo{
+			Snap:  snap,
+			Name:  name,
+			slots: app.SlotNames,
+			plugs: app.PlugNames,
+		}
+	}
+	// Collect app-level implicit definitions of plugs and slots
+	for _, app := range y.RawApps {
+		for _, name := range app.PlugNames {
+			if _, ok := snap.Plugs[name]; !ok {
+				snap.Plugs[name] = &PlugInfo{
+					Snap:      snap,
+					Name:      name,
+					Interface: name,
+				}
+			}
+		}
+		for _, name := range app.SlotNames {
+			if _, ok := snap.Slots[name]; !ok {
+				snap.Slots[name] = &SlotInfo{
+					Snap:      snap,
+					Name:      name,
+					Interface: name,
+				}
+			}
+		}
+	}
+	// Bind apps to plugs and slots
+	for appName, app := range y.RawApps {
+		for _, slotName := range app.SlotNames {
+			slot := snap.Slots[slotName]
+			slot.apps = append(slot.apps, appName)
+		}
+		for _, plugName := range app.PlugNames {
+			plug := snap.Plugs[plugName]
+			plug.apps = append(plug.apps, appName)
+		}
+	}
+	// Bind unbound plugs and slots to all apps
+	for _, plug := range snap.Plugs {
+		if len(plug.apps) == 0 {
+			for name := range y.RawApps {
+				plug.apps = append(plug.apps, name)
+			}
+		}
+	}
+	for _, slot := range snap.Slots {
+		if len(slot.apps) == 0 {
+			for name := range y.RawApps {
+				slot.apps = append(slot.apps, name)
+			}
+		}
+	}
+	// Bind unbound apps to all plugs and slots
+	for _, app := range snap.Apps {
+		// NOTE: This used RawPlugs and RawSlots so that implicitly defined
+		// (non-top-level) plugs and slots don't get bound here.
+		if len(app.plugs) == 0 {
+			for name := range y.RawPlugs {
+				app.plugs = append(app.plugs, name)
+			}
+		}
+		if len(app.slots) == 0 {
+			for name := range y.RawSlots {
+				app.slots = append(app.slots, name)
+			}
+		}
+	}
 	// FIXME: validation of the fields
+	return snap, nil
+}
 
-	return &s, nil
+func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (string, map[string]interface{}, error) {
+	switch data.(type) {
+	case map[interface{}]interface{}:
+		attrs := make(map[string]interface{})
+		iface := ""
+		for keyData, valueData := range data.(map[interface{}]interface{}) {
+			key, ok := keyData.(string)
+			if !ok {
+				return "", nil, fmt.Errorf("%s %q has attribute that is not a string (found %T)",
+					plugOrSlot, name, keyData)
+			}
+			if strings.HasPrefix(key, "$") {
+				return "", nil, fmt.Errorf("%s %q uses reserved attribute %q", plugOrSlot, name, key)
+			}
+			// XXX: perhaps we could special-case "label" the same way?
+			if key == "interface" {
+				value, ok := valueData.(string)
+				if !ok {
+					return "", nil, fmt.Errorf("interface name on %s %q is not a string (found %T)",
+						plugOrSlot, name, valueData)
+				}
+				iface = value
+			} else {
+				attrs[key] = valueData
+			}
+		}
+		if len(attrs) == 0 {
+			attrs = nil
+		}
+		if iface == "" {
+			return "", nil, fmt.Errorf("%s %q doesn't define interface name", plugOrSlot, name)
+		}
+		return iface, attrs, nil
+	case string:
+		return data.(string), nil, nil
+	case nil:
+		return name, nil, nil
+	default:
+		return "", nil, fmt.Errorf("%s %q has malformed definition (found %T)", plugOrSlot, name, data)
+	}
 }

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -199,11 +199,11 @@ apps:
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
 	c.Check(plug.Snap, Equals, info)
-	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
+	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
-	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
-	c.Check(app.Slots(), HasLen, 0)
+	c.Check(app.Plugs, DeepEquals, map[string]*snap.PlugInfo{plug.Name: plug})
+	c.Check(app.Slots, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalPlugsExplicitlyDefinedExplicitlyBoundToApps(c *C) {
@@ -229,11 +229,11 @@ apps:
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
 	c.Check(plug.Snap, Equals, info)
-	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
+	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
-	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
-	c.Check(app.Slots(), HasLen, 0)
+	c.Check(app.Plugs, DeepEquals, map[string]*snap.PlugInfo{plug.Name: plug})
+	c.Check(app.Slots, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalPlugsImplicitlyDefinedExplicitlyBoundToApps(c *C) {
@@ -257,11 +257,11 @@ apps:
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
 	c.Check(plug.Snap, Equals, info)
-	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
+	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
-	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
-	c.Check(app.Slots(), HasLen, 0)
+	c.Check(app.Plugs, DeepEquals, map[string]*snap.PlugInfo{plug.Name: plug})
+	c.Check(app.Slots, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalCorruptedPlugWithoutInterfaceName(c *C) {
@@ -449,11 +449,11 @@ apps:
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
 	c.Check(slot.Snap, Equals, info)
-	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
+	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
-	c.Check(app.Plugs(), HasLen, 0)
-	c.Check(app.Slots(), DeepEquals, []*snap.SlotInfo{slot})
+	c.Check(app.Plugs, HasLen, 0)
+	c.Check(app.Slots, DeepEquals, map[string]*snap.SlotInfo{slot.Name: slot})
 }
 
 func (s *YamlSuite) TestUnmarshalSlotsExplicitlyDefinedExplicitlyBoundToApps(c *C) {
@@ -479,11 +479,11 @@ apps:
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
 	c.Check(slot.Snap, Equals, info)
-	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
+	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
-	c.Check(app.Plugs(), HasLen, 0)
-	c.Check(app.Slots(), DeepEquals, []*snap.SlotInfo{slot})
+	c.Check(app.Plugs, HasLen, 0)
+	c.Check(app.Slots, DeepEquals, map[string]*snap.SlotInfo{slot.Name: slot})
 }
 
 func (s *YamlSuite) TestUnmarshalSlotsImplicitlyDefinedExplicitlyBoundToApps(c *C) {
@@ -507,11 +507,11 @@ apps:
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
 	c.Check(slot.Snap, Equals, info)
-	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
+	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
-	c.Check(app.Plugs(), HasLen, 0)
-	c.Check(app.Slots(), DeepEquals, []*snap.SlotInfo{slot})
+	c.Check(app.Plugs, HasLen, 0)
+	c.Check(app.Slots, DeepEquals, map[string]*snap.SlotInfo{slot.Name: slot})
 }
 
 func (s *YamlSuite) TestUnmarshalCorruptedSlotWithoutInterfaceName(c *C) {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -199,7 +199,7 @@ apps:
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
 	c.Check(plug.Snap, Equals, info)
-	c.Check(plug.Apps(), DeepEquals, []*snap.AppInfo{app})
+	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
 
 	c.Assert(app, Not(IsNil))
 	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
@@ -229,7 +229,7 @@ apps:
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
 	c.Check(plug.Snap, Equals, info)
-	c.Check(plug.Apps(), DeepEquals, []*snap.AppInfo{app})
+	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
 
 	c.Assert(app, Not(IsNil))
 	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
@@ -257,7 +257,7 @@ apps:
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
 	c.Check(plug.Snap, Equals, info)
-	c.Check(plug.Apps(), DeepEquals, []*snap.AppInfo{app})
+	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
 
 	c.Assert(app, Not(IsNil))
 	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
@@ -449,7 +449,7 @@ apps:
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
 	c.Check(slot.Snap, Equals, info)
-	c.Check(slot.Apps(), DeepEquals, []*snap.AppInfo{app})
+	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
 
 	c.Assert(app, Not(IsNil))
 	c.Check(app.Plugs(), HasLen, 0)
@@ -479,7 +479,7 @@ apps:
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
 	c.Check(slot.Snap, Equals, info)
-	c.Check(slot.Apps(), DeepEquals, []*snap.AppInfo{app})
+	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
 
 	c.Assert(app, Not(IsNil))
 	c.Check(app.Plugs(), HasLen, 0)
@@ -507,7 +507,7 @@ apps:
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
 	c.Check(slot.Snap, Equals, info)
-	c.Check(slot.Apps(), DeepEquals, []*snap.AppInfo{app})
+	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{"app": app})
 
 	c.Assert(app, Not(IsNil))
 	c.Check(app.Plugs(), HasLen, 0)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -264,15 +264,28 @@ apps:
 	c.Check(app.Slots, HasLen, 0)
 }
 
-func (s *YamlSuite) TestUnmarshalCorruptedPlugWithoutInterfaceName(c *C) {
+func (s *YamlSuite) TestUnmarshalPlugWithoutInterfaceName(c *C) {
 	// NOTE: yaml content cannot use tabs, indent the section with spaces.
-	_, err := snap.InfoFromSnapYaml([]byte(`
+	info, err := snap.InfoFromSnapYaml([]byte(`
 name: snap
 plugs:
-    net:
+    network-client:
         ipv6-aware: true
 `))
-	c.Assert(err, ErrorMatches, `plug "net" doesn't define interface name`)
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	c.Check(info.Apps, HasLen, 0)
+	plug := info.Plugs["network-client"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Name, Equals, "network-client")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Attrs, DeepEquals, map[string]interface{}{"ipv6-aware": true})
+	c.Check(plug.Label, Equals, "")
+	c.Check(plug.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalCorruptedPlugWithNonStringInterfaceName(c *C) {
@@ -514,15 +527,28 @@ apps:
 	c.Check(app.Slots, DeepEquals, map[string]*snap.SlotInfo{slot.Name: slot})
 }
 
-func (s *YamlSuite) TestUnmarshalCorruptedSlotWithoutInterfaceName(c *C) {
+func (s *YamlSuite) TestUnmarshalSlotWithoutInterfaceName(c *C) {
 	// NOTE: yaml content cannot use tabs, indent the section with spaces.
-	_, err := snap.InfoFromSnapYaml([]byte(`
+	info, err := snap.InfoFromSnapYaml([]byte(`
 name: snap
 slots:
-    net:
+    network-client:
         ipv6-aware: true
 `))
-	c.Assert(err, ErrorMatches, `slot "net" doesn't define interface name`)
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	c.Check(info.Apps, HasLen, 0)
+	slot := info.Slots["network-client"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Name, Equals, "network-client")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"ipv6-aware": true})
+	c.Check(slot.Label, Equals, "")
+	c.Check(slot.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringInterfaceName(c *C) {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -17,10 +17,12 @@
  *
  */
 
-package snap
+package snap_test
 
 import (
 	"testing"
+
+	"github.com/ubuntu-core/snappy/snap"
 
 	. "gopkg.in/check.v1"
 )
@@ -39,14 +41,531 @@ type: app
 `)
 
 func (s *InfoSnapYamlTestSuite) TestSimple(c *C) {
-	info, err := InfoFromSnapYaml(mockYaml)
+	info, err := snap.InfoFromSnapYaml(mockYaml)
 	c.Assert(err, IsNil)
 	c.Assert(info.Name, Equals, "foo")
 	c.Assert(info.Version, Equals, "1.0")
-	c.Assert(info.Type, Equals, TypeApp)
+	c.Assert(info.Type, Equals, snap.TypeApp)
 }
 
 func (s *InfoSnapYamlTestSuite) TestFail(c *C) {
-	_, err := InfoFromSnapYaml([]byte("random-crap"))
+	_, err := snap.InfoFromSnapYaml([]byte("random-crap"))
 	c.Assert(err, ErrorMatches, "(?m)info failed to parse:.*")
+}
+
+type YamlSuite struct{}
+
+var _ = Suite(&YamlSuite{})
+
+func (s *YamlSuite) TestUnmarshalGarbage(c *C) {
+	_, err := snap.InfoFromSnapYaml([]byte(`"`))
+	c.Assert(err, ErrorMatches, ".*: yaml: found unexpected end of stream")
+}
+
+func (s *YamlSuite) TestUnmarshalEmpty(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(``))
+	c.Assert(err, IsNil)
+	c.Assert(info.Plugs, HasLen, 0)
+	c.Assert(info.Slots, HasLen, 0)
+	c.Assert(info.Apps, HasLen, 0)
+}
+
+// Tests focusing on plugs
+
+func (s *YamlSuite) TestUnmarshalStandaloneImplicitPlug(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    network-client:
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	plug := info.Plugs["network-client"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Name, Equals, "network-client")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneAbbreviatedPlug(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net: network-client
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	plug := info.Plugs["net"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Name, Equals, "net")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneMinimalisticPlug(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net:
+        interface: network-client
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	plug := info.Plugs["net"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Name, Equals, "net")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneCompletePlug(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net:
+        interface: network-client
+        ipv6-aware: true
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	plug := info.Plugs["net"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Name, Equals, "net")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Attrs, DeepEquals, map[string]interface{}{"ipv6-aware": true})
+	c.Check(plug.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalLastPlugDefinitionWins(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net:
+        interface: network-client
+        attr: 1
+    net:
+        interface: network-client
+        attr: 2
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	plug := info.Plugs["net"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Name, Equals, "net")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Attrs, DeepEquals, map[string]interface{}{"attr": 2})
+	c.Check(plug.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalPlugsExplicitlyDefinedImplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    network-client:
+apps:
+    app:
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	c.Check(info.Apps, HasLen, 1)
+	plug := info.Plugs["network-client"]
+	app := info.Apps["app"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Name, Equals, "network-client")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Attrs, HasLen, 0)
+	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Apps(), DeepEquals, []*snap.AppInfo{app})
+
+	c.Assert(app, Not(IsNil))
+	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
+	c.Check(app.Slots(), HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalPlugsExplicitlyDefinedExplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net: network-client
+apps:
+    app:
+        plugs: ["net"]
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	c.Check(info.Apps, HasLen, 1)
+	plug := info.Plugs["net"]
+	app := info.Apps["app"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Name, Equals, "net")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Attrs, HasLen, 0)
+	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Apps(), DeepEquals, []*snap.AppInfo{app})
+
+	c.Assert(app, Not(IsNil))
+	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
+	c.Check(app.Slots(), HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalPlugsImplicitlyDefinedExplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+apps:
+    app:
+        plugs: ["network-client"]
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	c.Check(info.Apps, HasLen, 1)
+	plug := info.Plugs["network-client"]
+	app := info.Apps["app"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Name, Equals, "network-client")
+	c.Check(plug.Interface, Equals, "network-client")
+	c.Check(plug.Attrs, HasLen, 0)
+	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Apps(), DeepEquals, []*snap.AppInfo{app})
+
+	c.Assert(app, Not(IsNil))
+	c.Check(app.Plugs(), DeepEquals, []*snap.PlugInfo{plug})
+	c.Check(app.Slots(), HasLen, 0)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithoutInterfaceName(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net:
+        ipv6-aware: true
+`))
+	c.Assert(err, ErrorMatches, `plug "net" doesn't define interface name`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithNonStringInterfaceName(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net:
+        interface: 1.0
+        ipv6-aware: true
+`))
+	c.Assert(err, ErrorMatches, `interface name on plug "net" is not a string \(found float64\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithNonStringAttributes(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net:
+        1: ok
+`))
+	c.Assert(err, ErrorMatches, `plug "net" has attribute that is not a string \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithUnexpectedType(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    net: 5
+`))
+	c.Assert(err, ErrorMatches, `plug "net" has malformed definition \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalReservedPlugAttribute(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    serial:
+        interface: serial-port
+        $baud-rate: [9600]
+`))
+	c.Assert(err, ErrorMatches, `plug "serial" uses reserved attribute "\$baud-rate"`)
+}
+
+// Tests focusing on slots
+
+func (s *YamlSuite) TestUnmarshalStandaloneImplicitSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    network-client:
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	slot := info.Slots["network-client"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Name, Equals, "network-client")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneAbbreviatedSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net: network-client
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	slot := info.Slots["net"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Name, Equals, "net")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneMinimalisticSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net:
+        interface: network-client
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	slot := info.Slots["net"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Name, Equals, "net")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneCompleteSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net:
+        interface: network-client
+        ipv6-aware: true
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	slot := info.Slots["net"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Name, Equals, "net")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"ipv6-aware": true})
+	c.Check(slot.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalLastSlotDefinitionWins(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net:
+        interface: network-client
+        attr: 1
+    net:
+        interface: network-client
+        attr: 2
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	slot := info.Slots["net"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Name, Equals, "net")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"attr": 2})
+	c.Check(slot.Snap, Equals, info)
+}
+
+func (s *YamlSuite) TestUnmarshalSlotsExplicitlyDefinedImplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    network-client:
+apps:
+    app:
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	c.Check(info.Apps, HasLen, 1)
+	slot := info.Slots["network-client"]
+	app := info.Apps["app"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Name, Equals, "network-client")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Attrs, HasLen, 0)
+	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Apps(), DeepEquals, []*snap.AppInfo{app})
+
+	c.Assert(app, Not(IsNil))
+	c.Check(app.Plugs(), HasLen, 0)
+	c.Check(app.Slots(), DeepEquals, []*snap.SlotInfo{slot})
+}
+
+func (s *YamlSuite) TestUnmarshalSlotsExplicitlyDefinedExplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net: network-client
+apps:
+    app:
+        slots: ["net"]
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	c.Check(info.Apps, HasLen, 1)
+	slot := info.Slots["net"]
+	app := info.Apps["app"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Name, Equals, "net")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Attrs, HasLen, 0)
+	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Apps(), DeepEquals, []*snap.AppInfo{app})
+
+	c.Assert(app, Not(IsNil))
+	c.Check(app.Plugs(), HasLen, 0)
+	c.Check(app.Slots(), DeepEquals, []*snap.SlotInfo{slot})
+}
+
+func (s *YamlSuite) TestUnmarshalSlotsImplicitlyDefinedExplicitlyBoundToApps(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+apps:
+    app:
+        slots: ["network-client"]
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	c.Check(info.Apps, HasLen, 1)
+	slot := info.Slots["network-client"]
+	app := info.Apps["app"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Name, Equals, "network-client")
+	c.Check(slot.Interface, Equals, "network-client")
+	c.Check(slot.Attrs, HasLen, 0)
+	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Apps(), DeepEquals, []*snap.AppInfo{app})
+
+	c.Assert(app, Not(IsNil))
+	c.Check(app.Plugs(), HasLen, 0)
+	c.Check(app.Slots(), DeepEquals, []*snap.SlotInfo{slot})
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithoutInterfaceName(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net:
+        ipv6-aware: true
+`))
+	c.Assert(err, ErrorMatches, `slot "net" doesn't define interface name`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringInterfaceName(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net:
+        interface: 1.0
+        ipv6-aware: true
+`))
+	c.Assert(err, ErrorMatches, `interface name on slot "net" is not a string \(found float64\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringAttributes(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net:
+        1: ok
+`))
+	c.Assert(err, ErrorMatches, `slot "net" has attribute that is not a string \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithUnexpectedType(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    net: 5
+`))
+	c.Assert(err, ErrorMatches, `slot "net" has malformed definition \(found int\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalReservedSlotAttribute(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    serial:
+        interface: serial-port
+        $baud-rate: [9600]
+`))
+	c.Assert(err, ErrorMatches, `slot "serial" uses reserved attribute "\$baud-rate"`)
 }

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -86,9 +86,12 @@ plugs:
 	plug := info.Plugs["network-client"]
 
 	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
 	c.Check(plug.Name, Equals, "network-client")
 	c.Check(plug.Interface, Equals, "network-client")
-	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Attrs, HasLen, 0)
+	c.Check(plug.Label, Equals, "")
+	c.Check(plug.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalStandaloneAbbreviatedPlug(c *C) {
@@ -105,9 +108,12 @@ plugs:
 	plug := info.Plugs["net"]
 
 	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
 	c.Check(plug.Name, Equals, "net")
 	c.Check(plug.Interface, Equals, "network-client")
-	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Attrs, HasLen, 0)
+	c.Check(plug.Label, Equals, "")
+	c.Check(plug.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalStandaloneMinimalisticPlug(c *C) {
@@ -125,9 +131,12 @@ plugs:
 	plug := info.Plugs["net"]
 
 	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
 	c.Check(plug.Name, Equals, "net")
 	c.Check(plug.Interface, Equals, "network-client")
-	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Attrs, HasLen, 0)
+	c.Check(plug.Label, Equals, "")
+	c.Check(plug.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalStandaloneCompletePlug(c *C) {
@@ -146,10 +155,12 @@ plugs:
 	plug := info.Plugs["net"]
 
 	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
 	c.Check(plug.Name, Equals, "net")
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, DeepEquals, map[string]interface{}{"ipv6-aware": true})
-	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Label, Equals, "")
+	c.Check(plug.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalLastPlugDefinitionWins(c *C) {
@@ -171,10 +182,12 @@ plugs:
 	plug := info.Plugs["net"]
 
 	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
 	c.Check(plug.Name, Equals, "net")
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, DeepEquals, map[string]interface{}{"attr": 2})
-	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Label, Equals, "")
+	c.Check(plug.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalPlugsExplicitlyDefinedImplicitlyBoundToApps(c *C) {
@@ -195,10 +208,11 @@ apps:
 	app := info.Apps["app"]
 
 	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
 	c.Check(plug.Name, Equals, "network-client")
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
-	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Label, Equals, "")
 	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
@@ -225,10 +239,11 @@ apps:
 	app := info.Apps["app"]
 
 	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
 	c.Check(plug.Name, Equals, "net")
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
-	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Label, Equals, "")
 	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
@@ -253,10 +268,11 @@ apps:
 	app := info.Apps["app"]
 
 	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
 	c.Check(plug.Name, Equals, "network-client")
 	c.Check(plug.Interface, Equals, "network-client")
 	c.Check(plug.Attrs, HasLen, 0)
-	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Label, Equals, "")
 	c.Check(plug.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
@@ -288,6 +304,30 @@ plugs:
 	c.Check(plug.Apps, HasLen, 0)
 }
 
+func (s *YamlSuite) TestUnmarshalPlugWithLabel(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    bool-file:
+        label: Disk I/O indicator
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	c.Check(info.Apps, HasLen, 0)
+	plug := info.Plugs["bool-file"]
+
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Name, Equals, "bool-file")
+	c.Check(plug.Interface, Equals, "bool-file")
+	c.Check(plug.Attrs, HasLen, 0)
+	c.Check(plug.Label, Equals, "Disk I/O indicator")
+	c.Check(plug.Apps, HasLen, 0)
+}
+
 func (s *YamlSuite) TestUnmarshalCorruptedPlugWithNonStringInterfaceName(c *C) {
 	// NOTE: yaml content cannot use tabs, indent the section with spaces.
 	_, err := snap.InfoFromSnapYaml([]byte(`
@@ -298,6 +338,17 @@ plugs:
         ipv6-aware: true
 `))
 	c.Assert(err, ErrorMatches, `interface name on plug "net" is not a string \(found float64\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedPlugWithNonStringLabel(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    bool-file:
+        label: 1.0
+`))
+	c.Assert(err, ErrorMatches, `label of plug "bool-file" is not a string \(found float64\)`)
 }
 
 func (s *YamlSuite) TestUnmarshalCorruptedPlugWithNonStringAttributes(c *C) {
@@ -349,9 +400,12 @@ slots:
 	slot := info.Slots["network-client"]
 
 	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
 	c.Check(slot.Name, Equals, "network-client")
 	c.Check(slot.Interface, Equals, "network-client")
-	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Attrs, HasLen, 0)
+	c.Check(slot.Label, Equals, "")
+	c.Check(slot.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalStandaloneAbbreviatedSlot(c *C) {
@@ -368,9 +422,12 @@ slots:
 	slot := info.Slots["net"]
 
 	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
 	c.Check(slot.Name, Equals, "net")
 	c.Check(slot.Interface, Equals, "network-client")
-	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Attrs, HasLen, 0)
+	c.Check(slot.Label, Equals, "")
+	c.Check(slot.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalStandaloneMinimalisticSlot(c *C) {
@@ -388,9 +445,12 @@ slots:
 	slot := info.Slots["net"]
 
 	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
 	c.Check(slot.Name, Equals, "net")
 	c.Check(slot.Interface, Equals, "network-client")
-	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Attrs, HasLen, 0)
+	c.Check(slot.Label, Equals, "")
+	c.Check(slot.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalStandaloneCompleteSlot(c *C) {
@@ -409,10 +469,12 @@ slots:
 	slot := info.Slots["net"]
 
 	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
 	c.Check(slot.Name, Equals, "net")
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"ipv6-aware": true})
-	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Label, Equals, "")
+	c.Check(slot.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalLastSlotDefinitionWins(c *C) {
@@ -434,10 +496,12 @@ slots:
 	slot := info.Slots["net"]
 
 	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
 	c.Check(slot.Name, Equals, "net")
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, DeepEquals, map[string]interface{}{"attr": 2})
-	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Label, Equals, "")
+	c.Check(slot.Apps, HasLen, 0)
 }
 
 func (s *YamlSuite) TestUnmarshalSlotsExplicitlyDefinedImplicitlyBoundToApps(c *C) {
@@ -458,10 +522,11 @@ apps:
 	app := info.Apps["app"]
 
 	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
 	c.Check(slot.Name, Equals, "network-client")
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
-	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Label, Equals, "")
 	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
@@ -488,10 +553,11 @@ apps:
 	app := info.Apps["app"]
 
 	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
 	c.Check(slot.Name, Equals, "net")
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
-	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Label, Equals, "")
 	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
@@ -516,10 +582,11 @@ apps:
 	app := info.Apps["app"]
 
 	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
 	c.Check(slot.Name, Equals, "network-client")
 	c.Check(slot.Interface, Equals, "network-client")
 	c.Check(slot.Attrs, HasLen, 0)
-	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Label, Equals, "")
 	c.Check(slot.Apps, DeepEquals, map[string]*snap.AppInfo{app.Name: app})
 
 	c.Assert(app, Not(IsNil))
@@ -551,6 +618,31 @@ slots:
 	c.Check(slot.Apps, HasLen, 0)
 }
 
+func (s *YamlSuite) TestUnmarshalSlotWithLabel(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    led0:
+        interface: bool-file
+        label: Front panel LED (red)
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name, Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	c.Check(info.Apps, HasLen, 0)
+	slot := info.Slots["led0"]
+
+	c.Assert(slot, Not(IsNil))
+	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Name, Equals, "led0")
+	c.Check(slot.Interface, Equals, "bool-file")
+	c.Check(slot.Attrs, HasLen, 0)
+	c.Check(slot.Label, Equals, "Front panel LED (red)")
+	c.Check(slot.Apps, HasLen, 0)
+}
+
 func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringInterfaceName(c *C) {
 	// NOTE: yaml content cannot use tabs, indent the section with spaces.
 	_, err := snap.InfoFromSnapYaml([]byte(`
@@ -561,6 +653,17 @@ slots:
         ipv6-aware: true
 `))
 	c.Assert(err, ErrorMatches, `interface name on slot "net" is not a string \(found float64\)`)
+}
+
+func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringLabel(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    bool-file:
+        label: 1.0
+`))
+	c.Assert(err, ErrorMatches, `label of slot "bool-file" is not a string \(found float64\)`)
 }
 
 func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringAttributes(c *C) {


### PR DESCRIPTION
This patch extends snap.Info to understand apps (partially), plugs and
slots. This is sufficient to discover all interface details from a raw
yaml file.

The API allows individual sub-objects (like app, plug or slot) to refer
back to the snap for other bits of information (e.g. snap name).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>