### PR TITLE
store/auth: add helper to get discharge macaroon

### DIFF
--- a/store/auth.go
+++ b/store/auth.go
@@ -162,7 +162,7 @@ func ReadStoreToken() (*StoreToken, error) {
 	return &readStoreToken, nil
 }
 
-// RequestPackageAccessMacaroon requests a macaroon for accessing package data from the ubuntu store
+// RequestPackageAccessMacaroon requests a macaroon for accessing package data from the ubuntu store.
 func RequestPackageAccessMacaroon() (string, error) {
 	const errorPrefix = "cannot get package access macaroon from store: "
 
@@ -200,7 +200,7 @@ func RequestPackageAccessMacaroon() (string, error) {
 	return responseData.Macaroon, nil
 }
 
-// DischargeAuthCaveat returns a macaroon with the store auth caveat discharged
+// DischargeAuthCaveat returns a macaroon with the store auth caveat discharged.
 func DischargeAuthCaveat(username, password, macaroon, otp string) (string, error) {
 	const errorPrefix = "cannot get discharge macaroon from store: "
 

--- a/store/auth.go
+++ b/store/auth.go
@@ -200,9 +200,9 @@ func RequestPackageAccessMacaroon() (string, error) {
 	return responseData.Macaroon, nil
 }
 
-// RequestDischargeMacaroon requests a discharge macaroon for an existing macaroon
-func RequestDischargeMacaroon(username, password, macaroon, otp string) (string, error) {
-	const errorPrefix = "cannot get discharge macaroon: "
+// DischargeAuthCaveat returns a macaroon with the store auth caveat discharged
+func DischargeAuthCaveat(username, password, macaroon, otp string) (string, error) {
+	const errorPrefix = "cannot get discharge macaroon from store: "
 
 	data := map[string]string{
 		"email":    username,
@@ -244,7 +244,10 @@ func RequestDischargeMacaroon(username, password, macaroon, otp string) (string,
 			return "", ErrAuthenticationNeeds2fa
 		}
 
-		return "", fmt.Errorf(errorPrefix+"%v", msg.Message)
+		if msg.Message != "" {
+			return "", fmt.Errorf(errorPrefix+"%v", msg.Message)
+		}
+		fallthrough
 
 	case !httpStatusCodeSuccess(resp.StatusCode):
 		return "", fmt.Errorf(errorPrefix+"server returned status %d", resp.StatusCode)

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -167,19 +167,19 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroonError(c *C) {
 	c.Assert(macaroon, Equals, "")
 }
 
-func (s *authTestSuite) TestRequestDischargeMacaroon(c *C) {
+func (s *authTestSuite) TestDischargeAuthCaveat(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, mockStoreReturnDischarge)
 	}))
 	defer mockServer.Close()
 	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := RequestDischargeMacaroon("guy@example.com", "passwd", "root-macaroon", "")
+	discharge, err := DischargeAuthCaveat("guy@example.com", "passwd", "root-macaroon", "")
 	c.Assert(err, IsNil)
 	c.Assert(discharge, Equals, "the-discharge-macaroon-serialized-data")
 }
 
-func (s *authTestSuite) TestRequestDischargeMacaroonNeeds2fa(c *C) {
+func (s *authTestSuite) TestDischargeAuthCaveatNeeds2fa(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(mockStoreNeeds2faHTTPCode)
 		io.WriteString(w, mockStoreNeeds2fa)
@@ -187,12 +187,12 @@ func (s *authTestSuite) TestRequestDischargeMacaroonNeeds2fa(c *C) {
 	defer mockServer.Close()
 	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := RequestDischargeMacaroon("foo@example.com", "passwd", "root-macaroon", "")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
 	c.Assert(err, Equals, ErrAuthenticationNeeds2fa)
 	c.Assert(discharge, Equals, "")
 }
 
-func (s *authTestSuite) TestRequestDischargeMacaroonInvalidLogin(c *C) {
+func (s *authTestSuite) TestDischargeAuthCaveatInvalidLogin(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(mockStoreInvalidLoginCode)
 		io.WriteString(w, mockStoreInvalidLogin)
@@ -200,32 +200,32 @@ func (s *authTestSuite) TestRequestDischargeMacaroonInvalidLogin(c *C) {
 	defer mockServer.Close()
 	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := RequestDischargeMacaroon("foo@example.com", "passwd", "root-macaroon", "")
-	c.Assert(err, ErrorMatches, "cannot get discharge macaroon: Provided email/password is not correct.")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: Provided email/password is not correct.")
 	c.Assert(discharge, Equals, "")
 }
 
-func (s *authTestSuite) TestRequestDischargeMacaroonMissingData(c *C) {
+func (s *authTestSuite) TestDischargeAuthCaveatMissingData(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, mockStoreReturnNoMacaroon)
 	}))
 	defer mockServer.Close()
 	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := RequestDischargeMacaroon("foo@example.com", "passwd", "root-macaroon", "")
-	c.Assert(err, ErrorMatches, "cannot get discharge macaroon: empty macaroon returned")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: empty macaroon returned")
 	c.Assert(discharge, Equals, "")
 }
 
-func (s *authTestSuite) TestRequestDischargeMacaroonError(c *C) {
+func (s *authTestSuite) TestDischargeAuthCaveatError(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
 	defer mockServer.Close()
 	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := RequestDischargeMacaroon("foo@example.com", "passwd", "root-macaroon", "")
-	c.Assert(err, ErrorMatches, "cannot get discharge macaroon: server returned status 500")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: server returned status 500")
 	c.Assert(discharge, Equals, "")
 }
 

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -81,6 +81,12 @@ const mockStoreReturnMacaroon = `
 }
 `
 
+const mockStoreReturnDischarge = `
+{
+    "discharge_macaroon": "the-discharge-macaroon-serialized-data"
+}
+`
+
 const mockStoreReturnNoMacaroon = `{}`
 
 func (s *authTestSuite) TestRequestStoreToken(c *C) {
@@ -159,6 +165,68 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroonError(c *C) {
 	macaroon, err := RequestPackageAccessMacaroon()
 	c.Assert(err, ErrorMatches, "cannot get package access macaroon from store: store server returned status 500")
 	c.Assert(macaroon, Equals, "")
+}
+
+func (s *authTestSuite) TestRequestDischargeMacaroon(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, mockStoreReturnDischarge)
+	}))
+	defer mockServer.Close()
+	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+
+	discharge, err := RequestDischargeMacaroon("guy@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, IsNil)
+	c.Assert(discharge, Equals, "the-discharge-macaroon-serialized-data")
+}
+
+func (s *authTestSuite) TestRequestDischargeMacaroonNeeds2fa(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(mockStoreNeeds2faHTTPCode)
+		io.WriteString(w, mockStoreNeeds2fa)
+	}))
+	defer mockServer.Close()
+	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+
+	discharge, err := RequestDischargeMacaroon("foo@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, Equals, ErrAuthenticationNeeds2fa)
+	c.Assert(discharge, Equals, "")
+}
+
+func (s *authTestSuite) TestRequestDischargeMacaroonInvalidLogin(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(mockStoreInvalidLoginCode)
+		io.WriteString(w, mockStoreInvalidLogin)
+	}))
+	defer mockServer.Close()
+	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+
+	discharge, err := RequestDischargeMacaroon("foo@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, ErrorMatches, "cannot get discharge macaroon: Provided email/password is not correct.")
+	c.Assert(discharge, Equals, "")
+}
+
+func (s *authTestSuite) TestRequestDischargeMacaroonMissingData(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, mockStoreReturnNoMacaroon)
+	}))
+	defer mockServer.Close()
+	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+
+	discharge, err := RequestDischargeMacaroon("foo@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, ErrorMatches, "cannot get discharge macaroon: empty macaroon returned")
+	c.Assert(discharge, Equals, "")
+}
+
+func (s *authTestSuite) TestRequestDischargeMacaroonError(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer mockServer.Close()
+	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+
+	discharge, err := RequestDischargeMacaroon("foo@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, ErrorMatches, "cannot get discharge macaroon: server returned status 500")
+	c.Assert(discharge, Equals, "")
 }
 
 func (s *authTestSuite) TestWriteStoreToken(c *C) {


### PR DESCRIPTION
Add DischargeAuthCaveat to request SSO for a discharge macaroon, for a given macaroon, by providing user credentials.