### PR TITLE
snapmgr: add progress reporting via progress adapter

### DIFF
--- a/overlord/snapstate/progress.go
+++ b/overlord/snapstate/progress.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"github.com/ubuntu-core/snappy/overlord/state"
+)
+
+// Adapt the snappy.progress.Meter to the task progress until we
+// have native install/update/remove
+type TaskProgressAdapter struct {
+	task  *state.Task
+	total float64
+}
+
+// Start sets total
+func (t *TaskProgressAdapter) Start(pkg string, total float64) {
+	t.total = total
+}
+
+// Set sets the current progress
+func (t *TaskProgressAdapter) Set(current float64) {
+	t.task.State().Lock()
+	defer t.task.State().Unlock()
+	t.task.SetProgress(int(current), int(t.total))
+}
+
+// SetTotal sets tht maximum progress
+func (t *TaskProgressAdapter) SetTotal(total float64) {
+	t.total = total
+}
+
+// Finished set the progress to 100%
+func (t *TaskProgressAdapter) Finished() {
+	t.task.State().Lock()
+	defer t.task.State().Unlock()
+	t.task.SetProgress(int(t.total), int(t.total))
+}
+
+// Write does nothing
+func (t *TaskProgressAdapter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+// Notify notifies
+func (t *TaskProgressAdapter) Notify(msg string) {
+	t.task.Logf(msg)
+}
+
+// Spin does nothing
+func (t *TaskProgressAdapter) Spin(msg string) {
+}
+
+// Agreed does nothing
+func (t *TaskProgressAdapter) Agreed(intro, license string) bool {
+	return false
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -26,7 +26,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/ubuntu-core/snappy/overlord/state"
-	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snappy"
 )
 
@@ -100,7 +99,8 @@ func (m *SnapManager) doInstallSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	t.State().Unlock()
 
-	_, err := m.backend.Install(inst.Name, inst.Channel, inst.Flags, &progress.NullProgress{})
+	pb := &TaskProgressAdapter{task: t}
+	_, err := m.backend.Install(inst.Name, inst.Channel, inst.Flags, pb)
 	return err
 }
 
@@ -112,7 +112,8 @@ func (m *SnapManager) doUpdateSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	t.State().Unlock()
 
-	err := m.backend.Update(inst.Name, inst.Channel, inst.Flags, &progress.NullProgress{})
+	pb := &TaskProgressAdapter{task: t}
+	err := m.backend.Update(inst.Name, inst.Channel, inst.Flags, pb)
 	return err
 }
 
@@ -125,8 +126,9 @@ func (m *SnapManager) doRemoveSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	t.State().Unlock()
 
+	pb := &TaskProgressAdapter{task: t}
 	name, _ := snappy.SplitDeveloper(rm.Name)
-	err := m.backend.Remove(name, rm.Flags, &progress.NullProgress{})
+	err := m.backend.Remove(name, rm.Flags, pb)
 	return err
 }
 
@@ -139,8 +141,9 @@ func (m *SnapManager) doPurgeSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	t.State().Unlock()
 
+	pb := &TaskProgressAdapter{task: t}
 	name, _ := snappy.SplitDeveloper(purge.Name)
-	err := m.backend.Purge(name, purge.Flags, &progress.NullProgress{})
+	err := m.backend.Purge(name, purge.Flags, pb)
 	return err
 }
 
@@ -153,8 +156,9 @@ func (m *SnapManager) doRollbackSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	t.State().Unlock()
 
+	pb := &TaskProgressAdapter{task: t}
 	name, _ := snappy.SplitDeveloper(rollback.Name)
-	_, err := m.backend.Rollback(name, rollback.Version, &progress.NullProgress{})
+	_, err := m.backend.Rollback(name, rollback.Version, pb)
 	return err
 }
 
@@ -167,8 +171,9 @@ func (m *SnapManager) doSetActiveSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	t.State().Unlock()
 
+	pb := &TaskProgressAdapter{task: t}
 	name, _ := snappy.SplitDeveloper(setActive.Name)
-	return m.backend.SetActive(name, setActive.Active, &progress.NullProgress{})
+	return m.backend.SetActive(name, setActive.Active, pb)
 }
 
 // Ensure implements StateManager.Ensure.


### PR DESCRIPTION
[based on https://github.com/ubuntu-core/snappy/pull/676]

For easy review https://github.com/mvo5/snappy/compare/feature/snapmgr-in-daemon...mvo5:feature/snapmgr-in-daemon-progress?expand=1

This branch adds progress reporting to the snapmgr task. Note that this just an intermediate step until the snapmgr uses native install code instead of calling snappy.Install.