### PR TITLE
snap: unbreak snap install after d152db76 broke it

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -93,6 +93,16 @@ type cmdOp struct {
 	op func(*client.Client, string) (string, error)
 }
 
+func (x *cmdOp) Execute([]string) error {
+	cli := Client()
+	uuid, err := x.op(cli, x.Positional.Snap)
+	if err != nil {
+		return err
+	}
+
+	return wait(cli, uuid)
+}
+
 type cmdInstall struct {
 	Channel    string `long:"channel" description:"Install from this channel instead of the device's default"`
 	Positional struct {
@@ -100,11 +110,31 @@ type cmdInstall struct {
 	} `positional-args:"yes" required:"yes"`
 }
 
+func (x *cmdInstall) Execute([]string) error {
+	cli := Client()
+	uuid, err := cli.InstallSnap(x.Positional.Snap, x.Channel)
+	if err != nil {
+		return err
+	}
+
+	return wait(cli, uuid)
+}
+
 type cmdRefresh struct {
 	Channel    string `long:"channel" description:"Refresh to the latest on this channel, and track this channel henceforth"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
+}
+
+func (x *cmdRefresh) Execute([]string) error {
+	cli := Client()
+	uuid, err := cli.RefreshSnap(x.Positional.Snap, x.Channel)
+	if err != nil {
+		return err
+	}
+
+	return wait(cli, uuid)
 }
 
 func init() {
@@ -126,14 +156,4 @@ func init() {
 
 	addCommand("install", shortInstallHelp, longInstallHelp, func() interface{} { return &cmdInstall{} })
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() interface{} { return &cmdRefresh{} })
-}
-
-func (x *cmdOp) Execute([]string) error {
-	cli := Client()
-	uuid, err := x.op(cli, x.Positional.Snap)
-	if err != nil {
-		return err
-	}
-
-	return wait(cli, uuid)
 }

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -36,7 +36,8 @@ func (s *SnapSuite) TestInstall(c *check.C) {
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/2.0/snaps/foo.bar")
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
-				"action": "install",
+				"action":  "install",
+				"channel": "chan",
 			})
 			w.WriteHeader(http.StatusAccepted)
 			fmt.Fprintln(w, `{"type":"async", "result":{"resource": "/2.0/operations/42"}, "status_code": 202}`)
@@ -54,9 +55,11 @@ func (s *SnapSuite) TestInstall(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"install", "foo.bar"})
+	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "chan", "foo.bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "")
 	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(n, check.Equals, 3)
 }


### PR DESCRIPTION
When channels got added in d152db76, the cmdInstall/cmdRefresh types
got no "Execute()" functions. This broke install/refresh.