### PR TITLE
debian: warn about installing ubuntu-core-snapd-units on desktop systems

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+snapd (1.9.1) UNRELEASED; urgency=medium
+
+  [ Daniel Holbach ]
+  * Add warning about installing ubuntu-core-snapd-units on Desktop systems.
+  * Add ${misc:Depends} to ubuntu-core-snapd-units.
+
+  [ Michael Vogt ]
+  *
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Tue, 12 Apr 2016 13:23:31 +0200
+
 snapd (1.9) xenial; urgency=medium
 
   * rename source and binary package to "snapd"

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Build-Depends: bash-completion,
                python3,
                python3-markdown,
                squashfs-tools
-Standards-Version: 3.9.6
+Standards-Version: 3.9.7
 Homepage: https://github.com/ubuntu-core/snappy
 Vcs-Browser: https://github.com/ubuntu-core/snappy
 Vcs-Git: https://github.com/ubuntu-core/snappy.git
@@ -55,7 +55,7 @@ Description: Tool to interact with Ubuntu Core Snappy.
 
 Package: ubuntu-core-snapd-units
 Architecture: any
-Depends: snapd
+Depends: snapd, ${misc:Depends}
 Replaces: ubuntu-snappy (<< 1.9)
 Breaks: ubuntu-snappy (<< 1.9)
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
@@ -63,6 +63,8 @@ Built-Using: ${misc:Built-Using}
 Description: Scripts for snapd that should only run on ubuntu core systems.
  This package contains systemd services that need to run on ubuntu core
  systems.
+ .
+ This package should not be installed on a Desktop system.
 
 Package: ubuntu-snappy
 Architecture: all


### PR DESCRIPTION
 * Add warning about installing ubuntu-core-snapd-units on Desktop systems.
 * Add ${misc:Depends} to ubuntu-core-snapd-units.
