### PR TITLE
testutil: improve MockCmd features 

### DIFF
--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -79,3 +79,14 @@ func (cmd *MockCmd) Calls() []string {
 	text = strings.TrimSuffix(text, "\n")
 	return strings.Split(text, "\n")
 }
+
+// ForgetCalls purges the list of calls made so far
+func (cmd *MockCmd) ForgetCalls() {
+	err := os.Remove(cmd.logFile)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		panic(err)
+	}
+}

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -72,6 +72,9 @@ func (cmd *MockCmd) Restore() {
 // Calls returns a list of calls that were made to the mock command.
 func (cmd *MockCmd) Calls() []string {
 	calls, err := ioutil.ReadFile(cmd.logFile)
+	if os.IsNotExist(err) {
+		return nil
+	}
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This branch adds .ForgetCalls() and fixes a panic in .Calls() when no calls were made yet.