### PR TITLE
interfaces/builtin: auto-connect unity7 and x11

### DIFF
--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -149,5 +149,6 @@ func NewUnity7Interface() interfaces.Interface {
 		connectedPlugAppArmor: unity7ConnectedPlugAppArmor,
 		connectedPlugSecComp:  unity7ConnectedPlugSecComp,
 		reservedForOS:         true,
+		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -128,5 +128,5 @@ func (s *Unity7InterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 }
 
 func (s *Unity7InterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.AutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -51,5 +51,6 @@ func NewX11Interface() interfaces.Interface {
 		connectedPlugAppArmor: x11ConnectedPlugAppArmor,
 		connectedPlugSecComp:  x11ConnectedPlugSecComp,
 		reservedForOS:         true,
+		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -128,5 +128,5 @@ func (s *X11InterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 }
 
 func (s *X11InterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.AutoConnect(), Equals, true)
 }


### PR DESCRIPTION
We really want to make desktop apps work out of the box.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>