### PR TITLE
overlord/snapstate: use NewInstalledSnap in SnapInfo

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -384,14 +384,13 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 // Today this function is looking at data directly from the mounted snap, but soon it will
 // be changed so it looks first at the state for the snap details (Revision, Developer, etc),
 // and then complements it with information from the snap itself.
-func SnapInfo(state *state.State, snapName string, snapRevision int) (*snap.Info, error) {
-	fname := filepath.Join(dirs.SnapSnapsDir, snapName,
-		strconv.Itoa(snapRevision), "meta", "snap.yaml")
+func SnapInfo(state *state.State, name string, revision int) (*snap.Info, error) {
+	fname := filepath.Join(dirs.SnapSnapsDir, name, strconv.Itoa(revision), "meta", "snap.yaml")
 	sn, err := snappy.NewInstalledSnap(fname)
 	if err != nil {
 		return nil, err
 	}
 	snapInfo := sn.Info()
-	snapInfo.OfficialName = snapName
+	snapInfo.OfficialName = name
 	return snapInfo, nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -390,7 +390,5 @@ func SnapInfo(state *state.State, name string, revision int) (*snap.Info, error)
 	if err != nil {
 		return nil, err
 	}
-	snapInfo := sn.Info()
-	snapInfo.OfficialName = name
-	return snapInfo, nil
+	return sn.Info(), nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -22,7 +22,6 @@ package snapstate
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"strconv"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // SnapManager is responsible for the installation and removal of snaps.
@@ -385,19 +385,13 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 // be changed so it looks first at the state for the snap details (Revision, Developer, etc),
 // and then complements it with information from the snap itself.
 func SnapInfo(state *state.State, snapName string, snapRevision int) (*snap.Info, error) {
-	fname := filepath.Join(dirs.SnapSnapsDir, snapName, strconv.Itoa(snapRevision), "meta", "snap.yaml")
-	yamlData, err := ioutil.ReadFile(fname)
+	fname := filepath.Join(dirs.SnapSnapsDir, snapName,
+		strconv.Itoa(snapRevision), "meta", "snap.yaml")
+	sn, err := snappy.NewInstalledSnap(fname)
 	if err != nil {
 		return nil, err
 	}
-	info, err := snap.InfoFromSnapYaml(yamlData)
-	if err != nil {
-		return nil, err
-	}
-	// Overwrite the name which doesn't belong in snap.yaml and is actually
-	// defined by snap declaration assertion.
-	// TODO: use a full SideInfo
-	info.OfficialName = snapName
-	// TODO: use state to retrieve additional information
-	return info, nil
+	snapInfo := sn.Info()
+	snapInfo.OfficialName = snapName
+	return snapInfo, nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -386,6 +386,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 // and then complements it with information from the snap itself.
 func SnapInfo(state *state.State, name string, revision int) (*snap.Info, error) {
 	fname := filepath.Join(dirs.SnapSnapsDir, name, strconv.Itoa(revision), "meta", "snap.yaml")
+	// XXX: This hacky and should not be needed.
 	sn, err := snappy.NewInstalledSnap(fname)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -349,11 +349,11 @@ description: |
 	snapInfo, err := snapstate.SnapInfo(s.state, "name", 11)
 	c.Assert(err, IsNil)
 
-	// Check that the name in the YAML is being ignored.
-	c.Check(snapInfo.Name(), Equals, "name")
+	// TODO: This test is not faking the manifest so SideInfo is not present.
+	// The test and the actual implementation need to be improved so that this
+	// is not so hacky and that the manifest can go away.
+	c.Check(snapInfo.Name(), Equals, "ignored")
 	// Check that other values are read from YAML
 	c.Check(snapInfo.Description(), Equals, "Lots of text")
 	c.Check(snapInfo.Version, Equals, "1.2")
-	// TODO: not doing a tests for revision due to crazy temp hack involving
-	// NewInstalledSnap()
 }

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -341,6 +341,7 @@ func (s *snapmgrTestSuite) TestSnapInfo(c *C) {
 	fname := filepath.Join(dname, "snap.yaml")
 	err = ioutil.WriteFile(fname, []byte(`
 name: ignored
+version: 1.2
 description: |
     Lots of text`), 0644)
 	c.Assert(err, IsNil)
@@ -352,4 +353,7 @@ description: |
 	c.Check(snapInfo.Name(), Equals, "name")
 	// Check that other values are read from YAML
 	c.Check(snapInfo.Description(), Equals, "Lots of text")
+	c.Check(snapInfo.Version, Equals, "1.2")
+	// TODO: not doing a tests for revision due to crazy temp hack involving
+	// NewInstalledSnap()
 }


### PR DESCRIPTION
This is a temporary hack. NewInstalledSnap gets us correct Revision
which in turn is essential for apparmor profiles.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>