### PR TITLE
interfaces: change SecurityBackend.Remove take a string

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -369,7 +369,7 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 
 // removeSnap "removes" an "installed" snap.
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
-	err := s.backend.Remove(snapInfo)
+	err := s.backend.Remove(snapInfo.Name())
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
 }

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -37,5 +37,5 @@ type SecurityBackend interface {
 	// Remove removes and unloads security artefacts of a given snap.
 	//
 	// This method should be called during the process of removing a snap.
-	Remove(snapInfo *snap.Info) error
+	Remove(snapName string) error
 }

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -44,20 +44,21 @@ type Backend struct{}
 //
 // DBus has no concept of a complain mode so developerMode is not supported
 func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
+	snapName := snapInfo.Name()
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityDBus)
 	if err != nil {
-		return fmt.Errorf("cannot obtain DBus security snippets for snap %q: %s", snapInfo.Name(), err)
+		return fmt.Errorf("cannot obtain DBus security snippets for snap %q: %s", snapName, err)
 	}
 	// Get the files that this snap should have
 	content, err := b.combineSnippets(snapInfo, snippets)
 	if err != nil {
-		return fmt.Errorf("cannot obtain expected DBus configuration files for snap %q: %s", snapInfo.Name(), err)
+		return fmt.Errorf("cannot obtain expected DBus configuration files for snap %q: %s", snapName, err)
 	}
-	glob := fmt.Sprintf("%s.conf", interfaces.SecurityTagGlob(snapInfo))
+	glob := fmt.Sprintf("%s.conf", interfaces.SecurityTagGlob(snapName))
 	_, _, err = osutil.EnsureDirState(dirs.SnapBusPolicyDir, glob, content)
 	if err != nil {
-		return fmt.Errorf("cannot synchronize DBus configuration files for snap %q: %s", snapInfo.Name(), err)
+		return fmt.Errorf("cannot synchronize DBus configuration files for snap %q: %s", snapName, err)
 	}
 	return nil
 }
@@ -65,11 +66,11 @@ func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interface
 // Remove removes dbus configuration files of a given snap.
 //
 // This method should be called after removing a snap.
-func (b *Backend) Remove(snapInfo *snap.Info) error {
-	glob := fmt.Sprintf("%s.conf", interfaces.SecurityTagGlob(snapInfo))
+func (b *Backend) Remove(snapName string) error {
+	glob := fmt.Sprintf("%s.conf", interfaces.SecurityTagGlob(snapName))
 	_, _, err := osutil.EnsureDirState(dirs.SnapBusPolicyDir, glob, nil)
 	if err != nil {
-		return fmt.Errorf("cannot synchronize DBus configuration files for snap %q: %s", snapInfo.Name(), err)
+		return fmt.Errorf("cannot synchronize DBus configuration files for snap %q: %s", snapName, err)
 	}
 	return nil
 }

--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -234,7 +234,7 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 
 // removeSnap "removes" an "installed" snap.
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
-	err := s.backend.Remove(snapInfo)
+	err := s.backend.Remove(snapInfo.Name())
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
 }

--- a/interfaces/naming.go
+++ b/interfaces/naming.go
@@ -35,6 +35,6 @@ func SecurityTag(appInfo *snap.AppInfo) string {
 
 // SecurityTagGlob returns a pattern that matches all security tags belonging to
 // the same snap as the given app.
-func SecurityTagGlob(snapInfo *snap.Info) string {
-	return fmt.Sprintf("snap.%s.%s", snapInfo.Name(), "*")
+func SecurityTagGlob(snapName string) string {
+	return fmt.Sprintf("snap.%s.%s", snapName, "*")
 }

--- a/interfaces/naming_test.go
+++ b/interfaces/naming_test.go
@@ -36,6 +36,5 @@ func (s *NamingSuite) TestSecurityTag(c *C) {
 }
 
 func (s *NamingSuite) TestSecurityTagGlob(c *C) {
-	snapInfo := &snap.Info{SuggestedName: "http"}
-	c.Check(SecurityTagGlob(snapInfo), Equals, "snap.http.*")
+	c.Check(SecurityTagGlob("http"), Equals, "snap.http.*")
 }

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -52,30 +52,31 @@ type Backend struct{}
 // This method should be called after changing plug, slots, connections between
 // them or application present in the snap.
 func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interfaces.Repository) error {
+	snapName := snapInfo.Name()
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecuritySecComp)
 	if err != nil {
-		return fmt.Errorf("cannot obtain security snippets for snap %q: %s", snapInfo.Name(), err)
+		return fmt.Errorf("cannot obtain security snippets for snap %q: %s", snapName, err)
 	}
 	// Get the files that this snap should have
 	content, err := b.combineSnippets(snapInfo, developerMode, snippets)
 	if err != nil {
-		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapInfo.Name(), err)
+		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
-	glob := interfaces.SecurityTagGlob(snapInfo)
+	glob := interfaces.SecurityTagGlob(snapName)
 	_, _, err = osutil.EnsureDirState(dirs.SnapSeccompDir, glob, content)
 	if err != nil {
-		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapInfo.Name(), err)
+		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, err)
 	}
 	return nil
 }
 
 // Remove removes seccomp profiles of a given snap.
-func (b *Backend) Remove(snapInfo *snap.Info) error {
-	glob := interfaces.SecurityTagGlob(snapInfo)
+func (b *Backend) Remove(snapName string) error {
+	glob := interfaces.SecurityTagGlob(snapName)
 	_, _, err := osutil.EnsureDirState(dirs.SnapSeccompDir, glob, nil)
 	if err != nil {
-		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapInfo.Name(), err)
+		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, err)
 	}
 	return nil
 }

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -225,7 +225,7 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 
 // removeSnap "removes" an "installed" snap.
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
-	err := s.backend.Remove(snapInfo)
+	err := s.backend.Remove(snapInfo.Name())
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
 }

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -249,7 +249,7 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 
 // removeSnap "removes" an "installed" snap.
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
-	err := s.backend.Remove(snapInfo)
+	err := s.backend.Remove(snapInfo.Name())
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
 }


### PR DESCRIPTION
This patch changes the SecurityBackend interface to take a simple string
in the Remove() method. This matches the similar changes made earlier
today to RemoveSnap() and DisconnectSnap().

The rationale is also that it should be possible to remove security of a
snap with just the name alone. This matches all the other code in the
upcoming doRemoveSecurity handler in the interfaces manager.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>