### PR TITLE
interfaces: rename terminology for security backends

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -65,13 +65,13 @@ func (b *Backend) UseLegacyTemplate(template []byte) {
 	b.legacyTemplate = template
 }
 
-// Configure creates and loads apparmor security profiles specific to a given
-// snap. The snap can be in developer mode to make security violations
-// non-fatal to the offending application process.
+// Setup creates and loads apparmor profiles specific to a given snap.
+// The snap can be in developer mode to make security violations non-fatal to
+// the offending application process.
 //
 // This method should be called after changing plug, slots, connections between
 // them or application present in the snap.
-func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityAppArmor)
 	if err != nil {
@@ -95,8 +95,8 @@ func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *inter
 	return errUnload
 }
 
-// Deconfigure removes security artefacts of a given snap.
-func (b *Backend) Deconfigure(snapInfo *snap.Info) error {
+// Remove removes and unloads apparmor profiles of a given snap.
+func (b *Backend) Remove(snapInfo *snap.Info) error {
 	glob := interfaces.SecurityTagGlob(snapInfo)
 	_, removed, errEnsure := osutil.EnsureDirState(dirs.SnapAppArmorDir, glob, nil)
 	errUnload := unloadProfiles(removed)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -103,7 +103,7 @@ func (s *backendSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-// Tests for Configure() and Deconfigure()
+// Tests for Setup() and Remove()
 const sambaYamlV1 = `
 name: samba
 version: 1
@@ -147,7 +147,7 @@ func (s *backendSuite) TestSecurityIsStable(c *C) {
 	for _, developerMode := range []bool{true, false} {
 		snapInfo := s.installSnap(c, developerMode, sambaYamlV1)
 		s.parserCmd.ForgetCalls()
-		err := s.backend.Configure(snapInfo, developerMode, s.repo)
+		err := s.backend.Setup(snapInfo, developerMode, s.repo)
 		c.Assert(err, IsNil)
 		// profiles are not re-compiled or re-loaded when nothing changes
 		c.Check(s.parserCmd.Calls(), HasLen, 0)
@@ -226,7 +226,7 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(sambaYamlV1))
 	c.Assert(err, IsNil)
 	// NOTE: we don't call apparmor.MockTemplate()
-	err = s.backend.Configure(snapInfo, false, s.repo)
+	err = s.backend.Setup(snapInfo, false, s.repo)
 	c.Assert(err, IsNil)
 	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 	data, err := ioutil.ReadFile(profile)
@@ -254,7 +254,7 @@ func (s *backendSuite) TestCustomTemplateUsedOnRequest(c *C) {
 `))
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(sambaYamlV1))
 	c.Assert(err, IsNil)
-	err = s.backend.Configure(snapInfo, false, s.repo)
+	err = s.backend.Setup(snapInfo, false, s.repo)
 	c.Assert(err, IsNil)
 	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 	data, err := ioutil.ReadFile(profile)
@@ -348,7 +348,7 @@ func (s *backendSuite) installSnap(c *C, developerMode bool, snapYaml string) *s
 	// this won't come from snap.yaml
 	snapInfo.Developer = "acme"
 	s.addPlugsSlots(c, snapInfo)
-	err = s.backend.Configure(snapInfo, developerMode, s.repo)
+	err = s.backend.Setup(snapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return snapInfo
 }
@@ -362,14 +362,14 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
 	s.removePlugsSlots(c, oldSnapInfo)
 	s.addPlugsSlots(c, newSnapInfo)
