### PR TITLE
interfaces/apparmor: switch to repository methods for adding/removing snaps

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -365,7 +365,8 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 	// this won't come from snap.yaml
 	newSnapInfo.Developer = "acme"
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
-	s.removePlugsSlots(c, oldSnapInfo)
+	err = s.repo.RemoveSnap(oldSnapInfo.Name())
+	c.Assert(err, IsNil)
 	err = s.repo.AddSnap(newSnapInfo)
 	c.Assert(err, IsNil)
 	err = s.backend.Setup(newSnapInfo, developerMode, s.repo)
@@ -377,10 +378,6 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
 	err := s.backend.Remove(snapInfo.Name())
 	c.Assert(err, IsNil)
-	s.removePlugsSlots(c, snapInfo)
-}
-
-func (s *backendSuite) removePlugsSlots(c *C, snapInfo *snap.Info) {
-	err := s.repo.RemoveSnap(snapInfo.Name())
+	err = s.repo.RemoveSnap(snapInfo.Name())
 	c.Assert(err, IsNil)
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -351,7 +351,8 @@ func (s *backendSuite) installSnap(c *C, developerMode bool, snapYaml string) *s
 	c.Assert(err, IsNil)
 	// this won't come from snap.yaml
 	snapInfo.Developer = "acme"
-	s.addPlugsSlots(c, snapInfo)
+	err = s.repo.AddSnap(snapInfo)
+	c.Assert(err, IsNil)
 	err = s.backend.Setup(snapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return snapInfo
@@ -365,7 +366,8 @@ func (s *backendSuite) updateSnap(c *C, oldSnapInfo *snap.Info, developerMode bo
 	newSnapInfo.Developer = "acme"
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
 	s.removePlugsSlots(c, oldSnapInfo)
-	s.addPlugsSlots(c, newSnapInfo)
+	err = s.repo.AddSnap(newSnapInfo)
+	c.Assert(err, IsNil)
 	err = s.backend.Setup(newSnapInfo, developerMode, s.repo)
 	c.Assert(err, IsNil)
 	return newSnapInfo
@@ -376,11 +378,6 @@ func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
 	err := s.backend.Remove(snapInfo.Name())
 	c.Assert(err, IsNil)
 	s.removePlugsSlots(c, snapInfo)
-}
-
-func (s *backendSuite) addPlugsSlots(c *C, snapInfo *snap.Info) {
-	err := s.repo.AddSnap(snapInfo)
-	c.Assert(err, IsNil)
 }
 
 func (s *backendSuite) removePlugsSlots(c *C, snapInfo *snap.Info) {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -381,12 +381,6 @@ func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
 }
 
 func (s *backendSuite) removePlugsSlots(c *C, snapInfo *snap.Info) {
-	for _, plug := range s.repo.Plugs(snapInfo.Name()) {
-		err := s.repo.RemovePlug(plug.Snap.Name(), plug.Name)
-		c.Assert(err, IsNil)
-	}
-	for _, slot := range s.repo.Slots(snapInfo.Name()) {
-		err := s.repo.RemoveSlot(slot.Snap.Name(), slot.Name)
-		c.Assert(err, IsNil)
-	}
+	err := s.repo.RemoveSnap(snapInfo.Name())
+	c.Assert(err, IsNil)
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -379,16 +379,8 @@ func (s *backendSuite) removeSnap(c *C, snapInfo *snap.Info) {
 }
 
 func (s *backendSuite) addPlugsSlots(c *C, snapInfo *snap.Info) {
-	for _, plugInfo := range snapInfo.Plugs {
-		plug := &interfaces.Plug{PlugInfo: plugInfo}
-		err := s.repo.AddPlug(plug)
-		c.Assert(err, IsNil)
-	}
-	for _, slotInfo := range snapInfo.Slots {
-		slot := &interfaces.Slot{SlotInfo: slotInfo}
-		err := s.repo.AddSlot(slot)
-		c.Assert(err, IsNil)
-	}
+	err := s.repo.AddSnap(snapInfo)
+	c.Assert(err, IsNil)
 }
 
 func (s *backendSuite) removePlugsSlots(c *C, snapInfo *snap.Info) {


### PR DESCRIPTION
This branch changes apparmor backend tests to use real ``Repository.AddSnap`` and ``Repository.RemoveSnap``. The replaced code dates before those functions were merged and they are a complete and better replacement.