### PR TITLE
overlord/snapstate: use NewInstalledSnap in SnapInfo

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // SnapManager is responsible for the installation and removal of snaps.
@@ -394,6 +395,12 @@ func SnapInfo(state *state.State, snapName, snapVersion string) (*snap.Info, err
 	if err != nil {
 		return nil, err
 	}
+	// XXX: Gross hack, Use NewInstalledSnap to get the revision
+	otherSnap, err := snappy.NewInstalledSnap(fname)
+	if err != nil {
+		return nil, err
+	}
+	info.Revision = otherSnap.Revision()
 	// Overwrite the name which doesn't belong in snap.yaml and is actually
 	// defined by snap declaration assertion.
 	// TODO: use a full SideInfo

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -341,6 +341,7 @@ func (s *snapmgrTestSuite) TestSnapInfo(c *C) {
 	fname := filepath.Join(dname, "snap.yaml")
 	err = ioutil.WriteFile(fname, []byte(`
 name: ignored
+version: 1.2
 description: |
     Lots of text`), 0644)
 	c.Assert(err, IsNil)
@@ -352,4 +353,7 @@ description: |
 	c.Check(snapInfo.Name(), Equals, "name")
 	// Check that other values are read from YAML
 	c.Check(snapInfo.Description(), Equals, "Lots of text")
+	c.Check(snapInfo.Version, Equals, "1.2")
+	// TODO: not doing a tests for revision due to crazy temp hack involving
+	// NewInstalledSnap()
 }


### PR DESCRIPTION
This is a temporary hack. NewInstalledSnap gets us correct Revision
which in turn is essential for apparmor profiles.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>