### PR TITLE
interfaces: change RemoveSnap to take string argument

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -628,11 +628,9 @@ func (r *Repository) AddSnap(snapInfo *snap.Info) error {
 // RemoveSnap does not remove connections. The caller is responsible for
 // ensuring that connections are broken before calling this method. If this
 // constraint is violated then no changes are made and an error is returned.
-func (r *Repository) RemoveSnap(snapInfo *snap.Info) error {
+func (r *Repository) RemoveSnap(snapName string) error {
 	r.m.Lock()
 	defer r.m.Unlock()
-
-	snapName := snapInfo.Name()
 
 	for plugName, plug := range r.plugs[snapName] {
 		if len(plug.Connections) > 0 {

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -949,38 +949,38 @@ func (s *AddRemoveSuite) TestAddSnapErrorsOnExistingSnapSlots(c *C) {
 }
 
 func (s AddRemoveSuite) TestRemoveRemovesPlugs(c *C) {
-	consumer, err := s.addSnap(c, testConsumerYaml)
+	_, err := s.addSnap(c, testConsumerYaml)
 	c.Assert(err, IsNil)
-	s.repo.RemoveSnap(consumer)
+	s.repo.RemoveSnap("consumer")
 	c.Assert(s.repo.Plug("consumer", "iface"), IsNil)
 }
 
 func (s AddRemoveSuite) TestRemoveRemovesSlots(c *C) {
-	producer, err := s.addSnap(c, testProducerYaml)
+	_, err := s.addSnap(c, testProducerYaml)
 	c.Assert(err, IsNil)
-	s.repo.RemoveSnap(producer)
+	s.repo.RemoveSnap("producer")
 	c.Assert(s.repo.Plug("producer", "iface"), IsNil)
 }
 
 func (s *AddRemoveSuite) TestRemoveSnapErrorsOnStillConnectedPlug(c *C) {
-	consumer, err := s.addSnap(c, testConsumerYaml)
+	_, err := s.addSnap(c, testConsumerYaml)
 	c.Assert(err, IsNil)
 	_, err = s.addSnap(c, testProducerYaml)
 	c.Assert(err, IsNil)
 	err = s.repo.Connect("consumer", "iface", "producer", "iface")
 	c.Assert(err, IsNil)
-	err = s.repo.RemoveSnap(consumer)
+	err = s.repo.RemoveSnap("consumer")
 	c.Assert(err, ErrorMatches, "cannot remove connected plug consumer.iface")
 }
 
 func (s *AddRemoveSuite) TestRemoveSnapErrorsOnStillConnectedSlot(c *C) {
 	_, err := s.addSnap(c, testConsumerYaml)
 	c.Assert(err, IsNil)
-	producer, err := s.addSnap(c, testProducerYaml)
+	_, err = s.addSnap(c, testProducerYaml)
 	c.Assert(err, IsNil)
 	err = s.repo.Connect("consumer", "iface", "producer", "iface")
 	c.Assert(err, IsNil)
-	err = s.repo.RemoveSnap(producer)
+	err = s.repo.RemoveSnap("producer")
 	c.Assert(err, ErrorMatches, "cannot remove connected slot producer.iface")
 }
 


### PR DESCRIPTION
This patch aligns RemoveSnap with DisconnectSnap. The function relies on
the name of the snap only. Taking the full snap.Info object might be
undesired in some ways (e.g. the snap is no longer present and info file
cannot be read).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>