### PR TITLE
interfaces/apparmor: clean up template parsing

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -51,18 +51,18 @@ import (
 
 // Backend is responsible for maintaining apparmor profiles for ubuntu-core-launcher.
 type Backend struct {
-	// customTemplate exists to support old-security which goes
+	// legacyTemplate exists to support old-security which goes
 	// beyond what is possible with pure security snippets.
 	//
 	// If non-empty then it overrides the built-in template.
-	customTemplate []byte
+	legacyTemplate []byte
 }
 
 // UseLegacyTemplate switches from default apparmor template to a custom
 // template. This also implies that a fixed set of apparmor variables will be
 // injected into this template. The set is compatible with Ubuntu core 15.04.
 func (b *Backend) UseLegacyTemplate(template []byte) {
-	b.customTemplate = template
+	b.legacyTemplate = template
 }
 
 // Configure creates and loads apparmor security profiles specific to a given

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -118,9 +118,8 @@ var (
 	placeholderVar           = []byte("###VAR###")
 	placeholderSnippets      = []byte("###SNIPPETS###")
 	placeholderProfileAttach = []byte("###PROFILEATTACH###")
-	// XXX: This needs to be verified by security team.
-	attachPattern  = regexp.MustCompile(`\(attach_disconnected\)`)
-	attachComplain = []byte("(attach_disconnected,complain)")
+	attachPattern            = regexp.MustCompile(`\(attach_disconnected\)`)
+	attachComplain           = []byte("(attach_disconnected,complain)")
 )
 
 // combineSnippets combines security snippets collected from all the interfaces

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -55,7 +55,7 @@ type Backend struct {
 	// beyond what is possible with pure security snippets.
 	//
 	// If non-empty then it overrides the built-in template.
-	CustomTemplate string
+	CustomTemplate []byte
 }
 
 // Configure creates and loads apparmor security profiles specific to a given

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -51,11 +51,18 @@ import (
 
 // Backend is responsible for maintaining apparmor profiles for ubuntu-core-launcher.
 type Backend struct {
-	// CustomTemplate exists to support old-security which goes
+	// customTemplate exists to support old-security which goes
 	// beyond what is possible with pure security snippets.
 	//
 	// If non-empty then it overrides the built-in template.
-	CustomTemplate []byte
+	customTemplate []byte
+}
+
+// UseLegacyTemplate switches from default apparmor template to a custom
+// template. This also implies that a fixed set of apparmor variables will be
+// injected into this template. The set is compatible with Ubuntu core 15.04.
+func (b *Backend) UseLegacyTemplate(template []byte) {
+	b.customTemplate = template
 }
 
 // Configure creates and loads apparmor security profiles specific to a given

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -42,10 +42,12 @@ type backendSuite struct {
 	cmds    map[string]*testutil.MockCmd
 }
 
-var _ = Suite(&backendSuite{})
+var _ = Suite(&backendSuite{
+	backend: &apparmor.Backend{},
+})
 
 func (s *backendSuite) SetUpTest(c *C) {
-	s.backend = &apparmor.Backend{}
+	s.backend.CustomTemplate = ""
 	// Isolate this test to a temporary directory
 	s.rootDir = c.MkDir()
 	dirs.SetRootDir(s.rootDir)
@@ -210,15 +212,14 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 }
 
 func (s *backendSuite) TestCustomTemplateUsedOnRequest(c *C) {
-	err := s.backend.UseLegacyTemplate([]byte(`
+	s.backend.CustomTemplate = `
 # Description: Custom template for testing
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected) {
 	FOO
 }
-`))
-	c.Assert(err, IsNil)
+`
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(sambaYamlV1))
 	c.Assert(err, IsNil)
 	err = s.backend.Configure(snapInfo, false, s.repo)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -217,6 +217,7 @@ func (s *backendSuite) TestCustomTemplateUsedOnRequest(c *C) {
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected) {
+	###SNIPPETS###
 	FOO
 }
 `))
@@ -255,6 +256,7 @@ const commonPrefix = `
 var combineSnippetsScenarios = []combineSnippetsScenario{{
 	content: commonPrefix + `
 profile "snap.samba.smbd" (attach_disconnected) {
+
 }
 `,
 }, {
@@ -268,6 +270,7 @@ snippet
 	developerMode: true,
 	content: commonPrefix + `
 profile "snap.samba.smbd" (attach_disconnected,complain) {
+
 }
 `,
 }, {
@@ -284,6 +287,7 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 	restore := apparmor.MockTemplate([]byte("\n" +
 		"###VAR###\n" +
 		"###PROFILEATTACH### (attach_disconnected) {\n" +
+		"###SNIPPETS###\n" +
 		"}\n"))
 	defer restore()
 	for _, scenario := range combineSnippetsScenarios {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -50,7 +50,9 @@ func (s *backendSuite) SetUpTest(c *C) {
 	s.rootDir = c.MkDir()
 	dirs.SetRootDir(s.rootDir)
 	// Mock away any real apparmor interaction
-	s.cmds = apparmor.MockExternalCommands(c)
+	s.cmds = map[string]*testutil.MockCmd{
+		"apparmor_parser": testutil.MockCommand(c, "apparmor_parser", ""),
+	}
 	// Prepare a directory for apparmor profiles.
 	// NOTE: Normally this is a part of the OS snap.
 	err := os.MkdirAll(dirs.SnapAppArmorDir, 0700)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -281,10 +281,10 @@ snippet
 
 func (s *backendSuite) TestCombineSnippets(c *C) {
 	// NOTE: replace the real template with a shorter variant
-	restore := apparmor.MockTemplate("\n" +
+	restore := apparmor.MockTemplate([]byte("\n" +
 		"###VAR###\n" +
 		"###PROFILEATTACH### (attach_disconnected) {\n" +
-		"}\n")
+		"}\n"))
 	defer restore()
 	for _, scenario := range combineSnippetsScenarios {
 		s.iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -42,12 +42,10 @@ type backendSuite struct {
 	cmds    map[string]*testutil.MockCmd
 }
 
-var _ = Suite(&backendSuite{
-	backend: &apparmor.Backend{},
-})
+var _ = Suite(&backendSuite{})
 
 func (s *backendSuite) SetUpTest(c *C) {
-	s.backend.CustomTemplate = ""
+	s.backend = &apparmor.Backend{}
 	// Isolate this test to a temporary directory
 	s.rootDir = c.MkDir()
 	dirs.SetRootDir(s.rootDir)
@@ -210,14 +208,15 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 }
 
 func (s *backendSuite) TestCustomTemplateUsedOnRequest(c *C) {
-	s.backend.CustomTemplate = `
+	err := s.backend.UseLegacyTemplate([]byte(`
 # Description: Custom template for testing
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected) {
 	FOO
 }
-`
+`))
+	c.Assert(err, IsNil)
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(sambaYamlV1))
 	c.Assert(err, IsNil)
 	err = s.backend.Configure(snapInfo, false, s.repo)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -47,7 +47,7 @@ var _ = Suite(&backendSuite{
 })
 
 func (s *backendSuite) SetUpTest(c *C) {
-	s.backend.CustomTemplate = ""
+	s.backend.CustomTemplate = nil
 	// Isolate this test to a temporary directory
 	s.rootDir = c.MkDir()
 	dirs.SetRootDir(s.rootDir)
@@ -212,14 +212,14 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 }
 
 func (s *backendSuite) TestCustomTemplateUsedOnRequest(c *C) {
-	s.backend.CustomTemplate = `
+	s.backend.CustomTemplate = []byte(`
 # Description: Custom template for testing
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected) {
 	FOO
 }
-`
+`)
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(sambaYamlV1))
 	c.Assert(err, IsNil)
 	err = s.backend.Configure(snapInfo, false, s.repo)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -47,7 +47,7 @@ var _ = Suite(&backendSuite{
 })
 
 func (s *backendSuite) SetUpTest(c *C) {
-	s.backend.CustomTemplate = nil
+	s.backend.UseLegacyTemplate(nil)
 	// Isolate this test to a temporary directory
 	s.rootDir = c.MkDir()
 	dirs.SetRootDir(s.rootDir)
@@ -212,14 +212,14 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 }
 
 func (s *backendSuite) TestCustomTemplateUsedOnRequest(c *C) {
-	s.backend.CustomTemplate = []byte(`
+	s.backend.UseLegacyTemplate([]byte(`
 # Description: Custom template for testing
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected) {
 	FOO
 }
-`)
+`))
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(sambaYamlV1))
 	c.Assert(err, IsNil)
 	err = s.backend.Configure(snapInfo, false, s.repo)

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -37,6 +37,6 @@ func MockProfilesPath(t *testutil.BaseTest, profiles string) {
 // replace it with a shorter snippet.
 func MockTemplate(fakeTemplate string) (restore func()) {
 	orig := defaultTemplate
-	defaultTemplate = []byte(fakeTemplate)
+	defaultTemplate = fakeTemplate
 	return func() { defaultTemplate = orig }
 }

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -39,7 +39,7 @@ func MockProfilesPath(t *testutil.BaseTest, profiles string) {
 // replace it with a shorter snippet.
 func MockTemplate(fakeTemplate string) (restore func()) {
 	orig := defaultTemplate
-	defaultTemplate = fakeTemplate
+	defaultTemplate = []byte(fakeTemplate)
 	return func() { defaultTemplate = orig }
 }
 

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -35,7 +35,7 @@ func MockProfilesPath(t *testutil.BaseTest, profiles string) {
 //
 // NOTE: The real apparmor template is long. For testing it is convenient for
 // replace it with a shorter snippet.
-func MockTemplate(fakeTemplate string) (restore func()) {
+func MockTemplate(fakeTemplate []byte) (restore func()) {
 	orig := defaultTemplate
 	defaultTemplate = fakeTemplate
 	return func() { defaultTemplate = orig }

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -20,8 +20,6 @@
 package apparmor
 
 import (
-	"gopkg.in/check.v1"
-
 	"github.com/ubuntu-core/snappy/testutil"
 )
 
@@ -41,12 +39,4 @@ func MockTemplate(fakeTemplate string) (restore func()) {
 	orig := defaultTemplate
 	defaultTemplate = []byte(fakeTemplate)
 	return func() { defaultTemplate = orig }
-}
-
-// MockExternalCommands mocks and returns MockCmd for each of the external
-// commands used in this package.
-func MockExternalCommands(c *check.C) map[string]*testutil.MockCmd {
-	return map[string]*testutil.MockCmd{
-		"apparmor_parser": testutil.MockCommand(c, "apparmor_parser", ""),
-	}
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -286,5 +286,6 @@ var defaultTemplate = []byte(`
   /sys/devices/**/ r,
   /sys/class/ r,
   /sys/class/**/ r,
-}
 `)
+
+// NOTE: there is no trailing } above ^^

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -286,5 +286,7 @@ var defaultTemplate = []byte(`
   /sys/devices/**/ r,
   /sys/class/ r,
   /sys/class/**/ r,
+
+###SNIPPETS###
 }
 `)

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -286,6 +286,5 @@ var defaultTemplate = []byte(`
   /sys/devices/**/ r,
   /sys/class/ r,
   /sys/class/**/ r,
+}
 `)
-
-// NOTE: there is no trailing } above ^^

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -24,7 +24,7 @@ package apparmor
 // It can be overridden for testing using MockTemplate().
 //
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/templates/ubuntu-core/16.04/default
-var defaultTemplate = `
+var defaultTemplate = []byte(`
 # Description: Allows access to app-specific directories and basic runtime
 # Usage: common
 
@@ -287,4 +287,4 @@ var defaultTemplate = `
   /sys/class/ r,
   /sys/class/**/ r,
 }
-`
+`)

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -24,7 +24,7 @@ package apparmor
 // It can be overridden for testing using MockTemplate().
 //
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/templates/ubuntu-core/16.04/default
-var defaultTemplate = []byte(`
+var defaultTemplate = `
 # Description: Allows access to app-specific directories and basic runtime
 # Usage: common
 
@@ -286,6 +286,5 @@ var defaultTemplate = []byte(`
   /sys/devices/**/ r,
   /sys/class/ r,
   /sys/class/**/ r,
-`)
-
-// NOTE: there is no trailing } above ^^
+}
+`

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -24,7 +24,7 @@ package apparmor
 // It can be overridden for testing using MockTemplate().
 //
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/templates/ubuntu-core/16.04/default
-var defaultTemplate = `
+var defaultTemplate = []byte(`
 # Description: Allows access to app-specific directories and basic runtime
 # Usage: common
 
@@ -286,5 +286,6 @@ var defaultTemplate = `
   /sys/devices/**/ r,
   /sys/class/ r,
   /sys/class/**/ r,
-}
-`
+`)
+
+// NOTE: there is no trailing } above ^^

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -95,7 +95,7 @@ var (
 // profile. That same content also decides if the profile is enforcing or
 // advisory (complain). This is used to implement developer mode.
 func (b *Backend) aaHeader(appInfo *snap.AppInfo, developerMode bool) []byte {
-	header := b.customTemplate
+	header := b.legacyTemplate
 	if header == nil {
 		header = []byte(defaultTemplate)
 	}

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -95,15 +95,15 @@ var (
 // profile. That same content also decides if the profile is enforcing or
 // advisory (complain). This is used to implement developer mode.
 func (b *Backend) aaHeader(appInfo *snap.AppInfo, developerMode bool) []byte {
-	header := b.legacyTemplate
-	if header == nil {
-		header = defaultTemplate
+	template := b.legacyTemplate
+	if template == nil {
+		template = defaultTemplate
 	}
-	header = bytes.TrimRight(header, "\n}")
+	template = bytes.TrimRight(template, "\n}")
 	if developerMode {
-		header = attachPattern.ReplaceAll(header, attachComplain)
+		template = attachPattern.ReplaceAll(template, attachComplain)
 	}
-	return templatePattern.ReplaceAllFunc(header, func(in []byte) []byte {
+	return templatePattern.ReplaceAllFunc(template, func(in []byte) []byte {
 		switch string(in) {
 		case "###VAR###":
 			// TODO: use modern variables when default template is compatible

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -97,7 +97,7 @@ var (
 func (b *Backend) aaHeader(appInfo *snap.AppInfo, developerMode bool) []byte {
 	header := b.legacyTemplate
 	if header == nil {
-		header = []byte(defaultTemplate)
+		header = defaultTemplate
 	}
 	header = bytes.TrimRight(header, "\n}")
 	if developerMode {

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/dbus"
@@ -96,14 +95,11 @@ var (
 // profile. That same content also decides if the profile is enforcing or
 // advisory (complain). This is used to implement developer mode.
 func (b *Backend) aaHeader(appInfo *snap.AppInfo, developerMode bool) []byte {
-	var text string
-	if len(b.CustomTemplate) == 0 {
-		text = defaultTemplate
-	} else {
-		text = b.CustomTemplate
+	header := b.CustomTemplate
+	if header == nil {
+		header = []byte(defaultTemplate)
 	}
-	text = strings.TrimRight(text, "\n}")
-	header := []byte(text)
+	header = bytes.TrimRight(header, "\n}")
 	if developerMode {
 		header = attachPattern.ReplaceAll(header, attachComplain)
 	}

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -22,15 +22,14 @@ package apparmor
 import (
 	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/dbus"
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-// legacyVariablees returns text defining some apparmor variables that work
-// with legacy apparmor templates.
+// writeLegacyVariablees writes definitions of apparmor variables that work
+// with legacy apparmor templates to the specified buffer.
 //
 // The variables are expanded by apparmor parser. They are (currently):
 //  - APP_APPNAME
@@ -39,31 +38,29 @@ import (
 //  - APP_PKGNAME
 //  - APP_VERSION
 //  - INSTALL_DIR
-// They can be changed but this has to match changes in template.go.
 //
 // In addition, the set of variables listed here interacts with old-security
-// interface since there the base template is provided by a particular 3rd
-// party snap, not by snappy.
-func legacyVariables(appInfo *snap.AppInfo) string {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "@{APP_APPNAME}=\"%s\"\n", appInfo.Name)
+// interface. The old-security interface allows snap developers to bundle a
+// custom tepmlate and those are expected to be compatible with variables
+// defined in 15.04.
+func writeLegacyVariables(buf *bytes.Buffer, appInfo *snap.AppInfo) {
+	fmt.Fprintf(buf, "@{APP_APPNAME}=\"%s\"\n", appInfo.Name)
 	// TODO: replace with app.SecurityTag()
-	fmt.Fprintf(&buf, "@{APP_ID_DBUS}=\"%s\"\n",
+	fmt.Fprintf(buf, "@{APP_ID_DBUS}=\"%s\"\n",
 		dbus.SafePath(fmt.Sprintf("%s.%s_%s_%s",
 			appInfo.Snap.Name, appInfo.Snap.Developer, appInfo.Name, appInfo.Snap.Version)))
 	// XXX: How is this different from APP_ID_DBUS?
-	fmt.Fprintf(&buf, "@{APP_PKGNAME_DBUS}=\"%s\"\n",
+	fmt.Fprintf(buf, "@{APP_PKGNAME_DBUS}=\"%s\"\n",
 		dbus.SafePath(fmt.Sprintf("%s.%s", appInfo.Snap.Name, appInfo.Snap.Developer)))
 	// TODO: stop using .Developer, investigate how this is used.
-	fmt.Fprintf(&buf, "@{APP_PKGNAME}=\"%s.%s\"\n", appInfo.Snap.Name, appInfo.Snap.Developer)
+	fmt.Fprintf(buf, "@{APP_PKGNAME}=\"%s.%s\"\n", appInfo.Snap.Name, appInfo.Snap.Developer)
 	// TODO: switch to .Revision
-	fmt.Fprintf(&buf, "@{APP_VERSION}=\"%s\"\n", appInfo.Snap.Version)
-	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"\n")
-	return buf.String()
+	fmt.Fprintf(buf, "@{APP_VERSION}=\"%s\"\n", appInfo.Snap.Version)
+	fmt.Fprintf(buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"\n")
 }
 
-// modenVariables returns text defining some apparmor variables that
-// work with non-legacy apparmor templates.
+// writeModenVariables writes definition of apparmor variables that work with
+// non-legacy apparmor templates to the specified buffer.
 //
 // XXX: Straw-man: can we just expose the following apparmor variables...
 //
@@ -72,38 +69,60 @@ func legacyVariables(appInfo *snap.AppInfo) string {
 // @{SNAP_NAME}=app.SnapName
 //
 // ...have everything work correctly?
-func modernVariables(appInfo *snap.AppInfo) string {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
-	fmt.Fprintf(&buf, "@{APP_SECURITY_TAG}=\"%s\"\n", interfaces.SecurityTag(appInfo))
-	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name)
-	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"\n")
-	return buf.String()
+func writeModernVariables(buf *bytes.Buffer, appInfo *snap.AppInfo) {
+	fmt.Fprintf(buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
+	fmt.Fprintf(buf, "@{APP_SECURITY_TAG}=\"%s\"\n", interfaces.SecurityTag(appInfo))
+	fmt.Fprintf(buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name)
+	fmt.Fprintf(buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"\n")
 }
 
-// aaHeader returns the topmost part of the generated apparmor profile.
+// writeProfileAttach writes the profile attachment line of the apparmor profile.
 //
-// The header contains a few lines of apparmor variables that are referenced by
-// the template as well as the syntax that begins the content of the actual
-// profile. That same content also decides if the profile is enforcing or
-// advisory (complain). This is used to implement developer mode.
-func (b *Backend) aaHeader(appInfo *snap.AppInfo, developerMode bool) []byte {
-	var text string
-	// Use a different template when requested.
-	if len(b.CustomTemplate) == 0 {
-		text = strings.TrimRight(defaultTemplate, "\n}")
-		// TODO: switch to modernVariables() after the default template is
-		// compatible with them.
-		text = strings.Replace(text, "###VAR###\n", legacyVariables(appInfo), 1)
-	} else {
-		text = strings.TrimRight(b.CustomTemplate, "\n}")
-		text = strings.Replace(text, "###VAR###\n", legacyVariables(appInfo), 1)
-	}
+// The line typically looks like this:
+//
+//   profile "snap.http.GET" (attach_disconnected) {
+func writeProfileAttach(buf *bytes.Buffer, appInfo *snap.AppInfo, developerMode bool) {
+	fmt.Fprintf(buf, "profile \"%s\" (attach_disconnected", interfaces.SecurityTag(appInfo))
 	if developerMode {
 		// XXX: This needs to be verified by security team.
-		text = strings.Replace(text, "(attach_disconnected)", "(attach_disconnected,complain)", 1)
+		fmt.Fprintf(buf, ",complain")
 	}
-	text = strings.Replace(text, "###PROFILEATTACH###",
-		fmt.Sprintf("profile \"%s\"", interfaces.SecurityTag(appInfo)), 1)
-	return []byte(text)
+	fmt.Fprintf(buf, ") {\n")
+}
+
+const (
+	placeholderVar           = "###VAR###"
+	placeholderProfileAttach = "###PROFILEATTACH###"
+	expectedProfileHeader    = "###PROFILEATTACH### (attach_disconnected) {"
+)
+
+// parseTemplate processes an apparmor template
+func parseTemplate(template []byte) (imports, body []byte, err error) {
+	varStart := bytes.Index(template, []byte(placeholderVar))
+	if varStart == -1 {
+		return nil, nil, fmt.Errorf("cannot find placeholder: %q", placeholderVar)
+	}
+	varEndOffset := bytes.IndexRune(template[varStart:], '\n')
+	if varEndOffset == -1 {
+		return nil, nil, fmt.Errorf("missing newline after placeholder: %q", placeholderVar)
+	}
+	profileAttachStart := bytes.Index(template, []byte(placeholderProfileAttach))
+	if profileAttachStart == -1 {
+		return nil, nil, fmt.Errorf("cannot find placeholder: %q", placeholderProfileAttach)
+	}
+	profileAttachEndOffset := bytes.IndexRune(template[profileAttachStart:], '\n')
+	if profileAttachEndOffset == -1 {
+		return nil, nil, fmt.Errorf("missing newline after placeholder: %q", placeholderProfileAttach)
+	}
+	if string(template[profileAttachStart:profileAttachStart+profileAttachEndOffset]) != expectedProfileHeader {
+		return nil, nil, fmt.Errorf("unsupported profile header (wanted: %s)", expectedProfileHeader)
+	}
+	curlyBraceIndex := bytes.LastIndexByte(template, '}')
+	if curlyBraceIndex == -1 {
+		return nil, nil, fmt.Errorf("missing closing curly brace")
+	}
+	imports = template[:varStart]
+	// NOTE: +1 gets rid of the newline so that we get just the body
+	body = template[profileAttachStart+profileAttachEndOffset+1 : curlyBraceIndex]
+	return imports, body, nil
 }

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -22,14 +22,15 @@ package apparmor
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/dbus"
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-// writeLegacyVariablees writes definitions of apparmor variables that work
-// with legacy apparmor templates to the specified buffer.
+// legacyVariablees returns text defining some apparmor variables that work
+// with legacy apparmor templates.
 //
 // The variables are expanded by apparmor parser. They are (currently):
 //  - APP_APPNAME
@@ -38,29 +39,31 @@ import (
 //  - APP_PKGNAME
 //  - APP_VERSION
 //  - INSTALL_DIR
+// They can be changed but this has to match changes in template.go.
 //
 // In addition, the set of variables listed here interacts with old-security
-// interface. The old-security interface allows snap developers to bundle a
-// custom tepmlate and those are expected to be compatible with variables
-// defined in 15.04.
-func writeLegacyVariables(buf *bytes.Buffer, appInfo *snap.AppInfo) {
-	fmt.Fprintf(buf, "@{APP_APPNAME}=\"%s\"\n", appInfo.Name)
+// interface since there the base template is provided by a particular 3rd
+// party snap, not by snappy.
+func legacyVariables(appInfo *snap.AppInfo) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "@{APP_APPNAME}=\"%s\"\n", appInfo.Name)
 	// TODO: replace with app.SecurityTag()
-	fmt.Fprintf(buf, "@{APP_ID_DBUS}=\"%s\"\n",
+	fmt.Fprintf(&buf, "@{APP_ID_DBUS}=\"%s\"\n",
 		dbus.SafePath(fmt.Sprintf("%s.%s_%s_%s",
 			appInfo.Snap.Name, appInfo.Snap.Developer, appInfo.Name, appInfo.Snap.Version)))
 	// XXX: How is this different from APP_ID_DBUS?
-	fmt.Fprintf(buf, "@{APP_PKGNAME_DBUS}=\"%s\"\n",
+	fmt.Fprintf(&buf, "@{APP_PKGNAME_DBUS}=\"%s\"\n",
 		dbus.SafePath(fmt.Sprintf("%s.%s", appInfo.Snap.Name, appInfo.Snap.Developer)))
 	// TODO: stop using .Developer, investigate how this is used.
-	fmt.Fprintf(buf, "@{APP_PKGNAME}=\"%s.%s\"\n", appInfo.Snap.Name, appInfo.Snap.Developer)
+	fmt.Fprintf(&buf, "@{APP_PKGNAME}=\"%s.%s\"\n", appInfo.Snap.Name, appInfo.Snap.Developer)
 	// TODO: switch to .Revision
-	fmt.Fprintf(buf, "@{APP_VERSION}=\"%s\"\n", appInfo.Snap.Version)
-	fmt.Fprintf(buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"\n")
+	fmt.Fprintf(&buf, "@{APP_VERSION}=\"%s\"\n", appInfo.Snap.Version)
+	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"\n")
+	return buf.String()
 }
 
-// writeModenVariables writes definition of apparmor variables that work with
-// non-legacy apparmor templates to the specified buffer.
+// modenVariables returns text defining some apparmor variables that
+// work with non-legacy apparmor templates.
 //
 // XXX: Straw-man: can we just expose the following apparmor variables...
 //
@@ -69,60 +72,38 @@ func writeLegacyVariables(buf *bytes.Buffer, appInfo *snap.AppInfo) {
 // @{SNAP_NAME}=app.SnapName
 //
 // ...have everything work correctly?
-func writeModernVariables(buf *bytes.Buffer, appInfo *snap.AppInfo) {
-	fmt.Fprintf(buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
-	fmt.Fprintf(buf, "@{APP_SECURITY_TAG}=\"%s\"\n", interfaces.SecurityTag(appInfo))
-	fmt.Fprintf(buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name)
-	fmt.Fprintf(buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"\n")
+func modernVariables(appInfo *snap.AppInfo) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
+	fmt.Fprintf(&buf, "@{APP_SECURITY_TAG}=\"%s\"\n", interfaces.SecurityTag(appInfo))
+	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name)
+	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"\n")
+	return buf.String()
 }
 
-// writeProfileAttach writes the profile attachment line of the apparmor profile.
+// aaHeader returns the topmost part of the generated apparmor profile.
 //
-// The line typically looks like this:
-//
-//   profile "snap.http.GET" (attach_disconnected) {
-func writeProfileAttach(buf *bytes.Buffer, appInfo *snap.AppInfo, developerMode bool) {
-	fmt.Fprintf(buf, "profile \"%s\" (attach_disconnected", interfaces.SecurityTag(appInfo))
+// The header contains a few lines of apparmor variables that are referenced by
+// the template as well as the syntax that begins the content of the actual
+// profile. That same content also decides if the profile is enforcing or
+// advisory (complain). This is used to implement developer mode.
+func (b *Backend) aaHeader(appInfo *snap.AppInfo, developerMode bool) []byte {
+	var text string
+	// Use a different template when requested.
+	if len(b.CustomTemplate) == 0 {
+		text = strings.TrimRight(defaultTemplate, "\n}")
+		// TODO: switch to modernVariables() after the default template is
+		// compatible with them.
+		text = strings.Replace(text, "###VAR###\n", legacyVariables(appInfo), 1)
+	} else {
+		text = strings.TrimRight(b.CustomTemplate, "\n}")
+		text = strings.Replace(text, "###VAR###\n", legacyVariables(appInfo), 1)
+	}
 	if developerMode {
 		// XXX: This needs to be verified by security team.
-		fmt.Fprintf(buf, ",complain")
+		text = strings.Replace(text, "(attach_disconnected)", "(attach_disconnected,complain)", 1)
 	}
-	fmt.Fprintf(buf, ") {\n")
-}
-
-const (
-	placeholderVar           = "###VAR###"
-	placeholderProfileAttach = "###PROFILEATTACH###"
-	expectedProfileHeader    = "###PROFILEATTACH### (attach_disconnected) {"
-)
-
-// parseTemplate processes an apparmor template
-func parseTemplate(template []byte) (imports, body []byte, err error) {
-	varStart := bytes.Index(template, []byte(placeholderVar))
-	if varStart == -1 {
-		return nil, nil, fmt.Errorf("cannot find placeholder: %q", placeholderVar)
-	}
-	varEndOffset := bytes.IndexRune(template[varStart:], '\n')
-	if varEndOffset == -1 {
-		return nil, nil, fmt.Errorf("missing newline after placeholder: %q", placeholderVar)
-	}
-	profileAttachStart := bytes.Index(template, []byte(placeholderProfileAttach))
-	if profileAttachStart == -1 {
-		return nil, nil, fmt.Errorf("cannot find placeholder: %q", placeholderProfileAttach)
-	}
-	profileAttachEndOffset := bytes.IndexRune(template[profileAttachStart:], '\n')
-	if profileAttachEndOffset == -1 {
-		return nil, nil, fmt.Errorf("missing newline after placeholder: %q", placeholderProfileAttach)
-	}
-	if string(template[profileAttachStart:profileAttachStart+profileAttachEndOffset]) != expectedProfileHeader {
-		return nil, nil, fmt.Errorf("unsupported profile header (wanted: %s)", expectedProfileHeader)
-	}
-	curlyBraceIndex := bytes.LastIndexByte(template, '}')
-	if curlyBraceIndex == -1 {
-		return nil, nil, fmt.Errorf("missing closing curly brace")
-	}
-	imports = template[:varStart]
-	// NOTE: +1 gets rid of the newline so that we get just the body
-	body = template[profileAttachStart+profileAttachEndOffset+1 : curlyBraceIndex]
-	return imports, body, nil
+	text = strings.Replace(text, "###PROFILEATTACH###",
+		fmt.Sprintf("profile \"%s\"", interfaces.SecurityTag(appInfo)), 1)
+	return []byte(text)
 }

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -95,7 +95,7 @@ var (
 // profile. That same content also decides if the profile is enforcing or
 // advisory (complain). This is used to implement developer mode.
 func (b *Backend) aaHeader(appInfo *snap.AppInfo, developerMode bool) []byte {
-	header := b.CustomTemplate
+	header := b.customTemplate
 	if header == nil {
 		header = []byte(defaultTemplate)
 	}

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -82,7 +82,9 @@ func modernVariables(appInfo *snap.AppInfo) []byte {
 }
 
 var (
-	templatePattern = regexp.MustCompile("(###[^#]+###)")
+	templatePattern          = regexp.MustCompile("(###[^#]+###)")
+	placeholderVar           = []byte("###VAR###")
+	placeholderProfileAttach = []byte("###PROFILEATTACH###")
 	// XXX: This needs to be verified by security team.
 	attachPattern  = regexp.MustCompile(`\(attach_disconnected\)`)
 	attachComplain = []byte("(attach_disconnected,complain)")
@@ -103,13 +105,13 @@ func (b *Backend) aaHeader(appInfo *snap.AppInfo, developerMode bool) []byte {
 	if developerMode {
 		template = attachPattern.ReplaceAll(template, attachComplain)
 	}
-	return templatePattern.ReplaceAllFunc(template, func(in []byte) []byte {
-		switch string(in) {
-		case "###VAR###":
+	return templatePattern.ReplaceAllFunc(template, func(placeholder []byte) []byte {
+		switch {
+		case bytes.Equal(placeholder, placeholderVar):
 			// TODO: use modern variables when default template is compatible
 			// with them and the custom template is not used.
 			return legacyVariables(appInfo)
-		case "###PROFILEATTACH###":
+		case bytes.Equal(placeholder, placeholderProfileAttach):
 			return []byte(fmt.Sprintf("profile \"%s\"", interfaces.SecurityTag(appInfo)))
 		}
 		return nil


### PR DESCRIPTION
This branch contains two changes that were requested on an earlier review but didn't get finished before this feature was merged. The key change is the switch to a using buffers instead of strings for policy generation.