### PR TITLE
overlord: switch to interfaces for security tasks

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -40,7 +40,7 @@ func wait(client *client.Client, uuid string) error {
 			return op.Err()
 		}
 
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1000 * time.Millisecond)
 	}
 }
 

--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -28,6 +28,7 @@ package apparmor
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,6 +42,7 @@ import (
 // If no such profile was previously loaded then it is simply added to the kernel.
 // If there was a profile with the same name before, that profile is replaced.
 func LoadProfile(fname string) error {
+	log.Printf("Loading apparmor profile: %q\n", fname)
 	// Use no-expr-simplify since expr-simplify is actually slower on armhf (LP: #1383858)
 	output, err := exec.Command(
 		"apparmor_parser", "--replace", "--write-cache", "-O",
@@ -57,6 +59,7 @@ func LoadProfile(fname string) error {
 // The operation is done with: apparmor_parser --remove $name
 // The binary cache file is removed from /var/cache/apparmor
 func UnloadProfile(name string) error {
+	log.Printf("Unloading apparmor profile: %q\n", name)
 	output, err := exec.Command("apparmor_parser", "--remove", name).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cannot unload apparmor profile: %s\napparmor_parser output:\n%s", err, string(output))

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -58,6 +58,10 @@ type Backend struct {
 	legacyTemplate []byte
 }
 
+func (b *Backend) String() string {
+	return "apparmor"
+}
+
 // UseLegacyTemplate switches from default apparmor template to a custom
 // template. This also implies that a fixed set of apparmor variables will be
 // injected into this template. The set is compatible with Ubuntu core 15.04.

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -216,33 +216,33 @@ var defaultTemplate = []byte(`
   @{PROC}/net/dev r,
 
   # Read-only for the install directory
-  @{INSTALL_DIR}/@{APP_PKGNAME}/                   r,
-  @{INSTALL_DIR}/@{APP_PKGNAME}/@{APP_VERSION}/    r,
-  @{INSTALL_DIR}/@{APP_PKGNAME}/@{APP_VERSION}/**  mrklix,
+  @{INSTALL_DIR}/@{SNAP_NAME}/                   r,
+  @{INSTALL_DIR}/@{SNAP_NAME}/@{SNAP_VERSION}/    r,
+  @{INSTALL_DIR}/@{SNAP_NAME}/@{SNAP_VERSION}/**  mrklix,
 
   # Don't log noisy python denials (see LP: #1496895 for more details)
-  deny @{INSTALL_DIR}/@{APP_PKGNAME}/**/__pycache__/             w,
-  deny @{INSTALL_DIR}/@{APP_PKGNAME}/**/__pycache__/*.pyc.[0-9]* w,
+  deny @{INSTALL_DIR}/@{SNAP_NAME}/**/__pycache__/             w,
+  deny @{INSTALL_DIR}/@{SNAP_NAME}/**/__pycache__/*.pyc.[0-9]* w,
 
   # Read-only home area for other versions
-  owner @{HOME}/apps/@{APP_PKGNAME}/                  r,
-  owner @{HOME}/apps/@{APP_PKGNAME}/**                mrkix,
-  owner @{HOME}/snaps/@{APP_PKGNAME}/                  r,
-  owner @{HOME}/snaps/@{APP_PKGNAME}/**                mrkix,
+  owner @{HOME}/apps/@{SNAP_NAME}/                  r,
+  owner @{HOME}/apps/@{SNAP_NAME}/**                mrkix,
+  owner @{HOME}/snaps/@{SNAP_NAME}/                  r,
+  owner @{HOME}/snaps/@{SNAP_NAME}/**                mrkix,
 
   # Writable home area for this version.
-  owner @{HOME}/apps/@{APP_PKGNAME}/@{APP_VERSION}/** wl,
-  owner @{HOME}/snaps/@{APP_PKGNAME}/@{APP_VERSION}/** wl,
+  owner @{HOME}/apps/@{SNAP_NAME}/@{SNAP_VERSION}/** wl,
+  owner @{HOME}/snaps/@{SNAP_NAME}/@{SNAP_VERSION}/** wl,
 
   # Read-only system area for other versions
-  /var/lib/apps/@{APP_PKGNAME}/   r,
-  /var/lib/apps/@{APP_PKGNAME}/** mrkix,
-  /var/lib/snaps/@{APP_PKGNAME}/   r,
-  /var/lib/snaps/@{APP_PKGNAME}/** mrkix,
+  /var/lib/apps/@{SNAP_NAME}/   r,
+  /var/lib/apps/@{SNAP_NAME}/** mrkix,
+  /var/lib/snaps/@{SNAP_NAME}/   r,
+  /var/lib/snaps/@{SNAP_NAME}/** mrkix,
 
   # Writable system area only for this version
-  /var/lib/apps/@{APP_PKGNAME}/@{APP_VERSION}/** wl,
-  /var/lib/snaps/@{APP_PKGNAME}/@{APP_VERSION}/** wl,
+  /var/lib/apps/@{SNAP_NAME}/@{SNAP_VERSION}/** wl,
+  /var/lib/snaps/@{SNAP_NAME}/@{SNAP_VERSION}/** wl,
 
   # The ubuntu-core-launcher creates an app-specific private restricted /tmp
   # and will fail to launch the app if something goes wrong. As such, we can
@@ -251,17 +251,17 @@ var defaultTemplate = []byte(`
   /tmp/** mrwlkix,
 
   # Also do the same for shm
-  /{dev,run}/shm/snaps/@{APP_PKGNAME}/                  r,
-  /{dev,run}/shm/snaps/@{APP_PKGNAME}/**                rk,
-  /{dev,run}/shm/snaps/@{APP_PKGNAME}/@{APP_VERSION}/   r,
-  /{dev,run}/shm/snaps/@{APP_PKGNAME}/@{APP_VERSION}/** mrwlkix,
+  /{dev,run}/shm/snaps/@{SNAP_NAME}/                  r,
+  /{dev,run}/shm/snaps/@{SNAP_NAME}/**                rk,
+  /{dev,run}/shm/snaps/@{SNAP_NAME}/@{SNAP_VERSION}/   r,
+  /{dev,run}/shm/snaps/@{SNAP_NAME}/@{SNAP_VERSION}/** mrwlkix,
 
   # Allow apps from the same package to communicate with each other via an
   # abstract or anonymous socket
-  unix peer=(label=@{APP_PKGNAME}_*),
+  unix peer=(label=@{SNAP_NAME}_*),
 
   # Allow apps from the same package to signal each other via signals
-  signal peer=@{APP_PKGNAME}_*,
+  signal peer=@{SNAP_NAME}_*,
 
   # for 'udevadm trigger --verbose --dry-run --tag-match=snappy-assign'
   /{,s}bin/udevadm ixr,

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -45,6 +45,11 @@ import (
 // party snap, not by snappy.
 func legacyVariables(appInfo *snap.AppInfo) []byte {
 	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name())
+	fmt.Fprintf(&buf, "@{SNAP_VERSION}=\"%s\"\n", appInfo.Snap.Version)
+	fmt.Fprintf(&buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
+	fmt.Fprintf(&buf, "@{APP_SECURITY_TAG}=\"%s\"\n", interfaces.SecurityTag(appInfo))
+	// Real legacy vars
 	fmt.Fprintf(&buf, "@{APP_APPNAME}=\"%s\"\n", appInfo.Name)
 	// TODO: replace with app.SecurityTag()
 	fmt.Fprintf(&buf, "@{APP_ID_DBUS}=\"%s\"\n",

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -73,9 +73,10 @@ func legacyVariables(appInfo *snap.AppInfo) []byte {
 // ...have everything work correctly?
 func modernVariables(appInfo *snap.AppInfo) []byte {
 	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name())
+	fmt.Fprintf(&buf, "@{SNAP_VERSION}=\"%s\"\n", appInfo.Snap.Version)
 	fmt.Fprintf(&buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
 	fmt.Fprintf(&buf, "@{APP_SECURITY_TAG}=\"%s\"\n", interfaces.SecurityTag(appInfo))
-	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name())
 	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"")
 	return buf.Bytes()
 }

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -40,6 +40,10 @@ import (
 // Backend is responsible for maintaining DBus policy files.
 type Backend struct{}
 
+func (b *Backend) String() string {
+	return "dbus"
+}
+
 // Setup creates dbus configuration files specific to a given snap.
 //
 // DBus has no concept of a complain mode so developerMode is not supported

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -45,6 +45,10 @@ import (
 // Backend is responsible for maintaining seccomp profiles for ubuntu-core-launcher.
 type Backend struct{}
 
+func (b *Backend) String() string {
+	return "seccomp"
+}
+
 // Setup creates seccomp profiles specific to a given snap.
 // The snap can be in developer mode to make security violations non-fatal to
 // the offending application process.

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -37,6 +37,10 @@ import (
 // Backend is responsible for maintaining udev rules.
 type Backend struct{}
 
+func (b *Backend) String() string {
+	return "udev"
+}
+
 // Setup creates udev rules specific to a given snap.
 // If any of the rules are changed or removed then udev database is reloaded.
 //

--- a/interfaces/udev/udev.go
+++ b/interfaces/udev/udev.go
@@ -21,6 +21,7 @@ package udev
 
 import (
 	"fmt"
+	"log"
 	"os/exec"
 )
 
@@ -29,6 +30,7 @@ import (
 // The commands are: udevadm control --reload-rules
 //                   udevadm trigger
 func ReloadRules() error {
+	log.Printf("Reloading udev rules and running triggers\n")
 	output, err := exec.Command("udevadm", "control", "--reload-rules").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cannot reload udev rules: %s\nudev output:\n%s", err, string(output))

--- a/osutil/sync_dir.go
+++ b/osutil/sync_dir.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -63,6 +64,10 @@ var errSameState = fmt.Errorf("file state has not changed")
 //
 // In all cases, the function returns the first error it has encountered.
 func EnsureDirState(dir, glob string, content map[string]*FileState) (changed, removed []string, err error) {
+	log.Printf("EnsureDirState: ENTER, on %q (glob %q) len(content): %d\n", dir, glob, len(content))
+	for name, fs := range content {
+		log.Printf("  %q: %q\n", name, string(fs.Content[:25]))
+	}
 	if _, err := filepath.Match(glob, "foo"); err != nil {
 		panic(fmt.Sprintf("EnsureDirState got invalid pattern %q: %s", glob, err))
 	}
@@ -116,6 +121,8 @@ func EnsureDirState(dir, glob string, content map[string]*FileState) (changed, r
 	}
 	sort.Strings(changed)
 	sort.Strings(removed)
+	log.Printf("EnsureDirState: LEAVE, changed: %q, removed: %q, firstErr: %s\n",
+		changed, removed, firstErr)
 	return changed, removed, firstErr
 }
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -28,8 +28,14 @@ import (
 
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/interfaces/apparmor"
 	"github.com/ubuntu-core/snappy/interfaces/builtin"
+	"github.com/ubuntu-core/snappy/interfaces/dbus"
+	"github.com/ubuntu-core/snappy/interfaces/seccomp"
+	"github.com/ubuntu-core/snappy/interfaces/udev"
+	"github.com/ubuntu-core/snappy/overlord/snapstate"
 	"github.com/ubuntu-core/snappy/overlord/state"
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 // InterfaceManager is responsible for the maintenance of interfaces in
@@ -58,7 +64,108 @@ func Manager(s *state.State) (*InterfaceManager, error) {
 
 	runner.AddHandler("connect", m.doConnect, nil)
 	runner.AddHandler("disconnect", m.doDisconnect, nil)
+	runner.AddHandler("setup-snap-security", m.doSetupSnapSecurity, m.doRemoveSnapSecurity)
+	runner.AddHandler("remove-snap-security", m.doRemoveSnapSecurity, m.doSetupSnapSecurity)
 	return m, nil
+}
+
+func (m *InterfaceManager) doSetupSnapSecurity(task *state.Task, _ *tomb.Tomb) error {
+	task.State().Lock()
+	defer task.State().Unlock()
+
+	// Get snap.Info from bits handed by the snap manager.
+	ss, err := snapstate.TaskSnapSetup(task)
+	if err != nil {
+		return err
+	}
+	snapInfo, err := snapstate.SnapInfo(task.State(), ss.Name, ss.Version)
+	if err != nil {
+		return err
+	}
+	snapName := snapInfo.Name()
+
+	// The snap may have been updated so perform the following operation to
+	// ensure that we are always working on the correct state:
+	//
+	// - disconnect all connections to/from the given snap
+	//   - remembering the snaps that were affected by this operation
+	// - remove the (old) snap from the interfaces repository
+	// - add the (new) snap to the interfaces repository
+	// - restore connections based on what is kept in the state
+	//   - if a connection cannot be restored then remove it from the state
+	// - setup the security of all the affected snaps
+	affectedSnaps, err := m.repo.DisconnectSnap(snapName)
+	if err != nil {
+		return err
+	}
+	// XXX: what about snap renames? We should remove the old name (or switch
+	// to IDs in the interfaces repository)
+	if err := m.repo.RemoveSnap(snapName); err != nil {
+		return err
+	}
+	if err := m.repo.AddSnap(snapInfo); err != nil {
+		return err
+	}
+	// TODO: re-connect all connection affecting given snap
+	// TODO:  - removing failed connections from the state
+	if len(affectedSnaps) == 0 {
+		affectedSnaps = append(affectedSnaps, snapInfo)
+	}
+	for _, snapInfo := range affectedSnaps {
+		for _, backend := range securityBackendsForSnap(snapInfo) {
+			developerMode := false // TODO: move this to snap.Info
+			if err := backend.Setup(snapInfo, developerMode, m.repo); err != nil {
+				return state.Retry
+			}
+		}
+	}
+	return nil
+}
+
+func (m *InterfaceManager) doRemoveSnapSecurity(task *state.Task, _ *tomb.Tomb) error {
+	task.State().Lock()
+	defer task.State().Unlock()
+
+	// Get snap.Info from bits handed by the snap manager.
+	ss, err := snapstate.TaskSnapSetup(task)
+	if err != nil {
+		return err
+	}
+	snapInfo, err := snapstate.SnapInfo(task.State(), ss.Name, ss.Version)
+	if err != nil {
+		return err
+	}
+	snapName := snapInfo.Name()
+	affectedSnaps, err := m.repo.DisconnectSnap(snapName)
+	if err != nil {
+		return err
+	}
+	// TODO: remove all connections from the state
+	if err := m.repo.RemoveSnap(snapName); err != nil {
+
+		return err
+	}
+	if len(affectedSnaps) == 0 {
+		affectedSnaps = append(affectedSnaps, snapInfo)
+	}
+	for _, snapInfo := range affectedSnaps {
+		for _, backend := range securityBackendsForSnap(snapInfo) {
+			if err := backend.Remove(snapInfo.Name()); err != nil {
+				return state.Retry
+			}
+		}
+	}
+	return nil
+}
+
+func securityBackendsForSnap(snapInfo *snap.Info) []interfaces.SecurityBackend {
+	aaBackend := &apparmor.Backend{}
+	// TODO: Implement special provisions for apparmor and old-security when
+	// old-security becomes a real interface. When that happens we nee to call
+	// backend.UseLegacyTemplate() with the alternate template offered by the
+	// old-security interface.
+	return []interfaces.SecurityBackend{
+		aaBackend, &seccomp.Backend{}, &dbus.Backend{}, &udev.Backend{}}
 }
 
 // Connect returns a set of tasks for connecting an interface.

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -19,6 +19,12 @@
 
 package snapstate
 
+import (
+	"gopkg.in/tomb.v2"
+
+	"github.com/ubuntu-core/snappy/overlord/state"
+)
+
 type ManagerBackend managerBackend
 
 func SetSnapManagerBackend(s *SnapManager, b ManagerBackend) {
@@ -27,4 +33,12 @@ func SetSnapManagerBackend(s *SnapManager, b ManagerBackend) {
 
 func SetSnapstateBackend(b ManagerBackend) {
 	backend = b
+}
+
+// AddForeignTaskHandlers registers handlers for tasks handled outside of the snap manager.
+func (m *SnapManager) AddForeignTaskHandlers() {
+	// Add fake handlers for tasks handled by interfaces manager
+	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error { return nil }
+	m.runner.AddHandler("setup-snap-security", fakeHandler, fakeHandler)
+	m.runner.AddHandler("remove-snap-security", fakeHandler, fakeHandler)
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -84,12 +84,10 @@ func Manager(s *state.State) (*SnapManager, error) {
 	runner.AddHandler("download-snap", m.doDownloadSnap, nil)
 	runner.AddHandler("mount-snap", m.doMountSnap, m.undoMountSnap)
 	runner.AddHandler("copy-snap-data", m.doCopySnapData, m.undoCopySnapData)
-	runner.AddHandler("setup-snap-security", m.doSetupSnapSecurity, m.doRemoveSnapSecurity)
 	runner.AddHandler("link-snap", m.doLinkSnap, m.undoLinkSnap)
 
 	// remove releated
 	runner.AddHandler("unlink-snap", m.doUnlinkSnap, nil)
-	runner.AddHandler("remove-snap-security", m.doRemoveSnapSecurity, nil)
 	runner.AddHandler("remove-snap-files", m.doRemoveSnapFiles, nil)
 	runner.AddHandler("remove-snap-data", m.doRemoveSnapData, nil)
 
@@ -172,17 +170,6 @@ func (m *SnapManager) doUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	pb := &TaskProgressAdapter{task: t}
 	return m.backend.UnlinkSnap(ss.MountDir(), pb)
-}
-
-func (m *SnapManager) doRemoveSnapSecurity(t *state.Task, _ *tomb.Tomb) error {
-	t.State().Lock()
-	ss, err := TaskSnapSetup(t)
-	t.State().Unlock()
-	if err != nil {
-		return err
-	}
-
-	return m.backend.RemoveSnapSecurity(ss.MountDir())
 }
 
 func (m *SnapManager) doRemoveSnapFiles(t *state.Task, _ *tomb.Tomb) error {
@@ -309,17 +296,6 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	return m.backend.SetupSnap(ss.SnapPath, ss.Flags)
-}
-
-func (m *SnapManager) doSetupSnapSecurity(t *state.Task, _ *tomb.Tomb) error {
-	t.State().Lock()
-	ss, err := TaskSnapSetup(t)
-	t.State().Unlock()
-	if err != nil {
-		return err
-	}
-
-	return m.backend.SetupSnapSecurity(ss.MountDir())
 }
 
 func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -61,7 +61,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	var err error
 	s.snapmgr, err = snapstate.Manager(s.state)
 	c.Assert(err, IsNil)
-
+	s.snapmgr.AddForeignTaskHandlers()
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 	snapstate.SetSnapstateBackend(s.fakeBackend)
 }
@@ -119,7 +119,7 @@ func (s *snapmgrTestSuite) TestInstallIntegration(c *C) {
 	s.state.Lock()
 
 	// ensure all our tasks ran
-	c.Assert(s.fakeBackend.ops, HasLen, 6)
+	c.Assert(s.fakeBackend.ops, HasLen, 5)
 	c.Assert(s.fakeBackend.ops, DeepEquals, []fakeOp{
 		fakeOp{
 			op:      "download",
@@ -136,10 +136,6 @@ func (s *snapmgrTestSuite) TestInstallIntegration(c *C) {
 		},
 		fakeOp{
 			op:   "copy-data",
-			name: "/snaps/some-snap/1.0",
-		},
-		fakeOp{
-			op:   "setup-snap-security",
 			name: "/snaps/some-snap/1.0",
 		},
 		fakeOp{
@@ -190,7 +186,7 @@ func (s *snapmgrTestSuite) TestInstallLocalIntegration(c *C) {
 	s.state.Lock()
 
 	// ensure only local install was run, i.e. first action is check-snap
-	c.Assert(s.fakeBackend.ops, HasLen, 5)
+	c.Assert(s.fakeBackend.ops, HasLen, 4)
 	c.Check(s.fakeBackend.ops[0].op, Equals, "check-snap")
 	c.Check(s.fakeBackend.ops[0].name, Matches, `.*/mock.snap`)
 }
@@ -208,7 +204,7 @@ func (s *snapmgrTestSuite) TestRemoveIntegration(c *C) {
 	defer s.snapmgr.Stop()
 	s.state.Lock()
 
-	c.Assert(s.fakeBackend.ops, HasLen, 5)
+	c.Assert(s.fakeBackend.ops, HasLen, 4)
 	c.Assert(s.fakeBackend.ops, DeepEquals, []fakeOp{
 		fakeOp{
 			op:   "can-remove",
@@ -216,10 +212,6 @@ func (s *snapmgrTestSuite) TestRemoveIntegration(c *C) {
 		},
 		fakeOp{
 			op:   "unlink-snap",
-			name: "/snaps/some-snap/1.64872",
-		},
-		fakeOp{
-			op:   "remove-snap-security",
 			name: "/snaps/some-snap/1.64872",
 		},
 		fakeOp{

--- a/snappy/binaries.go
+++ b/snappy/binaries.go
@@ -34,14 +34,6 @@ import (
 	"github.com/ubuntu-core/snappy/snap/snapenv"
 )
 
-// XXX: this needs to change in the new interfaces world!
-// it will need to be a SecurityTag value
-func getSecurityProfileFromApp(app *snap.AppInfo) string {
-	cleanedName := strings.Replace(app.Name, "/", "-", -1)
-
-	return fmt.Sprintf("%s_%s_%s", app.Snap.Name(), cleanedName, app.Snap.Version)
-}
-
 // generate the name
 // TODO: => AppInfo.WrapperPath
 func generateBinaryName(app *snap.AppInfo) string {

--- a/snappy/binaries.go
+++ b/snappy/binaries.go
@@ -92,7 +92,6 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 	}
 
 	actualBinPath := binPathForBinary(pkgPath, app)
-	aaProfile := getSecurityProfileFromApp(app)
 
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("wrapper").Parse(wrapperTemplate))
@@ -114,10 +113,10 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 		SnapArch:    arch.UbuntuArchitecture(),
 		SnapPath:    pkgPath,
 		Version:     app.Snap.Version,
-		UdevAppName: fmt.Sprintf("%s.%s", app.Snap.Name(), app.Name),
+		UdevAppName: fmt.Sprintf("snap.%s.%s", app.Snap.Name(), app.Name),
 		Home:        "$HOME",
 		Target:      actualBinPath,
-		AaProfile:   aaProfile,
+		AaProfile:   fmt.Sprintf("snap.%s.%s", app.Snap.Name(), app.Name),
 	}
 
 	oldVars := []string{}

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -359,13 +359,6 @@ func ActivateSnap(s *Snap, inter interacter) error {
 		return fmt.Errorf("cannot activate snap while another one is active: %v", currentActiveDir)
 	}
 
-	// generate the security policy from the snap.yaml
-	// Note that this must happen before binaries/services are
-	// generated because serices may get started
-	if err := SetupSnapSecurity(s); err != nil {
-		return err
-	}
-
 	if err := GenerateWrappers(s, inter); err != nil {
 		return err
 	}

--- a/snappy/services.go
+++ b/snappy/services.go
@@ -70,7 +70,6 @@ func generateSnapServicesFile(app *snap.AppInfo, baseDir string) (string, error)
 		socketFileName = filepath.Base(generateSocketFileName(app))
 	}
 
-	aaProfile := getSecurityProfileFromApp(app)
 	return systemd.New(dirs.GlobalRootDir, nil).GenServiceFile(
 		&systemd.ServiceDescription{
 			SnapName:       app.Snap.Name(),
@@ -82,10 +81,10 @@ func generateSnapServicesFile(app *snap.AppInfo, baseDir string) (string, error)
 			Stop:           app.Stop,
 			PostStop:       app.PostStop,
 			StopTimeout:    serviceStopTimeout(app),
-			AaProfile:      aaProfile,
+			AaProfile:      fmt.Sprintf("snap.%s.%s", app.Snap.Name(), app.Name),
 			BusName:        app.BusName,
 			Type:           app.Daemon,
-			UdevAppName:    fmt.Sprintf("%s.%s", app.Snap.Name(), app.Name),
+			UdevAppName:    fmt.Sprintf("snap.%s.%s", app.Snap.Name(), app.Name),
 			Socket:         app.Socket,
 			SocketFileName: socketFileName,
 			Restart:        app.RestartCond,


### PR DESCRIPTION
This branch switches to interfaces for all security tasks.

There are dragons ahead. This branch is not tested except for unit tests. I'm pushing it for early review and for actual testing.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
