### PR TITLE
daemon,store: add login API endpoint to daemon

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -45,6 +45,7 @@ import (
 	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snappy"
+	"github.com/ubuntu-core/snappy/store"
 )
 
 // increase this every time you make a minor (backwards-compatible)
@@ -54,6 +55,7 @@ const apiCompatLevel = "0"
 var api = []*Command{
 	rootCmd,
 	sysInfoCmd,
+	loginCmd,
 	appIconCmd,
 	snapsCmd,
 	snapCmd,
@@ -76,6 +78,11 @@ var (
 		Path:    "/v2/system-info",
 		GuestOK: true,
 		GET:     sysInfo,
+	}
+
+	loginCmd = &Command{
+		Path: "/v2/login",
+		POST: loginUser,
 	}
 
 	appIconCmd = &Command{
@@ -155,6 +162,46 @@ func sysInfo(c *Command, r *http.Request) Response {
 	}
 
 	return SyncResponse(m)
+}
+
+func loginUser(c *Command, r *http.Request) Response {
+	var loginData struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		Otp      string `json:"otp"`
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&loginData); err != nil {
+		return BadRequest("can't decode login data from request body: %v", err)
+	}
+
+	macaroon, err := store.RequestPackageAccessMacaroon()
+	if err != nil {
+		return InternalError("couldn't get package access macaroon")
+	}
+
+	discharge, err := store.DischargeAuthCaveat(loginData.Username, loginData.Password, macaroon, loginData.Otp)
+	if err == store.ErrAuthenticationNeeds2fa {
+		return Unauthorized("TWOFACTOR_REQUIRED")
+	}
+	if err != nil {
+		return Unauthorized("couldn't get discharge authorization")
+	}
+
+	discharges := []string{discharge}
+	macaroons := map[string]interface{}{
+		"macaroon":   macaroon,
+		"discharges": discharges,
+	}
+
+	overlord := c.d.overlord
+	state := overlord.State()
+	state.Lock()
+	state.Set("macaroons", macaroons)
+	state.Unlock()
+
+	return SyncResponse(macaroons)
 }
 
 type metarepo interface {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -473,21 +473,25 @@ func (s *apiSuite) TestLoginUser(c *check.C) {
 
 	rsp = loginUser(snapCmd, req).(*resp)
 
-	expected := userAuthState{
-		Username:   "username",
+	expected := loginResponseData{
 		Macaroon:   "the-macaroon-serialized-data",
-		Discharges: []string{"the-discharge-macaroon-serialized-data"}}
-
+		Discharges: []string{"the-discharge-macaroon-serialized-data"},
+	}
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
 	var auth authState
+	expectedState := userAuthState{
+		Username:   "username",
+		Macaroon:   "the-macaroon-serialized-data",
+		Discharges: []string{"the-discharge-macaroon-serialized-data"},
+	}
 	state := snapCmd.d.overlord.State()
 	state.Lock()
 	state.Get("auth", &auth)
 	state.Unlock()
-	c.Check(auth, check.DeepEquals, authState{Users: []userAuthState{expected}})
+	c.Check(auth, check.DeepEquals, authState{Users: []userAuthState{expectedState}})
 }
 
 func (s *apiSuite) TestLoginUserBadRequest(c *check.C) {

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -228,6 +228,7 @@ type errorResponder func(string, ...interface{}) Response
 
 // standard error responses
 var (
+	Unauthorized   = makeErrorResponder(http.StatusUnauthorized)
 	NotFound       = makeErrorResponder(http.StatusNotFound)
 	BadRequest     = makeErrorResponder(http.StatusBadRequest)
 	BadMethod      = makeErrorResponder(http.StatusMethodNotAllowed)

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -99,7 +99,8 @@ func (r *resp) Self(*Command, *http.Request) Response {
 type errorKind string
 
 const (
-	errorKindLicenseRequired = errorKind("license-required")
+	errorKindLicenseRequired   = errorKind("license-required")
+	errorKindTwoFactorRequired = errorKind("two-factor-required")
 )
 
 type errorValue interface{}

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -150,6 +150,24 @@ Reserved for human-readable content describing the service.
 }
 ```
 
+## `/v2/login`
+### `POST`
+
+* Description: Log user in the store
+* Access: trusted
+* Operation: sync
+* Return: Dict with the authenticated user information.
+
+#### Sample result:
+
+```javascript
+{
+ "username": "username",
+ "macaroon": "serialized-store-macaroon",
+ "discharges": ["discharge-for-macaroon-authentication"]
+}
+```
+
 ## /v2/snaps
 ### GET
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -162,7 +162,6 @@ Reserved for human-readable content describing the service.
 
 ```javascript
 {
- "username": "username",
  "macaroon": "serialized-store-macaroon",
  "discharges": ["discharge-for-macaroon-authentication"]
 }

--- a/store/auth.go
+++ b/store/auth.go
@@ -32,11 +32,13 @@ import (
 )
 
 var (
-	myappsAPIBase          = myappsURL()
-	myappsPackageAccessAPI = myappsAPIBase + "/acl/package_access/"
+	myappsAPIBase = myappsURL()
+	// MyAppsPackageAccessAPI points to MyApps endpoint to get a package access macaroon
+	MyAppsPackageAccessAPI = myappsAPIBase + "/acl/package_access/"
 	ubuntuoneAPIBase       = authURL()
 	ubuntuoneOauthAPI      = ubuntuoneAPIBase + "/tokens/oauth"
-	ubuntuoneDischargeAPI  = ubuntuoneAPIBase + "/tokens/discharge"
+	// UbuntuoneDischargeAPI points to SSO endpoint to discharge a macaroon
+	UbuntuoneDischargeAPI = ubuntuoneAPIBase + "/tokens/discharge"
 )
 
 // StoreToken contains the personal token to access the store
@@ -167,7 +169,7 @@ func RequestPackageAccessMacaroon() (string, error) {
 	const errorPrefix = "cannot get package access macaroon from store: "
 
 	emptyJSONData := "{}"
-	req, err := http.NewRequest("POST", myappsPackageAccessAPI, strings.NewReader(emptyJSONData))
+	req, err := http.NewRequest("POST", MyAppsPackageAccessAPI, strings.NewReader(emptyJSONData))
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
@@ -217,7 +219,7 @@ func DischargeAuthCaveat(username, password, macaroon, otp string) (string, erro
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
 
-	req, err := http.NewRequest("POST", ubuntuoneDischargeAPI, strings.NewReader(string(dischargeJSONData)))
+	req, err := http.NewRequest("POST", UbuntuoneDischargeAPI, strings.NewReader(string(dischargeJSONData)))
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -136,7 +136,7 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroon(c *C) {
 		io.WriteString(w, mockStoreReturnMacaroon)
 	}))
 	defer mockServer.Close()
-	myappsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
+	MyAppsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
 
 	macaroon, err := RequestPackageAccessMacaroon()
 	c.Assert(err, IsNil)
@@ -148,7 +148,7 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroonMissingData(c *C) {
 		io.WriteString(w, mockStoreReturnNoMacaroon)
 	}))
 	defer mockServer.Close()
-	myappsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
+	MyAppsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
 
 	macaroon, err := RequestPackageAccessMacaroon()
 	c.Assert(err, ErrorMatches, "cannot get package access macaroon from store: empty macaroon returned")
@@ -160,7 +160,7 @@ func (s *authTestSuite) TestRequestPackageAccessMacaroonError(c *C) {
 		w.WriteHeader(500)
 	}))
 	defer mockServer.Close()
