### PR TITLE
store,snappy,daemon: get rid of confusing Description method in snap_local.go/snap_remote.go

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -28,6 +28,8 @@ import (
 
 // Snap holds the data for a snap as obtained from snapd.
 type Snap struct {
+	// XXX: actually add summary to the REST api when the store provides it
+	Summary       string `json:"summary"`
 	Description   string `json:"description"`
 	DownloadSize  int64  `json:"download_size"`
 	Icon          string `json:"icon"`

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -81,7 +81,7 @@ func (x *cmdFind) Execute([]string) error {
 
 	for _, name := range names {
 		snap := snaps[name]
-		fmt.Fprintf(w, "%s\t%s\t%s\n", name, snap.Version, snap.Description)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", name, snap.Version, snap.Summary)
 	}
 
 	return nil

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -217,10 +217,9 @@ func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {
 	s.parts = []*store.RemoteSnap{
 		&store.RemoteSnap{
 			Pkg: remote.Snap{
-				Name:    "foo",
-				Version: "v2",
-				// FIXME: sucks that title is descripton!
-				Title:        "description",
+				Name:         "foo",
+				Version:      "v2",
+				Description:  "description",
 				Developer:    "bar",
 				IconURL:      "meta/gui/icon.svg",
 				Type:         snap.TypeApp,

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -97,7 +97,7 @@ func mapSnap(localSnaps []*snappy.Snap, remotePart *store.RemoteSnap) map[string
 		_type = string(localSnap.Type())
 
 		icon = localSnap.Icon()
-		description = localSnap.Description()
+		description = localSnap.Info().Description
 		installedSize = localSnap.InstalledSize()
 
 		downloadSize = localSnap.DownloadSize()
@@ -113,7 +113,7 @@ func mapSnap(localSnaps []*snappy.Snap, remotePart *store.RemoteSnap) map[string
 			icon = remotePart.Icon()
 		}
 		if description == "" {
-			description = remotePart.Description()
+			description = remotePart.Info().Description
 		}
 
 		downloadSize = remotePart.DownloadSize()

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -36,10 +36,11 @@ type searchSuite struct {
 func (s *searchSuite) TestSearchMustPrintMatch(c *check.C) {
 	searchOutput := cli.ExecCommand(c, "snap", "find", "hello-world")
 
+	// XXX: Summary is empty atm, waiting for store support
 	expected := "(?ms)" +
 		"Name +Version +Summary *\n" +
 		".*" +
-		"^hello-world +.* +hello-world *\n" +
+		"^hello-world +.* *\n" +
 		".*"
 
 	c.Assert(searchOutput, check.Matches, expected)

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -57,6 +57,8 @@ func init() {
 func makeInstalledMockSnap(tempdir, snapYamlContent string) (yamlFile string, err error) {
 	const packageHello = `name: hello-snap
 version: 1.10
+summary: hello
+description: Hello...
 apps:
  hello:
   command: bin/hello
@@ -105,14 +107,15 @@ apps:
 		return "", err
 	}
 
-	if err := storeMinimalRemoteManifest(m.Name, testDeveloper, m.Version, "Hello", "remote-channel"); err != nil {
+	if err := storeMinimalRemoteManifest(m.Name, testDeveloper, m.Version, "hello-title", "Hello...", "remote-channel"); err != nil {
 		return "", err
 	}
 
 	return yamlFile, nil
 }
 
-func storeMinimalRemoteManifest(name, developer, version, desc, channel string) error {
+func storeMinimalRemoteManifest(name, developer, version, title, desc, channel string) error {
+	// XXX: title is unfortunate
 	if developer == SideloadedDeveloper {
 		panic("store remote manifest for sideloaded package")
 	}
@@ -120,6 +123,7 @@ func storeMinimalRemoteManifest(name, developer, version, desc, channel string) 
 		Name:        name,
 		Developer:   developer,
 		Version:     version,
+		Title:       title,
 		Description: desc,
 		Channel:     channel,
 	})
@@ -249,12 +253,12 @@ func makeTwoTestSnaps(c *C, snapType snap.Type, extra ...string) {
 	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
 	_, err := (&Overlord{}).Install(snapFile, AllowUnauthenticated|AllowGadget, inter)
 	c.Assert(err, IsNil)
-	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "1.0", "", "remote-channel"), IsNil)
+	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "1.0", "", "", "remote-channel"), IsNil)
 
 	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
 	_, err = (&Overlord{}).Install(snapFile, AllowUnauthenticated|AllowGadget, inter)
 	c.Assert(err, IsNil)
-	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "2.0", "", "remote-channel"), IsNil)
+	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "2.0", "", "", "remote-channel"), IsNil)
 
 	installed, err := (&Overlord{}).Installed()
 	c.Assert(err, IsNil)

--- a/snappy/info_test.go
+++ b/snappy/info_test.go
@@ -79,7 +79,7 @@ type: os`)
 	}
 
 	// now remove the channel
-	storeMinimalRemoteManifest("app", testDeveloper, "1.10", "Hello.", "")
+	storeMinimalRemoteManifest("app", testDeveloper, "1.10", "hello", "Hello.", "")
 	for _, t := range []T{
 		{fullNameWithChannel, snap.TypeApp, "app." + testDeveloper},
 	} {

--- a/snappy/overlord_test.go
+++ b/snappy/overlord_test.go
@@ -244,7 +244,7 @@ type: gadget
 `)
 	_, err := (&Overlord{}).Install(snapFile, AllowGadget, nil)
 	c.Assert(err, IsNil)
-	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "1.0", "", "remote-channel"), IsNil)
+	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "1.0", "", "", "remote-channel"), IsNil)
 
 	contentFile := filepath.Join(s.tempdir, "snaps", "foo", "1.0", "bin", "foo")
 	_, err = os.Stat(contentFile)
@@ -257,7 +257,7 @@ type: gadget
 `)
 	_, err = (&Overlord{}).Install(snapFile, 0, nil)
 	c.Check(err, IsNil)
-	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "2.0", "", "remote-channel"), IsNil)
+	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "2.0", "", "", "remote-channel"), IsNil)
 
 	// a package name fork, IOW, a different Gadget package.
 	snapFile = makeTestSnapPackage(c, `name: foo-fork

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -131,15 +131,6 @@ func (s *Snap) Revision() int {
 	return 0
 }
 
-// Description returns the summary description
-func (s *Snap) Description() string {
-	if r := s.remoteM; r != nil {
-		return r.Description
-	}
-
-	return s.m.Summary
-}
-
 // Developer returns the developer
 func (s *Snap) Developer() string {
 	if r := s.remoteM; r != nil {
@@ -196,6 +187,15 @@ func (s *Snap) InstalledSize() int64 {
 	return totalSize
 }
 
+func (s *Snap) description() string {
+	// store edits win!
+	if r := s.remoteM; r != nil {
+		return r.Description
+	}
+
+	return s.m.Description
+}
+
 // Info returns the snap.Info data.
 func (s *Snap) Info() *snap.Info {
 	return &snap.Info{
@@ -205,7 +205,8 @@ func (s *Snap) Info() *snap.Info {
 		Revision:    s.Revision(),
 		Type:        s.Type(),
 		Channel:     s.Channel(),
-		Description: s.Description(),
+		Summary:     s.m.Summary, // XXX: doesn't exist in the store yet anyway
+		Description: s.description(),
 	}
 }
 

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -136,7 +136,8 @@ func (s *SnapTestSuite) TestLocalSnapSimple(c *C) {
 	c.Check(snap.Name(), Equals, "hello-snap")
 	c.Check(snap.Version(), Equals, "1.10")
 	c.Check(snap.IsActive(), Equals, false)
-	c.Check(snap.Description(), Equals, "Hello")
+	c.Check(snap.Info().Summary, Equals, "hello")
+	c.Check(snap.Info().Description, Equals, "Hello...")
 	c.Check(snap.IsInstalled(), Equals, true)
 
 	apps := snap.Apps()
@@ -326,7 +327,7 @@ func (s *SnapTestSuite) TestUbuntuStoreRepositoryInstallRemoteSnap(c *C) {
 	c.Assert(installed, HasLen, 1)
 
 	c.Check(installed[0].Developer(), Equals, "bar")
-	c.Check(installed[0].Description(), Equals, "this is a description")
+	c.Check(installed[0].Info().Description, Equals, "this is a description")
 
 	_, err = os.Stat(filepath.Join(dirs.SnapMetaDir, "foo_1.0.manifest"))
 	c.Check(err, IsNil)

--- a/store/snap_remote.go
+++ b/store/snap_remote.go
@@ -52,11 +52,6 @@ func (s *RemoteSnap) Revision() int {
 	return s.Pkg.Revision
 }
 
-// Description returns the description
-func (s *RemoteSnap) Description() string {
-	return s.Pkg.Title
-}
-
 // Developer is the developer
 func (s *RemoteSnap) Developer() string {
 	return s.Pkg.Developer
@@ -86,7 +81,8 @@ func (s *RemoteSnap) Info() *snap.Info {
 		Revision:    s.Revision(),
 		Type:        s.Type(),
 		Channel:     s.Channel(),
-		Description: s.Description(),
+		Summary:     s.Pkg.Title,       // XXX: should be summary when the store provides it
+		Description: s.Pkg.Description, // XXX not quite right but ok for now
 	}
 }
 

--- a/store/snap_remote.go
+++ b/store/snap_remote.go
@@ -81,7 +81,7 @@ func (s *RemoteSnap) Info() *snap.Info {
 		Revision:    s.Revision(),
 		Type:        s.Type(),
 		Channel:     s.Channel(),
-		Summary:     "",       // XXX: should be summary when the store provides it
+		Summary:     "",                // XXX: should be summary when the store provides it
 		Description: s.Pkg.Description, // XXX not quite right but ok for now
 	}
 }

--- a/store/snap_remote.go
+++ b/store/snap_remote.go
@@ -81,7 +81,7 @@ func (s *RemoteSnap) Info() *snap.Info {
 		Revision:    s.Revision(),
 		Type:        s.Type(),
 		Channel:     s.Channel(),
-		Summary:     s.Pkg.Title,       // XXX: should be summary when the store provides it
+		Summary:     "",       // XXX: should be summary when the store provides it
 		Description: s.Pkg.Description, // XXX not quite right but ok for now
 	}
 }


### PR DESCRIPTION
This gets rid of confusing Description method in snap_local.go/snap_remote.go in favor of reading that out of snap.Infos.