### PR TITLE
dirs,interfaces/apparmor: remove unused apparmor cache entries

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -33,6 +33,7 @@ var (
 	SnapDataDir               string
 	SnapDataHomeGlob          string
 	SnapAppArmorDir           string
+	AppArmorCacheDir          string
 	SnapAppArmorAdditionalDir string
 	SnapSeccompDir            string
 	SnapUdevRulesDir          string
@@ -80,6 +81,7 @@ func SetRootDir(rootdir string) {
 	SnapDataDir = filepath.Join(rootdir, "/var/lib/snaps")
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/snaps/")
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
+	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")
 	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")
 	SnapSeccompDir = filepath.Join(rootdir, snappyDir, "seccomp", "profiles")
 	SnapMetaDir = filepath.Join(rootdir, snappyDir, "meta")

--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -52,18 +52,19 @@ func LoadProfile(fname string) error {
 	return nil
 }
 
-// RemoveCachedProfile removes binary cache file from /var/cache/apparmor
-func RemoveCachedProfile(profile string) error {
-	return os.Remove(filepath.Join(dirs.AppArmorCacheDir, profile))
-}
-
 // UnloadProfile removes the named profile from the running kernel.
 //
 // The operation is done with: apparmor_parser --remove $name
+// The binary cache file is removed from /var/cache/apparmor
 func UnloadProfile(name string) error {
 	output, err := exec.Command("apparmor_parser", "--remove", name).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cannot unload apparmor profile: %s\napparmor_parser output:\n%s", err, string(output))
+	}
+	err = os.Remove(filepath.Join(dirs.AppArmorCacheDir, name))
+	// It is not an error if the cache file wasn't there to remove.
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot remove apparmor profile cache: %s", err)
 	}
 	return nil
 }

--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/ubuntu-core/snappy/dirs"
@@ -49,6 +50,11 @@ func LoadProfile(fname string) error {
 		return fmt.Errorf("cannot load apparmor profile: %s\napparmor_parser output:\n%s", err, string(output))
 	}
 	return nil
+}
+
+// RemoveCachedProfile removes binary cache file from /var/cache/apparmor
+func RemoveCachedProfile(profile string) error {
+	return os.Remove(filepath.Join(dirs.AppArmorCacheDir, profile))
 }
 
 // UnloadProfile removes the named profile from the running kernel.

--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -31,6 +31,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/ubuntu-core/snappy/dirs"
 )
 
 // LoadProfile loads an apparmor profile from the given file.
@@ -41,7 +43,7 @@ func LoadProfile(fname string) error {
 	// Use no-expr-simplify since expr-simplify is actually slower on armhf (LP: #1383858)
 	output, err := exec.Command(
 		"apparmor_parser", "--replace", "--write-cache", "-O",
-		"no-expr-simplify", "--cache-loc=/var/cache/apparmor",
+		"no-expr-simplify", fmt.Sprintf("--cache-loc=%s", dirs.AppArmorCacheDir),
 		fname).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cannot load apparmor profile: %s\napparmor_parser output:\n%s", err, string(output))

--- a/interfaces/apparmor/apparmor_test.go
+++ b/interfaces/apparmor/apparmor_test.go
@@ -21,11 +21,14 @@ package apparmor_test
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/interfaces/apparmor"
 	"github.com/ubuntu-core/snappy/testutil"
 )
