### PR TITLE
snap, snappy: use revision for update

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -24,6 +24,7 @@ type Info struct {
 	Name        string
 	Developer   string
 	Version     string
+	Revision    int
 	Type        Type
 	Channel     string
 	Description string

--- a/snap/remote/remote.go
+++ b/snap/remote/remote.go
@@ -41,7 +41,7 @@ type Snap struct {
 	Prices          map[string]float64 `json:"prices,omitempty"`
 	Publisher       string             `json:"publisher,omitempty"`
 	RatingsAverage  float64            `json:"ratings_average,omitempty"`
-	Revision        int64              `json:"revision"`
+	Revision        int                `json:"revision"`
 	SupportURL      string             `json:"support_url"`
 	Title           string             `json:"title"`
 	Type            snap.Type          `json:"content,omitempty"`

--- a/snappy/datadir.go
+++ b/snappy/datadir.go
@@ -31,7 +31,7 @@ type SnapDataDir struct {
 	Base      string
 	Name      string
 	Developer string
-	Version   string
+	Revision  string
 }
 
 // QualifiedName returns the filesystem directory name for this SnapDataDir
@@ -46,13 +46,13 @@ func data1(spec, basedir string) []SnapDataDir {
 	var snaps []SnapDataDir
 	var filterns bool
 
-	verglob := "*"
+	revglob := "*"
 	specns := "*"
 
-	// Note that "=" is not legal in a snap name or a snap version
+	// Note that "=" is not legal in a snap name or a snap revision
 	idx := strings.IndexRune(spec, '=')
 	if idx > -1 {
-		verglob = spec[idx+1:]
+		revglob = spec[idx+1:]
 		spec = spec[:idx]
 	}
 
@@ -65,7 +65,7 @@ func data1(spec, basedir string) []SnapDataDir {
 		nameglob = spec + "." + specns
 	}
 
-	dirs, _ := filepath.Glob(filepath.Join(basedir, nameglob, verglob))
+	dirs, _ := filepath.Glob(filepath.Join(basedir, nameglob, revglob))
 
 	// “but, Chipaca”, I hear you say, “why are you doing all this all over
 	// again, when you could just use .Installed() on an appropriate repo,
@@ -76,8 +76,8 @@ func data1(spec, basedir string) []SnapDataDir {
 	// removed a package its snap.yaml is gone, its data is still there,
 	// and you want us to be able to clean that up.
 	for _, dir := range dirs {
-		version := filepath.Base(dir)
-		if version == "current" {
+		revision := filepath.Base(dir)
+		if revision == "current" {
 			continue
 		}
 		name := filepath.Base(filepath.Dir(dir))
@@ -98,7 +98,7 @@ func data1(spec, basedir string) []SnapDataDir {
 			Base:      basedir,
 			Name:      name,
 			Developer: developer,
-			Version:   version,
+			Revision:  revision,
 		})
 	}
 

--- a/snappy/datadir_test.go
+++ b/snappy/datadir_test.go
@@ -38,52 +38,52 @@ func (s *DataDirSuite) SetUpTest(c *C) {
 }
 
 func (s *DataDirSuite) TestSystemDataDirs(c *C) {
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDataDir, "foo.bar", "v1"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDataDir, "foo.bar", "1"), 0755), IsNil)
 	dds := DataDirs("foo")
 	c.Check(dds, DeepEquals, []SnapDataDir{{
 		Base:      dirs.SnapDataDir,
 		Name:      "foo",
 		Developer: "bar",
-		Version:   "v1",
+		Revision:  "1",
 	}})
 	c.Check(DataDirs("f"), HasLen, 0)
 	c.Check(DataDirs("foobar"), HasLen, 0)
 	c.Check(DataDirs("foo.bar"), HasLen, 1)
-	c.Check(DataDirs("foo=v1"), HasLen, 1)
-	c.Check(DataDirs("foo.bar=v1"), HasLen, 1)
+	c.Check(DataDirs("foo=1"), HasLen, 1)
+	c.Check(DataDirs("foo.bar=1"), HasLen, 1)
 }
 
 func (s *DataDirSuite) TestDataDirsNoDeveloper(c *C) {
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDataDir, "foo", "v1"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDataDir, "foo", "1"), 0755), IsNil)
 	dds := DataDirs("foo")
 	c.Check(dds, DeepEquals, []SnapDataDir{{
 		Base:      dirs.SnapDataDir,
 		Name:      "foo",
 		Developer: "",
-		Version:   "v1",
+		Revision:  "1",
 	}})
