### PR TITLE
overlord/state: make TaskRunner log observed errors

### DIFF
--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -20,7 +20,10 @@
 package state
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"strings"
 )
 
 // Status is used for status values for changes and tasks.
@@ -209,6 +212,51 @@ func (c *Change) Status() Status {
 func (c *Change) SetStatus(s Status) {
 	c.state.ensureLocked()
 	c.status = s
+}
+
+// changeError holds a set of task errors.
+type changeError struct {
+	errors []taskError
+}
+
+type taskError struct {
+	task  string
+	error string
+}
+
+func (e *changeError) Error() string {
+	var buf bytes.Buffer
+	buf.WriteString("cannot perform the following tasks:\n")
+	for _, te := range e.errors {
+		fmt.Fprintf(&buf, "- %s (%s)\n", te.task, te.error)
+	}
+	return strings.TrimSuffix(buf.String(), "\n")
+}
+
+// Err returns an error value based on errors that were logged for tasks registered
+// in this change, or nil if the task is not in ErrorStatus.
+func (c *Change) Err() error {
+	c.state.ensureLocked()
+	if c.Status() != ErrorStatus {
+		return nil
+	}
+	var errors []taskError
+	for tid := range c.taskIDs {
+		task := c.state.tasks[tid]
+		if task.Status() != ErrorStatus {
+			continue
+		}
+		for _, msg := range task.Log() {
+			if strings.HasPrefix(msg, LogError+": ") {
+				msg = strings.TrimPrefix(msg, LogError+": ")
+				errors = append(errors, taskError{task.Summary(), msg})
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return fmt.Errorf("internal inconsistency: change %q in ErrorStatus with no task errors logged", c.Kind())
+	}
+	return &changeError{errors}
 }
 
 // State returns the system State

--- a/overlord/state/change_test.go
+++ b/overlord/state/change_test.go
@@ -54,24 +54,7 @@ func (cs *changeSuite) TestGetSet(c *C) {
 	c.Check(v, Equals, 1)
 }
 
-func (cs *changeSuite) TestGetNeedsLock(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	chg := st.NewChange("install", "...")
-	st.Unlock()
-
-	var v int
-	c.Assert(func() { chg.Get("a", &v) }, PanicMatches, "internal error: accessing state without lock")
-}
-
-func (cs *changeSuite) TestSetNeedsLock(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	chg := st.NewChange("install", "...")
-	st.Unlock()
-
-	c.Assert(func() { chg.Set("a", 1) }, PanicMatches, "internal error: accessing state without lock")
-}
+// TODO Better testing of full change roundtripping via JSON.
 
 func (cs *changeSuite) TestNewTaskAddTaskAndTasks(c *C) {
 	st := state.New(nil)
@@ -122,33 +105,6 @@ func (cs *changeSuite) TestAddTasks(c *C) {
 	}
 }
 
-func (cs *changeSuite) TestAddTaskNeedsLocked(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	chg := st.NewChange("install", "...")
-	st.Unlock()
-
-	c.Assert(func() { chg.AddTask(nil) }, PanicMatches, "internal error: accessing state without lock")
-}
-
-func (cs *changeSuite) TestAddTasksNeedsLocked(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	chg := st.NewChange("install", "...")
-	st.Unlock()
-
-	c.Assert(func() { chg.AddTasks(nil) }, PanicMatches, "internal error: accessing state without lock")
-}
-
-func (cs *changeSuite) TestTasksNeedsLocked(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	chg := st.NewChange("install", "...")
-	st.Unlock()
-
-	c.Assert(func() { chg.Tasks() }, PanicMatches, "internal error: accessing state without lock")
-}
-
 func (cs *changeSuite) TestStatusAndSetStatus(c *C) {
 	st := state.New(nil)
 	st.Lock()
@@ -162,24 +118,6 @@ func (cs *changeSuite) TestStatusAndSetStatus(c *C) {
 	chg.SetStatus(state.RunningStatus)
 
 	c.Check(chg.Status(), Equals, state.RunningStatus)
-}
-
-func (cs *changeSuite) TestStatusNeedsLock(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	chg := st.NewChange("install", "...")
-	st.Unlock()
-
-	c.Assert(func() { chg.Status() }, PanicMatches, "internal error: accessing state without lock")
-}
-
-func (cs *changeSuite) TestSetStatusNeedsLock(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	chg := st.NewChange("install", "...")
-	st.Unlock()
-
-	c.Assert(func() { chg.SetStatus(state.WaitingStatus) }, PanicMatches, "internal error: accessing state without lock")
 }
 
 func (cs *changeSuite) TestStatusDerivedFromTasks(c *C) {
@@ -222,4 +160,61 @@ func (cs *changeSuite) TestState(c *C) {
 	st.Unlock()
 
 	c.Assert(chg.State(), Equals, st)
+}
+
+func (cs *changeSuite) TestErr(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("install", "...")
+
+	t1 := st.NewTask("download", "Download")
+	t2 := st.NewTask("activate", "Activate")
+
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+
+	c.Assert(chg.Err(), IsNil)
+
+	t1.SetStatus(state.ErrorStatus)
+	c.Assert(chg.Err(), IsNil)
+
+	t2.SetStatus(state.ErrorStatus)
+	c.Assert(chg.Err(), ErrorMatches, `internal inconsistency: change "install" in ErrorStatus with no task errors logged`)
+
+	t1.Errorf("Download error")
+	c.Assert(chg.Err(), ErrorMatches, ""+
+		"cannot perform the following tasks:\n"+
+		"- Download \\(Download error\\)")
+
+	// TODO Preserve task creation order for presentation purposes.
+	t2.Errorf("Activate error")
+	c.Assert(chg.Err(), ErrorMatches, ""+
+		"cannot perform the following tasks:\n"+
+		"- (Download|Activate) \\((Download|Activate) error\\)\n"+
+		"- (Download|Activate) \\((Download|Activate) error\\)")
+}
+
+func (cs *changeSuite) TestNeedsLock(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install", "...")
+	st.Unlock()
+
+	funcs := []func(){
+		func() { chg.Set("a", 1) },
+		func() { chg.Get("a", nil) },
+		func() { chg.Status() },
+		func() { chg.SetStatus(state.WaitingStatus) },
+		func() { chg.AddTask(nil) },
+		func() { chg.AddTasks(nil) },
+		func() { chg.Tasks() },
+		func() { chg.Err() },
+	}
+
+	for i, f := range funcs {
+		c.Logf("Testing function #%d", i)
+		c.Assert(f, PanicMatches, "internal error: accessing state without lock")
+	}
 }

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -184,6 +184,10 @@ func (t *Task) addLog(kind, format string, args []interface{}) {
 
 // Log returns the most recent messages logged into the task.
 //
+// Only the most recent entries logged are returned, potentially with
+// different behavior for different task statuses. How many entries
+// are returned is an implementation detail and may change over time.
+//
 // Messages are prefixed with one of the known message kinds.
 // See details about LogInfo and LogError.
 //
@@ -194,20 +198,16 @@ func (t *Task) Log() []string {
 	return t.log
 }
 
-// Logf logs textual information about the progress of the task.
-// Only the most recent entries logged are held in memory, potentially
-// with different behavior for different task statuses. How many entries
-// are held is an implementation detail and may change over time.
+// Logf logs information about the progress of the task.
 func (t *Task) Logf(format string, args ...interface{}) {
 	t.state.ensureLocked()
 	t.addLog(LogInfo, format, args)
 }
 
-// Errorf sets the task to ErrorStatus and logs the message as an error.
+// Errorf logs error information about the progress of the task.
 func (t *Task) Errorf(format string, args ...interface{}) {
 	t.state.ensureLocked()
 	t.addLog(LogError, format, args)
-	t.status = ErrorStatus
 }
 
 // Set associates value with key for future consulting by managers.

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -187,7 +187,6 @@ func (cs *taskSuite) TestErrorf(c *C) {
 
 	t.Errorf("Some %s", "error")
 	c.Assert(t.Log(), DeepEquals, []string{"ERROR: Some error"})
-	c.Assert(t.Status(), Equals, state.ErrorStatus)
 }
 
 func (ts *taskSuite) TestTaskMarshalsLog(c *C) {

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -69,7 +69,7 @@ func (r *TaskRunner) Handlers() map[string]HandlerFunc {
 	return r.handlers
 }
 
-// propagateError sets to ErrorStatus all tasks directly and indirectly waiting on t.
+// propagateError sets all tasks directly and indirectly waiting on t to ErrorStatus.
 func propagateError(task *Task) {
 	mark := append([]*Task(nil), task.HaltTasks()...)
 	i := 0

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -69,9 +69,8 @@ func (r *TaskRunner) Handlers() map[string]HandlerFunc {
 	return r.handlers
 }
 
-// taskFail marks task t and all tasks waiting (directly and indirectly on it) as in ErrorStatus.
-func taskFail(task *Task) {
-	task.SetStatus(ErrorStatus)
+// propagateError sets to ErrorStatus all tasks directly and indirectly waiting on t.
+func propagateError(task *Task) {
 	mark := append([]*Task(nil), task.HaltTasks()...)
 	i := 0
 	for i < len(mark) {
@@ -97,7 +96,7 @@ func (r *TaskRunner) run(fn HandlerFunc, task *Task) {
 
 		r.state.Lock()
 		defer r.state.Unlock()
-		switch tomb.Err() {
+		switch err := tomb.Err(); err {
 		case Retry:
 			// Do nothing. Handler asked to try again later.
 			// TODO: define how to control retry intervals,
@@ -110,7 +109,9 @@ func (r *TaskRunner) run(fn HandlerFunc, task *Task) {
 				r.state.EnsureBefore(0)
 			}
 		default:
-			taskFail(task)
+			task.SetStatus(ErrorStatus)
+			task.Errorf("%s", err)
+			propagateError(task)
 		}
 		return nil
 	})

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -247,4 +247,5 @@ func (ts *taskRunnerSuite) TestErrorPropagates(c *C) {
 	c.Check(dep1.Status(), Equals, state.ErrorStatus)
 	c.Check(dep2.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches, "(?s).*boom.*")
 }


### PR DESCRIPTION
Also change Task.Errorf so it doesn't fiddle with the status.
These are orthogonal concerns really.

Depends on #703.