-	err = s.backend.Configure(newSnapInfo, developerMode, s.repo)
+	err = s.backend.Setup(newSnapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return newSnapInfo
 }
 
 // removeSnap "removes" an "installed" snap.
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
-	err := s.backend.Deconfigure(snapInfo)
+	err := s.backend.Remove(snapInfo)
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
 }

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -26,16 +26,16 @@ import (
 // SecurityBackend abstracts interactions between the interface system and the
 // needs of a particular security system.
 type SecurityBackend interface {
-	// Configure creates and loads security artefacts specific to a given snap.
+	// Setup creates and loads security artefacts specific to a given snap.
 	// The snap can be in developer mode to make security violations non-fatal
 	// to the offending application process.
 	//
 	// This method should be called after changing plug, slots, connections
 	// between them or application present in the snap.
-	Configure(snapInfo *snap.Info, developerMode bool, repo *Repository) error
+	Setup(snapInfo *snap.Info, developerMode bool, repo *Repository) error
 
-	// Deconfigure removes security artefacts of a given snap.
+	// Remove removes and unloads security artefacts of a given snap.
 	//
 	// This method should be called during the process of removing a snap.
-	Deconfigure(snapInfo *snap.Info) error
+	Remove(snapInfo *snap.Info) error
 }

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -40,10 +40,10 @@ import (
 // Backend is responsible for maintaining DBus policy files.
 type Backend struct{}
 
-// Configure creates dbus configuration files specific to a given snap.
+// Setup creates dbus configuration files specific to a given snap.
 //
 // DBus has no concept of a complain mode so developerMode is not supported
-func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityDBus)
 	if err != nil {
@@ -62,10 +62,10 @@ func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *inter
 	return nil
 }
 
-// Deconfigure removes security artefacts of a given snap.
+// Remove removes dbus configuration files of a given snap.
 //
 // This method should be called after removing a snap.
-func (b *Backend) Deconfigure(snapInfo *snap.Info) error {
+func (b *Backend) Remove(snapInfo *snap.Info) error {
 	glob := fmt.Sprintf("%s.conf", interfaces.SecurityTagGlob(snapInfo))
 	_, _, err := osutil.EnsureDirState(dirs.SnapBusPolicyDir, glob, nil)
 	if err != nil {

--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -60,7 +60,7 @@ func (s *backendSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-// Tests for Configure() and Deconfigure()
+// Tests for Setup() and Remove()
 const sambaYamlV1 = `
 name: samba
 version: 1
@@ -215,7 +215,7 @@ func (s *backendSuite) installSnap(c *C, developerMode bool, snapYaml string) *s
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
 	s.addPlugsSlots(c, snapInfo)
-	err = s.backend.Configure(snapInfo, developerMode, s.repo)
+	err = s.backend.Setup(snapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return snapInfo
 }
@@ -227,14 +227,14 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
 	s.removePlugsSlots(c, oldSnapInfo)
 	s.addPlugsSlots(c, newSnapInfo)
-	err = s.backend.Configure(newSnapInfo, developerMode, s.repo)
+	err = s.backend.Setup(newSnapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return newSnapInfo
 }
 
 // removeSnap "removes" an "installed" snap.
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
-	err := s.backend.Deconfigure(snapInfo)
+	err := s.backend.Remove(snapInfo)
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
 }

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -45,13 +45,13 @@ import (
 // Backend is responsible for maintaining seccomp profiles for ubuntu-core-launcher.
 type Backend struct{}
 
-// Configure creates seccomp security profiles specific to a given snap. The
-// snap can be in developer mode to make security violations non-fatal to the
-// offending application process.
+// Setup creates seccomp profiles specific to a given snap.
+// The snap can be in developer mode to make security violations non-fatal to
+// the offending application process.
 //
 // This method should be called after changing plug, slots, connections between
 // them or application present in the snap.
-func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecuritySecComp)
 	if err != nil {
@@ -70,8 +70,8 @@ func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *inter
 	return nil
 }
 
-// Deconfigure removes security artefacts of a given snap.
-func (b *Backend) Deconfigure(snapInfo *snap.Info) error {
+// Remove removes seccomp profiles of a given snap.
+func (b *Backend) Remove(snapInfo *snap.Info) error {
 	glob := interfaces.SecurityTagGlob(snapInfo)
 	_, _, err := osutil.EnsureDirState(dirs.SnapSeccompDir, glob, nil)
 	if err != nil {

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -63,7 +63,7 @@ func (s *backendSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-// Tests for Configure() and Deconfigure()
+// Tests for Setup() and Remove()
 const sambaYamlV1 = `
 name: samba
 version: 1
@@ -141,7 +141,7 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(sambaYamlV1))
 	c.Assert(err, IsNil)
 	// NOTE: we don't call seccomp.MockTemplate()
-	err = s.backend.Configure(snapInfo, false, s.repo)
+	err = s.backend.Setup(snapInfo, false, s.repo)
 	c.Assert(err, IsNil)
 	profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
 	data, err := ioutil.ReadFile(profile)
@@ -206,7 +206,7 @@ func (s *backendSuite) installSnap(c *C, developerMode bool, snapYaml string) *s
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
 	s.addPlugsSlots(c, snapInfo)
-	err = s.backend.Configure(snapInfo, developerMode, s.repo)
+	err = s.backend.Setup(snapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return snapInfo
 }
@@ -218,14 +218,14 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
 	s.removePlugsSlots(c, oldSnapInfo)
 	s.addPlugsSlots(c, newSnapInfo)
-	err = s.backend.Configure(newSnapInfo, developerMode, s.repo)
+	err = s.backend.Setup(newSnapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return newSnapInfo
 }
 
 // removeSnap "removes" an "installed" snap.
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
-	err := s.backend.Deconfigure(snapInfo)
+	err := s.backend.Remove(snapInfo)
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
 }

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -37,13 +37,13 @@ import (
 // Backend is responsible for maintaining udev rules.
 type Backend struct{}
 
-// Configure creates udev rules specific to a given snap.
+// Setup creates udev rules specific to a given snap.
 // If any of the rules are changed or removed then udev database is reloaded.
 //
 // Since udev has no concept of a complain mode, developerMode is ignored.
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
-func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityUDev)
 	if err != nil {
 		return fmt.Errorf("cannot obtain udev security snippets for snap %q: %s", snapInfo.Name(), err)
@@ -56,13 +56,13 @@ func (b *Backend) Configure(snapInfo *snap.Info, developerMode bool, repo *inter
 	return ensureDirState(dirs.SnapUdevRulesDir, glob, content, snapInfo)
 }
 
-// Deconfigure removes udev rules specific to a given snap.
+// Remove removes udev rules specific to a given snap.
 // If any of the rules are removed then udev database is reloaded.
 //
 // This method should be called after removing a snap.
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
-func (b *Backend) Deconfigure(snapInfo *snap.Info) error {
+func (b *Backend) Remove(snapInfo *snap.Info) error {
 	glob := fmt.Sprintf("70-%s.rules", interfaces.SecurityTagGlob(snapInfo))
 	return ensureDirState(dirs.SnapUdevRulesDir, glob, nil, snapInfo)
 }

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -65,7 +65,7 @@ func (s *backendSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-// Tests for Configure() and Deconfigure()
+// Tests for Setup() and Remove()
 const sambaYamlV1 = `
 name: samba
 version: 1
@@ -123,7 +123,7 @@ func (s *backendSuite) TestSecurityIsStable(c *C) {
 	for _, developerMode := range []bool{true, false} {
 		snapInfo := s.installSnap(c, developerMode, sambaYamlV1)
 		s.udevadmCmd.ForgetCalls()
-		err := s.backend.Configure(snapInfo, developerMode, s.repo)
+		err := s.backend.Setup(snapInfo, developerMode, s.repo)
 		c.Assert(err, IsNil)
 		// rules are not re-loaded when nothing changes
 		c.Check(s.udevadmCmd.Calls(), HasLen, 0)
@@ -230,7 +230,7 @@ func (s *backendSuite) installSnap(c *C, developerMode bool, snapYaml string) *s
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
 	s.addPlugsSlots(c, snapInfo)
-	err = s.backend.Configure(snapInfo, developerMode, s.repo)
+	err = s.backend.Setup(snapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return snapInfo
 }
@@ -242,14 +242,14 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
 	s.removePlugsSlots(c, oldSnapInfo)
 	s.addPlugsSlots(c, newSnapInfo)
-	err = s.backend.Configure(newSnapInfo, developerMode, s.repo)
+	err = s.backend.Setup(newSnapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return newSnapInfo
 }
 
 // removeSnap "removes" an "installed" snap.
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
-	err := s.backend.Deconfigure(snapInfo)
+	err := s.backend.Remove(snapInfo)
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
 }


### PR DESCRIPTION
This patch changes security backends to use the following terms:

 - setup instead of configure
 - remove instead of deconfigure

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>