### PR TITLE
dirs, snappy: use /var/lib/snappy/bin instead of /snaps/bin

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -96,7 +96,7 @@ func SetRootDir(rootdir string) {
 
 	SnapStateFile = filepath.Join(rootdir, snappyDir, "state.json")
 
-	SnapBinariesDir = filepath.Join(SnapSnapsDir, "bin")
+	SnapBinariesDir = filepath.Join(rootdir, snappyDir, "bin")
 	SnapServicesDir = filepath.Join(rootdir, "/etc/systemd/system")
 	SnapBusPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/system.d")
 

--- a/etc/profile.d/apps-bin-path.sh
+++ b/etc/profile.d/apps-bin-path.sh
@@ -1,3 +1,3 @@
 # Expand the $PATH to include /snaps/bin which is what snappy applications
 # use
-PATH=$PATH:/snaps/bin
+PATH=$PATH:/var/lib/snappy/bin

--- a/snappy/desktop_test.go
+++ b/snappy/desktop_test.go
@@ -182,7 +182,7 @@ Exec=snap.app %U
 	e := sanitizeDesktopFile(snap, "/my/basedir", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
 Name=foo
-Exec=/snaps/bin/snap.app %U`)
+Exec=/var/lib/snappy/bin/snap.app %U`)
 }
 
 // we do not support TryExec (even if its a valid line), this test ensures
@@ -245,7 +245,7 @@ apps:
 
 	newl, err := rewriteExecLine(snap, "Exec=snap.app")
 	c.Assert(err, IsNil)
-	c.Assert(newl, Equals, "Exec=/snaps/bin/snap.app")
+	c.Assert(newl, Equals, "Exec=/var/lib/snappy/bin/snap.app")
 }
 
 func (s *SnapTestSuite) TestDesktopFileSanitizeDesktopActionsOk(c *C) {

--- a/snappy/services_test.go
+++ b/snappy/services_test.go
@@ -74,7 +74,7 @@ func (s *SnapTestSuite) TestAddPackageBinariesStripsGlobalRootdir(c *C) {
 	err = addPackageBinaries(snap.Info())
 	c.Assert(err, IsNil)
 
-	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/snaps/bin/hello-snap.hello"))
+	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/var/lib/snappy/bin/hello-snap.hello"))
 	c.Assert(err, IsNil)
 
 	needle := `


### PR DESCRIPTION
Small branch that moves the generated binaries from /snaps/bin to /var/lib/snappy/bin (as discussed during one of the recent sprints).