### PR TITLE
interfaces/builtin: rename some interfaces

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -39,7 +39,7 @@ var allInterfaces = []interfaces.Interface{
 	NewTimeserverControlInterface(),
 	NewTimezoneControlInterface(),
 	NewUnity7Interface(),
-	NewXInterface(),
+	NewX11Interface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -34,7 +34,7 @@ var allInterfaces = []interfaces.Interface{
 	NewNetworkBindInterface(),
 	NewNetworkControlInterface(),
 	NewNetworkObserveInterface(),
-	NewSnapControlInterface(),
+	NewSnapdControlInterface(),
 	NewSystemObserveInterface(),
 	NewTimeserverControlInterface(),
 	NewTimezoneControlInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -42,7 +42,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewNetworkBindInterface())
 	c.Check(all, DeepContains, builtin.NewNetworkControlInterface())
 	c.Check(all, DeepContains, builtin.NewNetworkObserveInterface())
-	c.Check(all, DeepContains, builtin.NewSnapControlInterface())
+	c.Check(all, DeepContains, builtin.NewSnapdControlInterface())
 	c.Check(all, DeepContains, builtin.NewSystemObserveInterface())
 	c.Check(all, DeepContains, builtin.NewTimeserverControlInterface())
 	c.Check(all, DeepContains, builtin.NewTimezoneControlInterface())

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -47,5 +47,5 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewTimeserverControlInterface())
 	c.Check(all, DeepContains, builtin.NewTimezoneControlInterface())
 	c.Check(all, DeepContains, builtin.NewUnity7Interface())
-	c.Check(all, DeepContains, builtin.NewXInterface())
+	c.Check(all, DeepContains, builtin.NewX11Interface())
 }

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -23,16 +23,16 @@ import (
 	"github.com/ubuntu-core/snappy/interfaces"
 )
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/snap-control
-const snapControlConnectedPlugAppArmor = `
+// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/snapd-control
+const snapdControlConnectedPlugAppArmor = `
 # Description: Can manage snaps via snapd.
 # Usage: reserved
 
 /run/snapd.socket rw,
 `
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/snap-control
-const snapControlConnectedPlugSecComp = `
+// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/snapd-control
+const snapdControlConnectedPlugSecComp = `
 # Description: Can use snapd.
 # Usage: reserved
 
@@ -48,12 +48,12 @@ socket
 socketpair
 `
 
