### PR TITLE
overlord/snapstate: add SnapInfo

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -230,6 +230,10 @@ func (m *SnapManager) Stop() {
 }
 
 // SnapInfo returns snap.Info for a given snap name and snap version.
+//
+// Snap name and version are used to locate the snap.yaml in the filesystem.
+// Some information is not present in the YAML and is looked up in the state
+// instead.
 func SnapInfo(state *state.State, snapName, snapVersion string) (*snap.Info, error) {
 	fname := filepath.Join(dirs.SnapSnapsDir, snapName, snapVersion, "meta", "snap.yaml")
 	yamlData, err := ioutil.ReadFile(fname)
@@ -240,7 +244,9 @@ func SnapInfo(state *state.State, snapName, snapVersion string) (*snap.Info, err
 	if err != nil {
 		return nil, err
 	}
-	// XXX: requested by pedronis
+	// Overwrite the name which doesn't belong in snap.yaml and is actually
+	// defined by snap declaration assertion.
 	info.Name = snapName
+	// TODO: use state to retrieve additional information
 	return info, nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -22,11 +22,15 @@ package snapstate
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/overlord/state"
+	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snappy"
 )
 
@@ -223,4 +227,21 @@ func (m *SnapManager) Wait() {
 // Stop implements StateManager.Stop.
 func (m *SnapManager) Stop() {
 	m.runner.Stop()
+}
+
+// SnapInfo returns snap.Info for a given snap name and snap version.
+func SnapInfo(state *state.State, snapName, snapVersion string) (*snap.Info, error) {
+	fname := filepath.Join(dirs.SnapSnapsDir, snapName, snapVersion, "meta", "snap.yaml")
+	yamlData, err := ioutil.ReadFile(fname)
+	if err != nil {
+		return nil, err
+	}
+	info, err := snap.InfoFromSnapYaml(yamlData)
+	if err != nil {
+		return nil, err
+	}
+	// XXX: requested by pedronis
+	info.Name = snapName
+	info.Version = snapVersion
+	return info, nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -229,11 +229,11 @@ func (m *SnapManager) Stop() {
 	m.runner.Stop()
 }
 
-// SnapInfo returns snap.Info for a given snap name and snap version.
+// SnapInfo returns the snap.Info for a snap in the system.
 //
-// Snap name and version are used to locate the snap.yaml in the filesystem.
-// Some information is not present in the YAML and is looked up in the state
-// instead.
+// Today this function is looking at data directly from the mounted snap, but soon it will
+// be changed so it looks first at the state for the snap details (Revision, Developer, etc),
+// and then complements it with information from the snap itself.
 func SnapInfo(state *state.State, snapName, snapVersion string) (*snap.Info, error) {
 	fname := filepath.Join(dirs.SnapSnapsDir, snapName, snapVersion, "meta", "snap.yaml")
 	yamlData, err := ioutil.ReadFile(fname)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -242,6 +242,5 @@ func SnapInfo(state *state.State, snapName, snapVersion string) (*snap.Info, err
 	}
 	// XXX: requested by pedronis
 	info.Name = snapName
-	info.Version = snapVersion
 	return info, nil
 }

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -243,17 +243,16 @@ func (s *snapmgrTestSuite) TestSnapInfo(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("")
 
-	// Write a snap.yaml with fake name and version
+	// Write a snap.yaml with fake name
 	dname := filepath.Join(dirs.SnapSnapsDir, "samba", "123", "meta")
 	err := os.MkdirAll(dname, 0775)
 	c.Assert(err, IsNil)
 	fname := filepath.Join(dname, "snap.yaml")
-	err = ioutil.WriteFile(fname, []byte("name: ---\nversion: ---\n"), 0644)
+	err = ioutil.WriteFile(fname, []byte("name: ---\n"), 0644)
 	c.Assert(err, IsNil)
 
-	// Ensure that name and version are overridden
+	// Ensure that name is overridden
 	snapInfo, err := snapstate.SnapInfo(s.state, "samba", "123")
 	c.Assert(err, IsNil)
 	c.Check(snapInfo.Name, Equals, "samba")
-	c.Check(snapInfo.Version, Equals, "123")
 }

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -244,15 +244,15 @@ func (s *snapmgrTestSuite) TestSnapInfo(c *C) {
 	defer dirs.SetRootDir("")
 
 	// Write a snap.yaml with fake name
-	dname := filepath.Join(dirs.SnapSnapsDir, "samba", "123", "meta")
+	dname := filepath.Join(dirs.SnapSnapsDir, "name", "version", "meta")
 	err := os.MkdirAll(dname, 0775)
 	c.Assert(err, IsNil)
 	fname := filepath.Join(dname, "snap.yaml")
-	err = ioutil.WriteFile(fname, []byte("name: ---\n"), 0644)
+	err = ioutil.WriteFile(fname, []byte("name: ignored"), 0644)
 	c.Assert(err, IsNil)
 
-	// Ensure that name is overridden
-	snapInfo, err := snapstate.SnapInfo(s.state, "samba", "123")
+	// Check that the name in the YAML is being ignored.
+	snapInfo, err := snapstate.SnapInfo(s.state, "name", "version")
 	c.Assert(err, IsNil)
-	c.Check(snapInfo.Name, Equals, "samba")
+	c.Check(snapInfo.Name, Equals, "name")
 }

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -248,11 +248,17 @@ func (s *snapmgrTestSuite) TestSnapInfo(c *C) {
 	err := os.MkdirAll(dname, 0775)
 	c.Assert(err, IsNil)
 	fname := filepath.Join(dname, "snap.yaml")
-	err = ioutil.WriteFile(fname, []byte("name: ignored"), 0644)
+	err = ioutil.WriteFile(fname, []byte(`
+name: ignored
+description: |
+    Lots of text`), 0644)
+	c.Assert(err, IsNil)
+
+	snapInfo, err := snapstate.SnapInfo(s.state, "name", "version")
 	c.Assert(err, IsNil)
 
 	// Check that the name in the YAML is being ignored.
-	snapInfo, err := snapstate.SnapInfo(s.state, "name", "version")
-	c.Assert(err, IsNil)
 	c.Check(snapInfo.Name, Equals, "name")
+	// Check that other values are read from YAML
+	c.Check(snapInfo.Description, Equals, "Lots of text")
 }


### PR DESCRIPTION
This branch adds a way to load snap.Info through the overlord and state.State instance.

I intend to use it in the interfaces manager whenever a snap.Info is requested. The function takes snap name and snap version (which can switch to snap revision) and always overwrites snap name and version in the loaded snap.yaml (since snap name and version=>revision is not a property of the yaml).
