### PR TITLE
debian: install snapd instead of ubuntu-snappy-cli in ADT

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,6 +1,5 @@
 Tests: integrationtests
 Restrictions: allow-stderr, isolation-container, rw-build-tree
-Depends: ubuntu-snappy-cli,
-         @builddeps@,
+Depends: @builddeps@,
          bzr,
          golang-golang-x-net-dev


### PR DESCRIPTION
Please only merge if this makes the autopkgtest job happy.