### PR TITLE
overlord: add stubs for configure/deconfigure security

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -58,7 +58,34 @@ func Manager(s *state.State) (*InterfaceManager, error) {
 
 	runner.AddHandler("connect", m.doConnect, nil)
 	runner.AddHandler("disconnect", m.doDisconnect, nil)
+	runner.AddHandler("configure-security", m.doConfigureSecurity, nil)
+	runner.AddHandler("deconfigure-security", m.doConfigureSecurity, nil)
 	return m, nil
+}
+
+func (m *InterfaceManager) doConfigureSecurity(task *state.Task, _ *tomb.Tomb) error {
+	task.State().Lock()
+	defer task.State().Unlock()
+	// TODO: disconnect all connections affecting given snap
+	// TODO:  - remembering affected snaps
+	// TODO: remove old version of the snap from repository
+	// TODO: add new version of the snap to repository
+	// TODO: re-connect all connection affecting given snap
+	// TODO:  - remembering affected snaps
+	// TODO: configure security of all affected snaps
+	return nil
+}
+
+func (m *InterfaceManager) doDeconfigureSecurity(task *state.Task, _ *tomb.Tomb) error {
+	task.State().Lock()
+	defer task.State().Unlock()
+	// TODO: disconnect all connections affecting given snap
+	// TODO:  - remembering affected snaps
+	// TODO: remove the snap from repository
+	// TODO: configure security of all affected snaps
+	//
+	// XXX: should we forget any persistent intents here?
+	return nil
 }
 
 // Connect returns a set of tasks for connecting an interface.

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -59,7 +59,7 @@ func Manager(s *state.State) (*InterfaceManager, error) {
 	runner.AddHandler("connect", m.doConnect, nil)
 	runner.AddHandler("disconnect", m.doDisconnect, nil)
 	runner.AddHandler("configure-security", m.doConfigureSecurity, nil)
-	runner.AddHandler("deconfigure-security", m.doConfigureSecurity, nil)
+	runner.AddHandler("deconfigure-security", m.doDeconfigureSecurity, nil)
 	return m, nil
 }
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snappy"
@@ -249,4 +250,26 @@ func SnapInfo(state *state.State, snapName, snapVersion string) (*snap.Info, err
 	info.Name = snapName
 	// TODO: use state to retrieve additional information
 	return info, nil
+}
+
+// ConfigureSecurity creates a task for configuring the security of a given snap.
+//
+// This method should be used when the snap is being installed or upgraded.
+func ConfigureSecurity(s *state.State, snapInfo *snap.Info) (*state.TaskSet, error) {
+	summary := fmt.Sprintf(i18n.G("Configure security for %s"), snapInfo.Name)
+	task := s.NewTask("configure-security", summary)
+	task.Set("snap-name", snapInfo.Name)
+	task.Set("snap-version", snapInfo.Version)
+	return state.NewTaskSet(task), nil
+}
+
+// DeconfigureSecurity creates a task for deconfiguring security of a given snap.
+//
+// This method should be used when the snap is being removed.
+func DeconfigureSecurity(s *state.State, snapInfo *snap.Info) (*state.TaskSet, error) {
+	summary := fmt.Sprintf(i18n.G("Deconfigure security for %s"), snapInfo.Name)
+	task := s.NewTask("deconfigure-security", summary)
+	task.Set("snap-name", snapInfo.Name)
+	task.Set("snap-version", snapInfo.Version)
+	return state.NewTaskSet(task), nil
 }


### PR DESCRIPTION
This patch adds stubs for configuring and decofiguring security of a
single snap. The intent of the patch is to start a discussion on the
intended logic of the stubs.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>