### PR TITLE
overlord,daemon: expose State on the Overlord, don't expose the StateEngine anymore

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -660,7 +660,7 @@ func (inst *snapInstruction) install() interface{} {
 	if inst.LeaveOld {
 		flags = 0
 	}
-	state := inst.overlord.StateEngine().State()
+	state := inst.overlord.State()
 	state.Lock()
 	msg := fmt.Sprintf(i18n.G("Install %q snap"), inst.pkg)
 	if inst.Channel != "stable" {
@@ -696,7 +696,7 @@ func (inst *snapInstruction) update() interface{} {
 	if inst.LeaveOld {
 		flags = 0
 	}
-	state := inst.overlord.StateEngine().State()
+	state := inst.overlord.State()
 	state.Lock()
 	msg := fmt.Sprintf(i18n.G("Update %q snap"), inst.pkg)
 	if inst.Channel != "stable" {
@@ -721,7 +721,7 @@ func (inst *snapInstruction) remove() interface{} {
 	if inst.LeaveOld {
 		flags = 0
 	}
-	state := inst.overlord.StateEngine().State()
+	state := inst.overlord.State()
 	state.Lock()
 	msg := fmt.Sprintf(i18n.G("Remove %q snap"), inst.pkg)
 	chg := state.NewChange("remove-snap", msg)
@@ -739,7 +739,7 @@ func (inst *snapInstruction) remove() interface{} {
 }
 
 func (inst *snapInstruction) purge() interface{} {
-	state := inst.overlord.StateEngine().State()
+	state := inst.overlord.State()
 	state.Lock()
 	msg := fmt.Sprintf(i18n.G("Purge %q snap"), inst.pkg)
 	chg := state.NewChange("purge-snap", msg)
@@ -757,7 +757,7 @@ func (inst *snapInstruction) purge() interface{} {
 }
 
 func (inst *snapInstruction) rollback() interface{} {
-	state := inst.overlord.StateEngine().State()
+	state := inst.overlord.State()
 	state.Lock()
 	msg := fmt.Sprintf(i18n.G("Rollback %q snap"), inst.pkg)
 	chg := state.NewChange("rollback-snap", msg)
@@ -777,7 +777,7 @@ func (inst *snapInstruction) rollback() interface{} {
 }
 
 func (inst *snapInstruction) activate() interface{} {
-	state := inst.overlord.StateEngine().State()
+	state := inst.overlord.State()
 	state.Lock()
 	msg := fmt.Sprintf(i18n.G("Activate %q snap"), inst.pkg)
 	chg := state.NewChange("activate-snap", msg)
@@ -795,7 +795,7 @@ func (inst *snapInstruction) activate() interface{} {
 }
 
 func (inst *snapInstruction) deactivate() interface{} {
-	state := inst.overlord.StateEngine().State()
+	state := inst.overlord.State()
 	state.Lock()
 	msg := fmt.Sprintf(i18n.G("Deactivate %q snap"), inst.pkg)
 	chg := state.NewChange("deactivate-snap", msg)

--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -31,3 +31,8 @@ func SetEnsureIntervalForTest(d time.Duration) (restore func()) {
 		ensureInterval = prev
 	}
 }
+
+// Engine exposes the state engine in an Overlord for tests.
+func (o *Overlord) Engine() *StateEngine {
+	return o.stateEng
+}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -209,9 +209,9 @@ func (o *Overlord) Settle() error {
 	return nil
 }
 
-// StateEngine returns the state engine used by the overlord.
-func (o *Overlord) StateEngine() *StateEngine {
-	return o.stateEng
+// State returns the system state managed by the overlord.
+func (o *Overlord) State() *state.State {
+	return o.stateEng.State()
 }
 
 // SnapManager returns the snap manager responsible for snaps under


### PR DESCRIPTION
This starts exposing system state directly from the Overlord with a State accessor. It also stops exposing the StateEngine, main reason was to get access to the state anyway, and most methods of the state engine are slightly dangerous used directly instead of through the patterns/control of the Overlord.