### PR TITLE
overlord: introduce TaskSet, have the change prep functions return TaskSet

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -61,30 +61,30 @@ func Manager(s *state.State) (*InterfaceManager, error) {
 	return m, nil
 }
 
-// Connect initiates a change connecting an interface.
+// Connect returns a set of tasks for connecting an interface.
 //
-func Connect(change *state.Change, plugSnap, plugName, slotSnap, slotName string) error {
+func Connect(s *state.State, plugSnap, plugName, slotSnap, slotName string) (state.TaskSet, error) {
 	// TODO: Store the intent-to-connect in the state so that we automatically
 	// try to reconnect on reboot (reconnection can fail or can connect with
 	// different parameters so we cannot store the actual connection details).
 	summary := fmt.Sprintf(i18n.G("Connect %s:%s to %s:%s"),
 		plugSnap, plugName, slotSnap, slotName)
-	task := change.NewTask("connect", summary)
+	task := s.NewTask("connect", summary)
 	task.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
 	task.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plugName})
-	return nil
+	return state.NewTaskSet(task), nil
 }
 
-// Disconnect initiates a change disconnecting an interface.
-func Disconnect(change *state.Change, plugSnap, plugName, slotSnap, slotName string) error {
+// Disconnect returns a set of tasks for  disconnecting an interface.
+func Disconnect(s *state.State, plugSnap, plugName, slotSnap, slotName string) (state.TaskSet, error) {
 	// TODO: Remove the intent-to-connect from the state so that we no longer
 	// automatically try to reconnect on reboot.
 	summary := fmt.Sprintf(i18n.G("Disconnect %s:%s from %s:%s"),
 		plugSnap, plugName, slotSnap, slotName)
-	task := change.NewTask("disconnect", summary)
+	task := s.NewTask("disconnect", summary)
 	task.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
 	task.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plugName})
