### PR TITLE
interfaces/builtin: look at snap type for reserved interfaces

### DIFF
--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 type evalSymlinksFn func(string) (string, error)
@@ -53,8 +54,7 @@ func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
-	// TODO: use slot.Snap.Type here (and snap.TypeOS)
-	if iface.reservedForOS && slot.Snap.Name() != "ubuntu-core" {
+	if iface.reservedForOS && slot.Snap.Type != snap.TypeOS {
 		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.name)
 	}
 	return nil

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&FirewallControlInterfaceSuite{
 	iface: builtin.NewFirewallControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "firewall-control",
 			Interface: "firewall-control",
 		},

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&HomeInterfaceSuite{
 	iface: builtin.NewHomeInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "home",
 			Interface: "home",
 		},

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&LocaleControlInterfaceSuite{
 	iface: builtin.NewLocaleControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "locale-control",
 			Interface: "locale-control",
 		},

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&LogObserveInterfaceSuite{
 	iface: builtin.NewLogObserveInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "log-observe",
 			Interface: "log-observe",
 		},

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&MountObserveInterfaceSuite{
 	iface: builtin.NewMountObserveInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "mount-observe",
 			Interface: "mount-observe",
 		},

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&NetworkBindInterfaceSuite{
 	iface: builtin.NewNetworkBindInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "network-bind",
 			Interface: "network-bind",
 		},

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&NetworkControlInterfaceSuite{
 	iface: builtin.NewNetworkControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "network-control",
 			Interface: "network-control",
 		},

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&NetworkObserveInterfaceSuite{
 	iface: builtin.NewNetworkObserveInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "network-observe",
 			Interface: "network-observe",
 		},

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&NetworkInterfaceSuite{
 	iface: builtin.NewNetworkInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "network",
 			Interface: "network",
 		},

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&SnapdControlInterfaceSuite{
 	iface: builtin.NewSnapdControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "snapd-control",
 			Interface: "snapd-control",
 		},

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&SystemObserveInterfaceSuite{
 	iface: builtin.NewSystemObserveInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "system-observe",
 			Interface: "system-observe",
 		},

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&TimeserverControlInterfaceSuite{
 	iface: builtin.NewTimeserverControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "timeserver-control",
 			Interface: "timeserver-control",
 		},

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&TimezoneControlInterfaceSuite{
 	iface: builtin.NewTimezoneControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "timezone-control",
 			Interface: "timezone-control",
 		},

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&Unity7InterfaceSuite{
 	iface: builtin.NewUnity7Interface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "unity7",
 			Interface: "unity7",
 		},

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&X11InterfaceSuite{
 	iface: builtin.NewX11Interface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core"},
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
 			Name:      "x11",
 			Interface: "x11",
 		},


### PR DESCRIPTION
This patch checks for the type of the snap instead of the snap name when
looking for the OS snap.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>