### PR TITLE
store,snappy: add an Assertion method to retrieve a single assertion from the assertion service

### DIFF
--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -240,15 +240,15 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryUpdates(c *C) {
 	var err error
 	s.storeCfg.BulkURI, err = url.Parse(mockServer.URL + "/updates/")
 	c.Assert(err, IsNil)
-	snap := store.NewUbuntuStoreSnapRepository(s.storeCfg, "")
-	c.Assert(snap, NotNil)
+	repo := store.NewUbuntuStoreSnapRepository(s.storeCfg, "")
+	c.Assert(repo, NotNil)
 
 	// override the real ActiveSnapIterByType to return our
 	// mock data
 	mockActiveSnapIterByType([]string{funkyAppName})
 
 	// the actual test
-	results, err := snapUpdates(snap)
+	results, err := snapUpdates(repo)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name(), Equals, funkyAppName)
@@ -260,13 +260,13 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryUpdatesNoSnaps(c *C) {
 	var err error
 	s.storeCfg.DetailsURI, err = url.Parse("https://some-uri")
 	c.Assert(err, IsNil)
-	snap := store.NewUbuntuStoreSnapRepository(s.storeCfg, "")
+	repo := store.NewUbuntuStoreSnapRepository(s.storeCfg, "")
 	c.Assert(snap, NotNil)
 
 	mockActiveSnapIterByType([]string{})
 
 	// the actual test
-	results, err := snapUpdates(snap)
+	results, err := snapUpdates(repo)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 0)
 }

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -261,7 +261,7 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryUpdatesNoSnaps(c *C) {
 	s.storeCfg.DetailsURI, err = url.Parse("https://some-uri")
 	c.Assert(err, IsNil)
 	repo := store.NewUbuntuStoreSnapRepository(s.storeCfg, "")
-	c.Assert(snap, NotNil)
+	c.Assert(repo, NotNil)
 
 	mockActiveSnapIterByType([]string{})
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -29,6 +29,9 @@ var (
 	// ErrSnapNotFound is returned when a snap can not be found
 	ErrSnapNotFound = errors.New("snap not found")
 
+	// ErrAssertionNotFound is returned when an assertion can not be found
+	ErrAssertionNotFound = errors.New("assertion not found")
+
 	// ErrAuthenticationNeeds2fa is returned if the authentication
 	// needs 2factor
 	ErrAuthenticationNeeds2fa = errors.New("authentication needs second factor")

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -71,6 +71,8 @@ type SnapUbuntuStoreRepository struct {
 	detailsURI    *url.URL
 	bulkURI       *url.URL
 	assertionsURI *url.URL
+	// reused http client
+	client *http.Client
 }
 
 func getStructFields(s interface{}) []string {
@@ -179,6 +181,7 @@ func NewUbuntuStoreSnapRepository(cfg *SnapUbuntuStoreConfig, storeID string) *S
 		detailsURI:    cfg.DetailsURI,
 		bulkURI:       cfg.BulkURI,
 		assertionsURI: cfg.AssertionsURI,
+		client:        &http.Client{},
 	}
 }
 
@@ -235,8 +238,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string) (*RemoteSnap, err
 	// set headers
 	s.configureStoreReq(req, "")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -284,8 +286,7 @@ func (s *SnapUbuntuStoreRepository) FindSnaps(searchTerm string, channel string)
 	s.configureStoreReq(req, "")
 	req.Header.Set("X-Ubuntu-Device-Channnel", channel)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -322,8 +323,7 @@ func (s *SnapUbuntuStoreRepository) Updates(installed []string) (snaps []*Remote
 	// (see LP: #1427155)
 	s.configureStoreReq(req, "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -431,8 +431,7 @@ func (s *SnapUbuntuStoreRepository) Assertion(assertType *asserts.AssertionType,
 	configureAuthHeader(req)
 	req.Header.Set("Accept", asserts.MediaType)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -112,14 +112,14 @@ func authURL() string {
 
 func assertsURL() string {
 	if os.Getenv("SNAPPY_USE_STAGING_SAS") != "" {
-		return "https://assertions.staging.ubuntu.com/v1"
+		return "https://assertions.staging.ubuntu.com/v1/"
 	}
 
 	if os.Getenv("SNAPPY_FORCE_SAS_URL") != "" {
 		return os.Getenv("SNAPPY_FORCE_SAS_URL")
 	}
 
-	return "https://assertions.ubuntu.com/v1"
+	return "https://assertions.ubuntu.com/v1/"
 }
 
 var defaultConfig = SnapUbuntuStoreConfig{}

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -197,7 +197,7 @@ func configureAuthHeader(req *http.Request) {
 	}
 }
 
-// // small helper that sets the correct http headers for the ubuntu store
+// small helper that sets the correct http headers for the ubuntu store
 func (s *SnapUbuntuStoreRepository) applyUbuntuStoreHeaders(req *http.Request, accept string) {
 	if accept == "" {
 		accept = "application/hal+json"

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 
 	"github.com/ubuntu-core/snappy/arch"
+	"github.com/ubuntu-core/snappy/asserts"
 	"github.com/ubuntu-core/snappy/oauth"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/release"
@@ -57,17 +58,19 @@ func NewRemoteSnap(data remote.Snap) *RemoteSnap {
 
 // SnapUbuntuStoreConfig represents the configuration to access the snap store
 type SnapUbuntuStoreConfig struct {
-	SearchURI  *url.URL
-	DetailsURI *url.URL
-	BulkURI    *url.URL
+	SearchURI     *url.URL
+	DetailsURI    *url.URL
+	BulkURI       *url.URL
+	AssertionsURI *url.URL
 }
 
 // SnapUbuntuStoreRepository represents the ubuntu snap store
 type SnapUbuntuStoreRepository struct {
-	storeID    string
-	searchURI  *url.URL
-	detailsURI *url.URL
-	bulkURI    *url.URL
+	storeID       string
+	searchURI     *url.URL
+	detailsURI    *url.URL
+	bulkURI       *url.URL
+	assertionsURI *url.URL
 }
 
 func getStructFields(s interface{}) []string {
@@ -107,6 +110,18 @@ func authURL() string {
 	return "https://login.ubuntu.com/api/v2"
 }
 
+func assertsURL() string {
+	if os.Getenv("SNAPPY_USE_STAGING_SAS") != "" {
+		return "https://assertions.staging.ubuntu.com/v1"
+	}
+
+	if os.Getenv("SNAPPY_FORCE_SAS_URL") != "" {
+		return os.Getenv("SNAPPY_FORCE_SAS_URL")
+	}
+
+	return "https://assertions.ubuntu.com/v1"
+}
+
 var defaultConfig = SnapUbuntuStoreConfig{}
 
 func init() {
@@ -133,6 +148,17 @@ func init() {
 		panic(err)
 	}
 	defaultConfig.BulkURI.RawQuery = v.Encode()
+
+	assertsBaseURI, err := url.Parse(assertsURL())
+	if err != nil {
+		panic(err)
+	}
+
+	defaultConfig.AssertionsURI, err = assertsBaseURI.Parse("assertions/")
+	if err != nil {
+		panic(err)
+	}
+
 }
 
 type searchResults struct {
@@ -148,26 +174,27 @@ func NewUbuntuStoreSnapRepository(cfg *SnapUbuntuStoreConfig, storeID string) *S
 	}
 	// see https://wiki.ubuntu.com/AppStore/Interfaces/ClickPackageIndex
 	return &SnapUbuntuStoreRepository{
-		storeID:    storeID,
-		searchURI:  cfg.SearchURI,
-		detailsURI: cfg.DetailsURI,
-		bulkURI:    cfg.BulkURI,
+		storeID:       storeID,
+		searchURI:     cfg.SearchURI,
+		detailsURI:    cfg.DetailsURI,
+		bulkURI:       cfg.BulkURI,
+		assertionsURI: cfg.AssertionsURI,
 	}
 }
 
-// small helper that sets the correct http headers for the ubuntu store
-func (s *SnapUbuntuStoreRepository) setUbuntuStoreHeaders(req *http.Request) {
-	var token *oauth.Token
-	ssoToken, _ := ReadStoreToken()
-	if ssoToken != nil {
-		token = &ssoToken.Token
+// setAuthHeader sets the authorization header
+func (s *SnapUbuntuStoreRepository) setAuthHeader(req *http.Request, token *StoreToken) {
+	if token != nil {
+		req.Header.Set("Authorization", oauth.MakePlaintextSignature(&token.Token))
 	}
-	s.setUbuntuStoreHeadersWithToken(req, token)
 }
 
-// same as above, but sometimes the request depends on the token, so you need to get it first
-func (s *SnapUbuntuStoreRepository) setUbuntuStoreHeadersWithToken(req *http.Request, token *oauth.Token) {
-	req.Header.Set("Accept", "application/hal+json")
+// // small helper that sets the correct http headers for the ubuntu store
+func (s *SnapUbuntuStoreRepository) setUbuntuStoreHeaders(req *http.Request, accept string) {
+	if accept == "" {
+		accept = "application/hal+json"
+	}
+	req.Header.Set("Accept", accept)
 
 	req.Header.Set("X-Ubuntu-Architecture", string(arch.UbuntuArchitecture()))
 	req.Header.Set("X-Ubuntu-Release", release.String())
@@ -176,10 +203,13 @@ func (s *SnapUbuntuStoreRepository) setUbuntuStoreHeadersWithToken(req *http.Req
 	if s.storeID != "" {
 		req.Header.Set("X-Ubuntu-Store", s.storeID)
 	}
+}
 
-	if token != nil {
-		req.Header.Set("Authorization", oauth.MakePlaintextSignature(token))
-	}
+// small helper that sets the correct http headers for a store request including auth
+func (s *SnapUbuntuStoreRepository) setStoreReqHeaders(req *http.Request, accept string) {
+	ssoToken, _ := ReadStoreToken()
+	s.setAuthHeader(req, ssoToken)
+	s.setUbuntuStoreHeaders(req, accept)
 }
 
 // Snap returns the RemoteSnap for the given name or an error.
@@ -196,7 +226,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string) (*RemoteSnap, err
 	}
 
 	// set headers
-	s.setUbuntuStoreHeaders(req)
+	s.setStoreReqHeaders(req, "")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -244,7 +274,7 @@ func (s *SnapUbuntuStoreRepository) FindSnaps(searchTerm string, channel string)
 	}
 
 	// set headers
-	s.setUbuntuStoreHeaders(req)
+	s.setStoreReqHeaders(req, "")
 	req.Header.Set("X-Ubuntu-Device-Channnel", channel)
 
 	client := &http.Client{}
@@ -281,10 +311,9 @@ func (s *SnapUbuntuStoreRepository) Updates(installed []string) (snaps []*Remote
 		return nil, err
 	}
 	// set headers
-	s.setUbuntuStoreHeaders(req)
 	// the updates call is a special snowflake right now
 	// (see LP: #1427155)
-	req.Header.Set("Accept", "application/json")
+	s.setStoreReqHeaders(req, "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -326,11 +355,7 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *RemoteSnap, pbar progre
 		}
 	}()
 
-	var token *oauth.Token
 	ssoToken, _ := ReadStoreToken()
-	if ssoToken != nil {
-		token = &ssoToken.Token
-	}
 
 	url := remoteSnap.Pkg.AnonDownloadURL
 	if url == "" || ssoToken != nil {
@@ -341,7 +366,8 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *RemoteSnap, pbar progre
 	if err != nil {
 		return "", err
 	}
-	s.setUbuntuStoreHeadersWithToken(req, token)
+	s.setAuthHeader(req, ssoToken)
+	s.setUbuntuStoreHeaders(req, "")
 
 	if err := download(remoteSnap.Name(), w, req, pbar); err != nil {
 		return "", err
@@ -374,4 +400,56 @@ var download = func(name string, w io.Writer, req *http.Request, pbar progress.M
 	}
 
 	return err
+}
+
+type assertionSvcError struct {
+	Status int    `json:"status"`
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+}
+
+// Assertion retrivies the assertion for the given type and primary key.
+func (s *SnapUbuntuStoreRepository) Assertion(assertType *asserts.AssertionType, primaryKey ...string) (asserts.Assertion, error) {
+	url, err := s.assertionsURI.Parse(path.Join(assertType.Name, path.Join(primaryKey...)))
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ssoToken, err := ReadStoreToken()
+	if err != nil {
+		s.setAuthHeader(req, ssoToken)
+	}
+	req.Header.Set("Accept", asserts.MediaType)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		if resp.Header.Get("Content-Type") == "application/json" {
+			var svcErr assertionSvcError
+			dec := json.NewDecoder(resp.Body)
+			if err := dec.Decode(&svcErr); err != nil {
+				return nil, fmt.Errorf("cannot decode assertion service error with HTTP status code %d: %v", resp.StatusCode, err)
+			}
+			if svcErr.Status == 404 {
+				return nil, ErrAssertionNotFound
+			}
+			return nil, fmt.Errorf("assertion service error: [%s] %q", svcErr.Title, svcErr.Detail)
+		}
+		return nil, fmt.Errorf("unexpected HTTP status code %d", resp.StatusCode)
+	}
+
+	// and decode assertion
+	dec := asserts.NewDecoder(resp.Body)
+	return dec.Decode()
 }

--- a/store/snap_remote_repo_test.go
+++ b/store/snap_remote_repo_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -462,6 +463,13 @@ func (t *remoteRepoTestSuite) TestAssertsURLDependsOnEnviron(c *C) {
 	after := assertsURL()
 
 	c.Check(before, Not(Equals), after)
+}
+
+func (t *remoteRepoTestSuite) TestDefaultConfig(c *C) {
+	c.Check(strings.HasPrefix(defaultConfig.SearchURI.String(), "https://search.apps.ubuntu.com/api/v1/search?"), Equals, true)
+	c.Check(defaultConfig.DetailsURI.String(), Equals, "https://search.apps.ubuntu.com/api/v1/package/")
+	c.Check(strings.HasPrefix(defaultConfig.BulkURI.String(), "https://search.apps.ubuntu.com/api/v1/click-metadata?"), Equals, true)
+	c.Check(defaultConfig.AssertionsURI.String(), Equals, "https://assertions.ubuntu.com/v1/assertions/")
 }
 
 var testAssertion = `type: snap-declaration

--- a/store/snap_remote_repo_test.go
+++ b/store/snap_remote_repo_test.go
@@ -250,11 +250,11 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	cfg := SnapUbuntuStoreConfig{
 		DetailsURI: detailsURI,
 	}
-	snap := NewUbuntuStoreSnapRepository(&cfg, "")
-	c.Assert(snap, NotNil)
+	repo := NewUbuntuStoreSnapRepository(&cfg, "")
+	c.Assert(repo, NotNil)
 
 	// the actual test
-	result, err := snap.Snap(funkyAppName+"."+funkyAppDeveloper, "edge")
+	result, err := repo.Snap(funkyAppName+"."+funkyAppDeveloper, "edge")
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, funkyAppName)
 	c.Check(result.Developer(), Equals, funkyAppDeveloper)
@@ -283,11 +283,11 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 	cfg := SnapUbuntuStoreConfig{
 		DetailsURI: detailsURI,
 	}
-	snap := NewUbuntuStoreSnapRepository(&cfg, "")
-	c.Assert(snap, NotNil)
+	repo := NewUbuntuStoreSnapRepository(&cfg, "")
+	c.Assert(repo, NotNil)
 
 	// the actual test
-	result, err := snap.Snap("no-such-pkg", "edge")
+	result, err := repo.Snap("no-such-pkg", "edge")
 	c.Assert(err, NotNil)
 	c.Assert(result, IsNil)
 }

--- a/store/snap_remote_repo_test.go
+++ b/store/snap_remote_repo_test.go
@@ -143,12 +143,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryHeaders(c *C) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	c.Assert(err, IsNil)
 
-	t.store.setStoreReqHeaders(req, "")
+	t.store.configureStoreReq(req, "")
 
 	c.Assert(req.Header.Get("X-Ubuntu-Release"), Equals, release.String())
 	c.Check(req.Header.Get("Accept"), Equals, "application/hal+json")
 
-	t.store.setStoreReqHeaders(req, "application/json")
+	t.store.configureStoreReq(req, "application/json")
 
 	c.Check(req.Header.Get("Accept"), Equals, "application/json")
 }


### PR DESCRIPTION
This adds an Assertion method to retrieve a single assertion from the assertion service.

It also cleans up a few places that were calling the store repo "snap" which was confusing I think.