### PR TITLE
overlord/state: fix lp1560628, in taskrunner let task goroutines clean up their tombs

### DIFF
--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -189,11 +189,10 @@ func (r *TaskRunner) Ensure() {
 // wait expectes to be called with th r.mu lock held
 func (r *TaskRunner) wait() {
 	for len(r.tombs) > 0 {
-		for id, t := range r.tombs {
+		for _, t := range r.tombs {
 			r.mu.Unlock()
 			t.Wait()
 			r.mu.Lock()
-			delete(r.tombs, id)
 			break
 		}
 	}

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -114,7 +114,7 @@ func (ts *taskRunnerSuite) TestEnsureComplex(c *C) {
 
 	defer r.Stop()
 
-	// run in a loop to ensure ordering is correct by pure chance
+	// run in a loop to ensure ordering is not correct by pure chance
 	for i := 0; i < 100; i++ {
 		st.Lock()
 		chg := st.NewChange("mock-install", "...")


### PR DESCRIPTION
Let the task goroutines clean their own tomb from the mapping, using Alive in Ensure made that happen too early when they hadn't set the task status yet causing spurious reruns.

Closes: #1560628