### PR TITLE
overlord: fix failures caused by the new info.Name()

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -169,7 +169,7 @@ func (f *fakeSnappyBackend) UndoLinkSnap(oldInstSnapPath, instSnapPath string) e
 
 func (f *fakeSnappyBackend) ActiveSnap(name string) *snap.Info {
 	return &snap.Info{
-		Name:    "an-active-snap",
-		Version: "1.64872",
+		SuggestedName: "an-active-snap",
+		Version:       "1.64872",
 	}
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -128,7 +128,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	// find current active and store in case we need to undo
 	if info := m.backend.ActiveSnap(ss.Name); info != nil {
-		ss.OldName = info.Name
+		ss.OldName = info.Name()
 		ss.OldVersion = info.Version
 	}
 


### PR DESCRIPTION
This fixes the recent master test failures.