-	return nil
+	return state.NewTaskSet(task), nil
 }
 
 func getPlugAndSlotRefs(task *state.Task) (*interfaces.PlugRef, *interfaces.SlotRef, error) {

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -59,10 +59,11 @@ func (s *interfaceManagerSuite) TestConnectAddsTask(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	change := s.state.NewChange("kind", "summary")
-	err := ifacestate.Connect(change, "consumer", "plug", "producer", "slot")
+	ts, err := ifacestate.Connect(s.state, "consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
-	c.Assert(change.Tasks(), HasLen, 1)
+
+	change := s.state.NewChange("kind", "summary")
+	change.AddTasks(ts)
 	task := change.Tasks()[0]
 	c.Assert(task.Kind(), Equals, "connect")
 	var plug interfaces.PlugRef
@@ -83,8 +84,9 @@ func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
 
 	s.addPlugSlotAndInterface(c)
 	change := s.state.NewChange("kind", "summary")
-	err := ifacestate.Connect(change, "consumer", "plug", "producer", "slot")
+	ts, err := ifacestate.Connect(s.state, "consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
+	change.AddTasks(ts)
 
 	s.state.Unlock()
 	s.mgr.Ensure()
@@ -116,10 +118,11 @@ func (s *interfaceManagerSuite) TestDisconnectAddsTask(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	change := s.state.NewChange("kind", "summary")
-	err := ifacestate.Disconnect(change, "consumer", "plug", "producer", "slot")
+	ts, err := ifacestate.Disconnect(s.state, "consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
-	c.Assert(change.Tasks(), HasLen, 1)
+
+	change := s.state.NewChange("kind", "summary")
+	change.AddTasks(ts)
 	task := change.Tasks()[0]
 	c.Assert(task.Kind(), Equals, "disconnect")
 	var plug interfaces.PlugRef
@@ -143,8 +146,9 @@ func (s *interfaceManagerSuite) TestEnsureProcessesDisconnectTask(c *C) {
 	err := repo.Connect("consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
 	change := s.state.NewChange("kind", "summary")
-	err = ifacestate.Disconnect(change, "consumer", "plug", "producer", "slot")
+	ts, err := ifacestate.Disconnect(s.state, "consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
+	change.AddTasks(ts)
 
 	s.state.Unlock()
 	s.mgr.Ensure()

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -304,7 +304,8 @@ func (ovs *overlordSuite) TestTrivialSettle(c *C) {
 	defer s.Unlock()
 
 	chg := s.NewChange("chg", "...")
-	t1 := chg.NewTask("runMgr1", "1...")
+	t1 := s.NewTask("runMgr1", "1...")
+	chg.AddTask(t1)
 
 	s.Unlock()
 
@@ -335,9 +336,10 @@ func (ovs *overlordSuite) TestSettleChain(c *C) {
 	defer s.Unlock()
 
 	chg := s.NewChange("chg", "...")
-	t1 := chg.NewTask("runMgr1", "1...")
-	t2 := chg.NewTask("runMgr2", "2...")
+	t1 := s.NewTask("runMgr1", "1...")
+	t2 := s.NewTask("runMgr2", "2...")
 	t2.WaitFor(t1)
+	chg.AddTasks(state.NewTaskSet(t1, t2))
 
 	s.Unlock()
 
@@ -379,7 +381,8 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	defer s.Unlock()
 
 	chg := s.NewChange("chg", "...")
-	t := chg.NewTask("runMgrEnsureBefore", "...")
+	t := s.NewTask("runMgrEnsureBefore", "...")
+	chg.AddTask(t)
 	s.Unlock()
 
 	o.Settle()

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -31,23 +31,23 @@ import (
 	"github.com/ubuntu-core/snappy/snappy"
 )
 
-// Install initiates a change installing snap.
+// Install returns a set of tasks for installing snap.
 // Note that the state must be locked by the caller.
-func Install(change *state.Change, snap, channel string) error {
-	t := change.NewTask("install-snap", fmt.Sprintf(i18n.G("Installing %q"), snap))
+func Install(s *state.State, snap, channel string) (state.TaskSet, error) {
+	t := s.NewTask("install-snap", fmt.Sprintf(i18n.G("Installing %q"), snap))
 	t.Set("name", snap)
 	t.Set("channel", channel)
 
-	return nil
+	return state.NewTaskSet(t), nil
 }
 
-// Remove initiates a change removing snap.
+// Remove returns a set of tasks for removing snap.
 // Note that the state must be locked by the caller.
-func Remove(change *state.Change, snap string) error {
-	t := change.NewTask("remove-snap", fmt.Sprintf(i18n.G("Removing %q"), snap))
+func Remove(s *state.State, snap string) (state.TaskSet, error) {
+	t := s.NewTask("remove-snap", fmt.Sprintf(i18n.G("Removing %q"), snap))
 	t.Set("name", snap)
 
-	return nil
+	return state.NewTaskSet(t), nil
 }
 
 type backendIF interface {

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -75,10 +75,11 @@ func (s *snapmgrTestSuite) TestInstallAddsTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	chg := s.state.NewChange("install", "installing foo")
-	snapstate.Install(chg, "some-snap", "some-channel")
+	ts, err := snapstate.Install(s.state, "some-snap", "some-channel")
+	c.Assert(err, IsNil)
 
-	c.Assert(s.state.Changes(), HasLen, 1)
+	chg := s.state.NewChange("install", "installing foo")
+	chg.AddTasks(ts)
 	c.Assert(chg.Tasks(), HasLen, 1)
 	c.Assert(chg.Tasks()[0].Kind(), Equals, "install-snap")
 }
@@ -87,24 +88,30 @@ func (s *snapmgrTestSuite) TestRemoveAddsTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	chg := s.state.NewChange("remove", "removing foo")
-	snapstate.Remove(chg, "foo")
+	ts, err := snapstate.Remove(s.state, "foo")
+	c.Assert(err, IsNil)
 
-	c.Assert(s.state.Changes(), HasLen, 1)
+	chg := s.state.NewChange("remove", "removing foo")
+	chg.AddTasks(ts)
 	c.Assert(chg.Tasks(), HasLen, 1)
 	c.Assert(chg.Tasks()[0].Kind(), Equals, "remove-snap")
 }
 
 func (s *snapmgrTestSuite) TestInstallIntegration(c *C) {
 	s.state.Lock()
-	chg := s.state.NewChange("install", "install a snap")
-	err := snapstate.Install(chg, "some-snap", "some-channel")
-	s.state.Unlock()
+	defer s.state.Unlock()
 
+	chg := s.state.NewChange("install", "install a snap")
+	ts, err := snapstate.Install(s.state, "some-snap", "some-channel")
 	c.Assert(err, IsNil)
+	chg.AddTasks(ts)
+
+	s.state.Unlock()
 	s.snapmgr.Ensure()
 	s.snapmgr.Wait()
 	defer s.snapmgr.Stop()
+
+	s.state.Lock()
 
 	c.Assert(s.fakeBackend.op, Equals, "install")
 	c.Assert(s.fakeBackend.name, Equals, "some-snap")
@@ -113,14 +120,17 @@ func (s *snapmgrTestSuite) TestInstallIntegration(c *C) {
 
 func (s *snapmgrTestSuite) TestRemoveIntegration(c *C) {
 	s.state.Lock()
+	defer s.state.Unlock()
 	chg := s.state.NewChange("remove", "remove a snap")
-	err := snapstate.Remove(chg, "some-remove-snap")
-	s.state.Unlock()
-
+	ts, err := snapstate.Remove(s.state, "some-remove-snap")
 	c.Assert(err, IsNil)
+	chg.AddTasks(ts)
+
+	s.state.Unlock()
 	s.snapmgr.Ensure()
 	s.snapmgr.Wait()
 	defer s.snapmgr.Stop()
+	s.state.Lock()
 
 	c.Assert(s.fakeBackend.op, Equals, "remove")
 	c.Assert(s.fakeBackend.name, Equals, "some-remove-snap")

--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -216,18 +216,21 @@ func (c *Change) State() *State {
 	return c.state
 }
 
-// NewTask creates a new task and registers it as a required task for the
-// state change to be accomplished.
-func (c *Change) NewTask(kind, summary string) *Task {
+// AddTask registers a task as a required task for the state change to
+// be accomplished.
+func (c *Change) AddTask(t *Task) {
 	c.state.ensureLocked()
-	id := c.state.genID()
-	t := newTask(c.state, id, kind, summary)
-	c.state.tasks[id] = t
-	c.taskIDs.add(id)
-	return t
+	c.taskIDs.add(t.ID())
 }
 
-// TODO: AddTask
+// AddTasks registers all the tasks in the set as a required for the
+// state change to be accomplished.
+func (c *Change) AddTasks(ts TaskSet) {
+	c.state.ensureLocked()
+	for tid := range ts {
+		c.taskIDs.add(tid)
+	}
+}
 
 // Tasks returns all the tasks this state change depends on.
 func (c *Change) Tasks() []*Task {

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -238,6 +238,17 @@ func (s *State) Changes() []*Change {
 	return res
 }
 
+// NewTask creates a new task.
+// It usually will be registered with a Change using AddTask or
+// through a TaskSet.
+func (s *State) NewTask(kind, summary string) *Task {
+	s.ensureLocked()
+	id := s.genID()
+	t := newTask(s, id, kind, summary)
+	s.tasks[id] = t
+	return t
+}
+
 // Tasks returns all tasks currently known to the state.
 func (s *State) Tasks() []*Task {
 	s.ensureLocked()

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -195,6 +195,14 @@ func (t *Task) WaitFor(another *Task) {
 	another.haltTasks.add(t.id)
 }
 
+// WaitAll registers all the tasks in the set as a requirement for t
+// to make progress and sets the status as WaitingStatus.
+func (t *Task) WaitAll(ts TaskSet) {
+	for _, tReq := range ts {
+		t.WaitFor(tReq)
+	}
+}
+
 // WaitTasks returns the list of tasks registered for t to wait for.
 func (t *Task) WaitTasks() []*Task {
 	t.state.ensureLocked()
@@ -205,4 +213,24 @@ func (t *Task) WaitTasks() []*Task {
 func (t *Task) HaltTasks() []*Task {
 	t.state.ensureLocked()
 	return t.haltTasks.tasks(t.state)
+}
+
+// A TaskSet holds a set of tasks.
+type TaskSet map[string]*Task
+
+// NewTaskSet returns a new TaskSet comprising the given tasks.
+func NewTaskSet(tasks ...*Task) TaskSet {
+	ts := make(TaskSet, len(tasks))
+	for _, t := range tasks {
+		ts[t.ID()] = t
+	}
+	return ts
+}
+
+// WaitFor registers a task as a requirement for the tasks in the set
+// to make progress and sets their status as WaitingStatus.
+func (ts TaskSet) WaitFor(another *Task) {
+	for _, t := range ts {
+		t.WaitFor(another)
+	}
 }

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -37,8 +37,7 @@ func (ts *taskSuite) TestNewTask(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 
 	c.Check(t.Kind(), Equals, "download")
 	c.Check(t.Summary(), Equals, "1...")
@@ -49,8 +48,7 @@ func (ts *taskSuite) TestGetSet(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 
 	t.Set("a", 1)
 
@@ -63,8 +61,7 @@ func (ts *taskSuite) TestGetSet(c *C) {
 func (ts *taskSuite) TestGetNeedsLock(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	var v int
@@ -74,8 +71,7 @@ func (ts *taskSuite) TestGetNeedsLock(c *C) {
 func (ts *taskSuite) TestSetNeedsLock(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	c.Assert(func() { t.Set("a", 1) }, PanicMatches, "internal error: accessing state without lock")
@@ -86,8 +82,7 @@ func (ts *taskSuite) TestStatusAndSetStatus(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 
 	c.Check(t.Status(), Equals, state.RunningStatus)
 
@@ -99,8 +94,7 @@ func (ts *taskSuite) TestStatusAndSetStatus(c *C) {
 func (ts *taskSuite) TestStatusNeedsLock(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	c.Assert(func() { t.Status() }, PanicMatches, "internal error: accessing state without lock")
@@ -109,8 +103,7 @@ func (ts *taskSuite) TestStatusNeedsLock(c *C) {
 func (ts *taskSuite) TestSetStatusNeedsLock(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	c.Assert(func() { t.SetStatus(state.DoneStatus) }, PanicMatches, "internal error: accessing state without lock")
@@ -121,8 +114,7 @@ func (ts *taskSuite) TestProgressAndSetProgress(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 
 	t.SetProgress(2, 99)
 
@@ -137,8 +129,7 @@ func (ts *taskSuite) TestProgressDefaults(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 
 	c.Check(t.Status(), Equals, state.RunningStatus)
 	cur, tot := t.Progress()
@@ -169,8 +160,7 @@ func (ts *taskSuite) TestProgressDefaults(c *C) {
 func (ts *taskSuite) TestProgressNeedsLock(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	c.Assert(func() { t.Progress() }, PanicMatches, "internal error: accessing state without lock")
@@ -179,8 +169,7 @@ func (ts *taskSuite) TestProgressNeedsLock(c *C) {
 func (ts *taskSuite) TestSetProgressNeedsLock(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	c.Assert(func() { t.SetProgress(2, 2) }, PanicMatches, "internal error: accessing state without lock")
@@ -189,8 +178,7 @@ func (ts *taskSuite) TestSetProgressNeedsLock(c *C) {
 func (ts *taskSuite) TestState(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	c.Assert(t.State(), Equals, st)
@@ -201,9 +189,8 @@ func (ts *taskSuite) TestTaskMarshalsWaitFor(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	chg := st.NewChange("install", "...")
-	t1 := chg.NewTask("download", "1...")
-	t2 := chg.NewTask("install", "2...")
+	t1 := st.NewTask("download", "1...")
+	t2 := st.NewTask("install", "2...")
 	t2.WaitFor(t1)
 
 	d, err := t2.MarshalJSON()
@@ -218,9 +205,8 @@ func (ts *taskSuite) TestTaskWaitFor(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	chg := st.NewChange("install", "...")
-	t1 := chg.NewTask("download", "1...")
-	t2 := chg.NewTask("install", "2...")
+	t1 := st.NewTask("download", "1...")
+	t2 := st.NewTask("install", "2...")
 	t2.WaitFor(t1)
 
 	c.Assert(t2.WaitTasks(), DeepEquals, []*state.Task{t1})
@@ -232,9 +218,8 @@ func (ts *taskSuite) TestTaskWaitFor(c *C) {
 func (cs *taskSuite) TestWaitForNeedsLocked(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t1 := chg.NewTask("download", "1...")
-	t2 := chg.NewTask("install", "2...")
+	t1 := st.NewTask("download", "1...")
+	t2 := st.NewTask("install", "2...")
 	st.Unlock()
 
 	c.Assert(func() { t2.WaitFor(t1) }, PanicMatches, "internal error: accessing state without lock")
@@ -243,8 +228,7 @@ func (cs *taskSuite) TestWaitForNeedsLocked(c *C) {
 func (cs *taskSuite) TestWaitTasksNeedsLocked(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	c.Assert(func() { t.WaitTasks() }, PanicMatches, "internal error: accessing state without lock")
@@ -253,9 +237,58 @@ func (cs *taskSuite) TestWaitTasksNeedsLocked(c *C) {
 func (cs *taskSuite) TestHaltTasksNeedsLocked(c *C) {
 	st := state.New(nil)
 	st.Lock()
-	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
 	st.Unlock()
 
 	c.Assert(func() { t.HaltTasks() }, PanicMatches, "internal error: accessing state without lock")
+}
+
+func (cs *taskSuite) TestNewTaskSet(c *C) {
+	ts0 := state.NewTaskSet()
+	c.Check(ts0, HasLen, 0)
+
+	st := state.New(nil)
+	st.Lock()
+	t1 := st.NewTask("download", "1...")
+	t2 := st.NewTask("install", "2...")
+	ts2 := state.NewTaskSet(t1, t2)
+	st.Unlock()
+
+	c.Check(ts2, HasLen, 2)
+}
+
+func (ts *taskSuite) TestTaskWaitAll(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	t1 := st.NewTask("download", "1...")
+	t2 := st.NewTask("install", "2...")
+	t3 := st.NewTask("setup", "3...")
+	t3.WaitAll(state.NewTaskSet(t1, t2))
+
+	c.Assert(t3.WaitTasks(), HasLen, 2)
+	c.Assert(t3.Status(), Equals, state.WaitingStatus)
+
+	c.Assert(t1.HaltTasks(), DeepEquals, []*state.Task{t3})
+	c.Assert(t2.HaltTasks(), DeepEquals, []*state.Task{t3})
+}
+
+func (ts *taskSuite) TestTaskSetWaitFor(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	t1 := st.NewTask("download", "1...")
+	t2 := st.NewTask("install", "2...")
+	t3 := st.NewTask("setup", "3...")
+	ts23 := state.NewTaskSet(t2, t3)
+	ts23.WaitFor(t1)
+
+	c.Assert(t2.Status(), Equals, state.WaitingStatus)
+	c.Assert(t2.WaitTasks(), DeepEquals, []*state.Task{t1})
+	c.Assert(t3.Status(), Equals, state.WaitingStatus)
+	c.Assert(t3.WaitTasks(), DeepEquals, []*state.Task{t1})
+
+	c.Assert(t1.HaltTasks(), HasLen, 2)
 }

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -63,7 +63,8 @@ func (ts *taskRunnerSuite) TestEnsureTrivial(c *C) {
 	// add a download task to the state tracker
 	st.Lock()
 	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
+	chg.AddTask(t)
 	taskCompleted.Add(1)
 	st.Unlock()
 
@@ -119,11 +120,14 @@ func (ts *taskRunnerSuite) TestEnsureComplex(c *C) {
 		chg := st.NewChange("mock-install", "...")
 
 		// create sub-tasks
-		tDl := chg.NewTask("download", "1...")
-		tUnp := chg.NewTask("unpack", "2...")
+		tDl := st.NewTask("download", "1...")
+		tUnp := st.NewTask("unpack", "2...")
 		tUnp.WaitFor(tDl)
-		tConf := chg.NewTask("configure", "3...")
+		chg.AddTask(tDl)
+		chg.AddTask(tUnp)
+		tConf := st.NewTask("configure", "3...")
 		tConf.WaitFor(tUnp)
+		chg.AddTask(tConf)
 		st.Unlock()
 
 		// ensure just kicks the go routine off
@@ -156,7 +160,8 @@ func (ts *taskRunnerSuite) TestErrorIsFinal(c *C) {
 	// add a download task to the state tracker
 	st.Lock()
 	chg := st.NewChange("install", "...")
-	chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
+	chg.AddTask(t)
 	st.Unlock()
 
 	defer r.Stop()
@@ -192,7 +197,8 @@ func (ts *taskRunnerSuite) TestStopCancelsGoroutines(c *C) {
 	// add a download task to the state tracker
 	st.Lock()
 	chg := st.NewChange("install", "...")
-	t := chg.NewTask("download", "1...")
+	t := st.NewTask("download", "1...")
+	chg.AddTask(t)
 	st.Unlock()
 
 	defer r.Stop()
@@ -223,11 +229,14 @@ func (ts *taskRunnerSuite) TestErrorPropagates(c *C) {
 
 	st.Lock()
 	chg := st.NewChange("install", "...")
-	errTask := chg.NewTask("erroring", "1...")
-	dep1 := chg.NewTask("dep", "2...")
+	errTask := st.NewTask("erroring", "1...")
+	dep1 := st.NewTask("dep", "2...")
 	dep1.WaitFor(errTask)
-	dep2 := chg.NewTask("dep", "3...")
+	dep2 := st.NewTask("dep", "3...")
 	dep2.WaitFor(dep1)
+	chg.AddTask(errTask)
+	chg.AddTask(dep1)
+	chg.AddTask(dep2)
 	st.Unlock()
 
 	defer r.Stop()

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -123,11 +123,10 @@ func (ts *taskRunnerSuite) TestEnsureComplex(c *C) {
 		tDl := st.NewTask("download", "1...")
 		tUnp := st.NewTask("unpack", "2...")
 		tUnp.WaitFor(tDl)
-		chg.AddTask(tDl)
-		chg.AddTask(tUnp)
+		chg.AddTasks(state.NewTaskSet(tDl, tUnp))
 		tConf := st.NewTask("configure", "3...")
 		tConf.WaitFor(tUnp)
-		chg.AddTask(tConf)
+		chg.AddTasks(state.NewTaskSet(tConf))
 		st.Unlock()
 
 		// ensure just kicks the go routine off
@@ -234,9 +233,7 @@ func (ts *taskRunnerSuite) TestErrorPropagates(c *C) {
 	dep1.WaitFor(errTask)
 	dep2 := st.NewTask("dep", "3...")
 	dep2.WaitFor(dep1)
-	chg.AddTask(errTask)
-	chg.AddTask(dep1)
-	chg.AddTask(dep2)
+	chg.AddTasks(state.NewTaskSet(errTask, dep1, dep2))
 	st.Unlock()
 
 	defer r.Stop()


### PR DESCRIPTION
This introduces support for TaskSet, and moves NewTask from Change to State.

The functions to prepare changes in *state/ subpackages now don't take a Change anymore but return a TaskSet instead. This should give us more flexibility into building changes with orthogonal bits coming from the different managers.