### PR TITLE
interfaces/apparmor: expand @{APP_PKGNAME} to just snap name

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -280,7 +280,7 @@ const commonPrefix = `
 @{APP_APPNAME}="smbd"
 @{APP_ID_DBUS}="samba_2eacme_5fsmbd_5f1"
 @{APP_PKGNAME_DBUS}="samba_2eacme"
-@{APP_PKGNAME}="samba.acme"
+@{APP_PKGNAME}="samba"
 @{APP_VERSION}="1"
 @{INSTALL_DIR}="{/snaps,/gadget}"`
 

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -54,7 +54,7 @@ func legacyVariables(appInfo *snap.AppInfo) []byte {
 	fmt.Fprintf(&buf, "@{APP_PKGNAME_DBUS}=\"%s\"\n",
 		dbus.SafePath(fmt.Sprintf("%s.%s", appInfo.Snap.Name(), appInfo.Snap.Developer)))
 	// TODO: stop using .Developer, investigate how this is used.
-	fmt.Fprintf(&buf, "@{APP_PKGNAME}=\"%s.%s\"\n", appInfo.Snap.Name(), appInfo.Snap.Developer)
+	fmt.Fprintf(&buf, "@{APP_PKGNAME}=\"%s\"\n", appInfo.Snap.Name())
 	// TODO: switch to .Revision
 	fmt.Fprintf(&buf, "@{APP_VERSION}=\"%s\"\n", appInfo.Snap.Version)
 	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"{/snaps,/gadget}\"")


### PR DESCRIPTION
This patch drops the .developer suffix from APP_PKGNAME since this is
the current filesystem layout.

NOTE: this was tested with actual device. :-)

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>