### PR TITLE
integration-tests: send fake revision that is higher than the installed one

### DIFF
--- a/integration-tests/testutils/store/store.go
+++ b/integration-tests/testutils/store/store.go
@@ -191,6 +191,18 @@ func (s *Store) bulkEndpoint(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, fmt.Sprintf("can get info for: %v: %v", fn, err), http.StatusBadRequest)
 				return
 			}
+			// TODO: This is a hack to ensure we have higher
+			//       revisions here than locally. The fake
+			//       snaps get versions like
+			//          "1.0+fake1+fake1+fake1"
+			//       so we can use this for now to generate
+			//       fake revisions. However in the longer
+			//       term we should read the real revision
+			//       of the snap, increment and add a ".aux"
+			//       file to the download directory of the
+			//       store that contains the revision and the
+			//       developer. The fake-store can then read
+			//       that file when sending the reply.
 			n := strings.Count(info.Version, "+fake") + 1
 
 			replyData = append(replyData, bulkReplyJSON{

--- a/integration-tests/testutils/store/store.go
+++ b/integration-tests/testutils/store/store.go
@@ -35,8 +35,11 @@ import (
 )
 
 var (
-	defaultAddr      = "localhost:11028"
+	defaultAddr = "localhost:11028"
+	// FIXME: make both hardcoded values configurable via
+	//        e.g. a "foo_1.0.snap.info" file next to the snap
 	defaultDeveloper = "canonical"
+	defaultRevision  = 424242
 )
 
 func rootEndpoint(w http.ResponseWriter, req *http.Request) {
@@ -196,7 +199,7 @@ func (s *Store) bulkEndpoint(w http.ResponseWriter, req *http.Request) {
 				Developer:       defaultDeveloper,
 				AnonDownloadURL: fmt.Sprintf("%s/download/%s", s.URL(), filepath.Base(fn)),
 				Version:         info.Version,
-				Revision:        info.Revision,
+				Revision:        defaultRevision,
 			})
 		}
 	}

--- a/integration-tests/testutils/store/store.go
+++ b/integration-tests/testutils/store/store.go
@@ -191,6 +191,7 @@ func (s *Store) bulkEndpoint(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, fmt.Sprintf("can get info for: %v: %v", fn, err), http.StatusBadRequest)
 				return
 			}
+			n := strings.Count(info.Version, "+fake") + 1
 
 			replyData = append(replyData, bulkReplyJSON{
 				Status:          "Published",
@@ -199,7 +200,7 @@ func (s *Store) bulkEndpoint(w http.ResponseWriter, req *http.Request) {
 				Developer:       defaultDeveloper,
 				AnonDownloadURL: fmt.Sprintf("%s/download/%s", s.URL(), filepath.Base(fn)),
 				Version:         info.Version,
-				Revision:        defaultRevision,
+				Revision:        n * defaultRevision,
 			})
 		}
 	}

--- a/integration-tests/testutils/store/store_test.go
+++ b/integration-tests/testutils/store/store_test.go
@@ -131,7 +131,7 @@ func (s *storeTestSuite) TestBulkEndpoint(c *C) {
         "origin": "canonical",
         "anon_download_url": "%s/download/foo_1_all.snap",
         "version": "1",
-        "revision": 0
+        "revision": 424242
     }
 ]`, s.store.URL()))
 }


### PR DESCRIPTION
Please only merge if the integration tests really are green. This sets the revision that the store sends to a higher number than the local revision (which is 0).