### PR TITLE
overlord/snapstate: use TaskSnapSetup consistently in all handlers

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -147,10 +147,8 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doUpdateSnap(t *state.Task, _ *tomb.Tomb) error {
-	var ss SnapSetup
-
 	t.State().Lock()
-	err := t.Get("snap-setup", &ss)
+	ss, err := TaskSnapSetup(t)
 	t.State().Unlock()
 	if err != nil {
 		return err
@@ -161,10 +159,8 @@ func (m *SnapManager) doUpdateSnap(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
-	var ss SnapSetup
-
 	t.State().Lock()
-	err := t.Get("snap-setup", &ss)
+	ss, err := TaskSnapSetup(t)
 	t.State().Unlock()
 	if err != nil {
 		return err
@@ -209,10 +205,8 @@ func (m *SnapManager) doRemoveSnapData(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doRollbackSnap(t *state.Task, _ *tomb.Tomb) error {
-	var ss SnapSetup
-
 	t.State().Lock()
-	err := t.Get("snap-setup", &ss)
+	ss, err := TaskSnapSetup(t)
 	t.State().Unlock()
 	if err != nil {
 		return err
@@ -224,10 +218,8 @@ func (m *SnapManager) doRollbackSnap(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doActivateSnap(t *state.Task, _ *tomb.Tomb) error {
-	var ss SnapSetup
-
 	t.State().Lock()
-	err := t.Get("snap-setup", &ss)
+	ss, err := TaskSnapSetup(t)
 	t.State().Unlock()
 	if err != nil {
 		return err
@@ -238,10 +230,8 @@ func (m *SnapManager) doActivateSnap(t *state.Task, _ *tomb.Tomb) error {
 }
 
 func (m *SnapManager) doDeactivateSnap(t *state.Task, _ *tomb.Tomb) error {
-	var ss SnapSetup
-
 	t.State().Lock()
-	err := t.Get("snap-setup", &ss)
+	ss, err := TaskSnapSetup(t)
 	t.State().Unlock()
 	if err != nil {
 		return err

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -81,6 +81,7 @@ func Install(s *state.State, snap, channel string, flags snappy.InstallFlags) (*
 // Note that the state must be locked by the caller.
 func Update(s *state.State, snap, channel string, flags snappy.InstallFlags) (*state.TaskSet, error) {
 	t := s.NewTask("update-snap", fmt.Sprintf(i18n.G("Updating %q"), snap))
+	t.Set("snap-setup-task", t.ID())
 	t.Set("snap-setup", SnapSetup{
 		Name:    snap,
 		Channel: channel,
@@ -128,6 +129,7 @@ func Remove(s *state.State, snapSpec string, flags snappy.RemoveFlags) (*state.T
 	// trigger remove
 	unlink := s.NewTask("unlink-snap", fmt.Sprintf(i18n.G("Deactivating %q"), snapSpec))
 	unlink.Set("snap-setup", ss)
+	unlink.Set("snap-setup-task", unlink.ID())
 
 	removeSecurity := s.NewTask("remove-snap-security", fmt.Sprintf(i18n.G("Removing security profile for %q"), snapSpec))
 	removeSecurity.WaitFor(unlink)
@@ -148,6 +150,7 @@ func Remove(s *state.State, snapSpec string, flags snappy.RemoveFlags) (*state.T
 // Note that the state must be locked by the caller.
 func Rollback(s *state.State, snap, ver string) (*state.TaskSet, error) {
 	t := s.NewTask("rollback-snap", fmt.Sprintf(i18n.G("Rolling back %q"), snap))
+	t.Set("snap-setup-task", t.ID())
 	t.Set("snap-setup", SnapSetup{
 		Name:    snap,
 		Version: ver,
@@ -161,6 +164,7 @@ func Rollback(s *state.State, snap, ver string) (*state.TaskSet, error) {
 func Activate(s *state.State, snap string) (*state.TaskSet, error) {
 	msg := fmt.Sprintf(i18n.G("Set active %q"), snap)
 	t := s.NewTask("activate-snap", msg)
+	t.Set("snap-setup-task", t.ID())
 	t.Set("snap-setup", SnapSetup{
 		Name: snap,
 	})
@@ -173,6 +177,7 @@ func Activate(s *state.State, snap string) (*state.TaskSet, error) {
 func Deactivate(s *state.State, snap string) (*state.TaskSet, error) {
 	msg := fmt.Sprintf(i18n.G("Set inactive %q"), snap)
 	t := s.NewTask("deactivate-snap", msg)
+	t.Set("snap-setup-task", t.ID())
 	t.Set("snap-setup", SnapSetup{
 		Name: snap,
 	})


### PR DESCRIPTION
This patch ensures that all of the tasks in the snap manager use
TaskSnapSetup to access SnapSetup data.

Some functions that create tasks had to be patched to store snap-setup-task
that TaskSnapSetup relies on to find the snap information.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>