-	myappsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
+	MyAppsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
 
 	macaroon, err := RequestPackageAccessMacaroon()
 	c.Assert(err, ErrorMatches, "cannot get package access macaroon from store: store server returned status 500")
@@ -172,7 +172,7 @@ func (s *authTestSuite) TestDischargeAuthCaveat(c *C) {
 		io.WriteString(w, mockStoreReturnDischarge)
 	}))
 	defer mockServer.Close()
-	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
 	discharge, err := DischargeAuthCaveat("guy@example.com", "passwd", "root-macaroon", "")
 	c.Assert(err, IsNil)
@@ -185,7 +185,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatNeeds2fa(c *C) {
 		io.WriteString(w, mockStoreNeeds2fa)
 	}))
 	defer mockServer.Close()
-	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
 	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
 	c.Assert(err, Equals, ErrAuthenticationNeeds2fa)
@@ -198,7 +198,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatInvalidLogin(c *C) {
 		io.WriteString(w, mockStoreInvalidLogin)
 	}))
 	defer mockServer.Close()
-	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
 	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
 	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: Provided email/password is not correct.")
@@ -210,7 +210,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatMissingData(c *C) {
 		io.WriteString(w, mockStoreReturnNoMacaroon)
 	}))
 	defer mockServer.Close()
-	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
 	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
 	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: empty macaroon returned")
@@ -222,7 +222,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatError(c *C) {
 		w.WriteHeader(500)
 	}))
 	defer mockServer.Close()
-	ubuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
 	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
 	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: server returned status 500")


### PR DESCRIPTION
Add login REST API to daemon enabling macaroon authentication with the store. Still missing snap client updates, and update requests to the store to use macaroons based authentication.