### PR TITLE
overlord,snap,snappy: make UndoSetupSnap and removeSnapFiles more robust, less NewInstalledSnap

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -40,7 +40,7 @@ type managerBackend interface {
 	LinkSnap(instSnapPath string) error
 	GarbageCollect(snap string, flags int, meter progress.Meter) error
 	// the undoers for install
-	UndoSetupSnap(snapFilePath string) error
+	UndoSetupSnap(s snap.PlaceInfo) error
 	UndoCopySnapData(instSnapPath string, flags int) error
 	UndoLinkSnap(oldInstSnapPath, instSnapPath string) error
 
@@ -48,7 +48,7 @@ type managerBackend interface {
 	CanRemove(instSnapPath string) error
 	UnlinkSnap(instSnapPath string, meter progress.Meter) error
 	RemoveSnapSecurity(instSnapPath string) error
-	RemoveSnapFiles(instSnapPath string, meter progress.Meter) error
+	RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error
 	RemoveSnapData(name string, revision int) error
 
 	// TODO: need to be split into fine grained tasks
@@ -64,14 +64,14 @@ type managerBackend interface {
 
 type defaultBackend struct{}
 
-func (s *defaultBackend) ActiveSnap(name string) *snap.Info {
+func (b *defaultBackend) ActiveSnap(name string) *snap.Info {
 	if snap := snappy.ActiveSnapByName(name); snap != nil {
 		return snap.Info()
 	}
 	return nil
 }
 
-func (s *defaultBackend) SnapByNameAndVersion(name, version string) *snap.Info {
+func (b *defaultBackend) SnapByNameAndVersion(name, version string) *snap.Info {
 	// XXX: use snapstate stuff!
 	installed, err := (&snappy.Overlord{}).Installed()
 	if err != nil {
@@ -85,21 +85,21 @@ func (s *defaultBackend) SnapByNameAndVersion(name, version string) *snap.Info {
 	return found[0].Info()
 }
 
-func (s *defaultBackend) Update(name, channel string, flags int, meter progress.Meter) error {
+func (b *defaultBackend) Update(name, channel string, flags int, meter progress.Meter) error {
 	// FIXME: support "channel" in snappy.Update()
 	_, err := snappy.Update(name, snappy.InstallFlags(flags), meter)
 	return err
 }
 
-func (s *defaultBackend) Rollback(name, ver string, meter progress.Meter) (string, error) {
+func (b *defaultBackend) Rollback(name, ver string, meter progress.Meter) (string, error) {
 	return snappy.Rollback(name, ver, meter)
 }
 
-func (s *defaultBackend) Activate(name string, active bool, meter progress.Meter) error {
+func (b *defaultBackend) Activate(name string, active bool, meter progress.Meter) error {
 	return snappy.SetActive(name, active, meter)
 }
 
-func (s *defaultBackend) Download(name, channel string, meter progress.Meter) (*snap.Info, string, error) {
+func (b *defaultBackend) Download(name, channel string, meter progress.Meter) (*snap.Info, string, error) {
 	mStore := snappy.NewConfiguredUbuntuStoreSnapRepository()
 	snap, err := mStore.Snap(name, channel)
 	if err != nil {
@@ -114,18 +114,18 @@ func (s *defaultBackend) Download(name, channel string, meter progress.Meter) (*
 	return snap, downloadedSnapFile, nil
 }
 
-func (s *defaultBackend) CheckSnap(snapFilePath string, flags int) error {
+func (b *defaultBackend) CheckSnap(snapFilePath string, flags int) error {
 	meter := &progress.NullProgress{}
 	return snappy.CheckSnap(snapFilePath, snappy.InstallFlags(flags), meter)
 }
 
-func (s *defaultBackend) SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, flags int) error {
+func (b *defaultBackend) SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, flags int) error {
 	meter := &progress.NullProgress{}
 	_, err := snappy.SetupSnap(snapFilePath, sideInfo, snappy.InstallFlags(flags), meter)
 	return err
 }
 
-func (s *defaultBackend) CopySnapData(snapInstPath string, flags int) error {
+func (b *defaultBackend) CopySnapData(snapInstPath string, flags int) error {
 	sn, err := snappy.NewInstalledSnap(filepath.Join(snapInstPath, "meta", "snap.yaml"))
 	if err != nil {
 		return err
@@ -134,7 +134,7 @@ func (s *defaultBackend) CopySnapData(snapInstPath string, flags int) error {
 	return snappy.CopyData(sn.Info(), snappy.InstallFlags(flags), meter)
 }
 
-func (s *defaultBackend) SetupSnapSecurity(snapInstPath string) error {
+func (b *defaultBackend) SetupSnapSecurity(snapInstPath string) error {
 	sn, err := snappy.NewInstalledSnap(filepath.Join(snapInstPath, "meta", "snap.yaml"))
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func (s *defaultBackend) SetupSnapSecurity(snapInstPath string) error {
 	return snappy.SetupSnapSecurity(sn)
 }
 
-func (s *defaultBackend) LinkSnap(snapInstPath string) error {
+func (b *defaultBackend) LinkSnap(snapInstPath string) error {
 	sn, err := snappy.NewInstalledSnap(filepath.Join(snapInstPath, "meta", "snap.yaml"))
 	if err != nil {
 		return err
@@ -155,13 +155,13 @@ func (s *defaultBackend) LinkSnap(snapInstPath string) error {
 	return snappy.UpdateCurrentSymlink(sn, meter)
 }
 
-func (s *defaultBackend) UndoSetupSnap(snapFilePath string) error {
+func (b *defaultBackend) UndoSetupSnap(s snap.PlaceInfo) error {
 	meter := &progress.NullProgress{}
-	snappy.UndoSetupSnap(snapFilePath, meter)
+	snappy.UndoSetupSnap(s, meter)
 	return nil
 }
 
-func (s *defaultBackend) UndoCopySnapData(instSnapPath string, flags int) error {
+func (b *defaultBackend) UndoCopySnapData(instSnapPath string, flags int) error {
 	sn, err := snappy.NewInstalledSnap(filepath.Join(instSnapPath, "meta", "snap.yaml"))
 	if err != nil {
 		return err
@@ -171,7 +171,7 @@ func (s *defaultBackend) UndoCopySnapData(instSnapPath string, flags int) error 
 	return nil
 }
 
-func (s *defaultBackend) UndoLinkSnap(oldInstSnapPath, instSnapPath string) error {
+func (b *defaultBackend) UndoLinkSnap(oldInstSnapPath, instSnapPath string) error {
 	new, err := snappy.NewInstalledSnap(filepath.Join(instSnapPath, "meta", "snap.yaml"))
 	if err != nil {
 		return err
@@ -192,7 +192,7 @@ func (s *defaultBackend) UndoLinkSnap(oldInstSnapPath, instSnapPath string) erro
 	return err2
 }
 
-func (s *defaultBackend) CanRemove(instSnapPath string) error {
+func (b *defaultBackend) CanRemove(instSnapPath string) error {
 	sn, err := snappy.NewInstalledSnap(filepath.Join(instSnapPath, "meta", "snap.yaml"))
 	if err != nil {
 		return err
@@ -203,7 +203,7 @@ func (s *defaultBackend) CanRemove(instSnapPath string) error {
 	return nil
 }
 
-func (s *defaultBackend) UnlinkSnap(instSnapPath string, meter progress.Meter) error {
+func (b *defaultBackend) UnlinkSnap(instSnapPath string, meter progress.Meter) error {
 	sn, err := snappy.NewInstalledSnap(filepath.Join(instSnapPath, "meta", "snap.yaml"))
 	if err != nil {
 		return err
@@ -212,7 +212,7 @@ func (s *defaultBackend) UnlinkSnap(instSnapPath string, meter progress.Meter) e
 	return snappy.UnlinkSnap(sn, meter)
 }
 
-func (s *defaultBackend) RemoveSnapSecurity(instSnapPath string) error {
+func (b *defaultBackend) RemoveSnapSecurity(instSnapPath string) error {
 	sn, err := snappy.NewInstalledSnap(filepath.Join(instSnapPath, "meta", "snap.yaml"))
 	if err != nil {
 		return err
@@ -220,14 +220,10 @@ func (s *defaultBackend) RemoveSnapSecurity(instSnapPath string) error {
 	return snappy.RemoveGeneratedSnapSecurity(sn)
 }
 
-func (s *defaultBackend) RemoveSnapFiles(instSnapPath string, meter progress.Meter) error {
-	sn, err := snappy.NewInstalledSnap(filepath.Join(instSnapPath, "meta", "snap.yaml"))
-	if err != nil {
-		return err
-	}
-	return snappy.RemoveSnapFiles(sn, meter)
+func (b *defaultBackend) RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error {
+	return snappy.RemoveSnapFiles(s, meter)
 }
-func (s *defaultBackend) RemoveSnapData(name string, revision int) error {
+func (b *defaultBackend) RemoveSnapData(name string, revision int) error {
 	// XXX: hack for now
 	sn, err := snappy.NewInstalledSnap(filepath.Join(dirs.SnapSnapsDir, name, strconv.Itoa(revision), "meta", "snap.yaml"))
 	if err != nil {
@@ -237,6 +233,6 @@ func (s *defaultBackend) RemoveSnapData(name string, revision int) error {
 	return snappy.RemoveSnapData(sn.Info())
 }
 
-func (s *defaultBackend) GarbageCollect(snap string, flags int, meter progress.Meter) error {
+func (b *defaultBackend) GarbageCollect(snap string, flags int, meter progress.Meter) error {
 	return snappy.GarbageCollect(snap, snappy.InstallFlags(flags), meter)
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -158,10 +158,10 @@ func (f *fakeSnappyBackend) LinkSnap(instSnapPath string) error {
 	return nil
 }
 
-func (f *fakeSnappyBackend) UndoSetupSnap(snapFilePath string) error {
+func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo) error {
 	f.ops = append(f.ops, fakeOp{
 		op:   "undo-setup-snap",
-		name: snapFilePath,
+		name: s.MountDir(),
 	})
 	return nil
 }
@@ -221,10 +221,10 @@ func (f *fakeSnappyBackend) RemoveSnapSecurity(instSnapPath string) error {
 	return nil
 }
 
-func (f *fakeSnappyBackend) RemoveSnapFiles(instSnapPath string, meter progress.Meter) error {
+func (f *fakeSnappyBackend) RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error {
 	f.ops = append(f.ops, fakeOp{
 		op:   "remove-snap-files",
-		name: instSnapPath,
+		name: s.MountDir(),
 	})
 	return nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -69,16 +69,20 @@ type snapState struct {
 	DevMode  bool             `json:"dev-mode,omitempty"`
 }
 
-// XXX: best this should helper from snap
-func (ss *SnapSetup) MountDir() string {
-	return filepath.Join(dirs.SnapSnapsDir, ss.Name, strconv.Itoa(ss.Revision))
+func (ss *SnapSetup) placeInfo() snap.PlaceInfo {
+	return snap.MinimalPlaceInfo(ss.Name, ss.Revision)
 }
 
+func (ss *SnapSetup) MountDir() string {
+	return ss.placeInfo().MountDir()
+}
+
+// XXX: should not be needed actually
 func (ss *SnapSetup) OldMountDir() string {
 	if ss.OldName == "" {
 		return ""
 	}
-	return filepath.Join(dirs.SnapSnapsDir, ss.OldName, strconv.Itoa(ss.OldRevision))
+	return snap.MinimalPlaceInfo(ss.OldName, ss.OldRevision).MountDir()
 }
 
 // Manager returns a new snap manager.
@@ -187,7 +191,7 @@ func (m *SnapManager) doRemoveSnapFiles(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	pb := &TaskProgressAdapter{task: t}
-	return m.backend.RemoveSnapFiles(ss.MountDir(), pb)
+	return m.backend.RemoveSnapFiles(ss.placeInfo(), pb)
 }
 
 func (m *SnapManager) doRemoveSnapData(t *state.Task, _ *tomb.Tomb) error {
@@ -286,7 +290,7 @@ func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	return m.backend.UndoSetupSnap(ss.MountDir())
+	return m.backend.UndoSetupSnap(ss.placeInfo())
 }
 
 func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {

--- a/snap/info.go
+++ b/snap/info.go
@@ -29,6 +29,29 @@ import (
 	"github.com/ubuntu-core/snappy/timeout"
 )
 
+// PlaceInfo offers all the information about where a snap and its data are located and exposed in the filesystem.
+type PlaceInfo interface {
+	// Name returns the name of the snap.
+	Name() string
+
+	//MountDir returns the base directory of the snap.
+	MountDir() string
+
+	// MountFile returns the path where the snap file that is mounted is installed.
+	MountFile() string
+
+	// DataDir returns the data directory of the snap.
+	DataDir() string
+
+	// DataHomeDir returns the per user data directory of the snap.
+	DataHomeDir() string
+}
+
+// MinimalPlaceInfo returns a PlaceInfo with just the location information for a snap of the given name and revision.
+func MinimalPlaceInfo(name string, revision int) PlaceInfo {
+	return &Info{SideInfo: SideInfo{OfficialName: name, Revision: revision}}
+}
+
 // SideInfo holds snap metadata that is not included in snap.yaml or for which the store is the canonical source.
 // It can be marshalled both as JSON and YAML.
 type SideInfo struct {
@@ -117,6 +140,9 @@ func (s *Info) DataDir() string {
 func (s *Info) DataHomeDir() string {
 	return filepath.Join(dirs.SnapDataHomeGlob, s.Name(), s.strRevno())
 }
+
+// sanity check that Info is a PlacInfo
+var _ PlaceInfo = (*Info)(nil)
 
 // PlugInfo provides information about a plug.
 type PlugInfo struct {

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -44,11 +44,7 @@ var findBootloader = partition.FindBootloader
 
 // removeKernelAssets removes the unpacked kernel/initrd for the given
 // kernel snap
-func removeKernelAssets(s *snap.Info, inter interacter) error {
-	if s.Type != snap.TypeKernel {
-		return fmt.Errorf("can not remove kernel assets from snap type %q", s.Type)
-	}
-
+func removeKernelAssets(s snap.PlaceInfo, inter interacter) error {
 	bootloader, err := findBootloader()
 	if err != nil {
 		return fmt.Errorf("no not remove kernel assets: %s", err)

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -21,6 +21,7 @@ package snappy
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -61,52 +62,52 @@ func CheckSnap(snapFilePath string, flags InstallFlags, meter progress.Meter) er
 
 // SetupSnap does prepare and mount the snap for further processing
 // It returns the installed path and an error
-func SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, flags InstallFlags, meter progress.Meter) (string, error) {
+func SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, flags InstallFlags, meter progress.Meter) (snap.PlaceInfo, error) {
 	inhibitHooks := (flags & InhibitHooks) != 0
 	allowUnauth := (flags & AllowUnauthenticated) != 0
 
 	s, snapf, err := openSnapFile(snapFilePath, allowUnauth, sideInfo)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	instdir := s.MountDir()
 
 	// the "gadget" snaps are special
 	if s.Type == snap.TypeGadget {
 		if err := installGadgetHardwareUdevRules(s); err != nil {
-			return "", err
+			return s, err
 		}
 	}
 
 	if err := os.MkdirAll(instdir, 0755); err != nil {
 		logger.Noticef("Can not create %q: %v", instdir, err)
-		return instdir, err
+		return s, err
 	}
 
 	// XXX: do this here as long as we are manifest based
 	if s.Revision != 0 { // not sideloaded
 		if err := SaveManifest(s); err != nil {
-			return instdir, err
+			return s, err
 		}
 	}
 
 	if err := snapf.Install(s.MountFile(), instdir); err != nil {
-		return instdir, err
+		return s, err
 	}
 
 	// generate the mount unit for the squashfs
 	if err := addSquashfsMount(s, inhibitHooks, meter); err != nil {
-		return instdir, err
+		return s, err
 	}
 
 	// FIXME: special handling is bad 'mkay
 	if s.Type == snap.TypeKernel {
 		if err := extractKernelAssets(s, snapf, flags, meter); err != nil {
-			return instdir, fmt.Errorf("failed to install kernel %s", err)
+			return s, fmt.Errorf("failed to install kernel %s", err)
 		}
 	}
 
-	return instdir, err
+	return s, err
 }
 
 func addSquashfsMount(s *snap.Info, inhibitHooks bool, inter interacter) error {
@@ -150,29 +151,26 @@ func removeSquashfsMount(baseDir string, inter interacter) error {
 	return nil
 }
 
-func UndoSetupSnap(installDir string, meter progress.Meter) {
+func UndoSetupSnap(s snap.PlaceInfo, meter progress.Meter) {
 	// SetupSnap did it not made far enough
-	if installDir == "" {
+	if !osutil.FileExists(s.MountDir()) {
 		return
 	}
 
-	// SetupSnap made it far enough to mount the snap, easy
-	s, err := NewInstalledSnap(filepath.Join(installDir, "meta", "snap.yaml"))
-	if err == nil {
-		if err := RemoveSnapFiles(s, meter); err != nil {
-			logger.Noticef("cannot remove snap files: %s", err)
-		}
+	if err := RemoveSnapFiles(s, meter); err != nil {
+		logger.Noticef("cannot remove snap files: %s", err)
 	}
 
-	snapPath := s.Info().MountFile()
+	mountDir := s.MountDir()
+	snapPath := s.MountFile()
 
 	// remove install dir and the snap blob itself
 	for _, path := range []string{
-		installDir,
+		mountDir,
 		snapPath,
 	} {
 		if err := os.RemoveAll(path); err != nil {
-			logger.Noticef("cannot remove snap package at %v: %s", installDir, err)
+			logger.Noticef("cannot remove snap package at %v: %s", mountDir, err)
 		}
 	}
 
@@ -431,11 +429,12 @@ func (o *Overlord) InstallWithSideInfo(snapFilePath string, sideInfo *snap.SideI
 		return nil, err
 	}
 
-	instPath, err := SetupSnap(snapFilePath, sideInfo, flags, meter)
+	minInfo, err := SetupSnap(snapFilePath, sideInfo, flags, meter)
 	defer func() {
 		if err != nil {
-			// XXX: needs sideInfo?
-			UndoSetupSnap(instPath, meter)
+			if minInfo != nil {
+				UndoSetupSnap(minInfo, meter)
+			}
 		}
 	}()
 	if err != nil {
@@ -472,7 +471,7 @@ func (o *Overlord) InstallWithSideInfo(snapFilePath string, sideInfo *snap.SideI
 	// if get this far we know the snap is actually mounted.
 	// XXX: use infos further but anyway this is going away mostly
 	// once we simplify u-d-f
-	newSnap, err := NewInstalledSnap(filepath.Join(instPath, "meta", "snap.yaml"))
+	newSnap, err := NewInstalledSnap(filepath.Join(newInfo.MountDir(), "meta", "snap.yaml"))
 	if err != nil {
 		return nil, err
 	}
@@ -579,21 +578,31 @@ func CanRemove(s *Snap) bool {
 }
 
 // RemoveSnapFiles removes the snap files from the disk
-func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
-	info := s.Info()
-	basedir := info.MountDir()
-	snapPath := info.MountFile()
+func RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error {
+	mountDir := s.MountDir()
+
+	// XXX: nicer way to do this
+	typ := snap.TypeApp
+	content, err := ioutil.ReadFile(filepath.Join(mountDir, "meta", "/snap.yaml"))
+	if err == nil {
+		info, err := snap.InfoFromSnapYaml(content)
+		if err == nil {
+			typ = info.Type
+		}
+	}
+
+	snapPath := s.MountFile()
 	// this also ensures that the mount unit stops
-	if err := removeSquashfsMount(basedir, meter); err != nil {
+	if err := removeSquashfsMount(mountDir, meter); err != nil {
 		return err
 	}
 
-	if err := os.RemoveAll(basedir); err != nil {
+	if err := os.RemoveAll(mountDir); err != nil {
 		return err
 	}
 
 	// best effort(?)
-	os.Remove(filepath.Dir(basedir))
+	os.Remove(filepath.Dir(mountDir))
 
 	// remove the snap
 	if err := os.RemoveAll(snapPath); err != nil {
@@ -601,8 +610,8 @@ func RemoveSnapFiles(s *Snap, meter progress.Meter) error {
 	}
 
 	// remove the kernel assets (if any)
-	if s.m.Type == snap.TypeKernel {
-		if err := removeKernelAssets(info, meter); err != nil {
+	if typ == snap.TypeKernel {
+		if err := removeKernelAssets(s, meter); err != nil {
 			logger.Noticef("removing kernel assets failed with %s", err)
 		}
 	}
@@ -622,7 +631,7 @@ func (o *Overlord) Uninstall(s *Snap, meter progress.Meter) error {
 		return err
 	}
 
-	if err := RemoveSnapFiles(s, meter); err != nil {
+	if err := RemoveSnapFiles(s.Info(), meter); err != nil {
 		return err
 	}
 

--- a/snappy/overlord_test.go
+++ b/snappy/overlord_test.go
@@ -562,3 +562,20 @@ apps:
 	c.Assert(osutil.FileExists(binaryWrapper), Equals, false)
 	c.Assert(osutil.FileExists(snapDir), Equals, false)
 }
+
+func (s *SnapTestSuite) TestInstallIncorrectSnapYamlErrors(c *C) {
+	snapPath := makeTestSnapPackage(c, `name: foo
+version: 1.0
+apps:
+ foo:
+  plugs: [invalid-chars!!]
+`)
+
+	si := &snap.SideInfo{
+		OfficialName: "bar",
+		Revision:     55,
+	}
+
+	_, err := (&Overlord{}).InstallWithSideInfo(snapPath, si, 0, &MockProgressMeter{})
+	c.Assert(err, NotNil)
+}

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -339,17 +339,6 @@ func (s *SquashfsTestSuite) TestInstallKernelSnapUnpacksKernelErrors(c *C) {
 	c.Assert(err, ErrorMatches, `can not extract kernel assets from snap type "app"`)
 }
 
-func (s *SquashfsTestSuite) TestInstallKernelSnapRemoveAssetsWrongType(c *C) {
-	snapYaml, err := makeInstalledMockSnap(packageHello, 11)
-	c.Assert(err, IsNil)
-
-	snap, err := NewInstalledSnap(snapYaml)
-	c.Assert(err, IsNil)
-
-	err = removeKernelAssets(snap.Info(), nil)
-	c.Assert(err, ErrorMatches, `can not remove kernel assets from snap type "app"`)
-}
-
 func (s *SquashfsTestSuite) TestActiveOSNotRemovable(c *C) {
 	snapYaml, err := makeInstalledMockSnap(packageOS, 11)
 	c.Assert(err, IsNil)

--- a/snappy/undo_test.go
+++ b/snappy/undo_test.go
@@ -66,17 +66,17 @@ func (s *undoTestSuite) TestUndoForSetupSnapSimple(c *C) {
 		Revision:     14,
 	}
 
-	instDir, err := SetupSnap(snapPath, &si, 0, &s.meter)
+	minInfo, err := SetupSnap(snapPath, &si, 0, &s.meter)
 	c.Assert(err, IsNil)
-	c.Assert(instDir, Equals, filepath.Join(dirs.SnapSnapsDir, "hello-snap/14"))
+	c.Assert(minInfo.MountDir(), Equals, filepath.Join(dirs.SnapSnapsDir, "hello-snap/14"))
 	l, _ := filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.mount"))
 	c.Assert(l, HasLen, 1)
 
 	// undo undoes the mount unit and the instdir creation
-	UndoSetupSnap(instDir, &s.meter)
+	UndoSetupSnap(minInfo, &s.meter)
 	l, _ = filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.mount"))
 	c.Assert(l, HasLen, 0)
-	c.Assert(osutil.FileExists(instDir), Equals, false)
+	c.Assert(osutil.FileExists(minInfo.MountDir()), Equals, false)
 }
 
 func (s *undoTestSuite) TestUndoForSetupSnapKernelUboot(c *C) {


### PR DESCRIPTION
should also address the issue attacked a bit differently in #866 