### PR TITLE
overlord/ifacestate: store the set of intended connections in the state

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -137,3 +137,13 @@ func (m *InterfaceManager) Stop() {
 	m.runner.Stop()
 
 }
+
+func getIntents(s *state.State) Intents {
+	var intents Intents
+	s.Get("connection-intents", &intents)
+	return intents
+}
+
+func setIntents(s *state.State, intents Intents) {
+	s.Set("connection-intents", intents)
+}

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -81,13 +81,18 @@ func Connect(s *state.State, plugSnap, plugName, slotSnap, slotName string) (*st
 
 // Disconnect returns a set of tasks for  disconnecting an interface.
 func Disconnect(s *state.State, plugSnap, plugName, slotSnap, slotName string) (*state.TaskSet, error) {
-	// TODO: Remove the intent-to-connect from the state so that we no longer
-	// automatically try to reconnect on reboot.
+	plugRef := interfaces.PlugRef{Snap: plugSnap, Name: plugName}
+	slotRef := interfaces.SlotRef{Snap: slotSnap, Name: slotName}
+	// Remove the intent to connect if one is present
+	intents := getIntents(s)
+	intents.Remove(Intent{Plug: plugRef, Slot: slotRef})
+	setIntents(s, intents)
+	// Create a task to do the actual disconnect operation
 	summary := fmt.Sprintf(i18n.G("Disconnect %s:%s from %s:%s"),
 		plugSnap, plugName, slotSnap, slotName)
 	task := s.NewTask("disconnect", summary)
-	task.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
-	task.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plugName})
+	task.Set("plug", plugRef)
+	task.Set("slot", slotRef)
 	return state.NewTaskSet(task), nil
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -64,14 +64,18 @@ func Manager(s *state.State) (*InterfaceManager, error) {
 // Connect returns a set of tasks for connecting an interface.
 //
 func Connect(s *state.State, plugSnap, plugName, slotSnap, slotName string) (*state.TaskSet, error) {
-	// TODO: Store the intent-to-connect in the state so that we automatically
-	// try to reconnect on reboot (reconnection can fail or can connect with
-	// different parameters so we cannot store the actual connection details).
+	plugRef := interfaces.PlugRef{Snap: plugSnap, Name: plugName}
+	slotRef := interfaces.SlotRef{Snap: slotSnap, Name: slotName}
+	// Store the intent to connect
+	intents := getIntents(s)
+	intents.Add(Intent{Plug: plugRef, Slot: slotRef})
+	setIntents(s, intents)
+	// Create a task to do the actual connect operation
 	summary := fmt.Sprintf(i18n.G("Connect %s:%s to %s:%s"),
 		plugSnap, plugName, slotSnap, slotName)
 	task := s.NewTask("connect", summary)
-	task.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
-	task.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plugName})
+	task.Set("plug", plugRef)
+	task.Set("slot", slotRef)
 	return state.NewTaskSet(task), nil
 }
 

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -63,6 +63,16 @@ func (s *interfaceManagerSuite) TestConnectTask(c *C) {
 	ts, err := ifacestate.Connect(s.state, "consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
 
+	// Connect stored the intent to connect
+	var intents ifacestate.Intents
+	err = s.state.Get("connection-intents", &intents)
+	c.Assert(err, IsNil)
+	c.Check(intents, DeepEquals, ifacestate.Intents{{
+		Plug: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		Slot: interfaces.SlotRef{Snap: "producer", Name: "slot"},
+	}})
+
+	// Connect created a task with appropriate data
 	task := ts.Tasks()[0]
 	c.Assert(task.Kind(), Equals, "connect")
 	var plug interfaces.PlugRef

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -127,9 +127,21 @@ func (s *interfaceManagerSuite) TestDisconnectTask(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	intents := ifacestate.Intents{{
+		Plug: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
+		Slot: interfaces.SlotRef{Snap: "producer", Name: "slot"},
+	}}
+	s.state.Set("connection-intents", intents)
+
 	ts, err := ifacestate.Disconnect(s.state, "consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
 
+	// Disconnect removed the intent to connect
+	err = s.state.Get("connection-intents", &intents)
+	c.Assert(err, IsNil)
+	c.Check(intents, HasLen, 0)
+
+	// Disconnect created a task with appropriate data
 	task := ts.Tasks()[0]
 	c.Assert(task.Kind(), Equals, "disconnect")
 	var plug interfaces.PlugRef

--- a/overlord/ifacestate/intents.go
+++ b/overlord/ifacestate/intents.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"github.com/ubuntu-core/snappy/interfaces"
+)
+
+// Intent expresses persistent intent to connect or disconnect certain plug and
+// slot.  Intents are a part of the persistent state of the manager.
+type Intent struct {
+	Action string             `json:"action"`
+	Plug   interfaces.PlugRef `json:"plug"`
+	Slot   interfaces.SlotRef `json:"slot"`
+}
+
+const (
+	// IntentConnect represents desire to connect a plug to a slot.
+	IntentConnect = "connect"
+	// IntentDisconnect represents desire to disconnect a plug from a slot.
+	IntentDisconnect = "disconnect"
+)

--- a/overlord/ifacestate/intents.go
+++ b/overlord/ifacestate/intents.go
@@ -23,17 +23,22 @@ import (
 	"github.com/ubuntu-core/snappy/interfaces"
 )
 
-// Intent expresses persistent intent to connect or disconnect certain plug and
-// slot.  Intents are a part of the persistent state of the manager.
+// Intent expresses persistent intent to connect a certain plug and slot.
+// Intents are a part of the persistent state of the manager.
 type Intent struct {
-	Action string             `json:"action"`
-	Plug   interfaces.PlugRef `json:"plug"`
-	Slot   interfaces.SlotRef `json:"slot"`
+	Plug interfaces.PlugRef `json:"plug"`
+	Slot interfaces.SlotRef `json:"slot"`
 }
 
-const (
-	// IntentConnect represents desire to connect a plug to a slot.
-	IntentConnect = "connect"
-	// IntentDisconnect represents desire to disconnect a plug from a slot.
-	IntentDisconnect = "disconnect"
-)
+// Intents is a slice of intents
+type Intents []Intent
+
+// Add add an intent to the list. Duplicate intents are merged.
+func (intents *Intents) Add(intent Intent) {
+	for _, otherIntent := range *intents {
+		if otherIntent == intent {
+			return
+		}
+	}
+	*intents = append(*intents, intent)
+}

--- a/overlord/ifacestate/intents.go
+++ b/overlord/ifacestate/intents.go
@@ -42,3 +42,13 @@ func (intents *Intents) Add(intent Intent) {
 	}
 	*intents = append(*intents, intent)
 }
+
+// Remove an intent from the list.
+func (intents *Intents) Remove(intent Intent) {
+	for i, otherIntent := range *intents {
+		if otherIntent == intent {
+			*intents = append((*intents)[:i], (*intents)[i+1:]...)
+			break
+		}
+	}
+}

--- a/overlord/ifacestate/intents_test.go
+++ b/overlord/ifacestate/intents_test.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"encoding/json"
+
+	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/overlord/ifacestate"
+)
+
+type intentSuite struct {
+	intent ifacestate.Intent
+}
+
+var _ = check.Suite(&intentSuite{
+	intent: ifacestate.Intent{
+		Action: ifacestate.IntentConnect,
+		Plug:   interfaces.PlugRef{"snap", "plug"},
+		Slot:   interfaces.SlotRef{"snap", "slot"},
+	},
+})
+
+func (s *intentSuite) TestMarshallToJSON(c *check.C) {
+	data, err := json.Marshal(s.intent)
+	c.Assert(err, check.IsNil)
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.DeepEquals, map[string]interface{}{
+		"action": "connect",
+		"plug": map[string]interface{}{
+			"snap": "snap",
+			"plug": "plug",
+		},
+		"slot": map[string]interface{}{
+			"snap": "snap",
+			"slot": "slot",
+		},
+	})
+}
+
+func (s *intentSuite) TestMarshallFromJSON(c *check.C) {
+	data := []byte(`
+	{
+		"action": "connect",
+		"plug": { 
+			"snap": "snap",
+			"plug": "plug"
+		},
+		"slot": { 
+			"snap": "snap",
+			"slot": "slot"
+		}
+	}`)
+	var intent ifacestate.Intent
+	err := json.Unmarshal(data, &intent)
+	c.Assert(err, check.IsNil)
+	c.Check(intent, check.DeepEquals, s.intent)
+}

--- a/overlord/ifacestate/intents_test.go
+++ b/overlord/ifacestate/intents_test.go
@@ -91,3 +91,13 @@ func (s *intentSuite) TestAdd(c *check.C) {
 	intents.Add(s.otherIntent)
 	c.Assert(intents, check.DeepEquals, ifacestate.Intents{s.intent, s.otherIntent})
 }
+
+func (s *intentSuite) TestRemove(c *check.C) {
+	intents := ifacestate.Intents{s.intent}
+	// Removing intents that are not present is harmless
+	intents.Remove(s.otherIntent)
+	c.Assert(intents, check.HasLen, 1)
+	// Removing intents that are present works
+	intents.Remove(s.intent)
+	c.Assert(intents, check.HasLen, 0)
+}


### PR DESCRIPTION
This branch adds the concept of Intent that is persistently stored by the interfaces manager.

When a connection is requested this fact is stored as an intent in the state. The operation is undone
for disconnections. Intents are persistent as they express an action that the system operator has performed.

Intents are also about to play an essential role when generating security on snap updates as they will be used to know which connections should be re-established when the snap changes.