### PR TITLE
overlord/snapstate: move locking to private task handlers

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -175,7 +175,9 @@ func (m *SnapManager) doUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doRemoveSnapSecurity(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
@@ -184,7 +186,9 @@ func (m *SnapManager) doRemoveSnapSecurity(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doRemoveSnapFiles(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
@@ -192,8 +196,11 @@ func (m *SnapManager) doRemoveSnapFiles(t *state.Task, _ *tomb.Tomb) error {
 	pb := &TaskProgressAdapter{task: t}
 	return m.backend.RemoveSnapFiles(ss.MountDir(), pb)
 }
+
 func (m *SnapManager) doRemoveSnapData(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
@@ -264,8 +271,6 @@ func TaskSnapSetup(t *state.Task) (*SnapSetup, error) {
 	var ss SnapSetup
 
 	st := t.State()
-	st.Lock()
-	defer st.Unlock()
 
 	var id string
 	err := t.Get("snap-setup-task", &id)
@@ -281,7 +286,9 @@ func TaskSnapSetup(t *state.Task) (*SnapSetup, error) {
 }
 
 func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
@@ -290,7 +297,9 @@ func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
@@ -303,7 +312,9 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doSetupSnapSecurity(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
@@ -312,7 +323,9 @@ func (m *SnapManager) doSetupSnapSecurity(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
@@ -321,15 +334,20 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
 
 	return m.backend.CopySnapData(ss.MountDir(), ss.Flags)
 }
+
 func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}
@@ -338,7 +356,9 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
+	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
+	t.State().Unlock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch moves locking from TaskSnapSetup to each of the private
handler methods.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>