### PR TITLE
store/auth: add helper to get package access macaroon from the store

### DIFF
--- a/store/auth.go
+++ b/store/auth.go
@@ -80,10 +80,10 @@ func RequestStoreToken(username, password, tokenName, otp string) (*StoreToken, 
 	}
 
 	req, err := http.NewRequest("POST", ubuntuoneOauthAPI, strings.NewReader(string(jsonData)))
-	req.Header.Set("content-type", "application/json")
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("content-type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -167,11 +167,11 @@ func RequestPackageAccessMacaroon() (string, error) {
 
 	emptyJSONData := "{}"
 	req, err := http.NewRequest("POST", myappsPackageAccessAPI, strings.NewReader(emptyJSONData))
-	req.Header.Set("accept", "application/json")
-	req.Header.Set("content-type", "application/json")
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
+	req.Header.Set("accept", "application/json")
+	req.Header.Set("content-type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/store/auth.go
+++ b/store/auth.go
@@ -163,7 +163,7 @@ func ReadStoreToken() (*StoreToken, error) {
 
 // RequestPackageAccessMacaroon requests a macaroon for accessing package data from the ubuntu store
 func RequestPackageAccessMacaroon() (string, error) {
-	emptyJsonData := ""
+	emptyJsonData := "{}"
 	req, err := http.NewRequest("POST", myappsPackageAccessAPI, strings.NewReader(emptyJsonData))
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("content-type", "application/json")

--- a/store/auth.go
+++ b/store/auth.go
@@ -163,27 +163,26 @@ func ReadStoreToken() (*StoreToken, error) {
 
 // RequestPackageAccessMacaroon requests a macaroon for accessing package data from the ubuntu store
 func RequestPackageAccessMacaroon() (string, error) {
-	const errorPrefix = "cannot get package access macaroon from store: %v"
+	const errorPrefix = "cannot get package access macaroon from store: "
 
 	emptyJSONData := "{}"
 	req, err := http.NewRequest("POST", myappsPackageAccessAPI, strings.NewReader(emptyJSONData))
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("content-type", "application/json")
 	if err != nil {
-		return "", fmt.Errorf(errorPrefix, err)
+		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf(errorPrefix, err)
+		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
 	defer resp.Body.Close()
 
 	// check return code, error on anything !200
 	if resp.StatusCode != 200 {
-		errorMsg := fmt.Sprintf("store server returned status %d", resp.StatusCode)
-		return "", fmt.Errorf(errorPrefix, errorMsg)
+		return "", fmt.Errorf(errorPrefix+"store server returned status %d", resp.StatusCode)
 	}
 
 	dec := json.NewDecoder(resp.Body)
@@ -191,11 +190,11 @@ func RequestPackageAccessMacaroon() (string, error) {
 		Macaroon string `json:"macaroon"`
 	}
 	if err := dec.Decode(&responseData); err != nil {
-		return "", fmt.Errorf(errorPrefix, err)
+		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
 
 	if responseData.Macaroon == "" {
-		return "", fmt.Errorf(errorPrefix, "empty macaroon returned")
+		return "", fmt.Errorf(errorPrefix + "empty macaroon returned")
 	}
 	return responseData.Macaroon, nil
 }

--- a/store/auth.go
+++ b/store/auth.go
@@ -176,7 +176,7 @@ func RequestPackageAccessMacaroon() (string, error) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf(errorPrefix, err)
 	}
 	defer resp.Body.Close()
 

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -83,8 +83,6 @@ const mockStoreReturnMacaroon = `
 
 const mockStoreReturnNoMacaroon = `{}`
 
-const mockStoreServerErrorHTTPCode = 500
-
 func (s *authTestSuite) TestRequestStoreToken(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, mockStoreReturnToken)
@@ -153,17 +151,16 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroonMissingData(c *C) {
 	c.Assert(macaroon, Equals, "")
 }
 
-func (s *authTestSuite) TestRequestPackageAccessMacaroonErrorShowsOopsId(c *C) {
+func (s *authTestSuite) TestRequestPackageAccessMacaroonError(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Oops-Id", "[42]")
-		w.WriteHeader(mockStoreServerErrorHTTPCode)
+		w.WriteHeader(500)
 	}))
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 	myappsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
 
 	macaroon, err := RequestPackageAccessMacaroon()
-	c.Assert(err, ErrorMatches, "failed to get store token: 500 Internal Server Error \\[42\\]")
+	c.Assert(err, ErrorMatches, "cannot get package access macaroon from store: store server returned status 500")
 	c.Assert(macaroon, Equals, "")
 }
 

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -147,7 +147,7 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroonMissingData(c *C) {
 	myappsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
 
 	macaroon, err := RequestPackageAccessMacaroon()
-	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "cannot get package access macaroon from store: empty macaroon returned")
 	c.Assert(macaroon, Equals, "")
 }
 

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -129,7 +129,6 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroon(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, mockStoreReturnMacaroon)
 	}))
-	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 	myappsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
 
@@ -142,7 +141,6 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroonMissingData(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, mockStoreReturnNoMacaroon)
 	}))
-	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 	myappsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
 
@@ -155,7 +153,6 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroonError(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
-	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 	myappsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
 


### PR DESCRIPTION
Add RequestPackageAccessMacaroon to request MyApps for a root macaroon giving package access (search, details and download) in the store.