### PR TITLE
interfaces/apparmor: unload removed profiles even if ensure fails

### DIFF
--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -77,10 +77,7 @@ func ensureDirState(dir, glob string, content map[string]*osutil.FileState, snap
 	if errEnsure != nil {
 		return fmt.Errorf("cannot synchronize udev rules for snap %q: %s", snapInfo.Name, errEnsure)
 	}
-	if errReload != nil {
-		return errReload
-	}
-	return nil
+	return errReload
 }
 
 // combineSnippets combines security snippets collected from all the interfaces


### PR DESCRIPTION
This patch updates the apparmor security backend based on the lessons
learned from the udev backend. When EnsureDirState fails we should
reload/unload all of the affected profiles before returning the error.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>