### PR TITLE
store: only use remoteSnap.pkg.DownloadURL if there is actually such URL

### DIFF
--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -333,7 +333,7 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *RemoteSnap, pbar progre
 	}
 
 	url := remoteSnap.Pkg.AnonDownloadURL
-	if url == "" || ssoToken != nil {
+	if url == "" || (ssoToken != nil && remoteSnap.Pkg.DownloadURL != "") {
 		url = remoteSnap.Pkg.DownloadURL
 	}
 


### PR DESCRIPTION
This fixes failing tests on my system that happens to have a sso token.