-	c.Check(DataDirs("foo=v1"), HasLen, 1)
+	c.Check(DataDirs("foo=1"), HasLen, 1)
 }
 
 func (s *DataDirSuite) TestHomeDataDirs(c *C) {
 	home := strings.Replace(dirs.SnapDataHomeGlob, "*", "user1", -1)
-	c.Assert(os.MkdirAll(filepath.Join(home, "foo.bar", "v1"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(home, "foo.bar", "1"), 0755), IsNil)
 	dds := DataDirs("foo")
 	c.Check(dds, DeepEquals, []SnapDataDir{{
 		Base:      dirs.SnapDataHomeGlob,
 		Name:      "foo",
 		Developer: "bar",
-		Version:   "v1",
+		Revision:  "1",
 	}})
 }
 
 func (s *DataDirSuite) TestEverywhichwhereDataDirs(c *C) {
 	home := strings.Replace(dirs.SnapDataHomeGlob, "*", "user1", -1)
-	c.Assert(os.MkdirAll(filepath.Join(home, "foo.bar", "v0"), 0755), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(home, "foo.bar", "v1"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(home, "foo.bar", "0"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(home, "foo.bar", "1"), 0755), IsNil)
 	c.Assert(os.Symlink("v1", filepath.Join(home, "foo.bar", "current")), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDataDir, "foo.xyzzy", "v1"), 0755), IsNil)
-	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDataDir, "foo", "v3"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDataDir, "foo.xyzzy", "1"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDataDir, "foo", "3"), 0755), IsNil)
 	c.Assert(os.Symlink("v3", filepath.Join(dirs.SnapDataDir, "foo", "current")), IsNil)
 	dds := DataDirs("foo")
 	c.Assert(dds, HasLen, 4)
