### PR TITLE
debian: fix systemd unit installs

### DIFF
--- a/debian/ubuntu-snappy-cli.install
+++ b/debian/ubuntu-snappy-cli.install
@@ -8,3 +8,15 @@ data/completion/snappy /usr/share/bash-completion/completions/
 etc/profile.d
 # etc/X11/Xsession.d will add to XDG_DATA_DIRS so that we have .desktop support
 etc/X11
+
+# systemd stuff
+
+# auto-update
+debian/*.timer /lib/systemd/system/
+debian/snappy-autopilot.service /lib/systemd/system/
+# snapd
+debian/*.socket /lib/systemd/system/
+debian/ubuntu-snappy.snapd.service /lib/systemd/system/
+# targets
+debian/*.target /lib/systemd/system/
+

--- a/debian/ubuntu-snappy.install
+++ b/debian/ubuntu-snappy.install
@@ -1,4 +1,3 @@
-debian/*.service /lib/systemd/system/
-debian/*.socket /lib/systemd/system/
-debian/*.target /lib/systemd/system/
-debian/*.timer /lib/systemd/system/
+debian/ubuntu-snappy.boot-ok.service /lib/systemd/system/
+debian/ubuntu-snappy.firstboot.service /lib/systemd/system/
+debian/ubuntu-snappy.run-hooks.service /lib/systemd/system/


### PR DESCRIPTION
Fix the systemd unit install so that ubuntu-snappy-cli is fully
functional including snapd. But all the "dangerous" jobs are
in ubuntu-snappy (first-boot, boot-ok etc).

LP: #1556241