### PR TITLE
many: drop SnapFile and snapYaml usage in early install

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -120,7 +120,7 @@ func (s *defaultBackend) CopySnapData(snapInstPath string, flags int) error {
 		return err
 	}
 	meter := &progress.NullProgress{}
-	return snappy.CopyData(sn, snappy.InstallFlags(flags), meter)
+	return snappy.CopyData(sn.Info(), snappy.InstallFlags(flags), meter)
 }
 
 func (s *defaultBackend) SetupSnapSecurity(snapInstPath string) error {
@@ -156,7 +156,7 @@ func (s *defaultBackend) UndoCopySnapData(instSnapPath string, flags int) error 
 		return err
 	}
 	meter := &progress.NullProgress{}
-	snappy.UndoCopyData(sn, snappy.InstallFlags(flags), meter)
+	snappy.UndoCopyData(sn.Info(), snappy.InstallFlags(flags), meter)
 	return nil
 }
 

--- a/snap/file.go
+++ b/snap/file.go
@@ -27,7 +27,8 @@ import (
 
 // File is the interface to interact with the low-level snap files
 type File interface {
-	Install(targetDir string) error
+	// Install copies the snap file to targetPath (and possibly unpacks it to mountDir)
+	Install(targetPath, mountDir string) error
 
 	// MetaMember returns data from a meta/ directory file member
 	MetaMember(name string) ([]byte, error)

--- a/snap/info.go
+++ b/snap/info.go
@@ -20,6 +20,7 @@
 package snap
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/ubuntu-core/snappy/dirs"
@@ -95,6 +96,11 @@ func (s *Info) Description() string {
 // BaseDir returns the base directory of the snap.
 func (s *Info) BaseDir() string {
 	return filepath.Join(dirs.SnapSnapsDir, s.Name(), s.Version)
+}
+
+// MountFile returns the path where the snap file that is mounted is installed.
+func (s *Info) MountFile() string {
+	return filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%s.snap", s.Name(), s.Version))
 }
 
 // PlugInfo provides information about a plug.

--- a/snap/info.go
+++ b/snap/info.go
@@ -93,8 +93,8 @@ func (s *Info) Description() string {
 	return s.OriginalDescription
 }
 
-// BaseDir returns the base directory of the snap.
-func (s *Info) BaseDir() string {
+// MountDir returns the base directory of the snap where it gets mounted.
+func (s *Info) MountDir() string {
 	return filepath.Join(dirs.SnapSnapsDir, s.Name(), s.Version)
 }
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -58,6 +58,9 @@ type Info struct {
 	Plugs            map[string]*PlugInfo
 	Slots            map[string]*SlotInfo
 
+	// legacy fields collected
+	Legacy *LegacyYaml
+
 	// The information in these fields is not present inside the snap blob itself.
 	SideInfo
 

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -42,7 +42,8 @@ type snapYaml struct {
 	Slots            map[string]interface{} `yaml:"slots,omitempty"`
 	Apps             map[string]appYaml     `yaml:"apps,omitempty"`
 
-	// TODO: missing legacy stuff still: config, gadget, kernel
+	// legacy fields collected
+	Legacy LegacyYaml `yaml:",inline"`
 }
 
 type plugYaml struct {
@@ -108,6 +109,9 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		Apps:                make(map[string]*AppInfo),
 		Plugs:               make(map[string]*PlugInfo),
 		Slots:               make(map[string]*SlotInfo),
+
+		// XXX: test this a bit here
+		Legacy: &y.Legacy,
 	}
 	// Collect top-level definitions of plugs
 	for name, data := range y.Plugs {

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -110,7 +110,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		Plugs:               make(map[string]*PlugInfo),
 		Slots:               make(map[string]*SlotInfo),
 
-		// XXX: test this a bit here
+		// just expose the parsed legacy yaml bits
 		Legacy: &y.Legacy,
 	}
 	// Collect top-level definitions of plugs

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -911,3 +911,20 @@ apps:
 		},
 	})
 }
+
+// legacy
+
+func (s *YamlSuite) TestLegacyParsing(c *C) {
+	y := []byte(`name: gadget-test
+version: 1.0
+gadget:
+  store:
+    id: my-store
+type: gadget
+`)
+	info, err := snap.InfoFromSnapYaml(y)
+	c.Assert(err, IsNil)
+
+	c.Assert(info.Legacy, NotNil)
+	c.Check(info.Legacy.Gadget.Store.ID, Equals, "my-store")
+}

--- a/snap/legacy.go
+++ b/snap/legacy.go
@@ -28,4 +28,9 @@ type LegacyYaml struct {
 	// gadget snap only
 	Gadget legacygadget.Gadget       `yaml:"gadget,omitempty"`
 	Config legacygadget.SystemConfig `yaml:"config,omitempty"`
+
+	// legacy kernel snap support
+	Kernel string `yaml:"kernel,omitempty"`
+	Initrd string `yaml:"initrd,omitempty"`
+	Dtbs   string `yaml:"dtbs,omitempty"`
 }

--- a/snap/legacy.go
+++ b/snap/legacy.go
@@ -1,0 +1,31 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap
+
+import (
+	"github.com/ubuntu-core/snappy/snap/legacygadget"
+)
+
+// LegacyYaml collects the legacy fields in snap.yaml that are up to be reworked.
+type LegacyYaml struct {
+	// gadget snap only
+	Gadget legacygadget.Gadget       `yaml:"gadget,omitempty"`
+	Config legacygadget.SystemConfig `yaml:"config,omitempty"`
+}

--- a/snap/legacygadget/gadget_yaml.go
+++ b/snap/legacygadget/gadget_yaml.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package legacygadget defines the legacy yaml specific to gadget snaps.
+package legacygadget
+
+// Gadget represents the structure inside the snap.yaml for the gadget component
+// of a gadget package type.
+type Gadget struct {
+	Store                Store    `yaml:"store,omitempty"`
+	Hardware             Hardware `yaml:"hardware,omitempty"`
+	Software             Software `yaml:"software,omitempty"`
+	SkipIfupProvisioning bool     `yaml:"skip-ifup-provisioning"`
+}
+
+// Hardware describes the hardware provided by the gadget snap
+type Hardware struct {
+	Assign     []HardwareAssign `yaml:"assign,omitempty"`
+	BootAssets *BootAssets      `yaml:"boot-assets,omitempty"`
+	Bootloader string           `yaml:"bootloader,omitempty"`
+}
+
+// Store holds information relevant to the store provided by a Gadget snap
+type Store struct {
+	ID string `yaml:"id,omitempty"`
+}
+
+// Software describes the installed software provided by a Gadget snap
+type Software struct {
+	BuiltIn []string `yaml:"built-in,omitempty"`
+}
+
+// BootAssets represent all the artifacts required for booting a system
+// that are particular to the board.
+type BootAssets struct {
+	Files    []BootAssetFiles    `yaml:"files,omitempty"`
+	RawFiles []BootAssetRawFiles `yaml:"raw-files,omitempty"`
+}
+
+// BootAssetRawFiles represent all the artifacts required for booting a system
+// that are particular to the board and require copying to specific sectors of
+// the disk
+type BootAssetRawFiles struct {
+	Path   string `yaml:"path"`
+	Offset string `yaml:"offset"`
+}
+
+// BootAssetFiles represent all the files required for booting a system
+// that are particular to the board
+type BootAssetFiles struct {
+	Path   string `yaml:"path"`
+	Target string `yaml:"target,omitempty"`
+}
+
+// HardwareAssign describes the hardware a app can use
+type HardwareAssign struct {
+	PartID string `yaml:"part-id,omitempty"`
+	Rules  []struct {
+		Kernel         string   `yaml:"kernel,omitempty"`
+		Subsystem      string   `yaml:"subsystem,omitempty"`
+		WithSubsystems string   `yaml:"with-subsystems,omitempty"`
+		WithDriver     string   `yaml:"with-driver,omitempty"`
+		WithAttrs      []string `yaml:"with-attrs,omitempty"`
+		WithProps      []string `yaml:"with-props,omitempty"`
+	} `yaml:"rules,omitempty"`
+}
+
+// SystemConfig is a config map holding configs for multiple packages
+type SystemConfig map[string]interface{}

--- a/snappy/binaries.go
+++ b/snappy/binaries.go
@@ -146,7 +146,7 @@ func addPackageBinaries(s *snap.Info) error {
 		return err
 	}
 
-	baseDir := s.BaseDir()
+	baseDir := s.MountDir()
 
 	for _, app := range s.Apps {
 		if app.Daemon != "" {

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -163,19 +163,19 @@ connect
 
 // makeTestSnapPackage creates a real snap package that can be installed on
 // disk using snapYamlContent as its meta/snap.yaml
-func makeTestSnapPackage(c *C, snapYamlContent string) (snapFile string) {
+func makeTestSnapPackage(c *C, snapYamlContent string) (snapPath string) {
 	return makeTestSnapPackageFull(c, snapYamlContent, true)
 }
 
-func makeTestSnapPackageWithFiles(c *C, snapYamlContent string, files [][]string) (snapFile string) {
+func makeTestSnapPackageWithFiles(c *C, snapYamlContent string, files [][]string) (snapPath string) {
 	return makeTestSnapPackageFullWithFiles(c, snapYamlContent, true, files)
 }
 
-func makeTestSnapPackageFull(c *C, snapYamlContent string, makeLicense bool) (snapFile string) {
+func makeTestSnapPackageFull(c *C, snapYamlContent string, makeLicense bool) (snapPath string) {
 	return makeTestSnapPackageFullWithFiles(c, snapYamlContent, makeLicense, [][]string{})
 }
 
-func makeTestSnapPackageFullWithFiles(c *C, snapYamlContent string, makeLicense bool, files [][]string) (snapFile string) {
+func makeTestSnapPackageFullWithFiles(c *C, snapYamlContent string, makeLicense bool, files [][]string) (snapPath string) {
 	tmpdir := c.MkDir()
 	// content
 	os.MkdirAll(filepath.Join(tmpdir, "bin"), 0755)
@@ -212,12 +212,12 @@ version: 1.0
 	// build it
 	err := osutil.ChDir(tmpdir, func() error {
 		var err error
-		snapFile, err = snapBuilderFunc(tmpdir, "")
+		snapPath, err = snapBuilderFunc(tmpdir, "")
 		c.Assert(err, IsNil)
 		return err
 	})
 	c.Assert(err, IsNil)
-	return filepath.Join(tmpdir, snapFile)
+	return filepath.Join(tmpdir, snapPath)
 }
 
 // makeTwoTestSnaps creates two real snaps of snap.Type of name
@@ -236,13 +236,13 @@ func makeTwoTestSnaps(c *C, snapType snap.Type, extra ...string) {
 		snapYamlContent += fmt.Sprintf("type: %s\n", snapType)
 	}
 
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err := (&Overlord{}).Install(snapFile, AllowUnauthenticated|AllowGadget, inter)
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err := (&Overlord{}).Install(snapPath, AllowUnauthenticated|AllowGadget, inter)
 	c.Assert(err, IsNil)
 	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "1.0", "", "", "remote-channel"), IsNil)
 
-	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
-	_, err = (&Overlord{}).Install(snapFile, AllowUnauthenticated|AllowGadget, inter)
+	snapPath = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
+	_, err = (&Overlord{}).Install(snapPath, AllowUnauthenticated|AllowGadget, inter)
 	c.Assert(err, IsNil)
 	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "2.0", "", "", "remote-channel"), IsNil)
 

--- a/snappy/desktop.go
+++ b/snappy/desktop.go
@@ -166,7 +166,7 @@ func addPackageDesktopFiles(s *snap.Info) error {
 		return err
 	}
 
-	baseDir := s.BaseDir()
+	baseDir := s.MountDir()
 
 	desktopFiles, err := filepath.Glob(filepath.Join(baseDir, "meta", "gui", "*.desktop"))
 	if err != nil {

--- a/snappy/desktop_test.go
+++ b/snappy/desktop_test.go
@@ -52,7 +52,7 @@ func (s *SnapTestSuite) TestAddPackageDesktopFiles(c *C) {
 	c.Assert(err, IsNil)
 
 	// generate .desktop file in the package baseDir
-	baseDir := snap.Info().BaseDir()
+	baseDir := snap.Info().MountDir()
 	err = os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755)
 	c.Assert(err, IsNil)
 

--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -88,7 +88,7 @@ func gadgetConfig() error {
 	}
 
 	pb := progress.MakeProgressBar()
-	for _, pkgName := range gadget.Gadget.Software.BuiltIn {
+	for _, pkgName := range gadget.Legacy.Gadget.Software.BuiltIn {
 		snap, ok := snapMap[pkgName]
 		if !ok {
 			return errNoSnapToActivate
@@ -98,7 +98,7 @@ func gadgetConfig() error {
 		}
 	}
 
-	for pkgName, conf := range gadget.Config {
+	for pkgName, conf := range gadget.Legacy.Config {
 		snap, ok := snapMap[pkgName]
 		if !ok {
 			// We want to error early as this is a disparity and gadget snap
@@ -189,7 +189,7 @@ var ifup = "/sbin/ifup"
 
 func enableFirstEther() error {
 	gadget, _ := getGadget()
-	if gadget != nil && gadget.Gadget.SkipIfupProvisioning {
+	if gadget != nil && gadget.Legacy.Gadget.SkipIfupProvisioning {
 		return nil
 	}
 

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/legacygadget"
 	"github.com/ubuntu-core/snappy/systemd"
 )
 
@@ -46,7 +47,7 @@ type FirstBootTestSuite struct {
 	globs        []string
 	ethdir       string
 	ifup         string
-	m            *snapYaml
+	m            *snap.LegacyYaml
 	e            error
 	snapMap      map[string]*Snap
 	snapMapErr   error
@@ -72,10 +73,10 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(tempdir, "etc", "systemd", "system", "multi-user.target.wants"), 0755)
 	c.Assert(err, IsNil)
 
-	configMyApp := make(SystemConfig)
+	configMyApp := make(legacygadget.SystemConfig)
 	configMyApp["hostname"] = "myhostname"
 
-	s.gadgetConfig = make(SystemConfig)
+	s.gadgetConfig = make(legacygadget.SystemConfig)
 	s.gadgetConfig["myapp"] = configMyApp
 
 	s.globs = globs
@@ -105,8 +106,14 @@ func (s *FirstBootTestSuite) TearDownTest(c *C) {
 	newSnapMap = newSnapMapImpl
 }
 
-func (s *FirstBootTestSuite) getGadget() (*snapYaml, error) {
-	return s.m, s.e
+func (s *FirstBootTestSuite) getGadget() (*snap.Info, error) {
+	if s.m != nil {
+		info := &snap.Info{
+			Legacy: s.m,
+		}
+		return info, nil
+	}
+	return nil, s.e
 }
 
 func (s *FirstBootTestSuite) newSnapMap() (map[string]*Snap, error) {
@@ -131,7 +138,7 @@ func (s *FirstBootTestSuite) newFakeApp() *Snap {
 }
 
 func (s *FirstBootTestSuite) TestFirstBootConfigure(c *C) {
-	s.m = &snapYaml{Config: s.gadgetConfig}
+	s.m = &snap.LegacyYaml{Config: s.gadgetConfig}
 	s.newFakeApp()
 	c.Assert(FirstBoot(), IsNil)
 	myAppConfig := fmt.Sprintf("config:\n  myapp:\n    hostname: myhostname\n")
@@ -145,12 +152,12 @@ func (s *FirstBootTestSuite) TestSoftwareActivate(c *C) {
 	yamlPath, err := makeInstalledMockSnap("")
 	c.Assert(err, IsNil)
 
-	snap, err := NewInstalledSnap(yamlPath)
+	snp, err := NewInstalledSnap(yamlPath)
 	c.Assert(err, IsNil)
-	c.Assert(snap.IsActive(), Equals, false)
-	name := snap.Name()
+	c.Assert(snp.IsActive(), Equals, false)
+	name := snp.Name()
 
-	s.m = &snapYaml{Gadget: Gadget{Software: Software{BuiltIn: []string{name}}}}
+	s.m = &snap.LegacyYaml{Gadget: legacygadget.Gadget{Software: legacygadget.Software{BuiltIn: []string{name}}}}
 
 	all, err := (&Overlord{}).Installed()
 	c.Check(err, IsNil)
@@ -206,7 +213,7 @@ func (s *FirstBootTestSuite) TestEnableFirstEtherSomeEth(c *C) {
 }
 
 func (s *FirstBootTestSuite) TestEnableFirstEtherGadgetNoIfup(c *C) {
-	s.m = &snapYaml{Gadget: Gadget{SkipIfupProvisioning: true}}
+	s.m = &snap.LegacyYaml{Gadget: legacygadget.Gadget{SkipIfupProvisioning: true}}
 	dir := c.MkDir()
 	_, err := os.Create(filepath.Join(dir, "eth42"))
 	c.Assert(err, IsNil)
@@ -265,7 +272,7 @@ func (s *FirstBootTestSuite) TestSystemSnapsEnablesOS(c *C) {
 }
 
 func (s *FirstBootTestSuite) TestSystemSnapsEnablesKernel(c *C) {
-	s.m = &snapYaml{Gadget: Gadget{Hardware: Hardware{Bootloader: "grub"}}}
+	s.m = &snap.LegacyYaml{Gadget: legacygadget.Gadget{Hardware: legacygadget.Hardware{Bootloader: "grub"}}}
 
 	s.ensureSystemSnapIsEnabledOnFirstBoot(c, mockKernelYaml, true)
 }

--- a/snappy/info.go
+++ b/snappy/info.go
@@ -38,13 +38,12 @@ const (
 	SideloadedDeveloper = "sideload"
 )
 
-// SystemConfig is a config map holding configs for multiple packages
-type SystemConfig map[string]interface{}
-
+/*
 // Configuration allows requesting a gadget snappy package type's config
 type Configuration interface {
 	GadgetConfig() SystemConfig
 }
+*/
 
 // BareName of a snap.Info is just its Name
 func BareName(p *snap.Info) string {

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -44,8 +44,8 @@ func makeCloudInitMetaData(c *C, content string) string {
 }
 
 func (s *SnapTestSuite) TestInstallInstall(c *C) {
-	snapFile := makeTestSnapPackage(c, "")
-	name, err := Install(snapFile, "channel", AllowUnauthenticated|DoInstallGC, &progress.NullProgress{})
+	snapPath := makeTestSnapPackage(c, "")
+	name, err := Install(snapPath, "channel", AllowUnauthenticated|DoInstallGC, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "foo")
 
@@ -59,8 +59,8 @@ func (s *SnapTestSuite) TestInstallInstall(c *C) {
 }
 
 func (s *SnapTestSuite) TestInstallNoHook(c *C) {
-	snapFile := makeTestSnapPackage(c, "")
-	name, err := Install(snapFile, "", AllowUnauthenticated|DoInstallGC|InhibitHooks, &progress.NullProgress{})
+	snapPath := makeTestSnapPackage(c, "")
+	name, err := Install(snapPath, "", AllowUnauthenticated|DoInstallGC|InhibitHooks, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "foo")
 
@@ -74,28 +74,28 @@ func (s *SnapTestSuite) TestInstallNoHook(c *C) {
 }
 
 func (s *SnapTestSuite) TestInstallInstallLicense(c *C) {
-	snapFile := makeTestSnapPackage(c, `
+	snapPath := makeTestSnapPackage(c, `
 name: foo
 version: 1.0
 vendor: Foo Bar <foo@example.com>
 license-agreement: explicit
 `)
 	ag := &MockProgressMeter{y: true}
-	name, err := Install(snapFile, "", AllowUnauthenticated|DoInstallGC, ag)
+	name, err := Install(snapPath, "", AllowUnauthenticated|DoInstallGC, ag)
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "foo")
 	c.Check(ag.license, Equals, "WTFPL")
 }
 
 func (s *SnapTestSuite) TestInstallInstallLicenseNo(c *C) {
-	snapFile := makeTestSnapPackage(c, `
+	snapPath := makeTestSnapPackage(c, `
 name: foo
 version: 1.0
 vendor: Foo Bar <foo@example.com>
 license-agreement: explicit
 `)
 	ag := &MockProgressMeter{y: false}
-	_, err := Install(snapFile, "", AllowUnauthenticated|DoInstallGC, ag)
+	_, err := Install(snapPath, "", AllowUnauthenticated|DoInstallGC, ag)
 	c.Assert(IsLicenseNotAccepted(err), Equals, true)
 	c.Check(ag.license, Equals, "WTFPL")
 }
@@ -109,16 +109,16 @@ func (s *SnapTestSuite) installThree(c *C, flags InstallFlags) {
 
 	snapYamlContent := `name: foo
 `
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err = Install(snapFile, "", flags, &progress.NullProgress{})
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err = Install(snapPath, "", flags, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
-	_, err = Install(snapFile, "", flags, &progress.NullProgress{})
+	snapPath = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
+	_, err = Install(snapPath, "", flags, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 3.0")
-	_, err = Install(snapFile, "", flags, &progress.NullProgress{})
+	snapPath = makeTestSnapPackage(c, snapYamlContent+"version: 3.0")
+	_, err = Install(snapPath, "", flags, &progress.NullProgress{})
 	c.Assert(err, IsNil)
 }
 

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -80,7 +80,7 @@ func extractKernelAssets(s *SnapFile, inter progress.Meter, flags InstallFlags) 
 	// check if we are on a "grub" system. if so, no need to unpack
 	// the kernel
 	if oem, err := getGadget(); err == nil {
-		if oem.Gadget.Hardware.Bootloader == "grub" {
+		if oem.Legacy.Gadget.Hardware.Bootloader == "grub" {
 			return nil
 		}
 	}

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ubuntu-core/snappy/partition"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
-	"github.com/ubuntu-core/snappy/snap/squashfs"
 )
 
 // dropVersionSuffix drops the kernel/initrd version suffix,
@@ -55,8 +54,7 @@ func removeKernelAssets(s *snap.Info, inter interacter) error {
 	}
 
 	// remove the kernel blob
-	// XXX: fix BlobPath
-	blobName := filepath.Base(squashfs.BlobPath(s.BaseDir()))
+	blobName := filepath.Base(s.MountFile())
 	dstDir := filepath.Join(bootloader.Dir(), blobName)
 	if err := os.RemoveAll(dstDir); err != nil {
 		return err
@@ -86,11 +84,8 @@ func extractKernelAssets(s *snap.Info, blobf snap.File, flags InstallFlags, inte
 		}
 	}
 
-	// FIXME: feels wrong to use the instdir here, need something better
-	//
 	// now do the kernel specific bits
-	// XXX: fix BlobPath
-	blobName := filepath.Base(squashfs.BlobPath(s.BaseDir()))
+	blobName := filepath.Base(s.MountFile())
 	dstDir := filepath.Join(bootloader.Dir(), blobName)
 	if err := os.MkdirAll(dstDir, 0755); err != nil {
 		return err
@@ -147,7 +142,7 @@ func setNextBoot(s *Snap) error {
 	case snap.TypeKernel:
 		bootvar = "snappy_kernel"
 	}
-	blobName := filepath.Base(squashfs.BlobPath(s.basedir))
+	blobName := filepath.Base(s.Info().MountFile())
 	if err := bootloader.SetBootVar(bootvar, blobName); err != nil {
 		return err
 	}
@@ -189,7 +184,7 @@ func kernelOrOsRebootRequired(s *Snap) bool {
 		return false
 	}
 
-	squashfsName := filepath.Base(stripGlobalRootDir(squashfs.BlobPath(s.basedir)))
+	squashfsName := filepath.Base(s.Info().MountFile())
 	if nextBootVer == squashfsName && goodBootVer != nextBootVer {
 		return true
 	}

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -66,7 +66,7 @@ func removeKernelAssets(s *snap.Info, inter interacter) error {
 // extractKernelAssets extracts kernel/initrd/dtb data from the given
 // Snap to a versionized bootloader directory so that the bootloader
 // can use it.
-func extractKernelAssets(s *snap.Info, blobf snap.File, flags InstallFlags, inter progress.Meter) error {
+func extractKernelAssets(s *snap.Info, snapf snap.File, flags InstallFlags, inter progress.Meter) error {
 	if s.Type != snap.TypeKernel {
 		return fmt.Errorf("can not extract kernel assets from snap type %q", s.Type)
 	}
@@ -100,7 +100,7 @@ func extractKernelAssets(s *snap.Info, blobf snap.File, flags InstallFlags, inte
 		if src == "" {
 			continue
 		}
-		if err := blobf.Unpack(src, dstDir); err != nil {
+		if err := snapf.Unpack(src, dstDir); err != nil {
 			return err
 		}
 		src = filepath.Join(dstDir, src)
@@ -115,7 +115,7 @@ func extractKernelAssets(s *snap.Info, blobf snap.File, flags InstallFlags, inte
 	if s.Legacy.Dtbs != "" {
 		src := filepath.Join(s.Legacy.Dtbs, "*")
 		dst := dstDir
-		if err := blobf.Unpack(src, dst); err != nil {
+		if err := snapf.Unpack(src, dst); err != nil {
 			return err
 		}
 	}

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -98,7 +98,7 @@ func SetupSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) (s
 
 	// FIXME: special handling is bad 'mkay
 	if s.Type == snap.TypeKernel {
-		if err := extractKernelAssets(sf, meter, flags); err != nil {
+		if err := extractKernelAssets(s, blobf, flags, meter); err != nil {
 			return instdir, fmt.Errorf("failed to install kernel %s", err)
 		}
 	}
@@ -478,16 +478,11 @@ func CanRemove(s *Snap) bool {
 	return true
 }
 
-<<<<<<< 0659bb853f5ac4a82b1de46b3593db46c2d4b397
 // RemoveSnapFiles removes the snap files from the disk
 func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
 	basedir = s.Info().Basedir()
 	// this also ensures that the mount unit stops
 	if err := removeSquashfsMount(basedir, meter); err != nil {
-=======
-	// ensure mount unit stops
-	if err := removeSquashfsMount(s.Info(), meter); err != nil {
->>>>>>> narrower signature for squashfs mount helpers
 		return err
 	}
 
@@ -506,7 +501,7 @@ func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
 
 	// remove the kernel assets (if any)
 	if s.m.Type == snap.TypeKernel {
-		if err := removeKernelAssets(s, meter); err != nil {
+		if err := removeKernelAssets(s.Info(), meter); err != nil {
 			logger.Noticef("removing kernel assets failed with %s", err)
 		}
 	}

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -77,7 +77,7 @@ func SetupSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) (s
 
 	// the "gadget" snaps are special
 	if s.Type == snap.TypeGadget {
-		if err := installGadgetHardwareUdevRules(s.m); err != nil {
+		if err := installGadgetHardwareUdevRules(s); err != nil {
 			return "", err
 		}
 	}
@@ -480,7 +480,7 @@ func CanRemove(s *Snap) bool {
 
 // RemoveSnapFiles removes the snap files from the disk
 func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
-	basedir = s.Info().Basedir()
+	basedir := s.Info().BaseDir()
 	// this also ensures that the mount unit stops
 	if err := removeSquashfsMount(basedir, meter); err != nil {
 		return err

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -44,7 +44,7 @@ func CheckSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) er
 	allowUnauth := (flags & AllowUnauthenticated) != 0
 
 	// we do not Verify() the package here. This is done earlier in
-	// NewSnapFile() to ensure that we do not mount/inspect
+	// openSnapFile() to ensure that we do not mount/inspect
 	// potentially dangerous snaps
 
 	s, snapf, err := openSnapFile(snapFilePath, allowUnauth, nil)
@@ -54,7 +54,7 @@ func CheckSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) er
 
 	// we do not security Verify() (check hashes) the package here.
 	// This is done earlier in
-	// NewSnapFile() to ensure that we do not mount/inspect
+	// openSnapFile() to ensure that we do not mount/inspect
 	// potentially dangerous snaps
 	return canInstall(s, snapf, allowGadget, meter)
 }

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -92,7 +92,7 @@ func SetupSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) (s
 	}
 
 	// generate the mount unit for the squashfs
-	if err := addSquashfsMount(s, instdir, inhibitHooks, meter); err != nil {
+	if err := addSquashfsMount(s, inhibitHooks, meter); err != nil {
 		return instdir, err
 	}
 
@@ -471,11 +471,16 @@ func CanRemove(s *Snap) bool {
 	return true
 }
 
+<<<<<<< 0659bb853f5ac4a82b1de46b3593db46c2d4b397
 // RemoveSnapFiles removes the snap files from the disk
 func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
 	basedir = s.Info().Basedir()
 	// this also ensures that the mount unit stops
 	if err := removeSquashfsMount(basedir, meter); err != nil {
+=======
+	// ensure mount unit stops
+	if err := removeSquashfsMount(s.Info(), meter); err != nil {
+>>>>>>> narrower signature for squashfs mount helpers
 		return err
 	}
 

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -158,12 +158,12 @@ func UndoSetupSnap(installDir string, meter progress.Meter) {
 		}
 	}
 
-	snapFile := s.Info().MountFile()
+	snapPath := s.Info().MountFile()
 
 	// remove install dir and the snap blob itself
 	for _, path := range []string{
 		installDir,
-		snapFile,
+		snapPath,
 	} {
 		if err := os.RemoveAll(path); err != nil {
 			logger.Noticef("cannot remove snap package at %v: %s", installDir, err)
@@ -559,7 +559,7 @@ func CanRemove(s *Snap) bool {
 func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
 	info := s.Info()
 	basedir := info.MountDir()
-	snapFile := info.MountFile()
+	snapPath := info.MountFile()
 	// this also ensures that the mount unit stops
 	if err := removeSquashfsMount(basedir, meter); err != nil {
 		return err
@@ -573,7 +573,7 @@ func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
 	os.Remove(filepath.Dir(basedir))
 
 	// remove the snap
-	if err := os.RemoveAll(snapFile); err != nil {
+	if err := os.RemoveAll(snapPath); err != nil {
 		return err
 	}
 

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -70,7 +70,7 @@ func SetupSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) (s
 	if err != nil {
 		return "", err
 	}
-	instdir := s.BaseDir()
+	instdir := s.MountDir()
 
 	// the "gadget" snaps are special
 	if s.Type == snap.TypeGadget {
@@ -105,7 +105,7 @@ func SetupSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) (s
 
 func addSquashfsMount(s *snap.Info, inhibitHooks bool, inter interacter) error {
 	squashfsPath := stripGlobalRootDir(s.MountFile())
-	whereDir := stripGlobalRootDir(s.BaseDir())
+	whereDir := stripGlobalRootDir(s.MountDir())
 
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), squashfsPath, whereDir)
@@ -177,7 +177,7 @@ func UndoSetupSnap(installDir string, meter progress.Meter) {
 
 // XXX: ideally should go from Info to Info, likely we will move to something else anyway
 func currentSnap(newSnap *snap.Info) *Snap {
-	currentActiveDir, _ := filepath.EvalSymlinks(filepath.Join(newSnap.BaseDir(), "..", "current"))
+	currentActiveDir, _ := filepath.EvalSymlinks(filepath.Join(newSnap.MountDir(), "..", "current"))
 	if currentActiveDir == "" {
 		return nil
 	}
@@ -558,7 +558,7 @@ func CanRemove(s *Snap) bool {
 // RemoveSnapFiles removes the snap files from the disk
 func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
 	info := s.Info()
-	basedir := info.BaseDir()
+	basedir := info.MountDir()
 	snapFile := info.MountFile()
 	// this also ensures that the mount unit stops
 	if err := removeSquashfsMount(basedir, meter); err != nil {

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -84,7 +84,7 @@ func SetupSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) (s
 		return instdir, err
 	}
 
-	if err := blobf.Install(instdir); err != nil {
+	if err := blobf.Install(s.MountFile(), instdir); err != nil {
 		return instdir, err
 	}
 

--- a/snappy/overlord_test.go
+++ b/snappy/overlord_test.go
@@ -47,8 +47,8 @@ func (s *SnapTestSuite) TestInstalled(c *C) {
 }
 
 func (s *SnapTestSuite) TestLocalSnapInstall(c *C) string {
-	snapFile := makeTestSnapPackage(c, "")
-	snap, err := (&Overlord{}).Install(snapFile, 0, nil)
+	snapPath := makeTestSnapPackage(c, "")
+	snap, err := (&Overlord{}).Install(snapPath, 0, nil)
 	c.Assert(err, IsNil)
 	c.Check(snap.Name(), Equals, "foo")
 
@@ -57,7 +57,7 @@ func (s *SnapTestSuite) TestLocalSnapInstall(c *C) string {
 	_, err = os.Stat(filepath.Join(s.tempdir, "var", "lib", "snaps", "foo", "1.0"))
 	c.Assert(err, IsNil)
 
-	return snapFile
+	return snapPath
 }
 
 // if the snap asks for accepting a license, and an agreer isn't provided,
@@ -225,11 +225,11 @@ func (s *SnapTestSuite) TestSnapRemove(c *C) {
 }
 
 func (s *SnapTestSuite) TestLocalGadgetSnapInstall(c *C) {
-	snapFile := makeTestSnapPackage(c, `name: foo
+	snapPath := makeTestSnapPackage(c, `name: foo
 version: 1.0
 type: gadget
 `)
-	_, err := (&Overlord{}).Install(snapFile, AllowGadget, nil)
+	_, err := (&Overlord{}).Install(snapPath, AllowGadget, nil)
 	c.Assert(err, IsNil)
 
 	contentFile := filepath.Join(s.tempdir, "snaps", "foo", "1.0", "bin", "foo")
@@ -238,11 +238,11 @@ type: gadget
 }
 
 func (s *SnapTestSuite) TestLocalGadgetSnapInstallVariants(c *C) {
-	snapFile := makeTestSnapPackage(c, `name: foo
+	snapPath := makeTestSnapPackage(c, `name: foo
 version: 1.0
 type: gadget
 `)
-	_, err := (&Overlord{}).Install(snapFile, AllowGadget, nil)
+	_, err := (&Overlord{}).Install(snapPath, AllowGadget, nil)
 	c.Assert(err, IsNil)
 	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "1.0", "", "", "remote-channel"), IsNil)
 
@@ -251,36 +251,36 @@ type: gadget
 	c.Assert(err, IsNil)
 
 	// a package update
-	snapFile = makeTestSnapPackage(c, `name: foo
+	snapPath = makeTestSnapPackage(c, `name: foo
 version: 2.0
 type: gadget
 `)
-	_, err = (&Overlord{}).Install(snapFile, 0, nil)
+	_, err = (&Overlord{}).Install(snapPath, 0, nil)
 	c.Check(err, IsNil)
 	c.Assert(storeMinimalRemoteManifest("foo", testDeveloper, "2.0", "", "", "remote-channel"), IsNil)
 
 	// a package name fork, IOW, a different Gadget package.
-	snapFile = makeTestSnapPackage(c, `name: foo-fork
+	snapPath = makeTestSnapPackage(c, `name: foo-fork
 version: 2.0
 type: gadget
 `)
-	_, err = (&Overlord{}).Install(snapFile, 0, nil)
+	_, err = (&Overlord{}).Install(snapPath, 0, nil)
 	c.Check(err, Equals, ErrGadgetPackageInstall)
 
 	// this will cause chaos, but let's test if it works
-	_, err = (&Overlord{}).Install(snapFile, AllowGadget, nil)
+	_, err = (&Overlord{}).Install(snapPath, AllowGadget, nil)
 	c.Check(err, IsNil)
 }
 
 func (s *SnapTestSuite) TestClickSetActive(c *C) {
 	snapYamlContent := `name: foo
 `
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err := (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err := (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
-	_, err = (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
+	_, err = (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 
 	// ensure v2 is active
@@ -317,8 +317,8 @@ func (s *SnapTestSuite) TestClickCopyData(c *C) {
 `
 	canaryData := []byte("ni ni ni")
 
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err = (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err = (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 	canaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "1.0", "canary.txt")
 	err = ioutil.WriteFile(canaryDataFile, canaryData, 0644)
@@ -326,8 +326,8 @@ func (s *SnapTestSuite) TestClickCopyData(c *C) {
 	err = ioutil.WriteFile(filepath.Join(homeData, "canary.home"), canaryData, 0644)
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
-	_, err = (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
+	_, err = (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 	newCanaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "2.0", "canary.txt")
 	content, err := ioutil.ReadFile(newCanaryDataFile)
@@ -349,15 +349,15 @@ func (s *SnapTestSuite) TestClickCopyDataNoUserHomes(c *C) {
 	snapYamlContent := `name: foo
 `
 	appDir := "foo"
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err := (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err := (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 	canaryDataFile := filepath.Join(dirs.SnapDataDir, appDir, "1.0", "canary.txt")
 	err = ioutil.WriteFile(canaryDataFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
-	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
-	_, err = (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
+	_, err = (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 	_, err = os.Stat(filepath.Join(dirs.SnapDataDir, appDir, "2.0", "canary.txt"))
 	c.Assert(err, IsNil)
@@ -369,8 +369,8 @@ apps:
  bar:
   command: bin/bar
 `
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err := (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err := (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 
 	// ensure that the binary wrapper file go generated with the right
@@ -382,8 +382,8 @@ apps:
 	c.Assert(strings.Contains(string(content), oldSnapBin), Equals, true)
 
 	// and that it gets updated on upgrade
-	snapFile = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
-	_, err = (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath = makeTestSnapPackage(c, snapYamlContent+"version: 2.0")
+	_, err = (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 	newSnapBin := filepath.Join(dirs.SnapSnapsDir[len(dirs.GlobalRootDir):], "foo", "2.0", "bin", "bar")
 	content, err = ioutil.ReadFile(binaryWrapper)
@@ -398,8 +398,8 @@ apps:
    command: bin/hello
    daemon: forking
 `
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err := (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err := (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 
 	servicesFile := filepath.Join(dirs.SnapServicesDir, "foo_service_1.0.service")
@@ -435,8 +435,8 @@ apps:
    command: bin/hello
    daemon: forking
 `
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err := (&Overlord{}).Install(snapFile, InhibitHooks, nil)
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err := (&Overlord{}).Install(snapPath, InhibitHooks, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(allSystemctl, HasLen, 0)
@@ -449,8 +449,8 @@ apps:
  bar:
   command: bin/bar
 `
-	snapFile := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
-	_, err := (&Overlord{}).Install(snapFile, AllowUnauthenticated, nil)
+	snapPath := makeTestSnapPackage(c, snapYamlContent+"version: 1.0")
+	_, err := (&Overlord{}).Install(snapPath, AllowUnauthenticated, nil)
 	c.Assert(err, IsNil)
 
 	// ensure that the binary wrapper file go generated with the right

--- a/snappy/services.go
+++ b/snappy/services.go
@@ -130,7 +130,7 @@ func generateBusPolicyFileName(app *snap.AppInfo) string {
 }
 
 func addPackageServices(s *snap.Info, inter interacter) error {
-	baseDir := s.BaseDir()
+	baseDir := s.MountDir()
 
 	for _, app := range s.Apps {
 		if app.Daemon == "" {

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -25,10 +25,10 @@ import (
 
 // openSnapBlob opens a snap blob returning both a snap.Info completed
 // with sideInfo (if not nil) and a corresponding snap.File.
-func openSnapFile(snapFile string, unsignedOk bool, sideInfo *snap.SideInfo) (*snap.Info, snap.File, error) {
+func openSnapFile(snapPath string, unsignedOk bool, sideInfo *snap.SideInfo) (*snap.Info, snap.File, error) {
 	// TODO: what precautions to take if unsignedOk == false ?
 
-	snapf, err := snap.Open(snapFile)
+	snapf, err := snap.Open(snapPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -20,9 +20,6 @@
 package snappy
 
 import (
-	"path/filepath"
-
-	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/snap"
 )
 
@@ -30,8 +27,6 @@ import (
 type SnapFile struct {
 	m   *snapYaml
 	deb snap.File
-
-	instdir string
 }
 
 // NewSnapFile loads a snap from the given snapFile
@@ -54,24 +49,10 @@ func NewSnapFile(snapFile string, unsignedOk bool) (*SnapFile, error) {
 		return nil, err
 	}
 
-	targetDir := dirs.SnapSnapsDir
-	instDir := filepath.Join(targetDir, m.Name, m.Version)
-
 	return &SnapFile{
-		instdir: instDir,
-		m:       m,
-		deb:     d,
+		m:   m,
+		deb: d,
 	}, nil
-}
-
-// Type returns the type of the Snap (app, gadget, ...)
-func (s *SnapFile) Type() snap.Type {
-	if s.m.Type != "" {
-		return s.m.Type
-	}
-
-	// if not declared its a app
-	return "app"
 }
 
 // Info returns the snap.Info data.
@@ -80,14 +61,4 @@ func (s *SnapFile) Info() *snap.Info {
 		return info
 	}
 	return nil
-}
-
-// Name returns the name
-func (s *SnapFile) Name() string {
-	return s.m.Name
-}
-
-// Version returns the version
-func (s *SnapFile) Version() string {
-	return s.m.Version
 }

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-// openSnapBlob opens a snap blob returning both a snap.Info completed
+// openSnapFile opens a snap blob returning both a snap.Info completed
 // with sideInfo (if not nil) and a corresponding snap.File.
 func openSnapFile(snapPath string, unsignedOk bool, sideInfo *snap.SideInfo) (*snap.Info, snap.File, error) {
 	// TODO: what precautions to take if unsignedOk == false ?

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -25,15 +25,15 @@ import (
 
 // openSnapBlob opens a snap blob returning both a snap.Info completed
 // with sideInfo (if not nil) and a corresponding snap.File.
-func openSnapBlob(snapFile string, unsignedOk bool, sideInfo *snap.SideInfo) (*snap.Info, snap.File, error) {
+func openSnapFile(snapFile string, unsignedOk bool, sideInfo *snap.SideInfo) (*snap.Info, snap.File, error) {
 	// TODO: what precautions to take if unsignedOk == false ?
 
-	blobf, err := snap.Open(snapFile)
+	snapf, err := snap.Open(snapFile)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	info, err := blobf.Info()
+	info, err := snapf.Info()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -44,5 +44,5 @@ func openSnapBlob(snapFile string, unsignedOk bool, sideInfo *snap.SideInfo) (*s
 		snapInfo.SideInfo = *sideInfo
 	}
 
-	return &snapInfo, blobf, nil
+	return &snapInfo, snapf, nil
 }

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/legacygadget"
 )
 
 // Snap represents a generic snap type
@@ -227,8 +228,8 @@ func (s *Snap) Apps() map[string]*AppYaml {
 }
 
 // GadgetConfig return a list of packages to configure
-func (s *Snap) GadgetConfig() SystemConfig {
-	return s.m.Config
+func (s *Snap) GadgetConfig() legacygadget.SystemConfig {
+	return s.info.Legacy.Config
 }
 
 // Install installs the snap (which does not make sense for an already

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -229,8 +229,8 @@ func checkLicenseAgreement(m *snapYaml, ag agreer, d snap.File, currentActiveDir
 	return nil
 }
 
-// XXX: don't take baseDir ?
-func addSquashfsMount(s *snap.Info, baseDir string, inhibitHooks bool, inter interacter) error {
+func addSquashfsMount(s *snap.Info, inhibitHooks bool, inter interacter) error {
+	baseDir := s.BaseDir()
 	// XXX: fix BlobPath
 	squashfsPath := stripGlobalRootDir(squashfs.BlobPath(baseDir))
 	whereDir := stripGlobalRootDir(baseDir)
@@ -253,7 +253,7 @@ func addSquashfsMount(s *snap.Info, baseDir string, inhibitHooks bool, inter int
 	return nil
 }
 
-func removeSquashfsMount(baseDir string, inter interacter) error {
+<func removeSquashfsMount(baseDir string, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	unit := systemd.MountUnitPath(stripGlobalRootDir(baseDir), "mount")
 	if osutil.FileExists(unit) {

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/snap"
-	"github.com/ubuntu-core/snappy/snap/legacygadget"
+	//"github.com/ubuntu-core/snappy/snap/legacygadget"
 	"github.com/ubuntu-core/snappy/snap/squashfs"
 	"github.com/ubuntu-core/snappy/systemd"
 	"github.com/ubuntu-core/snappy/timeout"
@@ -96,13 +96,14 @@ type snapYaml struct {
 	// FIXME: clarify those
 
 	// gadget snap only
-	Gadget legacygadget.Gadget       `yaml:"gadget,omitempty"`
-	Config legacygadget.SystemConfig `yaml:"config,omitempty"`
+	//Gadget legacygadget.Gadget       `yaml:"gadget,omitempty"`
+	//Config legacygadget.SystemConfig `yaml:"config,omitempty"`
 
 	// FIXME: move into a special kernel struct
-	Kernel string `yaml:"kernel,omitempty"`
-	Initrd string `yaml:"initrd,omitempty"`
-	Dtbs   string `yaml:"dtbs,omitempty"`
+	// XXX: xxx
+	//Kernel string `yaml:"kernel,omitempty"`
+	//Initrd string `yaml:"initrd,omitempty"`
+	//Dtbs   string `yaml:"dtbs,omitempty"`
 }
 
 func parseSnapYamlFile(yamlPath string) (*snapYaml, error) {

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/snap"
-	//"github.com/ubuntu-core/snappy/snap/legacygadget"
 	"github.com/ubuntu-core/snappy/snap/squashfs"
 	"github.com/ubuntu-core/snappy/systemd"
 	"github.com/ubuntu-core/snappy/timeout"
@@ -92,18 +91,6 @@ type snapYaml struct {
 
 	// Plugs maps the used "interfaces" to the apps
 	Plugs map[string]*plugYaml `yaml:"plugs,omitempty"`
-
-	// FIXME: clarify those
-
-	// gadget snap only
-	//Gadget legacygadget.Gadget       `yaml:"gadget,omitempty"`
-	//Config legacygadget.SystemConfig `yaml:"config,omitempty"`
-
-	// FIXME: move into a special kernel struct
-	// XXX: xxx
-	//Kernel string `yaml:"kernel,omitempty"`
-	//Initrd string `yaml:"initrd,omitempty"`
-	//Dtbs   string `yaml:"dtbs,omitempty"`
 }
 
 func parseSnapYamlFile(yamlPath string) (*snapYaml, error) {

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -236,7 +236,7 @@ func addSquashfsMount(s *snap.Info, inhibitHooks bool, inter interacter) error {
 	return nil
 }
 
-<func removeSquashfsMount(baseDir string, inter interacter) error {
+func removeSquashfsMount(baseDir string, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	unit := systemd.MountUnitPath(stripGlobalRootDir(baseDir), "mount")
 	if osutil.FileExists(unit) {

--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/legacygadget"
 	"github.com/ubuntu-core/snappy/snap/squashfs"
 	"github.com/ubuntu-core/snappy/systemd"
 	"github.com/ubuntu-core/snappy/timeout"
@@ -95,8 +96,8 @@ type snapYaml struct {
 	// FIXME: clarify those
 
 	// gadget snap only
-	Gadget Gadget       `yaml:"gadget,omitempty"`
-	Config SystemConfig `yaml:"config,omitempty"`
+	Gadget legacygadget.Gadget       `yaml:"gadget,omitempty"`
+	Config legacygadget.SystemConfig `yaml:"config,omitempty"`
 
 	// FIXME: move into a special kernel struct
 	Kernel string `yaml:"kernel,omitempty"`
@@ -188,6 +189,8 @@ func parseSnapYamlData(yamlData []byte, hasConfig bool) (*snapYaml, error) {
 	return &m, nil
 }
 
+// XXX: things below won't belong here soon, move them!
+
 // checkLicenseAgreement returns nil if it's ok to proceed with installing the
 // package, as deduced from the license agreement (which might involve asking
 // the user), or an error that explains the reason why installation should not
@@ -226,12 +229,14 @@ func checkLicenseAgreement(m *snapYaml, ag agreer, d snap.File, currentActiveDir
 	return nil
 }
 
-func addSquashfsMount(m *snapYaml, baseDir string, inhibitHooks bool, inter interacter) error {
+// XXX: don't take baseDir ?
+func addSquashfsMount(s *snap.Info, baseDir string, inhibitHooks bool, inter interacter) error {
+	// XXX: fix BlobPath
 	squashfsPath := stripGlobalRootDir(squashfs.BlobPath(baseDir))
 	whereDir := stripGlobalRootDir(baseDir)
 
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
-	mountUnitName, err := sysd.WriteMountUnitFile(m.Name, squashfsPath, whereDir)
+	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), squashfsPath, whereDir)
 	if err != nil {
 		return err
 	}

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -188,8 +188,8 @@ func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
 }
 
 func (s *SquashfsTestSuite) TestRemoveViaSquashfsWorks(c *C) {
-	snapFile := makeTestSnapPackage(c, packageHello)
-	snap, err := (&Overlord{}).Install(snapFile, 0, &MockProgressMeter{})
+	snapPath := makeTestSnapPackage(c, packageHello)
+	snap, err := (&Overlord{}).Install(snapPath, 0, &MockProgressMeter{})
 	c.Assert(err, IsNil)
 	installedSnap, err := NewInstalledSnap(filepath.Join(snap.MountDir(), "meta", "snap.yaml"))
 	c.Assert(err, IsNil)

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -169,7 +169,7 @@ func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
 	c.Assert(osutil.FileExists(p), Equals, true)
 
 	// now call remove and ensure they are gone
-	err = removeSquashfsMount(info.BaseDir(), i)
+	err = removeSquashfsMount(info.BaseDir(), inter)
 	c.Assert(err, IsNil)
 	p = filepath.Join(dirs.SnapServicesDir, "snaps-foo-1.0.mount")
 	c.Assert(osutil.FileExists(p), Equals, false)

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -136,7 +136,7 @@ func (s *SquashfsTestSuite) TestAddSquashfsMount(c *C) {
 		Architectures: []string{"all"},
 	}
 	inter := &MockProgressMeter{}
-	err := addSquashfsMount(info, filepath.Join(dirs.SnapSnapsDir, "foo/1.0"), true, inter)
+	err := addSquashfsMount(info, true, inter)
 	c.Assert(err, IsNil)
 
 	// ensure correct mount unit
@@ -153,9 +153,15 @@ Where=/snaps/foo/1.0
 }
 
 func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
-	info := &snap.Info{}
+	info := &snap.Info{
+		SideInfo: snap.SideInfo{
+			OfficialName: "foo",
+		},
+		Version:       "1.0",
+		Architectures: []string{"all"},
+	}
 	inter := &MockProgressMeter{}
-	err := addSquashfsMount(info, filepath.Join(dirs.SnapSnapsDir, "foo/1.0"), true, inter)
+	err := addSquashfsMount(info, true, inter)
 	c.Assert(err, IsNil)
 
 	// ensure we have the files
@@ -163,7 +169,7 @@ func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
 	c.Assert(osutil.FileExists(p), Equals, true)
 
 	// now call remove and ensure they are gone
-	err = removeSquashfsMount(filepath.Join(dirs.SnapSnapsDir, "foo/1.0"), i)
+	err = removeSquashfsMount(info.BaseDir(), i)
 	c.Assert(err, IsNil)
 	p = filepath.Join(dirs.SnapServicesDir, "snaps-foo-1.0.mount")
 	c.Assert(osutil.FileExists(p), Equals, false)

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -181,7 +181,7 @@ func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
 	c.Assert(osutil.FileExists(p), Equals, true)
 
 	// now call remove and ensure they are gone
-	err = removeSquashfsMount(info.BaseDir(), inter)
+	err = removeSquashfsMount(info.MountDir(), inter)
 	c.Assert(err, IsNil)
 	p = filepath.Join(dirs.SnapServicesDir, "snaps-foo-1.0.mount")
 	c.Assert(osutil.FileExists(p), Equals, false)
@@ -191,7 +191,7 @@ func (s *SquashfsTestSuite) TestRemoveViaSquashfsWorks(c *C) {
 	snapFile := makeTestSnapPackage(c, packageHello)
 	snap, err := (&Overlord{}).Install(snapFile, 0, &MockProgressMeter{})
 	c.Assert(err, IsNil)
-	installedSnap, err := NewInstalledSnap(filepath.Join(snap.BaseDir(), "meta", "snap.yaml"))
+	installedSnap, err := NewInstalledSnap(filepath.Join(snap.MountDir(), "meta", "snap.yaml"))
 	c.Assert(err, IsNil)
 
 	// after install the blob is in the right dir
@@ -280,7 +280,7 @@ func (s *SquashfsTestSuite) TestInstallKernelSnapRemovesKernelAssets(c *C) {
 	snapPkg := makeTestSnapPackageWithFiles(c, packageKernel, files)
 	snap, err := (&Overlord{}).Install(snapPkg, 0, &MockProgressMeter{})
 	c.Assert(err, IsNil)
-	installedSnap, err := NewInstalledSnap(filepath.Join(snap.BaseDir(), "meta", "snap.yaml"))
+	installedSnap, err := NewInstalledSnap(filepath.Join(snap.MountDir(), "meta", "snap.yaml"))
 	c.Assert(err, IsNil)
 	installedSnap.isActive = false
 

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -102,20 +102,20 @@ const packageHello = `name: hello-snap
 version: 1.10
 `
 
-func (s *SquashfsTestSuite) TestOpenSnapBlob(c *C) {
+func (s *SquashfsTestSuite) TestOpenSnapFile(c *C) {
 	snapPkg := makeTestSnapPackage(c, packageHello)
-	info, blobf, err := openSnapBlob(snapPkg, true, nil)
+	info, snapf, err := openSnapFile(snapPkg, true, nil)
 	c.Assert(err, IsNil)
 
 	// ensure the right backend got picked up
-	c.Assert(blobf, FitsTypeOf, &squashfs.Snap{})
+	c.Assert(snapf, FitsTypeOf, &squashfs.Snap{})
 	c.Check(info.Name(), Equals, "hello-snap")
 }
 
-func (s *SquashfsTestSuite) TestOpenSnapBlobSideInfo(c *C) {
+func (s *SquashfsTestSuite) TestOpenSnapFilebSideInfo(c *C) {
 	snapPkg := makeTestSnapPackage(c, packageHello)
 	si := snap.SideInfo{OfficialName: "blessed", Revision: 42}
-	info, _, err := openSnapBlob(snapPkg, true, &si)
+	info, _, err := openSnapFile(snapPkg, true, &si)
 	c.Assert(err, IsNil)
 
 	// check side info
@@ -306,10 +306,10 @@ func (s *SquashfsTestSuite) TestActiveKernelNotRemovable(c *C) {
 
 func (s *SquashfsTestSuite) TestInstallKernelSnapUnpacksKernelErrors(c *C) {
 	snapPkg := makeTestSnapPackage(c, packageHello)
-	snap, blobf, err := openSnapBlob(snapPkg, true, nil)
+	snap, snapf, err := openSnapFile(snapPkg, true, nil)
 	c.Assert(err, IsNil)
 
-	err = extractKernelAssets(snap, blobf, 0, nil)
+	err = extractKernelAssets(snap, snapf, 0, nil)
 	c.Assert(err, ErrorMatches, `can not extract kernel assets from snap type "app"`)
 }
 

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -298,7 +298,7 @@ func (s *SquashfsTestSuite) TestInstallKernelSnapUnpacksKernelErrors(c *C) {
 	snap, err := NewSnapFile(snapPkg, true)
 	c.Assert(err, IsNil)
 
-	err = extractKernelAssets(snap, nil, 0)
+	err = extractKernelAssets(snap.Info(), snap.deb, 0, nil)
 	c.Assert(err, ErrorMatches, `can not extract kernel assets from snap type "app"`)
 }
 
@@ -309,7 +309,7 @@ func (s *SquashfsTestSuite) TestInstallKernelSnapRemoveAssetsWrongType(c *C) {
 	snap, err := NewInstalledSnap(snapYaml)
 	c.Assert(err, IsNil)
 
-	err = removeKernelAssets(snap, nil)
+	err = removeKernelAssets(snap.Info(), nil)
 	c.Assert(err, ErrorMatches, `can not remove kernel assets from snap type "app"`)
 }
 

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -177,16 +177,13 @@ func (s *SquashfsTestSuite) TestRemoveSquashfsMountUnit(c *C) {
 
 func (s *SquashfsTestSuite) TestRemoveViaSquashfsWorks(c *C) {
 	snapFile := makeTestSnapPackage(c, packageHello)
-	_, err := (&Overlord{}).Install(snapFile, 0, &MockProgressMeter{})
+	installedSnap, err := (&Overlord{}).Install(snapFile, 0, &MockProgressMeter{})
 	c.Assert(err, IsNil)
 
 	// after install the blob is in the right dir
 	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-snap_1.10.snap")), Equals, true)
 
 	// now remove and ensure its gone
-	snap, err := NewSnapFile(snapFile, true)
-	c.Assert(err, IsNil)
-	installedSnap, err := newSnapFromYaml(filepath.Join(snap.instdir, "meta", "package.yaml"), snap.m)
 	err = (&Overlord{}).Uninstall(installedSnap, &MockProgressMeter{})
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello-snap_1.10.snap")), Equals, false)
@@ -267,16 +264,12 @@ func (s *SquashfsTestSuite) TestInstallKernelSnapRemovesKernelAssets(c *C) {
 		{"initrd.img-4.2", "...and I'm an initrd"},
 	}
 	snapPkg := makeTestSnapPackageWithFiles(c, packageKernel, files)
-	_, err := (&Overlord{}).Install(snapPkg, 0, &MockProgressMeter{})
+	installedSnap, err := (&Overlord{}).Install(snapPkg, 0, &MockProgressMeter{})
 	c.Assert(err, IsNil)
 	kernelAssetsDir := filepath.Join(s.bootloader.Dir(), "ubuntu-kernel_4.0-1.snap")
 	c.Assert(osutil.FileExists(kernelAssetsDir), Equals, true)
 
 	// ensure uninstall cleans the kernel assets
-	snap, err := NewSnapFile(snapPkg, true)
-	c.Assert(err, IsNil)
-	installedSnap, err := newSnapFromYaml(filepath.Join(snap.instdir, "meta", "package.yaml"), snap.m)
-	installedSnap.isActive = false
 	err = (&Overlord{}).Uninstall(installedSnap, &MockProgressMeter{})
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(kernelAssetsDir), Equals, false)

--- a/snappy/undo_test.go
+++ b/snappy/undo_test.go
@@ -123,13 +123,13 @@ version: 2.0`)
 	c.Assert(err, IsNil)
 
 	// copy data
-	err = CopyData(sn, 0, &s.meter)
+	err = CopyData(sn.Info(), 0, &s.meter)
 	c.Assert(err, IsNil)
 	v2data := filepath.Join(dirs.SnapDataDir, "hello/2.0")
 	l, _ := filepath.Glob(filepath.Join(v2data, "*"))
 	c.Assert(l, HasLen, 1)
 
-	UndoCopyData(sn, 0, &s.meter)
+	UndoCopyData(sn.Info(), 0, &s.meter)
 	l, _ = filepath.Glob(filepath.Join(v2data, "*"))
 	c.Assert(l, HasLen, 0)
 

--- a/snappy/undo_test.go
+++ b/snappy/undo_test.go
@@ -53,9 +53,9 @@ version: 1.0
 `
 
 func (s *undoTestSuite) TestUndoForSetupSnapSimple(c *C) {
-	snapFile := makeTestSnapPackage(c, helloSnap)
+	snapPath := makeTestSnapPackage(c, helloSnap)
 
-	instDir, err := SetupSnap(snapFile, 0, &s.meter)
+	instDir, err := SetupSnap(snapPath, 0, &s.meter)
 	c.Assert(err, IsNil)
 	c.Assert(instDir, Equals, filepath.Join(dirs.SnapSnapsDir, "hello-snap/1.0"))
 	l, _ := filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.mount"))
@@ -80,7 +80,7 @@ func (s *undoTestSuite) TestUndoForSetupSnapKernelUboot(c *C) {
 		{"lib/modules/4.4.0-14-generic/foo.ko", "a module"},
 		{"lib/firmware/bar.bin", "some firmware"},
 	}
-	snapFile := makeTestSnapPackageWithFiles(c, `name: kernel-snap
+	snapPath := makeTestSnapPackageWithFiles(c, `name: kernel-snap
 version: 1.0
 type: kernel
 
@@ -90,7 +90,7 @@ modules: lib/modules/4.4.0-14-generic
 firmware: lib/firmware
 `, testFiles)
 
-	instDir, err := SetupSnap(snapFile, 0, &s.meter)
+	instDir, err := SetupSnap(snapPath, 0, &s.meter)
 	c.Assert(err, IsNil)
 	l, _ := filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
 	c.Assert(l, HasLen, 1)


### PR DESCRIPTION
This branch does accomplish:

* gets rid of all usages of snapYaml in the early phase of install (where we were using SnapFile) in favor of snap.Info
* in the process moves legacy bits of snap.yaml syntax under Info.Legacy which just receives the parsed stuff without further processing (see snap/legacy.go, gadget yaml defs are moved under snap/legacygadget, processing is still in snappy/)
* drops some usages of NewSnapFile, for the rest gets rid of SnapFile and use openSnapBlob instead taking a path and a snap.SideInfo and returning a Info and snap.File
* use Info.MountFile (instead of BlobPath, make squashfs not need to know about snappy/dirs) and rename Info.BaseDir to Info.MountDir
* other cleanups

given that we still have snap.Snap for now there is some ugliness at the points where the code isn't moved yet to use Infos, especially when the two approaches meet, but still should set up things enough to be able to switch to use Revision for building disk paths. we can proceed with what to do with snap.Snap after.

There are still some vestigial uses of snapYaml which can also be dealt with later, and in security.go which should just die(tm).