@@ -97,25 +97,25 @@ func (s *DataDirSuite) TestEverywhichwhereDataDirs(c *C) {
 		Base:      dirs.SnapDataHomeGlob,
 		Name:      "foo",
 		Developer: "bar",
-		Version:   "v0",
+		Revision:  "0",
 	})
 	c.Check(dds[hi+1], DeepEquals, SnapDataDir{
 		Base:      dirs.SnapDataHomeGlob,
 		Name:      "foo",
 		Developer: "bar",
-		Version:   "v1",
+		Revision:  "1",
 	})
 	c.Check(dds[si], DeepEquals, SnapDataDir{
 		Base:      dirs.SnapDataDir,
 		Name:      "foo",
 		Developer: "",
-		Version:   "v3",
+		Revision:  "3",
 	})
 	c.Check(dds[si+1], DeepEquals, SnapDataDir{
 		Base:      dirs.SnapDataDir,
 		Name:      "foo",
 		Developer: "xyzzy",
-		Version:   "v1",
+		Revision:  "1",
 	})
 }
 

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -254,6 +254,7 @@ func (s *SnapTestSuite) TestUpdate(c *C) {
 			io.WriteString(w, `{
 "package_name": "foo",
 "version": "2",
+"revision": 1,
 "developer": "`+testDeveloper+`",
 "anon_download_url": "`+dlURL+`",
 "icon_url": "`+iconURL+`"
@@ -281,6 +282,7 @@ func (s *SnapTestSuite) TestUpdate(c *C) {
 		io.WriteString(w, `[{
 	"package_name": "foo",
 	"version": "2",
+        "revision": 1,
         "origin": "`+testDeveloper+`",
 	"anon_download_url": "`+dlURL+`",
 	"icon_url": "`+iconURL+`"
@@ -299,6 +301,7 @@ func (s *SnapTestSuite) TestUpdate(c *C) {
 	c.Assert(updates, HasLen, 1)
 	c.Check(updates[0].Name(), Equals, "foo")
 	c.Check(updates[0].Version(), Equals, "2")
+	c.Check(updates[0].Revision(), Equals, 1)
 	// ensure that we get a "local" snap back - not a remote one
 	c.Check(updates[0], FitsTypeOf, &Snap{})
 }

--- a/snappy/purge.go
+++ b/snappy/purge.go
@@ -38,7 +38,7 @@ const (
 
 var remove = removeSnapData
 
-// Purge a snap by a snapSpec string, name[.developer][=version]
+// Purge a snap by a snapSpec string, name[.developer][=revision]
 func Purge(snapSpec string, flags PurgeFlags, meter progress.Meter) error {
 	var e error
 	datadirs := DataDirs(snapSpec)
@@ -54,7 +54,7 @@ func Purge(snapSpec string, flags PurgeFlags, meter progress.Meter) error {
 	// .snap being installed for multiple users, or the .snap using both the
 	// snap data path as well as the user data path. They all need to be purged.
 	for _, datadir := range datadirs {
-		yamlPath := filepath.Join(dirs.SnapSnapsDir, datadir.QualifiedName(), datadir.Version, "meta", "snap.yaml")
+		yamlPath := filepath.Join(dirs.SnapSnapsDir, datadir.QualifiedName(), datadir.Revision, "meta", "snap.yaml")
 		snap, err := NewInstalledSnap(yamlPath, datadir.Developer)
 		if err != nil {
 			// no such snap installed
@@ -81,9 +81,9 @@ func Purge(snapSpec string, flags PurgeFlags, meter progress.Meter) error {
 
 	// Conduct the purge.
 	for _, datadir := range datadirs {
-		if err := remove(datadir.QualifiedName(), datadir.Version); err != nil {
+		if err := remove(datadir.QualifiedName(), datadir.Revision); err != nil {
 			e = err
-			meter.Notify(fmt.Sprintf("unable to purge %s version %s: %s", datadir.QualifiedName(), datadir.Version, err.Error()))
+			meter.Notify(fmt.Sprintf("unable to purge %s version %s: %s", datadir.QualifiedName(), datadir.Revision, err.Error()))
 		}
 	}
 

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -126,6 +126,15 @@ func (s *Snap) Version() string {
 	return s.m.Version
 }
 
+// Revision returns the revision
+func (s *Snap) Revision() int {
+	if s.remoteM != nil {
+		return s.remoteM.Revision
+	}
+
+	return 0
+}
+
 // Description returns the summary description
 func (s *Snap) Description() string {
 	if r := s.remoteM; r != nil {
@@ -201,6 +210,7 @@ func (s *Snap) Info() *snap.Info {
 		Name:        s.Name(),
 		Developer:   s.Developer(),
 		Version:     s.Version(),
+		Revision:    s.Revision(),
 		Type:        s.Type(),
 		Channel:     s.Channel(),
 		Description: s.Description(),

--- a/snappy/snap_remote.go
+++ b/snappy/snap_remote.go
@@ -52,6 +52,11 @@ func (s *RemoteSnap) Version() string {
 	return s.Pkg.Version
 }
 
+// Revision returns the revision
+func (s *RemoteSnap) Revision() int {
+	return s.Pkg.Revision
+}
+
 // Description returns the description
 func (s *RemoteSnap) Description() string {
 	return s.Pkg.Title
@@ -83,6 +88,7 @@ func (s *RemoteSnap) Info() *snap.Info {
 		Name:        s.Name(),
 		Developer:   s.Developer(),
 		Version:     s.Version(),
+		Revision:    s.Revision(),
 		Type:        s.Type(),
 		Channel:     s.Channel(),
 		Description: s.Description(),

--- a/snappy/snap_remote_repo.go
+++ b/snappy/snap_remote_repo.go
@@ -295,7 +295,7 @@ func (s *SnapUbuntuStoreRepository) SnapUpdates() (snaps []*RemoteSnap, err erro
 
 	for _, pkg := range updateData {
 		current := ActiveSnapByName(pkg.Name)
-		if current == nil || current.Version() != pkg.Version {
+		if current == nil || current.Revision() != pkg.Revision {
 			snap := NewRemoteSnap(pkg)
 			snaps = append(snaps, snap)
 		}


### PR DESCRIPTION
This includes a forwards-looking name change in datadir that doesn't affect its functionality.