### PR TITLE
interfaces, daemon, overlord: use snap.{Plug,Slot}Info natively

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -910,11 +910,33 @@ func getInterfaces(c *Command, r *http.Request) Response {
 	return SyncResponse(c.d.interfaces.Interfaces())
 }
 
+// plugJSON aids in marshaling Plug into JSON.
+type plugJSON struct {
+	Snap        string                 `json:"snap"`
+	Name        string                 `json:"plug"`
+	Interface   string                 `json:"interface"`
+	Attrs       map[string]interface{} `json:"attrs,omitempty"`
+	Apps        []string               `json:"apps,omitempty"`
+	Label       string                 `json:"label"`
+	Connections []interfaces.SlotRef   `json:"connections,omitempty"`
+}
+
+// slotJSON aids in marshaling Slot into JSON.
+type slotJSON struct {
+	Snap        string                 `json:"snap"`
+	Name        string                 `json:"slot"`
+	Interface   string                 `json:"interface"`
+	Attrs       map[string]interface{} `json:"attrs,omitempty"`
+	Apps        []string               `json:"apps,omitempty"`
+	Label       string                 `json:"label"`
+	Connections []interfaces.PlugRef   `json:"connections,omitempty"`
+}
+
 // interfaceAction is an action performed on the interface system.
 type interfaceAction struct {
-	Action string                `json:"action"`
-	Plugs  []interfaces.PlugJSON `json:"plugs,omitempty"`
-	Slots  []interfaces.SlotJSON `json:"slots,omitempty"`
+	Action string     `json:"action"`
+	Plugs  []plugJSON `json:"plugs,omitempty"`
+	Slots  []slotJSON `json:"slots,omitempty"`
 }
 
 // changeInterfaces controls the interfaces system.

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1407,8 +1407,8 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1441,8 +1441,8 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	d.interfaces.AddSlot(makeSlot("other-interface"))
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1475,8 +1475,8 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1508,8 +1508,8 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	d.interfaces.AddPlug(makePlug("interface"))
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1543,8 +1543,8 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1575,8 +1575,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1608,8 +1608,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	d.interfaces.AddPlug(makePlug("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1642,8 +1642,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1675,7 +1675,7 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plugs: []interfaces.PlugJSON{{
+		Plugs: []plugJSON{{
 			Snap:      "producer",
 			Name:      "plug",
 			Label:     "label",
@@ -1712,7 +1712,7 @@ func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plugs: []interfaces.PlugJSON{{
+		Plugs: []plugJSON{{
 			Snap:      "producer",
 			Name:      "plug",
 			Label:     "label",
@@ -1753,7 +1753,7 @@ func (s *apiSuite) TestAddPlugFailure(c *check.C) {
 	})
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plugs: []interfaces.PlugJSON{{
+		Plugs: []plugJSON{{
 			Snap:      "producer",
 			Name:      "plug",
 			Label:     "label",
@@ -1790,7 +1790,7 @@ func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 	d.interfaces.AddPlug(makePlug("interface"))
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1819,7 +1819,7 @@ func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1851,7 +1851,7 @@ func (s *apiSuite) TestRemovePlugFailure(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Plugs:  []plugJSON{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1880,7 +1880,7 @@ func (s *apiSuite) TestAddSlotSuccess(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slots: []interfaces.SlotJSON{{
+		Slots: []slotJSON{{
 			Snap:      "consumer",
 			Name:      "slot",
 			Label:     "label",
@@ -1916,7 +1916,7 @@ func (s *apiSuite) TestAddSlotDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slots: []interfaces.SlotJSON{{
+		Slots: []slotJSON{{
 			Snap:      "consumer",
 			Name:      "slot",
 			Label:     "label",
@@ -1957,7 +1957,7 @@ func (s *apiSuite) TestAddSlotFailure(c *check.C) {
 	})
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slots: []interfaces.SlotJSON{{
+		Slots: []slotJSON{{
 			Snap:      "consumer",
 			Name:      "slot",
 			Label:     "label",
@@ -1994,7 +1994,7 @@ func (s *apiSuite) TestRemoveSlotSuccess(c *check.C) {
 	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -2023,7 +2023,7 @@ func (s *apiSuite) TestRemoveSlotDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -2055,7 +2055,7 @@ func (s *apiSuite) TestRemoveSlotFailure(c *check.C) {
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
+		Slots:  []slotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1293,11 +1293,67 @@ func (s *apiSuite) TestInstallLicensedIntegration(c *check.C) {
 
 // Tests for GET /2.0/interfaces
 
+func makeTypicalPlug(ifaceName string) *interfaces.Plug {
+	snapInfo := &snap.Info{
+		Name: "producer",
+	}
+	plugInfo := &snap.PlugInfo{
+		Snap:      snapInfo,
+		Name:      "plug",
+		Interface: ifaceName,
+		Attrs:     map[string]interface{}{"key": "value"},
+		Label:     "label",
+	}
+	appInfo := &snap.AppInfo{
+		Snap:  snapInfo,
+		Name:  "app",
+		Plugs: map[string]*snap.PlugInfo{"plug": plugInfo},
+	}
+	snapInfo.Apps = map[string]*snap.AppInfo{"app": appInfo}
+	plugInfo.Apps = snapInfo.Apps
+	snapInfo.Plugs = map[string]*snap.PlugInfo{"plug": plugInfo}
+	return &interfaces.Plug{PlugInfo: plugInfo}
+}
+
+func makeTypicalConnectedPlug() *interfaces.Plug {
+	plug := makeTypicalPlug("interface")
+	plug.Connections = []interfaces.SlotRef{{Snap: "consumer", Name: "slot"}}
+	return plug
+}
+
+func makeTypicalSlot(ifaceName string) *interfaces.Slot {
+	snapInfo := &snap.Info{
+		Name: "consumer",
+	}
+	slotInfo := &snap.SlotInfo{
+		Snap:      snapInfo,
+		Name:      "slot",
+		Interface: ifaceName,
+		Attrs:     map[string]interface{}{"key": "value"},
+		Label:     "label",
+	}
+	appInfo := &snap.AppInfo{
+		Snap:  snapInfo,
+		Name:  "app",
+		Slots: map[string]*snap.SlotInfo{"slot": slotInfo},
+	}
+	snapInfo.Apps = map[string]*snap.AppInfo{"app": appInfo}
+	slotInfo.Apps = snapInfo.Apps
+	snapInfo.Slots = map[string]*snap.SlotInfo{"slot": slotInfo}
+	return &interfaces.Slot{SlotInfo: slotInfo}
+}
+
+func makeTypicalConnectedSlot() *interfaces.Slot {
+	slot := makeTypicalSlot("interface")
+	slot.Connections = []interfaces.PlugRef{{Snap: "producer", Name: "plug"}}
+	return slot
+}
+
 func (s *apiSuite) TestGetPlugs(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface", Label: "label"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface", Label: "label"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	req, err := http.NewRequest("GET", "/2.0/interfaces", nil)
 	c.Assert(err, check.IsNil)
@@ -1314,6 +1370,8 @@ func (s *apiSuite) TestGetPlugs(c *check.C) {
 					"snap":      "producer",
 					"plug":      "plug",
 					"interface": "interface",
+					"attrs":     map[string]interface{}{"key": "value"},
+					"apps":      []interface{}{"app"},
 					"label":     "label",
 					"connections": []interface{}{
 						map[string]interface{}{"snap": "consumer", "slot": "slot"},
@@ -1325,6 +1383,8 @@ func (s *apiSuite) TestGetPlugs(c *check.C) {
 					"snap":      "consumer",
 					"slot":      "slot",
 					"interface": "interface",
+					"attrs":     map[string]interface{}{"key": "value"},
+					"apps":      []interface{}{"app"},
 					"label":     "label",
 					"connections": []interface{}{
 						map[string]interface{}{"snap": "producer", "plug": "plug"},
@@ -1343,12 +1403,12 @@ func (s *apiSuite) TestGetPlugs(c *check.C) {
 func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1368,18 +1428,8 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 		"type":        "sync",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{{
-			Snap:        "producer",
-			Name:        "plug",
-			Interface:   "interface",
-			Connections: []interfaces.SlotRef{{Snap: "consumer", Name: "slot"}},
-		}},
-		Slots: []*interfaces.Slot{{
-			Snap:        "consumer",
-			Name:        "slot",
-			Interface:   "interface",
-			Connections: []interfaces.PlugRef{{Snap: "producer", Name: "plug"}},
-		}},
+		Plugs: []*interfaces.Plug{makeTypicalConnectedPlug()},
+		Slots: []*interfaces.Slot{makeTypicalConnectedSlot()},
 	})
 }
 
@@ -1387,12 +1437,12 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "other-interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "other-interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddSlot(makeTypicalSlot("other-interface"))
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1414,27 +1464,19 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{{
-			Snap:      "producer",
-			Name:      "plug",
-			Interface: "interface",
-		}},
-		Slots: []*interfaces.Slot{{
-			Snap:      "consumer",
-			Name:      "slot",
-			Interface: "other-interface",
-		}},
+		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
+		Slots: []*interfaces.Slot{makeTypicalSlot("other-interface")},
 	})
 }
 
 func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1456,22 +1498,18 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Slots: []*interfaces.Slot{{
-			Snap:      "consumer",
-			Name:      "slot",
-			Interface: "interface",
-		}},
+		Slots: []*interfaces.Slot{makeTypicalSlot("interface")},
 	})
 }
 
 func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
 	action := &interfaceAction{
 		Action: "connect",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1493,24 +1531,20 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{{
-			Snap:      "producer",
-			Name:      "plug",
-			Interface: "interface",
-		}},
+		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
 	})
 }
 
 func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1530,27 +1564,19 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 		"type":        "sync",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{{
-			Snap:      "producer",
-			Name:      "plug",
-			Interface: "interface",
-		}},
-		Slots: []*interfaces.Slot{{
-			Snap:      "consumer",
-			Name:      "slot",
-			Interface: "interface",
-		}},
+		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
+		Slots: []*interfaces.Slot{makeTypicalSlot("interface")},
 	})
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1572,22 +1598,18 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Slots: []*interfaces.Slot{{
-			Snap:      "consumer",
-			Name:      "slot",
-			Interface: "interface",
-		}},
+		Slots: []*interfaces.Slot{makeTypicalSlot("interface")},
 	})
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1609,23 +1631,19 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{{
-			Snap:      "producer",
-			Name:      "plug",
-			Interface: "interface",
-		}},
+		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
 	})
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1647,16 +1665,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{{
-			Snap:      "producer",
-			Name:      "plug",
-			Interface: "interface",
-		}},
-		Slots: []*interfaces.Slot{{
-			Snap:      "consumer",
-			Name:      "slot",
-			Interface: "interface",
-		}},
+		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
+		Slots: []*interfaces.Slot{makeTypicalSlot("interface")},
 	})
 }
 
@@ -1665,8 +1675,8 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plugs: []interfaces.Plug{{
-			Snap:      "snap",
+		Plugs: []interfaces.PlugJSON{{
+			Snap:      "producer",
 			Name:      "plug",
 			Label:     "label",
 			Interface: "interface",
@@ -1691,7 +1701,7 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 		"status_code": 201.0,
 		"type":        "sync",
 	})
-	c.Check(d.interfaces.Plug("snap", "plug"), check.DeepEquals, &action.Plugs[0])
+	c.Check(d.interfaces.Plug("producer", "plug"), check.DeepEquals, makeTypicalPlug("interface"))
 }
 
 func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
@@ -1702,7 +1712,7 @@ func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plugs: []interfaces.Plug{{
+		Plugs: []interfaces.PlugJSON{{
 			Snap:      "producer",
 			Name:      "plug",
 			Label:     "label",
@@ -1743,8 +1753,8 @@ func (s *apiSuite) TestAddPlugFailure(c *check.C) {
 	})
 	action := &interfaceAction{
 		Action: "add-plug",
-		Plugs: []interfaces.Plug{{
-			Snap:      "snap",
+		Plugs: []interfaces.PlugJSON{{
+			Snap:      "producer",
 			Name:      "plug",
 			Label:     "label",
 			Interface: "interface",
@@ -1771,16 +1781,16 @@ func (s *apiSuite) TestAddPlugFailure(c *check.C) {
 		"status_code": 400.0,
 		"type":        "error",
 	})
-	c.Check(d.interfaces.Plug("snap", "name"), check.IsNil)
+	c.Check(d.interfaces.Plug("producer", "name"), check.IsNil)
 }
 
 func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1799,17 +1809,17 @@ func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 		"status_code": 200.0,
 		"type":        "sync",
 	})
-	c.Check(d.interfaces.Plug("snap", "name"), check.IsNil)
+	c.Check(d.interfaces.Plug("producer", "name"), check.IsNil)
 }
 
 func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1836,12 +1846,12 @@ func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 func (s *apiSuite) TestRemovePlugFailure(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-plug",
-		Plugs:  []interfaces.Plug{{Snap: "producer", Name: "plug"}},
+		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1870,8 +1880,8 @@ func (s *apiSuite) TestAddSlotSuccess(c *check.C) {
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slots: []interfaces.Slot{{
-			Snap:      "snap",
+		Slots: []interfaces.SlotJSON{{
+			Snap:      "consumer",
 			Name:      "slot",
 			Label:     "label",
 			Interface: "interface",
@@ -1896,18 +1906,17 @@ func (s *apiSuite) TestAddSlotSuccess(c *check.C) {
 		"status_code": 201.0,
 		"type":        "sync",
 	})
-	c.Check(d.interfaces.Slot("snap", "slot"), check.DeepEquals, &action.Slots[0])
+	expected := makeTypicalSlot("interface")
+	c.Check(d.interfaces.Slot("consumer", "slot"), check.DeepEquals, expected)
 }
 
 func (s *apiSuite) TestAddSlotDisabled(c *check.C) {
 	d := newTestDaemon(c)
-	d.interfaces.AddInterface(&interfaces.TestInterface{
-		InterfaceName: "interface",
-	})
+	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slots: []interfaces.Slot{{
+		Slots: []interfaces.SlotJSON{{
 			Snap:      "consumer",
 			Name:      "slot",
 			Label:     "label",
@@ -1948,8 +1957,8 @@ func (s *apiSuite) TestAddSlotFailure(c *check.C) {
 	})
 	action := &interfaceAction{
 		Action: "add-slot",
-		Slots: []interfaces.Slot{{
-			Snap:      "snap",
+		Slots: []interfaces.SlotJSON{{
+			Snap:      "consumer",
 			Name:      "slot",
 			Label:     "label",
 			Interface: "interface",
@@ -1976,16 +1985,16 @@ func (s *apiSuite) TestAddSlotFailure(c *check.C) {
 		"status_code": 400.0,
 		"type":        "error",
 	})
-	c.Check(d.interfaces.Slot("snap", "name"), check.IsNil)
+	c.Check(d.interfaces.Slot("consumer", "name"), check.IsNil)
 }
 
 func (s *apiSuite) TestRemoveSlotSuccess(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -2004,17 +2013,17 @@ func (s *apiSuite) TestRemoveSlotSuccess(c *check.C) {
 		"status_code": 200.0,
 		"type":        "sync",
 	})
-	c.Check(d.interfaces.Slot("snap", "name"), check.IsNil)
+	c.Check(d.interfaces.Slot("consumer", "name"), check.IsNil)
 }
 
 func (s *apiSuite) TestRemoveSlotDisabled(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -2041,12 +2050,12 @@ func (s *apiSuite) TestRemoveSlotDisabled(c *check.C) {
 func (s *apiSuite) TestRemoveSlotFailure(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(&interfaces.Plug{Snap: "producer", Name: "plug", Interface: "interface"})
-	d.interfaces.AddSlot(&interfaces.Slot{Snap: "consumer", Name: "slot", Interface: "interface"})
+	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddSlot(makeTypicalSlot("interface"))
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-slot",
-		Slots:  []interfaces.Slot{{Snap: "consumer", Name: "slot"}},
+		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -2114,10 +2123,8 @@ func (s *apiSuite) TestMissingInterfaceAction(c *check.C) {
 }
 
 func (s *apiSuite) TestUnsupportedInterfaceAction(c *check.C) {
-	d := newTestDaemon(c)
-	action := &interfaceAction{
-		Action: "foo",
-	}
+	newTestDaemon(c)
+	action := &interfaceAction{Action: "foo"}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
 	buf := bytes.NewBuffer(text)
@@ -2137,7 +2144,6 @@ func (s *apiSuite) TestUnsupportedInterfaceAction(c *check.C) {
 		"status_code": 400.0,
 		"type":        "error",
 	})
-	c.Check(d.interfaces.Slot("snap", "name"), check.IsNil)
 }
 
 const (

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1293,7 +1293,7 @@ func (s *apiSuite) TestInstallLicensedIntegration(c *check.C) {
 
 // Tests for GET /2.0/interfaces
 
-func makeTypicalPlug(ifaceName string) *interfaces.Plug {
+func makePlug(ifaceName string) *interfaces.Plug {
 	snapInfo := &snap.Info{
 		Name: "producer",
 	}
@@ -1315,13 +1315,13 @@ func makeTypicalPlug(ifaceName string) *interfaces.Plug {
 	return &interfaces.Plug{PlugInfo: plugInfo}
 }
 
-func makeTypicalConnectedPlug() *interfaces.Plug {
-	plug := makeTypicalPlug("interface")
+func makeConnectedPlug() *interfaces.Plug {
+	plug := makePlug("interface")
 	plug.Connections = []interfaces.SlotRef{{Snap: "consumer", Name: "slot"}}
 	return plug
 }
 
-func makeTypicalSlot(ifaceName string) *interfaces.Slot {
+func makeSlot(ifaceName string) *interfaces.Slot {
 	snapInfo := &snap.Info{
 		Name: "consumer",
 	}
@@ -1343,8 +1343,8 @@ func makeTypicalSlot(ifaceName string) *interfaces.Slot {
 	return &interfaces.Slot{SlotInfo: slotInfo}
 }
 
-func makeTypicalConnectedSlot() *interfaces.Slot {
-	slot := makeTypicalSlot("interface")
+func makeConnectedSlot() *interfaces.Slot {
+	slot := makeSlot("interface")
 	slot.Connections = []interfaces.PlugRef{{Snap: "producer", Name: "plug"}}
 	return slot
 }
@@ -1352,8 +1352,8 @@ func makeTypicalConnectedSlot() *interfaces.Slot {
 func (s *apiSuite) TestGetPlugs(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	req, err := http.NewRequest("GET", "/2.0/interfaces", nil)
 	c.Assert(err, check.IsNil)
@@ -1403,8 +1403,8 @@ func (s *apiSuite) TestGetPlugs(c *check.C) {
 func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "connect",
 		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
@@ -1428,8 +1428,8 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 		"type":        "sync",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{makeTypicalConnectedPlug()},
-		Slots: []*interfaces.Slot{makeTypicalConnectedSlot()},
+		Plugs: []*interfaces.Plug{makeConnectedPlug()},
+		Slots: []*interfaces.Slot{makeConnectedSlot()},
 	})
 }
 
@@ -1437,8 +1437,8 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "other-interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
-	d.interfaces.AddSlot(makeTypicalSlot("other-interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
+	d.interfaces.AddSlot(makeSlot("other-interface"))
 	action := &interfaceAction{
 		Action: "connect",
 		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
@@ -1464,15 +1464,15 @@ func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
-		Slots: []*interfaces.Slot{makeTypicalSlot("other-interface")},
+		Plugs: []*interfaces.Plug{makePlug("interface")},
+		Slots: []*interfaces.Slot{makeSlot("other-interface")},
 	})
 }
 
 func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "connect",
 		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
@@ -1498,14 +1498,14 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Slots: []*interfaces.Slot{makeTypicalSlot("interface")},
+		Slots: []*interfaces.Slot{makeSlot("interface")},
 	})
 }
 
 func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
 	action := &interfaceAction{
 		Action: "connect",
 		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
@@ -1531,15 +1531,15 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
+		Plugs: []*interfaces.Plug{makePlug("interface")},
 	})
 }
 
 func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "disconnect",
@@ -1564,15 +1564,15 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 		"type":        "sync",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
-		Slots: []*interfaces.Slot{makeTypicalSlot("interface")},
+		Plugs: []*interfaces.Plug{makePlug("interface")},
+		Slots: []*interfaces.Slot{makeSlot("interface")},
 	})
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
 		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
@@ -1598,14 +1598,14 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Slots: []*interfaces.Slot{makeTypicalSlot("interface")},
+		Slots: []*interfaces.Slot{makeSlot("interface")},
 	})
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
 		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
@@ -1631,15 +1631,15 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
+		Plugs: []*interfaces.Plug{makePlug("interface")},
 	})
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "disconnect",
 		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
@@ -1665,8 +1665,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 		"type":        "error",
 	})
 	c.Assert(d.interfaces.Interfaces(), check.DeepEquals, &interfaces.Interfaces{
-		Plugs: []*interfaces.Plug{makeTypicalPlug("interface")},
-		Slots: []*interfaces.Slot{makeTypicalSlot("interface")},
+		Plugs: []*interfaces.Plug{makePlug("interface")},
+		Slots: []*interfaces.Slot{makeSlot("interface")},
 	})
 }
 
@@ -1701,7 +1701,7 @@ func (s *apiSuite) TestAddPlugSuccess(c *check.C) {
 		"status_code": 201.0,
 		"type":        "sync",
 	})
-	c.Check(d.interfaces.Plug("producer", "plug"), check.DeepEquals, makeTypicalPlug("interface"))
+	c.Check(d.interfaces.Plug("producer", "plug"), check.DeepEquals, makePlug("interface"))
 }
 
 func (s *apiSuite) TestAddPlugDisabled(c *check.C) {
@@ -1787,7 +1787,7 @@ func (s *apiSuite) TestAddPlugFailure(c *check.C) {
 func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
 	action := &interfaceAction{
 		Action: "remove-plug",
 		Plugs:  []interfaces.PlugJSON{{Snap: "producer", Name: "plug"}},
@@ -1815,7 +1815,7 @@ func (s *apiSuite) TestRemovePlugSuccess(c *check.C) {
 func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-plug",
@@ -1846,8 +1846,8 @@ func (s *apiSuite) TestRemovePlugDisabled(c *check.C) {
 func (s *apiSuite) TestRemovePlugFailure(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-plug",
@@ -1906,7 +1906,7 @@ func (s *apiSuite) TestAddSlotSuccess(c *check.C) {
 		"status_code": 201.0,
 		"type":        "sync",
 	})
-	expected := makeTypicalSlot("interface")
+	expected := makeSlot("interface")
 	c.Check(d.interfaces.Slot("consumer", "slot"), check.DeepEquals, expected)
 }
 
@@ -1991,7 +1991,7 @@ func (s *apiSuite) TestAddSlotFailure(c *check.C) {
 func (s *apiSuite) TestRemoveSlotSuccess(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	action := &interfaceAction{
 		Action: "remove-slot",
 		Slots:  []interfaces.SlotJSON{{Snap: "consumer", Name: "slot"}},
@@ -2019,7 +2019,7 @@ func (s *apiSuite) TestRemoveSlotSuccess(c *check.C) {
 func (s *apiSuite) TestRemoveSlotDisabled(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	d.enableInternalInterfaceActions = false
 	action := &interfaceAction{
 		Action: "remove-slot",
@@ -2050,8 +2050,8 @@ func (s *apiSuite) TestRemoveSlotDisabled(c *check.C) {
 func (s *apiSuite) TestRemoveSlotFailure(c *check.C) {
 	d := newTestDaemon(c)
 	d.interfaces.AddInterface(&interfaces.TestInterface{InterfaceName: "interface"})
-	d.interfaces.AddPlug(makeTypicalPlug("interface"))
-	d.interfaces.AddSlot(makeTypicalSlot("interface"))
+	d.interfaces.AddPlug(makePlug("interface"))
+	d.interfaces.AddSlot(makeSlot("interface"))
 	d.interfaces.Connect("producer", "plug", "consumer", "slot")
 	action := &interfaceAction{
 		Action: "remove-slot",

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/builtin"
+	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/testutil"
 )
 
@@ -50,41 +51,40 @@ type BoolFileInterfaceSuite struct {
 
 var _ = Suite(&BoolFileInterfaceSuite{
 	iface: &builtin.BoolFileInterface{},
-	gpioSlot: &interfaces.Slot{
-		Interface: "bool-file",
-		Attrs: map[string]interface{}{
-			"path": "/sys/class/gpio/gpio13/value",
-		},
-	},
-	ledSlot: &interfaces.Slot{
-		Interface: "bool-file",
-		Attrs: map[string]interface{}{
-			"path": "/sys/class/leds/input27::capslock/brightness",
-		},
-	},
-	missingPathSlot: &interfaces.Slot{
-		Interface: "bool-file",
-	},
-	badPathSlot: &interfaces.Slot{
-		Interface: "bool-file",
-		Attrs:     map[string]interface{}{"path": "path"},
-	},
-	parentDirPathSlot: &interfaces.Slot{
-		Interface: "bool-file",
-		Attrs: map[string]interface{}{
-			"path": "/sys/class/gpio/../value",
-		},
-	},
-	badInterfaceSlot: &interfaces.Slot{
-		Interface: "other-interface",
-	},
-	plug: &interfaces.Plug{
-		Interface: "bool-file",
-	},
-	badInterfacePlug: &interfaces.Plug{
-		Interface: "other-interface",
-	},
 })
+
+func (s *BoolFileInterfaceSuite) SetUpTest(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: ubuntu-core
+slots:
+    gpio:
+        interface: bool-file
+        path: /sys/class/gpio/gpio13/value
+    led:
+        interface: bool-file
+        path: "/sys/class/leds/input27::capslock/brightness"
+    missing-path: bool-file
+    bad-path:
+        interface: bool-file
+        path: path
+    parent-dir-path:
+        interface: bool-file
+        path: "/sys/class/gpio/../value"
+    bad-interface: other-interface
+plugs:
+    plug: bool-file
+    bad-interface: other-interface
+`))
+	c.Assert(err, IsNil)
+	s.gpioSlot = &interfaces.Slot{SlotInfo: info.Slots["gpio"]}
+	s.ledSlot = &interfaces.Slot{SlotInfo: info.Slots["led"]}
+	s.missingPathSlot = &interfaces.Slot{SlotInfo: info.Slots["missing-path"]}
+	s.badPathSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-path"]}
+	s.parentDirPathSlot = &interfaces.Slot{SlotInfo: info.Slots["parent-dir-path"]}
+	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-interface"]}
+	s.plug = &interfaces.Plug{PlugInfo: info.Plugs["plug"]}
+	s.badInterfacePlug = &interfaces.Plug{PlugInfo: info.Plugs["bad-interface"]}
+}
 
 func (s *BoolFileInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "bool-file")

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -52,7 +52,8 @@ func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
-	if iface.reservedForOS && slot.Snap != "ubuntu-core" {
+	// TODO: use slot.Snap.Type here (and snap.TypeOS)
+	if iface.reservedForOS && slot.Snap.Name != "ubuntu-core" {
 		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.name)
 	}
 	return nil

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -35,25 +35,21 @@ type NetworkBindInterfaceSuite struct {
 
 var _ = Suite(&NetworkBindInterfaceSuite{
 	iface: builtin.NewNetworkBindInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{Name: "ubuntu-core"},
+			Name:      "network-bind",
+			Interface: "network-bind",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{Name: "other"},
+			Name:      "network-bind",
+			Interface: "network-bind",
+		},
+	},
 })
-
-func (s *NetworkBindInterfaceSuite) SetUpTest(c *C) {
-	info1, err := snap.InfoFromSnapYaml([]byte(`
-name: ubuntu-core
-slots:
-    network-bind:
-`))
-	c.Assert(err, IsNil)
-	s.slot = &interfaces.Slot{SlotInfo: info1.Slots["network-bind"]}
-
-	info2, err := snap.InfoFromSnapYaml([]byte(`
-name: snap
-plugs:
-    network-bind:
-`))
-	c.Assert(err, IsNil)
-	s.plug = &interfaces.Plug{PlugInfo: info2.Plugs["network-bind"]}
-}
 
 func (s *NetworkBindInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "network-bind")

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -28,10 +28,9 @@ import (
 )
 
 type NetworkBindInterfaceSuite struct {
-	iface         interfaces.Interface
-	slot          *interfaces.Slot
-	otherSnapSlot *interfaces.Slot
-	plug          *interfaces.Plug
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
 }
 
 var _ = Suite(&NetworkBindInterfaceSuite{
@@ -48,20 +47,12 @@ slots:
 	s.slot = &interfaces.Slot{SlotInfo: info1.Slots["network-bind"]}
 
 	info2, err := snap.InfoFromSnapYaml([]byte(`
-name: some-snap
-slots:
-    network-bind:
-`))
-	c.Assert(err, IsNil)
-	s.otherSnapSlot = &interfaces.Slot{SlotInfo: info2.Slots["network-bind"]}
-
-	info3, err := snap.InfoFromSnapYaml([]byte(`
 name: snap
 plugs:
     network-bind:
 `))
 	c.Assert(err, IsNil)
-	s.plug = &interfaces.Plug{PlugInfo: info3.Plugs["network-bind"]}
+	s.plug = &interfaces.Plug{PlugInfo: info2.Plugs["network-bind"]}
 }
 
 func (s *NetworkBindInterfaceSuite) TestName(c *C) {
@@ -71,7 +62,11 @@ func (s *NetworkBindInterfaceSuite) TestName(c *C) {
 func (s *NetworkBindInterfaceSuite) TestSanitizeSlot(c *C) {
 	err := s.iface.SanitizeSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(s.otherSnapSlot)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{Name: "some-snap"},
+		Name:      "network-bind",
+		Interface: "network-bind",
+	}})
 	c.Assert(err, ErrorMatches, "network-bind slots are reserved for the operating system snap")
 }
 

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -24,12 +24,14 @@ import (
 
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/builtin"
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 type NetworkBindInterfaceSuite struct {
-	iface interfaces.Interface
-	slot  *interfaces.Slot
-	plug  *interfaces.Plug
+	iface         interfaces.Interface
+	slot          *interfaces.Slot
+	otherSnapSlot *interfaces.Slot
+	plug          *interfaces.Plug
 }
 
 var _ = Suite(&NetworkBindInterfaceSuite{
@@ -37,16 +39,29 @@ var _ = Suite(&NetworkBindInterfaceSuite{
 })
 
 func (s *NetworkBindInterfaceSuite) SetUpTest(c *C) {
-	s.slot = &interfaces.Slot{
-		Snap:      "ubuntu-core",
-		Name:      "network-bind",
-		Interface: "network-bind",
-	}
-	s.plug = &interfaces.Plug{
-		Snap:      "snap",
-		Name:      "network-bind",
-		Interface: "network-bind",
-	}
+	info1, err := snap.InfoFromSnapYaml([]byte(`
+name: ubuntu-core
+slots:
+    network-bind:
+`))
+	c.Assert(err, IsNil)
+	s.slot = &interfaces.Slot{SlotInfo: info1.Slots["network-bind"]}
+
+	info2, err := snap.InfoFromSnapYaml([]byte(`
+name: some-snap
+slots:
+    network-bind:
+`))
+	c.Assert(err, IsNil)
+	s.otherSnapSlot = &interfaces.Slot{SlotInfo: info2.Slots["network-bind"]}
+
+	info3, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    network-bind:
+`))
+	c.Assert(err, IsNil)
+	s.plug = &interfaces.Plug{PlugInfo: info3.Plugs["network-bind"]}
 }
 
 func (s *NetworkBindInterfaceSuite) TestName(c *C) {
@@ -56,11 +71,7 @@ func (s *NetworkBindInterfaceSuite) TestName(c *C) {
 func (s *NetworkBindInterfaceSuite) TestSanitizeSlot(c *C) {
 	err := s.iface.SanitizeSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{
-		Snap:      "some-snap",
-		Name:      "network-bind",
-		Interface: "network-bind",
-	})
+	err = s.iface.SanitizeSlot(s.otherSnapSlot)
 	c.Assert(err, ErrorMatches, "network-bind slots are reserved for the operating system snap")
 }
 
@@ -70,9 +81,9 @@ func (s *NetworkBindInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *NetworkBindInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{Interface: "other"}) },
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
 		PanicMatches, `slot is not of interface "network-bind"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{Interface: "other"}) },
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
 		PanicMatches, `plug is not of interface "network-bind"`)
 }
 

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -35,25 +35,21 @@ type NetworkInterfaceSuite struct {
 
 var _ = Suite(&NetworkInterfaceSuite{
 	iface: builtin.NewNetworkInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{Name: "ubuntu-core"},
+			Name:      "network",
+			Interface: "network",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{Name: "other"},
+			Name:      "network",
+			Interface: "network",
+		},
+	},
 })
-
-func (s *NetworkInterfaceSuite) SetUpTest(c *C) {
-	info1, err := snap.InfoFromSnapYaml([]byte(`
-name: ubuntu-core
-slots:
-    network:
-`))
-	c.Assert(err, IsNil)
-	s.slot = &interfaces.Slot{SlotInfo: info1.Slots["network"]}
-
-	info2, err := snap.InfoFromSnapYaml([]byte(`
-name: snap
-plugs:
-    network:
-`))
-	c.Assert(err, IsNil)
-	s.plug = &interfaces.Plug{PlugInfo: info2.Plugs["network"]}
-}
 
 func (s *NetworkInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "network")

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -28,10 +28,9 @@ import (
 )
 
 type NetworkInterfaceSuite struct {
-	iface         interfaces.Interface
-	slot          *interfaces.Slot
-	otherSnapSlot *interfaces.Slot
-	plug          *interfaces.Plug
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
 }
 
 var _ = Suite(&NetworkInterfaceSuite{
@@ -48,20 +47,12 @@ slots:
 	s.slot = &interfaces.Slot{SlotInfo: info1.Slots["network"]}
 
 	info2, err := snap.InfoFromSnapYaml([]byte(`
-name: some-snap
-slots:
-    network:
-`))
-	c.Assert(err, IsNil)
-	s.otherSnapSlot = &interfaces.Slot{SlotInfo: info2.Slots["network"]}
-
-	info3, err := snap.InfoFromSnapYaml([]byte(`
 name: snap
 plugs:
     network:
 `))
 	c.Assert(err, IsNil)
-	s.plug = &interfaces.Plug{PlugInfo: info3.Plugs["network"]}
+	s.plug = &interfaces.Plug{PlugInfo: info2.Plugs["network"]}
 }
 
 func (s *NetworkInterfaceSuite) TestName(c *C) {
@@ -71,7 +62,11 @@ func (s *NetworkInterfaceSuite) TestName(c *C) {
 func (s *NetworkInterfaceSuite) TestSanitizeSlot(c *C) {
 	err := s.iface.SanitizeSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(s.otherSnapSlot)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{Name: "some-snap"},
+		Name:      "network",
+		Interface: "network",
+	}})
 	c.Assert(err, ErrorMatches, "network slots are reserved for the operating system snap")
 }
 

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -23,17 +23,14 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 // Plug represents the potential of a given snap to connect to a slot.
 type Plug struct {
-	Snap        string                 `json:"snap"`
-	Name        string                 `json:"plug"`
-	Interface   string                 `json:"interface"`
-	Attrs       map[string]interface{} `json:"attrs,omitempty"`
-	Apps        []string               `json:"apps,omitempty"`
-	Label       string                 `json:"label"`
-	Connections []SlotRef              `json:"connections,omitempty"`
+	*snap.PlugInfo
+	Connections []SlotRef `json:"connections,omitempty"`
 }
 
 // PlugRef is a reference to a plug.
@@ -44,13 +41,8 @@ type PlugRef struct {
 
 // Slot represents a capacity offered by a snap.
 type Slot struct {
-	Snap        string                 `json:"snap"`
-	Name        string                 `json:"slot"`
-	Interface   string                 `json:"interface"`
-	Attrs       map[string]interface{} `json:"attrs,omitempty"`
-	Apps        []string               `json:"apps,omitempty"`
-	Label       string                 `json:"label"`
-	Connections []PlugRef              `json:"connections,omitempty"`
+	*snap.SlotInfo
+	Connections []PlugRef `json:"connections,omitempty"`
 }
 
 // SlotRef is a reference to a slot.

--- a/interfaces/json.go
+++ b/interfaces/json.go
@@ -23,8 +23,8 @@ import (
 	"encoding/json"
 )
 
-// PlugJSON aids in marshaling Plug into JSON.
-type PlugJSON struct {
+// plugJSON aids in marshaling Plug into JSON.
+type plugJSON struct {
 	Snap        string                 `json:"snap"`
 	Name        string                 `json:"plug"`
 	Interface   string                 `json:"interface"`
@@ -36,7 +36,7 @@ type PlugJSON struct {
 
 // MarshalJSON returns the JSON encoding of plug.
 func (plug *Plug) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&PlugJSON{
+	return json.Marshal(&plugJSON{
 		Snap:        plug.Snap.Name,
 		Name:        plug.Name,
 		Interface:   plug.Interface,
@@ -47,8 +47,8 @@ func (plug *Plug) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// SlotJSON aids in marshaling Slot into JSON.
-type SlotJSON struct {
+// slotJSON aids in marshaling Slot into JSON.
+type slotJSON struct {
 	Snap        string                 `json:"snap"`
 	Name        string                 `json:"slot"`
 	Interface   string                 `json:"interface"`
@@ -60,7 +60,7 @@ type SlotJSON struct {
 
 // MarshalJSON returns the JSON encoding of slot.
 func (slot *Slot) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&SlotJSON{
+	return json.Marshal(&slotJSON{
 		Snap:        slot.Snap.Name,
 		Name:        slot.Name,
 		Interface:   slot.Interface,

--- a/interfaces/json.go
+++ b/interfaces/json.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"encoding/json"
+)
+
+// PlugJSON aids in marshaling Plug into JSON.
+type PlugJSON struct {
+	Snap        string                 `json:"snap"`
+	Name        string                 `json:"plug"`
+	Interface   string                 `json:"interface"`
+	Attrs       map[string]interface{} `json:"attrs,omitempty"`
+	Apps        []string               `json:"apps,omitempty"`
+	Label       string                 `json:"label"`
+	Connections []SlotRef              `json:"connections,omitempty"`
+}
+
+// MarshalJSON returns the JSON encoding of plug.
+func (plug *Plug) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&PlugJSON{
+		Snap:        plug.Snap.Name,
+		Name:        plug.Name,
+		Interface:   plug.Interface,
+		Attrs:       plug.Attrs,
+		Apps:        plug.AppNames(),
+		Label:       plug.Label,
+		Connections: plug.Connections,
+	})
+}
+
+// SlotJSON aids in marshaling Slot into JSON.
+type SlotJSON struct {
+	Snap        string                 `json:"snap"`
+	Name        string                 `json:"slot"`
+	Interface   string                 `json:"interface"`
+	Attrs       map[string]interface{} `json:"attrs,omitempty"`
+	Apps        []string               `json:"apps,omitempty"`
+	Label       string                 `json:"label"`
+	Connections []PlugRef              `json:"connections,omitempty"`
+}
+
+// MarshalJSON returns the JSON encoding of slot.
+func (slot *Slot) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&SlotJSON{
+		Snap:        slot.Snap.Name,
+		Name:        slot.Name,
+		Interface:   slot.Interface,
+		Attrs:       slot.Attrs,
+		Apps:        slot.AppNames(),
+		Label:       slot.Label,
+		Connections: slot.Connections,
+	})
+}

--- a/interfaces/json.go
+++ b/interfaces/json.go
@@ -36,12 +36,16 @@ type plugJSON struct {
 
 // MarshalJSON returns the JSON encoding of plug.
 func (plug *Plug) MarshalJSON() ([]byte, error) {
+	var names []string
+	for name := range plug.Apps {
+		names = append(names, name)
+	}
 	return json.Marshal(&plugJSON{
 		Snap:        plug.Snap.Name,
 		Name:        plug.Name,
 		Interface:   plug.Interface,
 		Attrs:       plug.Attrs,
-		Apps:        plug.AppNames(),
+		Apps:        names,
 		Label:       plug.Label,
 		Connections: plug.Connections,
 	})
@@ -60,12 +64,16 @@ type slotJSON struct {
 
 // MarshalJSON returns the JSON encoding of slot.
 func (slot *Slot) MarshalJSON() ([]byte, error) {
+	var names []string
+	for name := range slot.Apps {
+		names = append(names, name)
+	}
 	return json.Marshal(&slotJSON{
 		Snap:        slot.Snap.Name,
 		Name:        slot.Name,
 		Interface:   slot.Interface,
 		Attrs:       slot.Attrs,
-		Apps:        slot.AppNames(),
+		Apps:        names,
 		Label:       slot.Label,
 		Connections: slot.Connections,
 	})

--- a/interfaces/json_test.go
+++ b/interfaces/json_test.go
@@ -1,0 +1,107 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	"encoding/json"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/snap"
+)
+
+type JSONSuite struct{}
+
+var _ = Suite(&JSONSuite{})
+
+func (s *JSONSuite) TestPlugMarshalJSON(c *C) {
+	plug := &Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{Name: "snap-name"},
+			Name:      "plug-name",
+			Interface: "interface",
+			Attrs:     map[string]interface{}{"key": "value"},
+			Apps: map[string]*snap.AppInfo{
+				"app-name": {
+					Name: "app-name",
+				},
+			},
+			Label: "label",
+		},
+		Connections: []SlotRef{{
+			Snap: "other-snap-name",
+			Name: "slot-name",
+		}},
+	}
+	data, err := json.Marshal(plug)
+	c.Assert(err, IsNil)
+	var repr map[string]interface{}
+	err = json.Unmarshal(data, &repr)
+	c.Assert(err, IsNil)
+	c.Check(repr, DeepEquals, map[string]interface{}{
+		"snap":      "snap-name",
+		"plug":      "plug-name",
+		"interface": "interface",
+		"attrs":     map[string]interface{}{"key": "value"},
+		"apps":      []interface{}{"app-name"},
+		"label":     "label",
+		"connections": []interface{}{
+			map[string]interface{}{"snap": "other-snap-name", "slot": "slot-name"},
+		},
+	})
+}
+
+func (s *JSONSuite) TestSlotMarshalJSON(c *C) {
+	slot := &Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{Name: "snap-name"},
+			Name:      "slot-name",
+			Interface: "interface",
+			Attrs:     map[string]interface{}{"key": "value"},
+			Apps: map[string]*snap.AppInfo{
+				"app-name": {
+					Name: "app-name",
+				},
+			},
+			Label: "label",
+		},
+		Connections: []PlugRef{{
+			Snap: "other-snap-name",
+			Name: "plug-name",
+		}},
+	}
+	data, err := json.Marshal(slot)
+	c.Assert(err, IsNil)
+	var repr map[string]interface{}
+	err = json.Unmarshal(data, &repr)
+	c.Assert(err, IsNil)
+	c.Check(repr, DeepEquals, map[string]interface{}{
+		"snap":      "snap-name",
+		"slot":      "slot-name",
+		"interface": "interface",
+		"attrs":     map[string]interface{}{"key": "value"},
+		"apps":      []interface{}{"app-name"},
+		"label":     "label",
+		"connections": []interface{}{
+			map[string]interface{}{"snap": "other-snap-name", "plug": "plug-name"},
+		},
+	})
+}

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -48,7 +48,7 @@ func (s *RepositorySuite) SetUpTest(c *C) {
 	provider, err := snap.InfoFromSnapYaml([]byte(`
 name: provider
 apps:
-    meta/hooks/plug:
+    app:
 plugs:
     plug:
         interface: interface
@@ -767,7 +767,7 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 	snippets, err := repo.SecuritySnippetsForSnap(s.plug.Snap.Name, testSecurity)
 	c.Assert(err, IsNil)
 	c.Check(snippets, DeepEquals, map[string][][]byte{
-		"meta/hooks/plug": [][]byte{
+		"app": [][]byte{
 			[]byte(`static plug snippet`),
 		},
 	})
@@ -784,7 +784,7 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 	snippets, err = repo.SecuritySnippetsForSnap(s.plug.Snap.Name, testSecurity)
 	c.Assert(err, IsNil)
 	c.Check(snippets, DeepEquals, map[string][][]byte{
-		"meta/hooks/plug": [][]byte{
+		"app": [][]byte{
 			[]byte(`static plug snippet`),
 			[]byte(`connection-specific plug snippet`),
 		},

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -25,6 +25,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	. "github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 type RepositorySuite struct {
@@ -43,26 +44,71 @@ var _ = Suite(&RepositorySuite{
 })
 
 func (s *RepositorySuite) SetUpTest(c *C) {
-	s.plug = &Plug{
-		Snap:      "provider",
-		Name:      "plug",
-		Interface: "interface",
-		Label:     "label",
-		Attrs:     map[string]interface{}{"attr": "value"},
-		Apps:      []string{"meta/hooks/plug"},
-	}
-	s.slot = &Slot{
-		Snap:      "consumer",
-		Name:      "slot",
-		Interface: "interface",
-		Label:     "label",
-		Attrs:     map[string]interface{}{"attr": "value"},
-		Apps:      []string{"app"},
-	}
+	// NOTE: the names provider/consumer are confusing. They will be fixed shortly.
+	provider, err := snap.InfoFromSnapYaml([]byte(`
+name: provider
+apps:
+    meta/hooks/plug:
+plugs:
+    plug:
+        interface: interface
+        label: label
+        attr: value
+`))
+	c.Assert(err, IsNil)
+	s.plug = &Plug{PlugInfo: provider.Plugs["plug"]}
+	consumer, err := snap.InfoFromSnapYaml([]byte(`
+name: consumer
+apps:
+    app:
+slots:
+    slot:
+        interface: interface
+        label: label
+        attr: value
+`))
+	c.Assert(err, IsNil)
+	s.slot = &Slot{SlotInfo: consumer.Slots["slot"]}
 	s.emptyRepo = NewRepository()
 	s.testRepo = NewRepository()
-	err := s.testRepo.AddInterface(s.iface)
+	err = s.testRepo.AddInterface(s.iface)
 	c.Assert(err, IsNil)
+}
+
+// plugFromYaml parses the given Yaml and returns Plug with the given name.
+func plugFromYaml(c *C, plugName string, yaml []byte) *Plug {
+	info, err := snap.InfoFromSnapYaml(yaml)
+	c.Assert(err, IsNil)
+	plugInfo := info.Plugs[plugName]
+	c.Assert(plugInfo, Not(IsNil))
+	return &Plug{PlugInfo: plugInfo}
+}
+
+// slotFromYaml parses the given Yaml and returns Slot with the given name.
+func slotFromYaml(c *C, slotName string, yaml []byte) *Slot {
+	info, err := snap.InfoFromSnapYaml(yaml)
+	c.Assert(err, IsNil)
+	slotInfo := info.Slots[slotName]
+	c.Assert(slotInfo, Not(IsNil))
+	return &Slot{SlotInfo: slotInfo}
+}
+
+func addPlugsAndSlotsFromYaml(c *C, repo *Repository, yamls ...[]byte) []*snap.Info {
+	result := make([]*snap.Info, len(yamls))
+	for i, yaml := range yamls {
+		info, err := snap.InfoFromSnapYaml(yaml)
+		c.Assert(err, IsNil)
+		result[i] = info
+		for _, plugInfo := range info.Plugs {
+			err := repo.AddPlug(&Plug{PlugInfo: plugInfo})
+			c.Assert(err, IsNil)
+		}
+		for _, slotInfo := range info.Slots {
+			err := repo.AddSlot(&Slot{SlotInfo: slotInfo})
+			c.Assert(err, IsNil)
+		}
+	}
+	return result
 }
 
 // Tests for Repository.AddInterface()
@@ -130,7 +176,7 @@ func (s *RepositorySuite) TestAddPlug(c *C) {
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
-	c.Assert(s.testRepo.Plug(s.plug.Snap, s.plug.Name), DeepEquals, s.plug)
+	c.Assert(s.testRepo.Plug(s.plug.Snap.Name, s.plug.Name), DeepEquals, s.plug)
 }
 
 func (s *RepositorySuite) TestAddPlugClash(c *C) {
@@ -139,26 +185,26 @@ func (s *RepositorySuite) TestAddPlugClash(c *C) {
 	err = s.testRepo.AddPlug(s.plug)
 	c.Assert(err, ErrorMatches, `cannot add plug, snap "provider" already has plug "plug"`)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
-	c.Assert(s.testRepo.Plug(s.plug.Snap, s.plug.Name), DeepEquals, s.plug)
+	c.Assert(s.testRepo.Plug(s.plug.Snap.Name, s.plug.Name), DeepEquals, s.plug)
 }
 
 func (s *RepositorySuite) TestAddPlugFailsWithInvalidSnapName(c *C) {
-	plug := &Plug{
-		Snap:      "bad-snap-",
-		Name:      "name",
-		Interface: "interface",
-	}
+	plug := plugFromYaml(c, "name", []byte(`
+name: bad-snap-
+plugs:
+    name: interface
+`))
 	err := s.testRepo.AddPlug(plug)
 	c.Assert(err, ErrorMatches, `invalid snap name: "bad-snap-"`)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
 }
 
 func (s *RepositorySuite) TestAddPlugFailsWithInvalidPlugName(c *C) {
-	plug := &Plug{
-		Snap:      "snap",
-		Name:      "bad-name-",
-		Interface: "interface",
-	}
+	plug := plugFromYaml(c, "bad-name-", []byte(`
+name: snap
+plugs:
+    bad-name-: interface
+`))
 	err := s.testRepo.AddPlug(plug)
 	c.Assert(err, ErrorMatches, `invalid interface name: "bad-name-"`)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
@@ -189,47 +235,24 @@ func (s *RepositorySuite) TestAddPlugFailsWithUnsanitizedPlug(c *C) {
 func (s *RepositorySuite) TestPlug(c *C) {
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
-	c.Assert(s.emptyRepo.Plug(s.plug.Snap, s.plug.Name), IsNil)
-	c.Assert(s.testRepo.Plug(s.plug.Snap, s.plug.Name), DeepEquals, s.plug)
+	c.Assert(s.emptyRepo.Plug(s.plug.Snap.Name, s.plug.Name), IsNil)
+	c.Assert(s.testRepo.Plug(s.plug.Snap.Name, s.plug.Name), DeepEquals, s.plug)
 }
 
 func (s *RepositorySuite) TestPlugSearch(c *C) {
-	err := s.testRepo.AddPlug(&Plug{
-		Snap:      "x",
-		Name:      "a",
-		Interface: s.plug.Interface,
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "x",
-		Name:      "b",
-		Interface: s.plug.Interface,
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "x",
-		Name:      "c",
-		Interface: s.plug.Interface,
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "y",
-		Name:      "a",
-		Interface: s.plug.Interface,
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "y",
-		Name:      "b",
-		Interface: s.plug.Interface,
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "y",
-		Name:      "c",
-		Interface: s.plug.Interface,
-	})
-	c.Assert(err, IsNil)
+	addPlugsAndSlotsFromYaml(c, s.testRepo, []byte(`
+name: x
+plugs:
+    a: interface
+    b: interface
+    c: interface
+`), []byte(`
+name: y
+plugs:
+    a: interface
+    b: interface
+    c: interface
+`))
 	// Plug() correctly finds plugs
 	c.Assert(s.testRepo.Plug("x", "a"), Not(IsNil))
 	c.Assert(s.testRepo.Plug("x", "b"), Not(IsNil))
@@ -244,13 +267,13 @@ func (s *RepositorySuite) TestPlugSearch(c *C) {
 func (s *RepositorySuite) TestRemovePlugSucceedsWhenPlugExistsAndDisconnected(c *C) {
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
-	err = s.testRepo.RemovePlug(s.plug.Snap, s.plug.Name)
+	err = s.testRepo.RemovePlug(s.plug.Snap.Name, s.plug.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
 }
 
 func (s *RepositorySuite) TestRemovePlugFailsWhenPlugDoesntExist(c *C) {
-	err := s.emptyRepo.RemovePlug(s.plug.Snap, s.plug.Name)
+	err := s.emptyRepo.RemovePlug(s.plug.Snap.Name, s.plug.Name)
 	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from snap "provider", no such plug`)
 }
 
@@ -259,66 +282,36 @@ func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// Removing a plug used by a slot returns an appropriate error
-	err = s.testRepo.RemovePlug(s.plug.Snap, s.plug.Name)
+	err = s.testRepo.RemovePlug(s.plug.Snap.Name, s.plug.Name)
 	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from snap "provider", it is still connected`)
 	// The plug is still there
-	slot := s.testRepo.Plug(s.plug.Snap, s.plug.Name)
+	slot := s.testRepo.Plug(s.plug.Snap.Name, s.plug.Name)
 	c.Assert(slot, Not(IsNil))
 }
 
 // Tests for Repository.AllPlugs()
 
 func (s *RepositorySuite) TestAllPlugsWithoutInterfaceName(c *C) {
-	// Note added in non-sorted order
-	err := s.testRepo.AddPlug(&Plug{
-		Snap:      "snap-b",
-		Name:      "name-a",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "snap-b",
-		Name:      "name-c",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "snap-b",
-		Name:      "name-b",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "snap-a",
-		Name:      "name-a",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
+	snaps := addPlugsAndSlotsFromYaml(c, s.testRepo, []byte(`
+name: snap-a
+plugs:
+    name-a: interface
+`), []byte(`
+name: snap-b
+plugs:
+    name-a: interface
+    name-b: interface
+    name-c: interface
+`))
 	// The result is sorted by snap and name
 	c.Assert(s.testRepo.AllPlugs(""), DeepEquals, []*Plug{
-		&Plug{
-			Snap:      "snap-a",
-			Name:      "name-a",
-			Interface: "interface",
-		},
-		&Plug{
-			Snap:      "snap-b",
-			Name:      "name-a",
-			Interface: "interface",
-		},
-		&Plug{
-			Snap:      "snap-b",
-			Name:      "name-b",
-			Interface: "interface",
-		},
-		&Plug{
-			Snap:      "snap-b",
-			Name:      "name-c",
-			Interface: "interface",
-		},
+		{PlugInfo: snaps[0].Plugs["name-a"]},
+		{PlugInfo: snaps[1].Plugs["name-a"]},
+		{PlugInfo: snaps[1].Plugs["name-b"]},
+		{PlugInfo: snaps[1].Plugs["name-c"]},
 	})
 }
 
@@ -326,72 +319,41 @@ func (s *RepositorySuite) TestAllPlugsWithInterfaceName(c *C) {
 	// Add another interface so that we can look for it
 	err := s.testRepo.AddInterface(&TestInterface{InterfaceName: "other-interface"})
 	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "snap",
-		Name:      "name-a",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "snap",
-		Name:      "name-b",
-		Interface: "other-interface",
-	})
-	c.Assert(err, IsNil)
+	snaps := addPlugsAndSlotsFromYaml(c, s.testRepo, []byte(`
+name: snap-a
+plugs:
+    name-a: interface
+`), []byte(`
+name: snap-b
+plugs:
+    name-a: interface
+    name-b: other-interface
+    name-c: interface
+`))
 	c.Assert(s.testRepo.AllPlugs("other-interface"), DeepEquals, []*Plug{
-		&Plug{
-			Snap:      "snap",
-			Name:      "name-b",
-			Interface: "other-interface",
-		},
+		{PlugInfo: snaps[1].Plugs["name-b"]},
 	})
 }
 
 // Tests for Repository.Plugs()
 
 func (s *RepositorySuite) TestPlugs(c *C) {
-	// Note added in non-sorted order
-	err := s.testRepo.AddPlug(&Plug{
-		Snap:      "snap-b",
-		Name:      "name-a",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "snap-b",
-		Name:      "name-c",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "snap-b",
-		Name:      "name-b",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{
-		Snap:      "snap-a",
-		Name:      "name-a",
-		Interface: "interface",
-	})
-	c.Assert(err, IsNil)
+	snaps := addPlugsAndSlotsFromYaml(c, s.testRepo, []byte(`
+name: snap-a
+plugs:
+    name-a: interface
+`), []byte(`
+name: snap-b
+plugs:
+    name-a: interface
+    name-b: interface
+    name-c: interface
+`))
 	// The result is sorted by snap and name
 	c.Assert(s.testRepo.Plugs("snap-b"), DeepEquals, []*Plug{
-		&Plug{
-			Snap:      "snap-b",
-			Name:      "name-a",
-			Interface: "interface",
-		},
-		&Plug{
-			Snap:      "snap-b",
-			Name:      "name-b",
-			Interface: "interface",
-		},
-		&Plug{
-			Snap:      "snap-b",
-			Name:      "name-c",
-			Interface: "interface",
-		},
+		{PlugInfo: snaps[1].Plugs["name-a"]},
+		{PlugInfo: snaps[1].Plugs["name-b"]},
+		{PlugInfo: snaps[1].Plugs["name-c"]},
 	})
 	// The result is empty if the snap is not known
 	c.Assert(s.testRepo.Plugs("snap-x"), HasLen, 0)
@@ -402,43 +364,49 @@ func (s *RepositorySuite) TestPlugs(c *C) {
 func (s *RepositorySuite) TestAllSlots(c *C) {
 	err := s.testRepo.AddInterface(&TestInterface{InterfaceName: "other-interface"})
 	c.Assert(err, IsNil)
-	// Add some slots
-	err = s.testRepo.AddSlot(&Slot{Snap: "snap-a", Name: "slot-b", Interface: "interface"})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddSlot(&Slot{Snap: "snap-b", Name: "slot-a", Interface: "other-interface"})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddSlot(&Slot{Snap: "snap-a", Name: "slot-a", Interface: "interface"})
-	c.Assert(err, IsNil)
+	snaps := addPlugsAndSlotsFromYaml(c, s.testRepo, []byte(`
+name: snap-a
+slots:
+    name-a: interface
+    name-b: interface
+`), []byte(`
+name: snap-b
+slots:
+    name-a: other-interface
+`))
 	// AllSlots("") returns all slots, sorted by snap and slot name
 	c.Assert(s.testRepo.AllSlots(""), DeepEquals, []*Slot{
-		&Slot{Snap: "snap-a", Name: "slot-a", Interface: "interface"},
-		&Slot{Snap: "snap-a", Name: "slot-b", Interface: "interface"},
-		&Slot{Snap: "snap-b", Name: "slot-a", Interface: "other-interface"},
+		{SlotInfo: snaps[0].Slots["name-a"]},
+		{SlotInfo: snaps[0].Slots["name-b"]},
+		{SlotInfo: snaps[1].Slots["name-a"]},
 	})
 	// AllSlots("") returns all slots, sorted by snap and slot name
 	c.Assert(s.testRepo.AllSlots("other-interface"), DeepEquals, []*Slot{
-		&Slot{Snap: "snap-b", Name: "slot-a", Interface: "other-interface"},
+		{SlotInfo: snaps[1].Slots["name-a"]},
 	})
 }
 
 // Tests for Repository.Slots()
 
 func (s *RepositorySuite) TestSlots(c *C) {
-	// Add some slots
-	err := s.testRepo.AddSlot(&Slot{Snap: "snap-a", Name: "slot-b", Interface: "interface"})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddSlot(&Slot{Snap: "snap-b", Name: "slot-a", Interface: "interface"})
-	c.Assert(err, IsNil)
-	err = s.testRepo.AddSlot(&Slot{Snap: "snap-a", Name: "slot-a", Interface: "interface"})
-	c.Assert(err, IsNil)
+	snaps := addPlugsAndSlotsFromYaml(c, s.testRepo, []byte(`
+name: snap-a
+slots:
+    name-a: interface
+    name-b: interface
+`), []byte(`
+name: snap-b
+slots:
+    name-a: interface
+`))
 	// Slots("snap-a") returns slots present in that snap
 	c.Assert(s.testRepo.Slots("snap-a"), DeepEquals, []*Slot{
-		&Slot{Snap: "snap-a", Name: "slot-a", Interface: "interface"},
-		&Slot{Snap: "snap-a", Name: "slot-b", Interface: "interface"},
+		{SlotInfo: snaps[0].Slots["name-a"]},
+		{SlotInfo: snaps[0].Slots["name-b"]},
 	})
 	// Slots("snap-b") returns slots present in that snap
 	c.Assert(s.testRepo.Slots("snap-b"), DeepEquals, []*Slot{
-		&Slot{Snap: "snap-b", Name: "slot-a", Interface: "interface"},
+		{SlotInfo: snaps[1].Slots["name-a"]},
 	})
 	// Slots("snap-c") returns no slots (because that snap doesn't exist)
 	c.Assert(s.testRepo.Slots("snap-c"), HasLen, 0)
@@ -451,12 +419,12 @@ func (s *RepositorySuite) TestSlots(c *C) {
 func (s *RepositorySuite) TestSlotSucceedsWhenSlotExists(c *C) {
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	slot := s.testRepo.Slot(s.slot.Snap, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Snap.Name, s.slot.Name)
 	c.Assert(slot, DeepEquals, s.slot)
 }
 
 func (s *RepositorySuite) TestSlotFailsWhenSlotDoesntExist(c *C) {
-	slot := s.testRepo.Slot(s.slot.Snap, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Snap.Name, s.slot.Name)
 	c.Assert(slot, IsNil)
 }
 
@@ -468,19 +436,25 @@ func (s *RepositorySuite) TestAddSlotFailsWhenInterfaceIsUnknown(c *C) {
 }
 
 func (s *RepositorySuite) TestAddSlotFailsWhenSlotNameIsInvalid(c *C) {
-	err := s.emptyRepo.AddSlot(&Slot{Snap: s.slot.Snap, Name: "bad-name-", Interface: s.slot.Interface})
+	slot := slotFromYaml(c, "bad-name-", []byte(`
+name: snap
+slots:
+    bad-name-: interface
+`))
+	err := s.emptyRepo.AddSlot(slot)
 	c.Assert(err, ErrorMatches, `invalid interface name: "bad-name-"`)
+	c.Assert(s.emptyRepo.AllSlots(""), HasLen, 0)
 }
 
 func (s *RepositorySuite) TestAddSlotFailsWithInvalidSnapName(c *C) {
-	slot := &Slot{
-		Snap:      "bad-snap-",
-		Name:      "name",
-		Interface: "interface",
-	}
-	err := s.testRepo.AddSlot(slot)
+	slot := slotFromYaml(c, "slot", []byte(`
+name: bad-snap-
+slots:
+    slot: interface
+`))
+	err := s.emptyRepo.AddSlot(slot)
 	c.Assert(err, ErrorMatches, `invalid snap name: "bad-snap-"`)
-	c.Assert(s.testRepo.AllSlots(""), HasLen, 0)
+	c.Assert(s.emptyRepo.AllSlots(""), HasLen, 0)
 }
 
 func (s *RepositorySuite) TestAddSlotFailsForDuplicates(c *C) {
@@ -509,7 +483,7 @@ func (s *RepositorySuite) TestAddSlotFailsWithUnsanitizedSlot(c *C) {
 func (s *RepositorySuite) TestAddSlotStoresCorrectData(c *C) {
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	slot := s.testRepo.Slot(s.slot.Snap, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Snap.Name, s.slot.Name)
 	// The added slot has the same data
 	c.Assert(slot, DeepEquals, s.slot)
 }
@@ -520,16 +494,16 @@ func (s *RepositorySuite) TestRemoveSlotSuccedsWhenSlotExistsAndDisconnected(c *
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Removing a vacant slot simply works
-	err = s.testRepo.RemoveSlot(s.slot.Snap, s.slot.Name)
+	err = s.testRepo.RemoveSlot(s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// The slot is gone now
-	slot := s.testRepo.Slot(s.slot.Snap, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Snap.Name, s.slot.Name)
 	c.Assert(slot, IsNil)
 }
 
 func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotDoesntExist(c *C) {
 	// Removing a slot that doesn't exist returns an appropriate error
-	err := s.testRepo.RemoveSlot(s.slot.Snap, s.slot.Name)
+	err := s.testRepo.RemoveSlot(s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, `cannot remove plug slot "slot" from snap "consumer", no such slot`)
 }
@@ -539,13 +513,13 @@ func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotIsConnected(c *C) {
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// Removing a slot occupied by a plug returns an appropriate error
-	err = s.testRepo.RemoveSlot(s.slot.Snap, s.slot.Name)
+	err = s.testRepo.RemoveSlot(s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from snap "consumer", it is still connected`)
 	// The slot is still there
-	slot := s.testRepo.Slot(s.slot.Snap, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Snap.Name, s.slot.Name)
 	c.Assert(slot, Not(IsNil))
 }
 
@@ -555,7 +529,7 @@ func (s *RepositorySuite) TestConnectFailsWhenPlugDoesNotExist(c *C) {
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Connecting an unknown plug returns an appropriate error
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot connect plug "plug" from snap "provider", no such plug`)
 }
 
@@ -563,7 +537,7 @@ func (s *RepositorySuite) TestConnectFailsWhenSlotDoesNotExist(c *C) {
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
 	// Connecting to an unknown slot returns an error
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot connect plug to slot "slot" from snap "consumer", no such slot`)
 }
 
@@ -572,26 +546,20 @@ func (s *RepositorySuite) TestConnectSucceedsWhenIdenticalConnectExists(c *C) {
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// Connecting exactly the same thing twice succeeds without an error but does nothing.
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// Only one connection is actually present.
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
 		Plugs: []*Plug{{
-			Snap:        s.plug.Snap,
-			Name:        s.plug.Name,
-			Interface:   s.plug.Interface,
-			Label:       s.plug.Label,
-			Connections: []SlotRef{{s.slot.Snap, s.slot.Name}},
+			PlugInfo:    s.plug.PlugInfo,
+			Connections: []SlotRef{{s.slot.Snap.Name, s.slot.Name}},
 		}},
 		Slots: []*Slot{{
-			Snap:        s.slot.Snap,
-			Name:        s.slot.Name,
-			Interface:   s.slot.Interface,
-			Label:       s.slot.Label,
-			Connections: []PlugRef{{s.plug.Snap, s.plug.Name}},
+			SlotInfo:    s.slot.SlotInfo,
+			Connections: []PlugRef{{s.plug.Snap.Name, s.plug.Name}},
 		}},
 	})
 }
@@ -599,13 +567,18 @@ func (s *RepositorySuite) TestConnectSucceedsWhenIdenticalConnectExists(c *C) {
 func (s *RepositorySuite) TestConnectFailsWhenSlotAndPlugAreIncompatible(c *C) {
 	otherInterface := &TestInterface{InterfaceName: "other-interface"}
 	err := s.testRepo.AddInterface(otherInterface)
+	plug := plugFromYaml(c, "plug", []byte(`
+name: provider
+plugs:
+    plug: other-interface
+`))
 	c.Assert(err, IsNil)
-	err = s.testRepo.AddPlug(&Plug{Snap: s.plug.Snap, Name: s.plug.Name, Interface: "other-interface"})
+	err = s.testRepo.AddPlug(plug)
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Connecting a plug to an incompatible slot fails with an appropriate error
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(plug.Snap.Name, plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot connect plug "provider:plug" \(interface "other-interface"\) to "consumer:slot" \(interface "interface"\)`)
 }
 
@@ -615,7 +588,7 @@ func (s *RepositorySuite) TestConnectSucceeds(c *C) {
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Connecting a plug works okay
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 }
 
@@ -625,7 +598,7 @@ func (s *RepositorySuite) TestDisconnectFailsWhenPlugDoesNotExist(c *C) {
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Disconnecting an unknown plug returns and appropriate error
-	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Disconnect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot disconnect plug "plug" from snap "provider", no such plug`)
 }
 
@@ -633,7 +606,7 @@ func (s *RepositorySuite) TestDisconnectFailsWhenSlotDoesNotExist(c *C) {
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
 	// Disconnecting from an unknown slot returns an appropriate error
-	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Disconnect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot disconnect plug from slot "slot" from snap "consumer", no such slot`)
 }
 
@@ -641,7 +614,7 @@ func (s *RepositorySuite) TestDisconnectFromSlotFailsWhenSlotDoesNotExist(c *C) 
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
 	// Disconnecting everything form an unknown slot returns an appropriate error
-	err = s.testRepo.Disconnect("", "", s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Disconnect("", "", s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot disconnect plug from slot "slot" from snap "consumer", no such slot`)
 }
 
@@ -649,7 +622,7 @@ func (s *RepositorySuite) TestDisconnectFromSnapFailsWhenSlotDoesNotExist(c *C) 
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
 	// Disconnecting all plugs from a snap that is not known returns an appropriate error
-	err = s.testRepo.Disconnect("", "", s.slot.Snap, "")
+	err = s.testRepo.Disconnect("", "", s.slot.Snap.Name, "")
 	c.Assert(err, ErrorMatches, `cannot disconnect plug from snap "consumer", no such snap`)
 }
 
@@ -659,7 +632,7 @@ func (s *RepositorySuite) TestDisconnectFailsWhenNotConnected(c *C) {
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Disconnecting a plug that is not connected returns an appropriate error
-	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Disconnect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot disconnect plug "plug" from snap "provider" from slot "slot" from snap "consumer", it is not connected`)
 }
 
@@ -669,7 +642,7 @@ func (s *RepositorySuite) TestDisconnectFromSnapDoesNothingWhenNotConnected(c *C
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Disconnecting a all plugs from a snap that uses nothing is not an error.
-	err = s.testRepo.Disconnect("", "", s.slot.Snap, "")
+	err = s.testRepo.Disconnect("", "", s.slot.Snap.Name, "")
 	c.Assert(err, IsNil)
 }
 
@@ -679,7 +652,7 @@ func (s *RepositorySuite) TestDisconnectFromSlotDoesNothingWhenNotConnected(c *C
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Disconnecting a all plugs from a slot that uses nothing is not an error.
-	err = s.testRepo.Disconnect("", "", s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Disconnect("", "", s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 }
 
@@ -688,24 +661,14 @@ func (s *RepositorySuite) TestDisconnectSucceeds(c *C) {
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// Disconnecting a connected plug works okay
-	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Disconnect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
-		Plugs: []*Plug{{
-			Snap:      s.plug.Snap,
-			Name:      s.plug.Name,
-			Interface: s.plug.Interface,
-			Label:     s.plug.Label,
-		}},
-		Slots: []*Slot{{
-			Snap:      s.slot.Snap,
-			Name:      s.slot.Name,
-			Interface: s.slot.Interface,
-			Label:     s.slot.Label,
-		}},
+		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
 	})
 }
 
@@ -714,24 +677,14 @@ func (s *RepositorySuite) TestDisconnectFromSnap(c *C) {
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// Disconnecting everything from a snap works OK
-	err = s.testRepo.Disconnect("", "", s.slot.Snap, "")
+	err = s.testRepo.Disconnect("", "", s.slot.Snap.Name, "")
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
-		Plugs: []*Plug{{
-			Snap:      s.plug.Snap,
-			Name:      s.plug.Name,
-			Interface: s.plug.Interface,
-			Label:     s.plug.Label,
-		}},
-		Slots: []*Slot{{
-			Snap:      s.slot.Snap,
-			Name:      s.slot.Name,
-			Interface: s.slot.Interface,
-			Label:     s.slot.Label,
-		}},
+		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
 	})
 }
 
@@ -740,24 +693,14 @@ func (s *RepositorySuite) TestDisconnectFromSlot(c *C) {
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// Disconnecting everything from a plug slot works OK
-	err = s.testRepo.Disconnect("", "", s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Disconnect("", "", s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
-		Plugs: []*Plug{{
-			Snap:      s.plug.Snap,
-			Name:      s.plug.Name,
-			Interface: s.plug.Interface,
-			Label:     s.plug.Label,
-		}},
-		Slots: []*Slot{{
-			Snap:      s.slot.Snap,
-			Name:      s.slot.Name,
-			Interface: s.slot.Interface,
-			Label:     s.slot.Label,
-		}},
+		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
 	})
 }
 
@@ -769,42 +712,26 @@ func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
 	err = s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// After connecting the result is as expected
-	err = s.testRepo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	ifaces := s.testRepo.Interfaces()
 	c.Assert(ifaces, DeepEquals, &Interfaces{
 		Plugs: []*Plug{{
-			Name:        s.plug.Name,
-			Snap:        s.plug.Snap,
-			Interface:   s.plug.Interface,
-			Label:       s.plug.Label,
-			Connections: []SlotRef{{s.slot.Snap, s.slot.Name}},
+			PlugInfo:    s.plug.PlugInfo,
+			Connections: []SlotRef{{s.slot.Snap.Name, s.slot.Name}},
 		}},
 		Slots: []*Slot{{
-			Snap:        s.slot.Snap,
-			Name:        s.slot.Name,
-			Interface:   s.slot.Interface,
-			Label:       s.slot.Label,
-			Connections: []PlugRef{{s.plug.Snap, s.plug.Name}},
+			SlotInfo:    s.slot.SlotInfo,
+			Connections: []PlugRef{{s.plug.Snap.Name, s.plug.Name}},
 		}},
 	})
 	// After disconnecting the connections become empty
-	err = s.testRepo.Disconnect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name)
+	err = s.testRepo.Disconnect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	ifaces = s.testRepo.Interfaces()
 	c.Assert(ifaces, DeepEquals, &Interfaces{
-		Plugs: []*Plug{{
-			Name:      s.plug.Name,
-			Snap:      s.plug.Snap,
-			Interface: s.plug.Interface,
-			Label:     s.plug.Label,
-		}},
-		Slots: []*Slot{{
-			Snap:      s.slot.Snap,
-			Name:      s.slot.Name,
-			Interface: s.slot.Interface,
-			Label:     s.slot.Label,
-		}},
+		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
 	})
 }
 
@@ -845,14 +772,14 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 	c.Assert(repo.AddSlot(s.slot), IsNil)
 	// Snaps should get static security now
 	var snippets map[string][][]byte
-	snippets, err := repo.SecuritySnippetsForSnap(s.plug.Snap, testSecurity)
+	snippets, err := repo.SecuritySnippetsForSnap(s.plug.Snap.Name, testSecurity)
 	c.Assert(err, IsNil)
 	c.Check(snippets, DeepEquals, map[string][][]byte{
 		"meta/hooks/plug": [][]byte{
 			[]byte(`static plug snippet`),
 		},
 	})
-	snippets, err = repo.SecuritySnippetsForSnap(s.slot.Snap, testSecurity)
+	snippets, err = repo.SecuritySnippetsForSnap(s.slot.Snap.Name, testSecurity)
 	c.Assert(err, IsNil)
 	c.Check(snippets, DeepEquals, map[string][][]byte{
 		"app": [][]byte{
@@ -860,9 +787,9 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 		},
 	})
 	// Establish connection between plug and slot
-	c.Assert(repo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name), IsNil)
+	c.Assert(repo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name), IsNil)
 	// Snaps should get static and connection-specific security now
-	snippets, err = repo.SecuritySnippetsForSnap(s.plug.Snap, testSecurity)
+	snippets, err = repo.SecuritySnippetsForSnap(s.plug.Snap.Name, testSecurity)
 	c.Assert(err, IsNil)
 	c.Check(snippets, DeepEquals, map[string][][]byte{
 		"meta/hooks/plug": [][]byte{
@@ -870,7 +797,7 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 			[]byte(`connection-specific plug snippet`),
 		},
 	})
-	snippets, err = repo.SecuritySnippetsForSnap(s.slot.Snap, testSecurity)
+	snippets, err = repo.SecuritySnippetsForSnap(s.slot.Snap.Name, testSecurity)
 	c.Assert(err, IsNil)
 	c.Check(snippets, DeepEquals, map[string][][]byte{
 		"app": [][]byte{
@@ -895,12 +822,12 @@ func (s *RepositorySuite) TestSecuritySnippetsForSnapFailureWithConnectionSnippe
 	c.Assert(repo.AddInterface(iface), IsNil)
 	c.Assert(repo.AddPlug(s.plug), IsNil)
 	c.Assert(repo.AddSlot(s.slot), IsNil)
-	c.Assert(repo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name), IsNil)
+	c.Assert(repo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name), IsNil)
 	var snippets map[string][][]byte
-	snippets, err := repo.SecuritySnippetsForSnap(s.plug.Snap, testSecurity)
+	snippets, err := repo.SecuritySnippetsForSnap(s.plug.Snap.Name, testSecurity)
 	c.Assert(err, ErrorMatches, "cannot compute snippet for provider")
 	c.Check(snippets, IsNil)
-	snippets, err = repo.SecuritySnippetsForSnap(s.slot.Snap, testSecurity)
+	snippets, err = repo.SecuritySnippetsForSnap(s.slot.Snap.Name, testSecurity)
 	c.Assert(err, ErrorMatches, "cannot compute snippet for consumer")
 	c.Check(snippets, IsNil)
 }
@@ -920,12 +847,12 @@ func (s *RepositorySuite) TestSecuritySnippetsForSnapFailureWithPermanentSnippet
 	c.Assert(repo.AddInterface(iface), IsNil)
 	c.Assert(repo.AddPlug(s.plug), IsNil)
 	c.Assert(repo.AddSlot(s.slot), IsNil)
-	c.Assert(repo.Connect(s.plug.Snap, s.plug.Name, s.slot.Snap, s.slot.Name), IsNil)
+	c.Assert(repo.Connect(s.plug.Snap.Name, s.plug.Name, s.slot.Snap.Name, s.slot.Name), IsNil)
 	var snippets map[string][][]byte
-	snippets, err := repo.SecuritySnippetsForSnap(s.plug.Snap, testSecurity)
+	snippets, err := repo.SecuritySnippetsForSnap(s.plug.Snap.Name, testSecurity)
 	c.Assert(err, ErrorMatches, "cannot compute static snippet for provider")
 	c.Check(snippets, IsNil)
-	snippets, err = repo.SecuritySnippetsForSnap(s.slot.Snap, testSecurity)
+	snippets, err = repo.SecuritySnippetsForSnap(s.slot.Snap.Name, testSecurity)
 	c.Assert(err, ErrorMatches, "cannot compute static snippet for consumer")
 	c.Check(snippets, IsNil)
 }

--- a/interfaces/sorting.go
+++ b/interfaces/sorting.go
@@ -46,8 +46,8 @@ type byPlugSnapAndName []*Plug
 func (c byPlugSnapAndName) Len() int      { return len(c) }
 func (c byPlugSnapAndName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 func (c byPlugSnapAndName) Less(i, j int) bool {
-	if c[i].Snap != c[j].Snap {
-		return c[i].Snap < c[j].Snap
+	if c[i].Snap.Name != c[j].Snap.Name {
+		return c[i].Snap.Name < c[j].Snap.Name
 	}
 	return c[i].Name < c[j].Name
 }
@@ -57,8 +57,8 @@ type bySlotSnapAndName []*Slot
 func (c bySlotSnapAndName) Len() int      { return len(c) }
 func (c bySlotSnapAndName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 func (c bySlotSnapAndName) Less(i, j int) bool {
-	if c[i].Snap != c[j].Snap {
-		return c[i].Snap < c[j].Snap
+	if c[i].Snap.Name != c[j].Snap.Name {
+		return c[i].Snap.Name < c[j].Snap.Name
 	}
 	return c[i].Name < c[j].Name
 }

--- a/interfaces/testtype_test.go
+++ b/interfaces/testtype_test.go
@@ -25,6 +25,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	. "github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 type TestInterfaceSuite struct {
@@ -35,20 +36,21 @@ type TestInterfaceSuite struct {
 
 var _ = Suite(&TestInterfaceSuite{
 	iface: &TestInterface{InterfaceName: "test"},
+	plug: &Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{Name: "snap"},
+			Name:      "name",
+			Interface: "test",
+		},
+	},
+	slot: &Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{Name: "snap"},
+			Name:      "name",
+			Interface: "test",
+		},
+	},
 })
-
-func (s *TestInterfaceSuite) SetUpTest(c *C) {
-	s.plug = plugFromYaml(c, "name", []byte(`
-name: snap
-plugs:
-    name: test
-`))
-	s.slot = slotFromYaml(c, "name", []byte(`
-name: snap
-slots:
-    name: test
-`))
-}
 
 // TestInterface has a working Name() function
 func (s *TestInterfaceSuite) TestName(c *C) {
@@ -75,11 +77,13 @@ func (s *TestInterfaceSuite) TestSanitizePlugError(c *C) {
 
 // TestInterface sanitization still checks for interface identity
 func (s *TestInterfaceSuite) TestSanitizePlugWrongInterface(c *C) {
-	plug := plugFromYaml(c, "name", []byte(`
-name: snap
-plugs:
-    name: other-interface 
-`))
+	plug := &Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{Name: "snap"},
+			Name:      "name",
+			Interface: "other-interface",
+		},
+	}
 	c.Assert(func() { s.iface.SanitizePlug(plug) }, Panics, "plug is not of interface \"test\"")
 }
 
@@ -103,11 +107,13 @@ func (s *TestInterfaceSuite) TestSanitizeSlotError(c *C) {
 
 // TestInterface sanitization still checks for interface identity
 func (s *TestInterfaceSuite) TestSanitizeSlotWrongInterface(c *C) {
-	slot := slotFromYaml(c, "name", []byte(`
-name: snap
-slots:
-    name: other-interface 
-`))
+	slot := &Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{Name: "snap"},
+			Name:      "name",
+			Interface: "interface",
+		},
+	}
 	c.Assert(func() { s.iface.SanitizeSlot(slot) }, Panics, "slot is not of interface \"test\"")
 }
 

--- a/interfaces/testtype_test.go
+++ b/interfaces/testtype_test.go
@@ -28,114 +28,117 @@ import (
 )
 
 type TestInterfaceSuite struct {
-	i Interface
+	iface Interface
+	plug  *Plug
+	slot  *Slot
 }
 
 var _ = Suite(&TestInterfaceSuite{
-	i: &TestInterface{InterfaceName: "test"},
+	iface: &TestInterface{InterfaceName: "test"},
 })
+
+func (s *TestInterfaceSuite) SetUpTest(c *C) {
+	s.plug = plugFromYaml(c, "name", []byte(`
+name: snap
+plugs:
+    name: test
+`))
+	s.slot = slotFromYaml(c, "name", []byte(`
+name: snap
+slots:
+    name: test
+`))
+}
 
 // TestInterface has a working Name() function
 func (s *TestInterfaceSuite) TestName(c *C) {
-	c.Assert(s.i.Name(), Equals, "test")
+	c.Assert(s.iface.Name(), Equals, "test")
 }
 
 // TestInterface doesn't do any sanitization by default
 func (s *TestInterfaceSuite) TestSanitizePlugOK(c *C) {
-	plug := &Plug{
-		Interface: "test",
-	}
-	err := s.i.SanitizePlug(plug)
+	err := s.iface.SanitizePlug(s.plug)
 	c.Assert(err, IsNil)
 }
 
 // TestInterface has provisions to customize sanitization
 func (s *TestInterfaceSuite) TestSanitizePlugError(c *C) {
-	i := &TestInterface{
+	iface := &TestInterface{
 		InterfaceName: "test",
 		SanitizePlugCallback: func(plug *Plug) error {
 			return fmt.Errorf("sanitize plug failed")
 		},
 	}
-	plug := &Plug{
-		Interface: "test",
-	}
-	err := i.SanitizePlug(plug)
+	err := iface.SanitizePlug(s.plug)
 	c.Assert(err, ErrorMatches, "sanitize plug failed")
 }
 
 // TestInterface sanitization still checks for interface identity
 func (s *TestInterfaceSuite) TestSanitizePlugWrongInterface(c *C) {
-	plug := &Plug{
-		Interface: "other-interface",
-	}
-	c.Assert(func() { s.i.SanitizePlug(plug) }, Panics, "plug is not of interface \"test\"")
+	plug := plugFromYaml(c, "name", []byte(`
+name: snap
+plugs:
+    name: other-interface 
+`))
+	c.Assert(func() { s.iface.SanitizePlug(plug) }, Panics, "plug is not of interface \"test\"")
 }
 
 // TestInterface doesn't do any sanitization by default
 func (s *TestInterfaceSuite) TestSanitizeSlotOK(c *C) {
-	slot := &Slot{
-		Interface: "test",
-	}
-	err := s.i.SanitizeSlot(slot)
+	err := s.iface.SanitizeSlot(s.slot)
 	c.Assert(err, IsNil)
 }
 
 // TestInterface has provisions to customize sanitization
 func (s *TestInterfaceSuite) TestSanitizeSlotError(c *C) {
-	i := &TestInterface{
+	iface := &TestInterface{
 		InterfaceName: "test",
 		SanitizeSlotCallback: func(slot *Slot) error {
 			return fmt.Errorf("sanitize slot failed")
 		},
 	}
-	slot := &Slot{
-		Interface: "test",
-	}
-	err := i.SanitizeSlot(slot)
+	err := iface.SanitizeSlot(s.slot)
 	c.Assert(err, ErrorMatches, "sanitize slot failed")
 }
 
 // TestInterface sanitization still checks for interface identity
 func (s *TestInterfaceSuite) TestSanitizeSlotWrongInterface(c *C) {
-	slot := &Slot{
-		Interface: "other-interface",
-	}
-	c.Assert(func() { s.i.SanitizeSlot(slot) }, Panics, "slot is not of interface \"test\"")
+	slot := slotFromYaml(c, "name", []byte(`
+name: snap
+slots:
+    name: other-interface 
+`))
+	c.Assert(func() { s.iface.SanitizeSlot(slot) }, Panics, "slot is not of interface \"test\"")
 }
 
 // TestInterface hands out empty plug security snippets
 func (s *TestInterfaceSuite) TestPlugSnippet(c *C) {
-	plug := &Plug{Interface: "test"}
-	slot := &Slot{Interface: "test"}
-	snippet, err := s.i.ConnectedPlugSnippet(plug, slot, SecurityAppArmor)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.ConnectedPlugSnippet(plug, slot, SecuritySecComp)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.ConnectedPlugSnippet(plug, slot, SecurityDBus)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.ConnectedPlugSnippet(plug, slot, "foo")
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }
 
 // TestInterface hands out empty slot security snippets
 func (s *TestInterfaceSuite) TestSlotSnippet(c *C) {
-	plug := &Plug{Interface: "test"}
-	slot := &Slot{Interface: "test"}
-	snippet, err := s.i.ConnectedSlotSnippet(plug, slot, SecurityAppArmor)
+	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.ConnectedSlotSnippet(plug, slot, SecuritySecComp)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.ConnectedSlotSnippet(plug, slot, SecurityDBus)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-	snippet, err = s.i.ConnectedSlotSnippet(plug, slot, "foo")
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 }

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/overlord/ifacestate"
 	"github.com/ubuntu-core/snappy/overlord/state"
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 func TestInterfaceManager(t *testing.T) { TestingT(t) }
@@ -100,15 +101,15 @@ func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {
 	repo := s.mgr.Repository()
 	c.Check(repo.Interfaces(), DeepEquals, &interfaces.Interfaces{
 		Slots: []*interfaces.Slot{{
-			Snap:        "producer",
-			Name:        "slot",
-			Interface:   "test",
+			SlotInfo: &snap.SlotInfo{
+				Snap: &snap.Info{Name: "producer"}, Name: "slot", Interface: "test",
+			},
 			Connections: []interfaces.PlugRef{{Snap: "consumer", Name: "plug"}},
 		}},
 		Plugs: []*interfaces.Plug{{
-			Snap:        "consumer",
-			Name:        "plug",
-			Interface:   "test",
+			PlugInfo: &snap.PlugInfo{
+				Snap: &snap.Info{Name: "consumer"}, Name: "plug", Interface: "test",
+			},
 			Connections: []interfaces.SlotRef{{Snap: "producer", Name: "slot"}},
 		}},
 	})
@@ -161,8 +162,10 @@ func (s *interfaceManagerSuite) TestEnsureProcessesDisconnectTask(c *C) {
 	c.Check(change.Status(), Equals, state.DoneStatus)
 	c.Check(repo.Interfaces(), DeepEquals, &interfaces.Interfaces{
 		// NOTE: the connection is gone now.
-		Slots: []*interfaces.Slot{{Snap: "producer", Name: "slot", Interface: "test"}},
-		Plugs: []*interfaces.Plug{{Snap: "consumer", Name: "plug", Interface: "test"}},
+		Slots: []*interfaces.Slot{{SlotInfo: &snap.SlotInfo{
+			Snap: &snap.Info{Name: "producer"}, Name: "slot", Interface: "test"}}},
+		Plugs: []*interfaces.Plug{{PlugInfo: &snap.PlugInfo{
+			Snap: &snap.Info{Name: "consumer"}, Name: "plug", Interface: "test"}}},
 	})
 }
 
@@ -170,8 +173,10 @@ func (s *interfaceManagerSuite) addPlugSlotAndInterface(c *C) {
 	repo := s.mgr.Repository()
 	err := repo.AddInterface(&interfaces.TestInterface{InterfaceName: "test"})
 	c.Assert(err, IsNil)
-	err = repo.AddSlot(&interfaces.Slot{Snap: "producer", Name: "slot", Interface: "test"})
+	err = repo.AddSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap: &snap.Info{Name: "producer"}, Name: "slot", Interface: "test"}})
 	c.Assert(err, IsNil)
-	err = repo.AddPlug(&interfaces.Plug{Snap: "consumer", Name: "plug", Interface: "test"})
+	err = repo.AddPlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{
+		Snap: &snap.Info{Name: "consumer"}, Name: "plug", Interface: "test"}})
 	c.Assert(err, IsNil)
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -43,6 +43,15 @@ type PlugInfo struct {
 	Apps      map[string]*AppInfo
 }
 
+// AppNames returns a list of applications names.
+func (plug *PlugInfo) AppNames() []string {
+	var names []string
+	for name := range plug.Apps {
+		names = append(names, name)
+	}
+	return names
+}
+
 // SlotInfo provides information about a slot.
 type SlotInfo struct {
 	Snap *Info
@@ -52,6 +61,15 @@ type SlotInfo struct {
 	Attrs     map[string]interface{}
 	Label     string
 	Apps      map[string]*AppInfo
+}
+
+// AppNames returns a list of applications names.
+func (slot *SlotInfo) AppNames() []string {
+	var names []string
+	for name := range slot.Apps {
+		names = append(names, name)
+	}
+	return names
 }
 
 // AppInfo provides information about a plug.

--- a/snap/info.go
+++ b/snap/info.go
@@ -43,15 +43,6 @@ type PlugInfo struct {
 	Apps      map[string]*AppInfo
 }
 
-// AppNames returns a list of applications names.
-func (plug *PlugInfo) AppNames() []string {
-	var names []string
-	for name := range plug.Apps {
-		names = append(names, name)
-	}
-	return names
-}
-
 // SlotInfo provides information about a slot.
 type SlotInfo struct {
 	Snap *Info
@@ -61,15 +52,6 @@ type SlotInfo struct {
 	Attrs     map[string]interface{}
 	Label     string
 	Apps      map[string]*AppInfo
-}
-
-// AppNames returns a list of applications names.
-func (slot *SlotInfo) AppNames() []string {
-	var names []string
-	for name := range slot.Apps {
-		names = append(names, name)
-	}
-	return names
 }
 
 // AppInfo provides information about a plug.


### PR DESCRIPTION
This patch changes interfaces, interfaces/builtin, daemon, overlord to be built upon
snap.PlugInfo and snap.PlugInfo. This cuts a lot of the duplicated data
and also gives us access to data that was previously provided via
side-channels, such as snap version and developer name.

The branch is divided by package for easier review process. Most of the changes affect test code
and various test fixtures.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>