### PR TITLE
snappy: re-add custom security profiles in old-security

### DIFF
--- a/snappy/security.go
+++ b/snappy/security.go
@@ -652,6 +652,17 @@ func (sd *SecurityDefinitions) generatePolicyForServiceBinaryResult(m *snapYaml,
 
 	sd.mergeAppArmorSecurityOverrides(&hwaccessOverrides)
 	if sd.SecurityPolicy != nil {
+		res.aaPolicy, err = getAppArmorCustomPolicy(m, res.id, filepath.Join(baseDir, sd.SecurityPolicy.AppArmor), sd.SecurityOverride)
+		if err != nil {
+			logger.Noticef("Failed to generate custom AppArmor policy for %s: %v", m.Name, err)
+			return nil, err
+		}
+		res.scPolicy, err = getSeccompCustomPolicy(m, res.id, filepath.Join(baseDir, sd.SecurityPolicy.Seccomp))
+		if err != nil {
+			logger.Noticef("Failed to generate custom seccomp policy for %s: %v", m.Name, err)
+			return nil, err
+		}
+
 	} else {
 		res.aaPolicy, err = getAppArmorTemplatedPolicy(m, res.id, sd.SecurityTemplate, sd.SecurityCaps, sd.SecurityOverride)
 		if err != nil {


### PR DESCRIPTION
Drive-by branch to re-add old-security and custom profiles support. I can add tests if needed but this code (security.go) will go away soon in favour of the interfaces code. This will make webdm work again.