### PR TITLE
interfaces: add SecurityBackend.Name for logging/debugging

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -58,7 +58,8 @@ type Backend struct {
 	legacyTemplate []byte
 }
 
-func (b *Backend) String() string {
+// Name returns the name of the backend.
+func (b *Backend) Name() string {
 	return "apparmor"
 }
 

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -58,6 +58,10 @@ type Backend struct {
 	legacyTemplate []byte
 }
 
+func (b *Backend) String() string {
+	return "apparmor"
+}
+
 // UseLegacyTemplate switches from default apparmor template to a custom
 // template. This also implies that a fixed set of apparmor variables will be
 // injected into this template. The set is compatible with Ubuntu core 15.04.

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -130,6 +130,10 @@ slots:
     iface:
 `
 
+func (s *backendSuite) TestName(c *C) {
+	c.Check(s.backend.Name(), Equals, "apparmor")
+}
+
 func (s *backendSuite) TestInstallingSnapWritesAndLoadsProfiles(c *C) {
 	developerMode := false
 	s.installSnap(c, developerMode, sambaYamlV1)

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -26,6 +26,10 @@ import (
 // SecurityBackend abstracts interactions between the interface system and the
 // needs of a particular security system.
 type SecurityBackend interface {
+	// Name returns the name of the backend.
+	// This is intended for diagnostic messages.
+	Name() string
+
 	// Setup creates and loads security artefacts specific to a given snap.
 	// The snap can be in developer mode to make security violations non-fatal
 	// to the offending application process.

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -40,7 +40,8 @@ import (
 // Backend is responsible for maintaining DBus policy files.
 type Backend struct{}
 
-func (b *Backend) String() string {
+// Name returns the name of the backend.
+func (b *Backend) Name() string {
 	return "dbus"
 }
 

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -40,6 +40,10 @@ import (
 // Backend is responsible for maintaining DBus policy files.
 type Backend struct{}
 
+func (b *Backend) String() string {
+	return "dbus"
+}
+
 // Setup creates dbus configuration files specific to a given snap.
 //
 // DBus has no concept of a complain mode so developerMode is not supported

--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -90,6 +90,10 @@ slots:
     iface:
 `
 
+func (s *backendSuite) TestName(c *C) {
+	c.Check(s.backend.Name(), Equals, "dbus")
+}
+
 func (s *backendSuite) TestInstallingSnapWritesConfigFiles(c *C) {
 	// NOTE: Hand out a permanent snippet so that .conf file is generated.
 	s.iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -45,6 +45,10 @@ import (
 // Backend is responsible for maintaining seccomp profiles for ubuntu-core-launcher.
 type Backend struct{}
 
+func (b *Backend) String() string {
+	return "seccomp"
+}
+
 // Setup creates seccomp profiles specific to a given snap.
 // The snap can be in developer mode to make security violations non-fatal to
 // the offending application process.

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -45,7 +45,8 @@ import (
 // Backend is responsible for maintaining seccomp profiles for ubuntu-core-launcher.
 type Backend struct{}
 
-func (b *Backend) String() string {
+// Name returns the name of the backend.
+func (b *Backend) Name() string {
 	return "seccomp"
 }
 

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -93,6 +93,10 @@ slots:
     iface:
 `
 
+func (s *backendSuite) TestName(c *C) {
+	c.Check(s.backend.Name(), Equals, "seccomp")
+}
+
 func (s *backendSuite) TestInstallingSnapWritesProfiles(c *C) {
 	developerMode := false
 	s.installSnap(c, developerMode, sambaYamlV1)

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -37,7 +37,8 @@ import (
 // Backend is responsible for maintaining udev rules.
 type Backend struct{}
 
-func (b *Backend) String() string {
+// Name returns the name of the backend.
+func (b *Backend) Name() string {
 	return "udev"
 }
 

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -37,6 +37,10 @@ import (
 // Backend is responsible for maintaining udev rules.
 type Backend struct{}
 
+func (b *Backend) String() string {
+	return "udev"
+}
+
 // Setup creates udev rules specific to a given snap.
 // If any of the rules are changed or removed then udev database is reloaded.
 //

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -95,6 +95,10 @@ slots:
     iface:
 `
 
+func (s *backendSuite) TestName(c *C) {
+	c.Check(s.backend.Name(), Equals, "udev")
+}
+
 func (s *backendSuite) TestInstallingSnapWritesAndLoadsRules(c *C) {
 	// NOTE: Hand out a permanent snippet so that .rules file is generated.
 	s.iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {


### PR DESCRIPTION
This is just a small help for debugging / logging. When printing a backend instance you get a nice backend name rather than the unhelpful ``&Backend{}``

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>