### PR TITLE
client,daemon: add progress information to the daemon

### DIFF
--- a/client/op.go
+++ b/client/op.go
@@ -28,6 +28,7 @@ import (
 type Operation interface {
 	Running() bool
 	Err() error
+	Progress() float64
 }
 
 // Operation fetches information about an operation given its UUID
@@ -41,6 +42,9 @@ func (client *Client) Operation(uuid string) (Operation, error) {
 type operation struct {
 	Status string          `json:"status"`
 	Output json.RawMessage `json:"output"`
+
+	ProgressCurrent int `json:"progress_current"`
+	ProgressTotal   int `json:"progress_total"`
 }
 
 func (op *operation) Err() error {
@@ -58,4 +62,11 @@ func (op *operation) Err() error {
 
 func (op *operation) Running() bool {
 	return op.Status == "running"
+}
+
+func (op *operation) Progress() float64 {
+	if op.ProgressTotal == 0 {
+		return 0.0
+	}
+	return float64(op.ProgressCurrent) / float64(op.ProgressTotal)
 }

--- a/client/op.go
+++ b/client/op.go
@@ -28,7 +28,7 @@ import (
 type Operation interface {
 	Running() bool
 	Err() error
-	Progress() (int64, int64)
+	Progress() (string, int64, int64)
 }
 
 // Operation fetches information about an operation given its UUID
@@ -43,8 +43,9 @@ type operation struct {
 	Status string          `json:"status"`
 	Output json.RawMessage `json:"output"`
 
-	ProgressCurrent int64 `json:"progress_current"`
-	ProgressTotal   int64 `json:"progress_total"`
+	ProgressMessage string `json:"progress_msg"`
+	ProgressCurrent int64  `json:"progress_current"`
+	ProgressTotal   int64  `json:"progress_total"`
 }
 
 func (op *operation) Err() error {
@@ -64,6 +65,6 @@ func (op *operation) Running() bool {
 	return op.Status == "running"
 }
 
-func (op *operation) Progress() (cur, total int64) {
-	return op.ProgressCurrent, op.ProgressTotal
+func (op *operation) Progress() (msg string, cur, total int64) {
+	return op.ProgressMessage, op.ProgressCurrent, op.ProgressTotal
 }

--- a/client/op.go
+++ b/client/op.go
@@ -28,7 +28,7 @@ import (
 type Operation interface {
 	Running() bool
 	Err() error
-	Progress() float64
+	Progress() (int64, int64)
 }
 
 // Operation fetches information about an operation given its UUID
@@ -43,8 +43,8 @@ type operation struct {
 	Status string          `json:"status"`
 	Output json.RawMessage `json:"output"`
 
-	ProgressCurrent int `json:"progress_current"`
-	ProgressTotal   int `json:"progress_total"`
+	ProgressCurrent int64 `json:"progress_current"`
+	ProgressTotal   int64 `json:"progress_total"`
 }
 
 func (op *operation) Err() error {
@@ -64,9 +64,6 @@ func (op *operation) Running() bool {
 	return op.Status == "running"
 }
 
-func (op *operation) Progress() float64 {
-	if op.ProgressTotal == 0 {
-		return 0.0
-	}
-	return float64(op.ProgressCurrent) / float64(op.ProgressTotal)
+func (op *operation) Progress() (cur, total int64) {
+	return op.ProgressCurrent, op.ProgressTotal
 }

--- a/client/op_test.go
+++ b/client/op_test.go
@@ -31,12 +31,15 @@ func (cs *clientSuite) TestClientOpRunning(c *check.C) {
   "created_at": "2010-01-01T01:01:01.010101Z",
   "updated_at": "2016-01-01T01:01:01.010101Z",
   "may_cancel": false,
-  "output": {}
+  "output": {},
+  "progress_current": 24,
+  "progress_total": 100
 }}`
 	op, err := cs.cli.Operation("foo")
 	c.Assert(err, check.IsNil)
 	c.Check(op.Running(), check.Equals, true)
 	c.Check(op.Err(), check.IsNil)
+	c.Check(op.Progress(), check.Equals, 0.24)
 }
 
 func (cs *clientSuite) TestClientOpFailed(c *check.C) {

--- a/client/op_test.go
+++ b/client/op_test.go
@@ -32,6 +32,7 @@ func (cs *clientSuite) TestClientOpRunning(c *check.C) {
   "updated_at": "2016-01-01T01:01:01.010101Z",
   "may_cancel": false,
   "output": {},
+  "progress_msg": "downloading the frobinator app",
   "progress_current": 24,
   "progress_total": 100
 }}`
@@ -39,7 +40,8 @@ func (cs *clientSuite) TestClientOpRunning(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(op.Running(), check.Equals, true)
 	c.Check(op.Err(), check.IsNil)
-	cur, total := op.Progress()
+	msg, cur, total := op.Progress()
+	c.Check(msg, check.Equals, "downloading the frobinator app")
 	c.Check(cur, check.Equals, int64(24))
 	c.Check(total, check.Equals, int64(100))
 }

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -93,6 +93,16 @@ type cmdOp struct {
 	op func(*client.Client, string) (string, error)
 }
 
+func (x *cmdOp) Execute([]string) error {
+	cli := Client()
+	uuid, err := x.op(cli, x.Positional.Snap)
+	if err != nil {
+		return err
+	}
+
+	return wait(cli, uuid)
+}
+
 type cmdInstall struct {
 	Channel    string `long:"channel" description:"Install from this channel instead of the device's default"`
 	Positional struct {
@@ -100,11 +110,31 @@ type cmdInstall struct {
 	} `positional-args:"yes" required:"yes"`
 }
 
+func (x *cmdInstall) Execute([]string) error {
+	cli := Client()
+	uuid, err := cli.InstallSnap(x.Positional.Snap, x.Channel)
+	if err != nil {
+		return err
+	}
+
+	return wait(cli, uuid)
+}
+
 type cmdRefresh struct {
 	Channel    string `long:"channel" description:"Refresh to the latest on this channel, and track this channel henceforth"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
+}
+
+func (x *cmdRefresh) Execute([]string) error {
+	cli := Client()
+	uuid, err := cli.RefreshSnap(x.Positional.Snap, x.Channel)
+	if err != nil {
+		return err
+	}
+
+	return wait(cli, uuid)
 }
 
 func init() {
@@ -126,14 +156,4 @@ func init() {
 
 	addCommand("install", shortInstallHelp, longInstallHelp, func() interface{} { return &cmdInstall{} })
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() interface{} { return &cmdRefresh{} })
-}
-
-func (x *cmdOp) Execute([]string) error {
-	cli := Client()
-	uuid, err := x.op(cli, x.Positional.Snap)
-	if err != nil {
-		return err
-	}
-
-	return wait(cli, uuid)
 }

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -24,16 +24,26 @@ import (
 
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/progress"
 )
 
 func wait(client *client.Client, uuid string) error {
+	pb := progress.NewTextProgress()
+	pb.Start("", 1.0)
 	for {
 		op, err := client.Operation(uuid)
 		if err != nil {
 			return err
 		}
 
+		if op.Progress() == 0.0 {
+			pb.Spin("")
+		} else {
+			pb.Set(op.Progress())
+		}
+
 		if !op.Running() {
+			pb.Finished()
 			return op.Err()
 		}
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -38,12 +38,12 @@ func wait(client *client.Client, uuid string) error {
 			return err
 		}
 
-		cur, total := op.Progress()
+		msg, cur, total := op.Progress()
 		if cur == 0 && total == 0 {
 			pb.Spin("")
 		} else {
 			if !started {
-				pb.Start("", float64(total))
+				pb.Start(msg, float64(total))
 				started = true
 			}
 			pb.Set(float64(cur))

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -29,17 +29,22 @@ import (
 
 func wait(client *client.Client, uuid string) error {
 	pb := progress.NewTextProgress()
-	pb.Start("", 1.0)
+	started := false
 	for {
 		op, err := client.Operation(uuid)
 		if err != nil {
 			return err
 		}
 
-		if op.Progress() == 0.0 {
+		cur, total := op.Progress()
+		if cur == 0 && total == 0 {
 			pb.Spin("")
 		} else {
-			pb.Set(op.Progress())
+			if !started {
+				pb.Start("", float64(total))
+				started = true
+			}
+			pb.Set(float64(cur))
 		}
 
 		if !op.Running() {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -36,7 +36,8 @@ func (s *SnapSuite) TestInstall(c *check.C) {
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/2.0/snaps/foo.bar")
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
-				"action": "install",
+				"action":  "install",
+				"channel": "chan",
 			})
 			w.WriteHeader(http.StatusAccepted)
 			fmt.Fprintln(w, `{"type":"async", "result":{"resource": "/2.0/operations/42"}, "status_code": 202}`)
@@ -54,9 +55,11 @@ func (s *SnapSuite) TestInstall(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"install", "foo.bar"})
+	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "chan", "foo.bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "")
 	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(n, check.Equals, 3)
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -633,18 +633,30 @@ func (inst *snapInstruction) Agreed(intro, license string) bool {
 }
 
 func (inst *snapInstruction) Start(pkg string, total float64) {
+	inst.task.mu.Lock()
+	defer inst.task.mu.Unlock()
+
 	inst.task.total = int(total)
 }
 
 func (inst *snapInstruction) Set(current float64) {
+	inst.task.mu.Lock()
+	defer inst.task.mu.Unlock()
+
 	inst.task.cur = int(current)
 }
 
 func (inst *snapInstruction) SetTotal(total float64) {
+	inst.task.mu.Lock()
+	defer inst.task.mu.Unlock()
+
 	inst.task.total = int(total)
 }
 
 func (inst *snapInstruction) Write(p []byte) (n int, err error) {
+	inst.task.mu.Lock()
+	defer inst.task.mu.Unlock()
+
 	inst.task.cur += len(p)
 	return len(p), nil
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -618,7 +618,7 @@ type snapInstruction struct {
 	LeaveOld bool         `json:"leave_old"`
 	License  *licenseData `json:"license"`
 	pkg      string
-	task     *Task
+	task     Task
 }
 
 // Agreed is part of the progress.Meter interface (q.v.)
@@ -770,7 +770,7 @@ func postSnap(c *Command, r *http.Request) Response {
 			return err
 		}
 		defer lock.Unlock()
-		inst.task = t
+		inst.task = *t
 		return f()
 	}).Map(route))
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -702,6 +702,7 @@ func (s *apiSuite) TestGetOpInfoIntegration(c *check.C) {
 		"created_at":       FormatTime(t.CreatedAt()),
 		"updated_at":       FormatTime(t.UpdatedAt()),
 		"output":           nil,
+		"progress_msg":     "",
 		"progress_current": 0,
 		"progress_total":   0,
 	})
@@ -721,6 +722,7 @@ func (s *apiSuite) TestGetOpInfoIntegration(c *check.C) {
 		"created_at":       FormatTime(t.CreatedAt()),
 		"updated_at":       FormatTime(t.UpdatedAt()),
 		"output":           "hello",
+		"progress_msg":     "",
 		"progress_current": 0,
 		"progress_total":   0,
 	})

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -671,7 +671,7 @@ func (s *apiSuite) TestGetOpInfoIntegration(c *check.C) {
 
 	ch := make(chan struct{})
 
-	t := d.AddTask(func() interface{} {
+	t := d.AddTask(func(t *Task) interface{} {
 		ch <- struct{}{}
 		return "hello"
 	})

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -684,12 +684,14 @@ func (s *apiSuite) TestGetOpInfoIntegration(c *check.C) {
 	c.Check(rsp.Status, check.Equals, http.StatusOK)
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
-		"resource":   "/2.0/operations/" + id,
-		"status":     TaskRunning,
-		"may_cancel": false,
-		"created_at": FormatTime(t.CreatedAt()),
-		"updated_at": FormatTime(t.UpdatedAt()),
-		"output":     nil,
+		"resource":         "/2.0/operations/" + id,
+		"status":           TaskRunning,
+		"may_cancel":       false,
+		"created_at":       FormatTime(t.CreatedAt()),
+		"updated_at":       FormatTime(t.UpdatedAt()),
+		"output":           nil,
+		"progress_current": 0,
+		"progress_total":   0,
 	})
 	tf1 := t.UpdatedAt().UTC().UnixNano()
 
@@ -701,12 +703,14 @@ func (s *apiSuite) TestGetOpInfoIntegration(c *check.C) {
 	c.Check(rsp.Status, check.Equals, http.StatusOK)
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
-		"resource":   "/2.0/operations/" + id,
-		"status":     TaskSucceeded,
-		"may_cancel": false,
-		"created_at": FormatTime(t.CreatedAt()),
-		"updated_at": FormatTime(t.UpdatedAt()),
-		"output":     "hello",
+		"resource":         "/2.0/operations/" + id,
+		"status":           TaskSucceeded,
+		"may_cancel":       false,
+		"created_at":       FormatTime(t.CreatedAt()),
+		"updated_at":       FormatTime(t.UpdatedAt()),
+		"output":           "hello",
+		"progress_current": 0,
+		"progress_total":   0,
 	})
 
 	tf2 := t.UpdatedAt().UTC().UnixNano()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -217,7 +217,7 @@ func (d *Daemon) Dying() <-chan struct{} {
 }
 
 // AddTask runs the given function as a task
-func (d *Daemon) AddTask(f func() interface{}) *Task {
+func (d *Daemon) AddTask(f func(t *Task) interface{}) *Task {
 	t := RunTask(f)
 	d.Lock()
 	defer d.Unlock()

--- a/daemon/task.go
+++ b/daemon/task.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -33,7 +34,9 @@ type Task struct {
 	t0     time.Time
 	tf     time.Time
 	output interface{}
+
 	// progress
+	mu    sync.Mutex
 	cur   int
 	total int
 }
@@ -106,6 +109,8 @@ func FormatTime(t time.Time) string {
 
 // Map the task onto a map[string]interface{}, using the given route for the Location()
 func (t *Task) Map(route *mux.Route) map[string]interface{} {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return map[string]interface{}{
 		"resource":         t.Location(route),
 		"status":           t.State(),

--- a/daemon/task.go
+++ b/daemon/task.go
@@ -37,6 +37,7 @@ type Task struct {
 
 	// progress
 	mu    sync.Mutex
+	msg   string
 	cur   int
 	total int
 }
@@ -118,6 +119,7 @@ func (t *Task) Map(route *mux.Route) map[string]interface{} {
 		"updated_at":       FormatTime(t.UpdatedAt()),
 		"may_cancel":       false,
 		"output":           t.Output(),
+		"progress_msg":     t.msg,
 		"progress_current": t.cur,
 		"progress_total":   t.total,
 	}

--- a/daemon/task.go
+++ b/daemon/task.go
@@ -33,6 +33,9 @@ type Task struct {
 	t0     time.Time
 	tf     time.Time
 	output interface{}
+	// progress
+	cur   int
+	total int
 }
 
 // A task can be in one of three states
@@ -104,12 +107,14 @@ func FormatTime(t time.Time) string {
 // Map the task onto a map[string]interface{}, using the given route for the Location()
 func (t *Task) Map(route *mux.Route) map[string]interface{} {
 	return map[string]interface{}{
-		"resource":   t.Location(route),
-		"status":     t.State(),
-		"created_at": FormatTime(t.CreatedAt()),
-		"updated_at": FormatTime(t.UpdatedAt()),
-		"may_cancel": false,
-		"output":     t.Output(),
+		"resource":         t.Location(route),
+		"status":           t.State(),
+		"created_at":       FormatTime(t.CreatedAt()),
+		"updated_at":       FormatTime(t.UpdatedAt()),
+		"may_cancel":       false,
+		"output":           t.Output(),
+		"progress_current": t.cur,
+		"progress_total":   t.total,
 	}
 }
 

--- a/daemon/task.go
+++ b/daemon/task.go
@@ -119,7 +119,7 @@ func (t *Task) Map(route *mux.Route) map[string]interface{} {
 }
 
 // RunTask creates a Task for the given function and runs it.
-func RunTask(f func() interface{}) *Task {
+func RunTask(f func(t *Task) interface{}) *Task {
 	id := UUID4()
 	t0 := time.Now()
 	t := &Task{
@@ -132,7 +132,7 @@ func RunTask(f func() interface{}) *Task {
 		defer func() {
 			t.tf = time.Now()
 		}()
-		out := f()
+		out := f(t)
 		t.output = out
 
 		switch out := out.(type) {

--- a/daemon/task_test.go
+++ b/daemon/task_test.go
@@ -37,7 +37,7 @@ func (s *taskSuite) TestTask(c *check.C) {
 
 	ch := make(chan struct{})
 
-	t := RunTask(func() interface{} {
+	t := RunTask(func(t *Task) interface{} {
 		ch <- struct{}{}
 		return 42
 	})
@@ -63,7 +63,7 @@ func (s *taskSuite) TestFails(c *check.C) {
 	ch := make(chan struct{})
 	err := errors.New("everything is broken")
 
-	t := RunTask(func() interface{} {
+	t := RunTask(func(t *Task) interface{} {
 		ch <- struct{}{}
 		return err
 	})


### PR DESCRIPTION
[this includes https://github.com/ubuntu-core/snappy/pull/710]

This adds basic progress information to the `snap` command. E.g.:

```
# ./snap install cap-test.mvo
1.23 MB / 1.23 MB [========================================] 100.00 % 1.75 MB/s 
```