### PR TITLE
snappy: add "download_url" in addition to "anon_download_url" in the tests

### DIFF
--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -164,6 +164,7 @@ func (s *SnapTestSuite) TestInstallAppTwiceFails(c *C) {
 "version": "2",
 "developer": "test",
 "anon_download_url": "`+dlURL+`",
+"download_url": "`+dlURL+`",
 "icon_url": "`+iconURL+`"
 }`)
 		case "/dl":
@@ -285,6 +286,7 @@ func (s *SnapTestSuite) TestUpdate(c *C) {
         "revision": 1,
         "origin": "`+testDeveloper+`",
 	"anon_download_url": "`+dlURL+`",
+	"download_url": "`+dlURL+`",
 	"icon_url": "`+iconURL+`"
 }]`)
 	}))

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -306,6 +306,7 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryInstallRemoteSnap(c *C) {
 
 	r := &store.RemoteSnap{}
 	r.Pkg.AnonDownloadURL = mockServer.URL + "/snap"
+	r.Pkg.DownloadURL = mockServer.URL + "/snap"
 	r.Pkg.IconURL = mockServer.URL + "/icon"
 	r.Pkg.Name = "foo"
 	r.Pkg.Developer = "bar"
@@ -360,6 +361,7 @@ apps:
 
 	r := &store.RemoteSnap{}
 	r.Pkg.AnonDownloadURL = mockServer.URL + "/snap"
+	r.Pkg.DownloadURL = mockServer.URL + "/snap"
 	r.Pkg.Developer = testDeveloper
 	r.Pkg.IconURL = mockServer.URL + "/icon"
 	r.Pkg.Name = "foo"


### PR DESCRIPTION
The store also provides the two urls (auth and anonymous). This fixes a test failure
when the tests are run locally with a sso token in the developers
home directory.

This is an updated version of https://github.com/ubuntu-core/snappy/pull/760 that only fixes the tests instead of adding a condition in the actual code that is never true for the real-world (only for the tests).