-// NewSnapControlInterface returns a new "snap-control" interface.
-func NewSnapControlInterface() interfaces.Interface {
+// NewSnapdControlInterface returns a new "snapd-control" interface.
+func NewSnapdControlInterface() interfaces.Interface {
 	return &commonInterface{
-		name: "snap-control",
-		connectedPlugAppArmor: snapControlConnectedPlugAppArmor,
-		connectedPlugSecComp:  snapControlConnectedPlugSecComp,
+		name: "snapd-control",
+		connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  snapdControlConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -27,58 +27,58 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-type SnapControlInterfaceSuite struct {
+type SnapdControlInterfaceSuite struct {
 	iface interfaces.Interface
 	slot  *interfaces.Slot
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&SnapControlInterfaceSuite{
-	iface: builtin.NewSnapControlInterface(),
+var _ = Suite(&SnapdControlInterfaceSuite{
+	iface: builtin.NewSnapdControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
-			Name:      "snap-control",
-			Interface: "snap-control",
+			Name:      "snapd-control",
+			Interface: "snapd-control",
 		},
 	},
 	plug: &interfaces.Plug{
 		PlugInfo: &snap.PlugInfo{
 			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "snap-control",
-			Interface: "snap-control",
+			Name:      "snapd-control",
+			Interface: "snapd-control",
 		},
 	},
 })
 
-func (s *SnapControlInterfaceSuite) TestName(c *C) {
-	c.Assert(s.iface.Name(), Equals, "snap-control")
+func (s *SnapdControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "snapd-control")
 }
 
-func (s *SnapControlInterfaceSuite) TestSanitizeSlot(c *C) {
+func (s *SnapdControlInterfaceSuite) TestSanitizeSlot(c *C) {
 	err := s.iface.SanitizeSlot(s.slot)
 	c.Assert(err, IsNil)
 	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
-		Name:      "snap-control",
-		Interface: "snap-control",
+		Name:      "snapd-control",
+		Interface: "snapd-control",
 	}})
-	c.Assert(err, ErrorMatches, "snap-control slots are reserved for the operating system snap")
+	c.Assert(err, ErrorMatches, "snapd-control slots are reserved for the operating system snap")
 }
 
-func (s *SnapControlInterfaceSuite) TestSanitizePlug(c *C) {
+func (s *SnapdControlInterfaceSuite) TestSanitizePlug(c *C) {
 	err := s.iface.SanitizePlug(s.plug)
 	c.Assert(err, IsNil)
 }
 
-func (s *SnapControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+func (s *SnapdControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "snap-control"`)
+		PanicMatches, `slot is not of interface "snapd-control"`)
 	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "snap-control"`)
+		PanicMatches, `plug is not of interface "snapd-control"`)
 }
 
-func (s *SnapControlInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+func (s *SnapdControlInterfaceSuite) TestUnusedSecuritySystems(c *C) {
 	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
 		interfaces.SecuritySecComp, interfaces.SecurityDBus,
 		interfaces.SecurityUDev}
@@ -101,7 +101,7 @@ func (s *SnapControlInterfaceSuite) TestUnusedSecuritySystems(c *C) {
 	c.Assert(snippet, IsNil)
 }
 
-func (s *SnapControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+func (s *SnapdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
@@ -112,7 +112,7 @@ func (s *SnapControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *SnapControlInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+func (s *SnapdControlInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
 	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
 	c.Assert(snippet, IsNil)
@@ -127,6 +127,6 @@ func (s *SnapControlInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 	c.Assert(snippet, IsNil)
 }
 
-func (s *SnapControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *SnapdControlInterfaceSuite) TestAutoConnect(c *C) {
 	c.Check(s.iface.AutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -24,7 +24,7 @@ import (
 )
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/x
-const xConnectedPlugAppArmor = `
+const x11ConnectedPlugAppArmor = `
 # Description: Can access the X server. Restricted because X does not prevent
 # eavesdropping or apps interfering with one another.
 # Usage: reserved
@@ -33,7 +33,7 @@ const xConnectedPlugAppArmor = `
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/x
-const xConnectedPlugSecComp = `
+const x11ConnectedPlugSecComp = `
 # Description: Can access the X server. Restricted because X does not prevent
 # eavesdropping or apps interfering with one another.
 # Usage: reserved
@@ -44,12 +44,12 @@ recvmsg
 shutdown
 `
 
-// NewXInterface returns a new "x" interface.
-func NewXInterface() interfaces.Interface {
+// NewX11Interface returns a new "x11" interface.
+func NewX11Interface() interfaces.Interface {
 	return &commonInterface{
-		name: "x",
-		connectedPlugAppArmor: xConnectedPlugAppArmor,
-		connectedPlugSecComp:  xConnectedPlugSecComp,
+		name: "x11",
+		connectedPlugAppArmor: x11ConnectedPlugAppArmor,
+		connectedPlugSecComp:  x11ConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -27,58 +27,58 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-type XInterfaceSuite struct {
+type X11InterfaceSuite struct {
 	iface interfaces.Interface
 	slot  *interfaces.Slot
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&XInterfaceSuite{
-	iface: builtin.NewXInterface(),
+var _ = Suite(&X11InterfaceSuite{
+	iface: builtin.NewX11Interface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
-			Name:      "x",
-			Interface: "x",
+			Name:      "x11",
+			Interface: "x11",
 		},
 	},
 	plug: &interfaces.Plug{
 		PlugInfo: &snap.PlugInfo{
 			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "x",
-			Interface: "x",
+			Name:      "x11",
+			Interface: "x11",
 		},
 	},
 })
 
-func (s *XInterfaceSuite) TestName(c *C) {
-	c.Assert(s.iface.Name(), Equals, "x")
+func (s *X11InterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "x11")
 }
 
-func (s *XInterfaceSuite) TestSanitizeSlot(c *C) {
+func (s *X11InterfaceSuite) TestSanitizeSlot(c *C) {
 	err := s.iface.SanitizeSlot(s.slot)
 	c.Assert(err, IsNil)
 	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
-		Name:      "x",
-		Interface: "x",
+		Name:      "x11",
+		Interface: "x11",
 	}})
-	c.Assert(err, ErrorMatches, "x slots are reserved for the operating system snap")
+	c.Assert(err, ErrorMatches, "x11 slots are reserved for the operating system snap")
 }
 
-func (s *XInterfaceSuite) TestSanitizePlug(c *C) {
+func (s *X11InterfaceSuite) TestSanitizePlug(c *C) {
 	err := s.iface.SanitizePlug(s.plug)
 	c.Assert(err, IsNil)
 }
 
-func (s *XInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+func (s *X11InterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "x"`)
+		PanicMatches, `slot is not of interface "x11"`)
 	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "x"`)
+		PanicMatches, `plug is not of interface "x11"`)
 }
 
-func (s *XInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+func (s *X11InterfaceSuite) TestUnusedSecuritySystems(c *C) {
 	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
 		interfaces.SecuritySecComp, interfaces.SecurityDBus,
 		interfaces.SecurityUDev}
@@ -101,7 +101,7 @@ func (s *XInterfaceSuite) TestUnusedSecuritySystems(c *C) {
 	c.Assert(snippet, IsNil)
 }
 
-func (s *XInterfaceSuite) TestUsedSecuritySystems(c *C) {
+func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
@@ -112,7 +112,7 @@ func (s *XInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *XInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+func (s *X11InterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
 	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
 	c.Assert(snippet, IsNil)
@@ -127,6 +127,6 @@ func (s *XInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 	c.Assert(snippet, IsNil)
 }
 
-func (s *XInterfaceSuite) TestAutoConnect(c *C) {
+func (s *X11InterfaceSuite) TestAutoConnect(c *C) {
 	c.Check(s.iface.AutoConnect(), Equals, false)
 }


### PR DESCRIPTION
This branch renames two interfaces:
 - ``x`` to ``x11``
 - ``snap-control`` to ``snapd-control``