### PR TITLE
interfaces: create directories for security files

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -40,6 +40,7 @@ package apparmor
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -89,7 +90,11 @@ func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interface
 		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
 	glob := interfaces.SecurityTagGlob(snapInfo.Name())
-	changed, removed, errEnsure := osutil.EnsureDirState(dirs.SnapAppArmorDir, glob, content)
+	dir := dirs.SnapAppArmorDir
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("cannot create directory for apparmor profiles %q: %s", dir, err)
+	}
+	changed, removed, errEnsure := osutil.EnsureDirState(dir, glob, content)
 	errReload := reloadProfiles(changed)
 	errUnload := unloadProfiles(removed)
 	if errEnsure != nil {

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -30,6 +30,7 @@ package dbus
 import (
 	"bytes"
 	"fmt"
+	"os"
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/interfaces"
@@ -61,7 +62,11 @@ func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interface
 		return fmt.Errorf("cannot obtain expected DBus configuration files for snap %q: %s", snapName, err)
 	}
 	glob := fmt.Sprintf("%s.conf", interfaces.SecurityTagGlob(snapName))
-	_, _, err = osutil.EnsureDirState(dirs.SnapBusPolicyDir, glob, content)
+	dir := dirs.SnapBusPolicyDir
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("cannot create directory for DBus configuration files %q: %s", dir, err)
+	}
+	_, _, err = osutil.EnsureDirState(dir, glob, content)
 	if err != nil {
 		return fmt.Errorf("cannot synchronize DBus configuration files for snap %q: %s", snapName, err)
 	}

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -35,6 +35,7 @@ package seccomp
 import (
 	"bytes"
 	"fmt"
+	"os"
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/interfaces"
@@ -69,7 +70,11 @@ func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interface
 		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
 	glob := interfaces.SecurityTagGlob(snapName)
-	_, _, err = osutil.EnsureDirState(dirs.SnapSeccompDir, glob, content)
+	dir := dirs.SnapSeccompDir
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("cannot create directory for seccomp profiles %q: %s", dir, err)
+	}
+	_, _, err = osutil.EnsureDirState(dir, glob, content)
 	if err != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, err)
 	}

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -27,6 +27,7 @@ package udev
 import (
 	"bytes"
 	"fmt"
+	"os"
 
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/interfaces"
@@ -59,7 +60,11 @@ func (b *Backend) Setup(snapInfo *snap.Info, developerMode bool, repo *interface
 		return fmt.Errorf("cannot obtain expected udev rules for snap %q: %s", snapName, err)
 	}
 	glob := fmt.Sprintf("70-%s.rules", interfaces.SecurityTagGlob(snapName))
-	return ensureDirState(dirs.SnapUdevRulesDir, glob, content, snapName)
+	dir := dirs.SnapUdevRulesDir
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("cannot create directory for udev rules %q: %s", dir, err)
+	}
+	return ensureDirState(dir, glob, content, snapName)
 }
 
 // Remove removes udev rules specific to a given snap.


### PR DESCRIPTION
This patch ensures that we have the right directory in the Setup method
of each of the four security backends. In the past we seemed to have
got a free ride on the old security code that did this for us.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>