### PR TITLE
debian/snappy-autopilot.timer: run four times a day

### DIFF
--- a/debian/snappy-autopilot.timer
+++ b/debian/snappy-autopilot.timer
@@ -2,9 +2,10 @@
 Description=Ubuntu Core Snappy AutoUpdate
 
 [Timer]
-OnCalendar=hourly
+OnCalendar=23,05,11,17:00
+RandomizedDelaySec=6h
+AccuracySec=10min
 Persistent=true
-AccuracySec=15min
 Unit=snappy-autopilot.service
 
 [Install]


### PR DESCRIPTION
Note this uses `RandomizedDelaySec` which is only there as of 16.