### PR TITLE
snap: use flags.Commander as the returned interface in addCommand

### DIFF
--- a/cmd/snap/cmd_ack.go
+++ b/cmd/snap/cmd_ack.go
@@ -23,6 +23,8 @@ import (
 	"io/ioutil"
 
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdAck struct {
@@ -44,7 +46,7 @@ database.
 `)
 
 func init() {
-	addCommand("ack", shortAckHelp, longAckHelp, func() interface{} {
+	addCommand("ack", shortAckHelp, longAckHelp, func() flags.Commander {
 		return &cmdAck{}
 	})
 }

--- a/cmd/snap/cmd_add_plug.go
+++ b/cmd/snap/cmd_add_plug.go
@@ -22,6 +22,8 @@ package main
 import (
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdAddInterface struct {
@@ -44,7 +46,7 @@ It will be removed in one of the future releases.
 `)
 
 func init() {
-	addExperimentalCommand("add-plug", shortAddPlugHelp, longAddPlugHelp, func() interface{} {
+	addExperimentalCommand("add-plug", shortAddPlugHelp, longAddPlugHelp, func() flags.Commander {
 		return &cmdAddInterface{}
 	})
 }

--- a/cmd/snap/cmd_add_slot.go
+++ b/cmd/snap/cmd_add_slot.go
@@ -22,6 +22,8 @@ package main
 import (
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdAddSlot struct {
@@ -44,7 +46,7 @@ It will be removed in one of the future releases.
 `)
 
 func init() {
-	addExperimentalCommand("add-slot", shortAddSlotHelp, longAddSlotHelp, func() interface{} {
+	addExperimentalCommand("add-slot", shortAddSlotHelp, longAddSlotHelp, func() flags.Commander {
 		return &cmdAddSlot{}
 	})
 }

--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -21,6 +21,8 @@ package main
 
 import (
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdConnect struct {
@@ -54,7 +56,7 @@ proceeds as above.
 `)
 
 func init() {
-	addCommand("connect", shortConnectHelp, longConnectHelp, func() interface{} {
+	addCommand("connect", shortConnectHelp, longConnectHelp, func() flags.Commander {
 		return &cmdConnect{}
 	})
 }

--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -21,6 +21,8 @@ package main
 
 import (
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdDisconnect struct {
@@ -49,7 +51,7 @@ Disconnects all plugs from the provided snap.
 `)
 
 func init() {
-	addCommand("disconnect", shortDisconnectHelp, longDisconnectHelp, func() interface{} {
+	addCommand("disconnect", shortDisconnectHelp, longDisconnectHelp, func() flags.Commander {
 		return &cmdDisconnect{}
 	})
 }

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 var shortFindHelp = i18n.G("Finds packages to install")
@@ -40,7 +42,7 @@ type cmdFind struct {
 }
 
 func init() {
-	addCommand("find", shortFindHelp, longFindHelp, func() interface{} {
+	addCommand("find", shortFindHelp, longFindHelp, func() flags.Commander {
 		return &cmdFind{}
 	})
 }

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -24,6 +24,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdInterfaces struct {
@@ -53,7 +55,7 @@ Filters the complete output so only plugs and/or slots matching the provided det
 `)
 
 func init() {
-	addCommand("interfaces", shortInterfacesHelp, longInterfacesHelp, func() interface{} {
+	addCommand("interfaces", shortInterfacesHelp, longInterfacesHelp, func() flags.Commander {
 		return &cmdInterfaces{}
 	})
 }

--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/ubuntu-core/snappy/asserts"
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdKnown struct {
@@ -42,7 +44,7 @@ shown must also have the specified headers matching the provided values.
 `)
 
 func init() {
-	addCommand("known", shortKnownHelp, longKnownHelp, func() interface{} {
+	addCommand("known", shortKnownHelp, longKnownHelp, func() flags.Commander {
 		return &cmdKnown{}
 	})
 }

--- a/cmd/snap/cmd_man.go
+++ b/cmd/snap/cmd_man.go
@@ -23,6 +23,8 @@ import (
 	"os"
 
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdMan struct{}
@@ -31,7 +33,7 @@ var shortManHelp = i18n.G("produces manpage")
 var longManHelp = i18n.G("produces manpage")
 
 func init() {
-	cmd := addCommand("man", shortManHelp, longManHelp, func() interface{} {
+	cmd := addCommand("man", shortManHelp, longManHelp, func() flags.Commander {
 		return &cmdMan{}
 	})
 	cmd.hidden = true

--- a/cmd/snap/cmd_remove_plug.go
+++ b/cmd/snap/cmd_remove_plug.go
@@ -21,6 +21,8 @@ package main
 
 import (
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdRemovePlug struct {
@@ -39,7 +41,7 @@ It will be removed in one of the future releases.
 `)
 
 func init() {
-	addExperimentalCommand("remove-plug", shortRemovePlugHelp, longRemovePlugHelp, func() interface{} {
+	addExperimentalCommand("remove-plug", shortRemovePlugHelp, longRemovePlugHelp, func() flags.Commander {
 		return &cmdRemovePlug{}
 	})
 }

--- a/cmd/snap/cmd_remove_slot.go
+++ b/cmd/snap/cmd_remove_slot.go
@@ -21,6 +21,8 @@ package main
 
 import (
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type cmdRemoveSlot struct {
@@ -39,7 +41,7 @@ It will be removed in one of the future releases.
 `)
 
 func init() {
-	addExperimentalCommand("remove-slot", shortRemoveSlotHelp, longRemoveSlotHelp, func() interface{} {
+	addExperimentalCommand("remove-slot", shortRemoveSlotHelp, longRemoveSlotHelp, func() flags.Commander {
 		return &cmdRemoveSlot{}
 	})
 }

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/ubuntu-core/snappy/client"
 	"github.com/ubuntu-core/snappy/i18n"
+
+	"github.com/jessevdk/go-flags"
 )
 
 func wait(client *client.Client, uuid string) error {
@@ -121,11 +123,11 @@ func init() {
 		{"deactivate", shortDeactivateHelp, longDeactivateHelp, (*client.Client).DeactivateSnap},
 	} {
 		op := s.op
-		addCommand(s.name, s.short, s.long, func() interface{} { return &cmdOp{op: op} })
+		addCommand(s.name, s.short, s.long, func() flags.Commander { return &cmdOp{op: op} })
 	}
 
-	addCommand("install", shortInstallHelp, longInstallHelp, func() interface{} { return &cmdInstall{} })
-	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() interface{} { return &cmdRefresh{} })
+	addCommand("install", shortInstallHelp, longInstallHelp, func() flags.Commander { return &cmdInstall{} })
+	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() flags.Commander { return &cmdRefresh{} })
 }
 
 func (x *cmdOp) Execute([]string) error {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -46,7 +46,7 @@ var optionsData options
 // cmdInfo holds information needed to call parser.AddCommand(...).
 type cmdInfo struct {
 	name, shortHelp, longHelp string
-	builder                   func() interface{}
+	builder                   func() flags.Commander
 	hidden                    bool
 }
 
@@ -58,7 +58,7 @@ var experimentalCommands []*cmdInfo
 
 // addCommand replaces parser.addCommand() in a way that is compatible with
 // re-constructing a pristine parser.
-func addCommand(name, shortHelp, longHelp string, builder func() interface{}) *cmdInfo {
+func addCommand(name, shortHelp, longHelp string, builder func() flags.Commander) *cmdInfo {
 	info := &cmdInfo{
 		name:      name,
 		shortHelp: shortHelp,
@@ -72,7 +72,7 @@ func addCommand(name, shortHelp, longHelp string, builder func() interface{}) *c
 // addExperimentalCommand replaces parser.addCommand() in a way that is
 // compatible with re-constructing a pristine parser. It is meant for
 // adding experimental commands.
-func addExperimentalCommand(name, shortHelp, longHelp string, builder func() interface{}) *cmdInfo {
+func addExperimentalCommand(name, shortHelp, longHelp string, builder func() flags.Commander) *cmdInfo {
 	info := &cmdInfo{
 		name:      name,
 		shortHelp: shortHelp,


### PR DESCRIPTION
This prevents mistakes like missing "Execute()" in a command
struct (like what happend in d152db76).

Should merge https://github.com/ubuntu-core/snappy/pull/710 first so that this actually compiles ;) But the fact that it does not compile is a very useful indicator that it is useful.