@@ -68,6 +71,22 @@ apparmor_parser output:
 `)
 	c.Assert(cmd.Calls(), DeepEquals, []string{
 		"--replace --write-cache -O no-expr-simplify --cache-loc=/var/cache/apparmor /path/to/snap.samba.smbd"})
+}
+
+// Tests for RemoveCachedProfile()
+
+func (s *appArmorSuite) TestRemoveCachedProfile(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
+	err := os.MkdirAll(dirs.AppArmorCacheDir, 0755)
+	c.Assert(err, IsNil)
+
+	fname := filepath.Join(dirs.AppArmorCacheDir, "profile")
+	ioutil.WriteFile(fname, []byte("blob"), 0600)
+	err = apparmor.RemoveCachedProfile("profile")
+	c.Assert(err, IsNil)
+	_, err = os.Stat(fname)
+	c.Check(os.IsNotExist(err), Equals, true)
 }
 
 // Tests for Profile.Unload()

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -91,7 +91,7 @@ func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *inter
 	if err != nil {
 		return err
 	}
-	err = unloadProfiles(removed)
+	err = unloadAndRemoveCachedProfiles(removed)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (b *Backend) Deconfigure(snapInfo *snap.Info) error {
 	if err != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapInfo.Name, err)
 	}
-	err = unloadProfiles(removed)
+	err = unloadAndRemoveCachedProfiles(removed)
 	if err != nil {
 		return err
 	}
@@ -169,11 +169,13 @@ func reloadProfiles(profiles []string) error {
 	return nil
 }
 
-func unloadProfiles(profiles []string) error {
+func unloadAndRemoveCachedProfiles(profiles []string) error {
 	for _, profile := range profiles {
-		err := UnloadProfile(profile)
-		if err != nil {
+		if err := UnloadProfile(profile); err != nil {
 			return fmt.Errorf("cannot unload apparmor profile %q: %s", profile, err)
+		}
+		if err := RemoveCachedProfile(profile); err != nil {
+			return fmt.Errorf("cannot remove cached apparmor profile %q: %s", profile, err)
 		}
 	}
 	return nil

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -91,7 +91,7 @@ func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *inter
 	if err != nil {
 		return err
 	}
-	err = unloadAndRemoveCachedProfiles(removed)
+	err = unloadProfiles(removed)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (b *Backend) Deconfigure(snapInfo *snap.Info) error {
 	if err != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapInfo.Name, err)
 	}
-	err = unloadAndRemoveCachedProfiles(removed)
+	err = unloadProfiles(removed)
 	if err != nil {
 		return err
 	}
@@ -169,13 +169,10 @@ func reloadProfiles(profiles []string) error {
 	return nil
 }
 
-func unloadAndRemoveCachedProfiles(profiles []string) error {
+func unloadProfiles(profiles []string) error {
 	for _, profile := range profiles {
 		if err := UnloadProfile(profile); err != nil {
 			return fmt.Errorf("cannot unload apparmor profile %q: %s", profile, err)
-		}
-		if err := RemoveCachedProfile(profile); err != nil {
-			return fmt.Errorf("cannot remove cached apparmor profile %q: %s", profile, err)
 		}
 	}
 	return nil

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -112,7 +112,7 @@ func (s *backendSuite) TestInstallingSnapWritesAndLoadsProfiles(c *C) {
 	c.Check(err, IsNil)
 	// apparmor_parser was used to load that file
 	c.Check(s.cmds["apparmor_parser"].Calls(), DeepEquals, []string{
-		fmt.Sprintf("--replace --write-cache -O no-expr-simplify --cache-loc=/var/cache/apparmor %s", profile),
+		fmt.Sprintf("--replace --write-cache -O no-expr-simplify --cache-loc=%s/var/cache/apparmor %s", s.rootDir, profile),
 	})
 }
 
@@ -153,7 +153,7 @@ func (s *backendSuite) TestUpdatingSnapMakesNeccesaryChanges(c *C) {
 		// apparmor_parser was used to reload the profile because snap version is
 		// inside the generated policy.
 		c.Check(s.cmds["apparmor_parser"].Calls(), DeepEquals, []string{
-			fmt.Sprintf("--replace --write-cache -O no-expr-simplify --cache-loc=/var/cache/apparmor %s", profile),
+			fmt.Sprintf("--replace --write-cache -O no-expr-simplify --cache-loc=%s/var/cache/apparmor %s", s.rootDir, profile),
 		})
 		s.removeSnap(c, snapInfo)
 	}
@@ -170,7 +170,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 		c.Check(err, IsNil)
 		// apparmor_parser was used to load the new profile
 		c.Check(s.cmds["apparmor_parser"].Calls(), DeepEquals, []string{
-			fmt.Sprintf("--replace --write-cache -O no-expr-simplify --cache-loc=/var/cache/apparmor %s", profile),
+			fmt.Sprintf("--replace --write-cache -O no-expr-simplify --cache-loc=%s/var/cache/apparmor %s", s.rootDir, profile),
 		})
 		s.removeSnap(c, snapInfo)
 	}


### PR DESCRIPTION
This branch ensures we remove entries from ``/var/cache/apparmor`` corresponding to removed apparmor profiles. We have to do this because ``apparmor_parser`` writes the cache but never removes it.