### PR TITLE
overlord,daemon: move the assertion database inside the assert manager

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1212,7 +1212,9 @@ func doAssert(c *Command, r *http.Request) Response {
 	if err != nil {
 		return BadRequest("can't decode request body into an assertion: %v", err)
 	}
-	if err := c.d.asserts.Add(a); err != nil {
+	// TODO/XXX: turn this into a Change/Task combination
+	amgr := c.d.overlord.AssertManager()
+	if err := amgr.DB().Add(a); err != nil {
 		// TODO: have a specific error to be able to return  409 for not newer revision?
 		return BadRequest("assert failed: %v", err)
 	}
@@ -1234,7 +1236,8 @@ func assertsFindMany(c *Command, r *http.Request) Response {
 	for k := range q {
 		headers[k] = q.Get(k)
 	}
-	assertions, err := c.d.asserts.FindMany(assertType, headers)
+	amgr := c.d.overlord.AssertManager()
+	assertions, err := amgr.DB().FindMany(assertType, headers)
 	if err == asserts.ErrNotFound {
 		return AssertResponse(nil, true)
 	} else if err != nil {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2231,7 +2231,7 @@ func (s *apiSuite) TestAssertOK(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Status, check.Equals, http.StatusOK)
 	// Verify (internal)
-	_, err = d.asserts.Find(asserts.AccountKeyType, map[string]string{
+	_, err = d.overlord.AssertManager().DB().Find(asserts.AccountKeyType, map[string]string{
 		"account-id":    "developer1",
 		"public-key-id": "adea89b00094c337",
 	})
@@ -2275,7 +2275,7 @@ func (s *apiSuite) TestAssertsFindManyAll(c *check.C) {
 	d := newTestDaemon(c)
 	a, err := asserts.Decode([]byte(testAccKey))
 	c.Assert(err, check.IsNil)
-	err = d.asserts.Add(a)
+	err = d.overlord.AssertManager().DB().Add(a)
 	c.Assert(err, check.IsNil)
 	// Execute
 	req, err := http.NewRequest("POST", "/2.0/assertions/account-key", nil)
@@ -2310,7 +2310,7 @@ func (s *apiSuite) TestAssertsFindManyFilter(c *check.C) {
 	d := newTestDaemon(c)
 	a, err := asserts.Decode([]byte(testAccKey))
 	c.Assert(err, check.IsNil)
-	err = d.asserts.Add(a)
+	err = d.overlord.AssertManager().DB().Add(a)
 	c.Assert(err, check.IsNil)
 	// Execute
 	req, err := http.NewRequest("POST", "/2.0/assertions/account-key?account-id=developer1", nil)
@@ -2338,7 +2338,7 @@ func (s *apiSuite) TestAssertsFindManyNoResults(c *check.C) {
 	d := newTestDaemon(c)
 	a, err := asserts.Decode([]byte(testAccKey))
 	c.Assert(err, check.IsNil)
-	err = d.asserts.Add(a)
+	err = d.overlord.AssertManager().DB().Add(a)
 	c.Assert(err, check.IsNil)
 	// Execute
 	req, err := http.NewRequest("POST", "/2.0/assertions/account-key?account-id=xyzzyx", nil)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -32,13 +31,10 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/tomb.v2"
 
-	"github.com/ubuntu-core/snappy/asserts"
-	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/builtin"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/notifications"
-	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/overlord"
 )
 
@@ -50,7 +46,6 @@ type Daemon struct {
 	listener     net.Listener
 	tomb         tomb.Tomb
 	router       *mux.Router
-	asserts      *asserts.Database
 	hub          *notifications.Hub
 	interfaces   *interfaces.Repository
 	// enableInternalInterfaceActions controls if adding and removing slots and plugs is allowed.
@@ -257,23 +252,9 @@ func (d *Daemon) DeleteTask(uuid string) error {
 	return errTaskStillRunning
 }
 
-func getTrustedAccountKey() string {
-	if !osutil.FileExists(dirs.SnapTrustedAccountKey) {
-		// XXX: allow this fallback here for integration tests,
-		// until we have a proper trusted public key shared
-		// with the store
-		return os.Getenv("SNAPPY_TRUSTED_ACCOUNT_KEY")
-	}
-	return dirs.SnapTrustedAccountKey
-}
-
 // New Daemon
 func New() (*Daemon, error) {
 	ovld, err := overlord.New()
-	if err != nil {
-		return nil, err
-	}
-	db, err := asserts.OpenSysDatabase(getTrustedAccountKey())
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +267,6 @@ func New() (*Daemon, error) {
 	return &Daemon{
 		overlord:   ovld,
 		tasks:      make(map[string]*Task),
-		asserts:    db,
 		hub:        notifications.NewHub(),
 		interfaces: interfacesRepo,
 		// TODO: Decide when this should be disabled by default.

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package assertstate_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/asserts"
+	"github.com/ubuntu-core/snappy/dirs"
+
+	"github.com/ubuntu-core/snappy/overlord/assertstate"
+	"github.com/ubuntu-core/snappy/overlord/state"
+)
+
+func TestAssertManager(t *testing.T) { TestingT(t) }
+
+type assertMgrSuite struct{}
+
+var _ = Suite(&assertMgrSuite{})
+
+func (ams *assertMgrSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (ams *assertMgrSuite) TestManagerAndDB(c *C) {
+	s := state.New(nil)
+	mgr, err := assertstate.Manager(s)
+	c.Assert(err, IsNil)
+
+	db := mgr.DB()
+	c.Check(db, FitsTypeOf, (*asserts.Database)(nil))
+}

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -44,7 +44,9 @@ type overlordSuite struct{}
 var _ = Suite(&overlordSuite{})
 
 func (ovs *overlordSuite) SetUpTest(c *C) {
-	dirs.SnapStateFile = filepath.Join(c.MkDir(), "test.json")
+	tmpdir := c.MkDir()
+	dirs.SetRootDir(tmpdir)
+	dirs.SnapStateFile = filepath.Join(tmpdir, "test.json")
 }
 
 func (ovs *overlordSuite) TearDownTest(c *C) {


### PR DESCRIPTION
This starts moving the assertion database from being on the daemon directly to be inside the assert manager where it belongs.  This hasn't started turning adding an assertion into a task yet though, something for a later PR.