### PR TITLE
interfaces/dbus: add SafePath

### DIFF
--- a/interfaces/dbus/dbus.go
+++ b/interfaces/dbus/dbus.go
@@ -1,0 +1,52 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package dbus implements interaction between snappy and dbus.
+//
+// Snappy creates dbus configuration files that describe how various
+// services on the system bus can communicate with other peers.
+//
+// Each configuration is an XML file containing <busconfig>...</busconfig>.
+// Particular security snippets define whole <policy>...</policy> entires.
+//
+// NOTE: This interacts with systemd.
+// TODO: Explain how this works (security).
+package dbus
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// SafePath returns a string suitable for use in a DBus object
+func SafePath(s string) string {
+	const allowed = `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`
+	buf := bytes.NewBuffer(make([]byte, 0, len(s)))
+
+	for _, c := range []byte(s) {
+		if strings.IndexByte(allowed, c) >= 0 {
+			fmt.Fprintf(buf, "%c", c)
+		} else {
+			fmt.Fprintf(buf, "_%02x", c)
+		}
+	}
+
+	return buf.String()
+}

--- a/interfaces/dbus/dbus_test.go
+++ b/interfaces/dbus/dbus_test.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package dbus_test
+
+import (
+	"testing"
+
+	"github.com/ubuntu-core/snappy/interfaces/dbus"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type dBusSuite struct{}
+
+var _ = Suite(&dBusSuite{})
+
+func (s *dBusSuite) TestSecurityGenDbusPath(c *C) {
+	c.Assert(dbus.SafePath("foo"), Equals, "foo")
+	c.Assert(dbus.SafePath("foo bar"), Equals, "foo_20bar")
+	c.Assert(dbus.SafePath("foo/bar"), Equals, "foo_2fbar")
+}


### PR DESCRIPTION
This is cherry-picked from snappy/ from the place that is likely to
get nuked soon so I'd like to save it :-)

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>