### PR TITLE
overlord/snapstate: use Revision as argument to SnapInfo

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -384,8 +384,8 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 // Today this function is looking at data directly from the mounted snap, but soon it will
 // be changed so it looks first at the state for the snap details (Revision, Developer, etc),
 // and then complements it with information from the snap itself.
-func SnapInfo(state *state.State, snapName, snapVersion string) (*snap.Info, error) {
-	fname := filepath.Join(dirs.SnapSnapsDir, snapName, snapVersion, "meta", "snap.yaml")
+func SnapInfo(state *state.State, snapName string, snapRevision int) (*snap.Info, error) {
+	fname := filepath.Join(dirs.SnapSnapsDir, snapName, strconv.Itoa(snapRevision), "meta", "snap.yaml")
 	yamlData, err := ioutil.ReadFile(fname)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -335,7 +335,7 @@ func (s *snapmgrTestSuite) TestSnapInfo(c *C) {
 	defer dirs.SetRootDir("")
 
 	// Write a snap.yaml with fake name
-	dname := filepath.Join(dirs.SnapSnapsDir, "name", "version", "meta")
+	dname := filepath.Join(dirs.SnapSnapsDir, "name", "11", "meta")
 	err := os.MkdirAll(dname, 0775)
 	c.Assert(err, IsNil)
 	fname := filepath.Join(dname, "snap.yaml")
@@ -345,7 +345,7 @@ description: |
     Lots of text`), 0644)
 	c.Assert(err, IsNil)
 
-	snapInfo, err := snapstate.SnapInfo(s.state, "name", "version")
+	snapInfo, err := snapstate.SnapInfo(s.state, "name", 11)
 	c.Assert(err, IsNil)
 
 	// Check that the name in the YAML is being ignored.


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>