### PR TITLE
many: separate copy-data from unlinking of current snap

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -175,7 +175,7 @@ version: %s
 	c.Assert(err, check.IsNil)
 
 	if active {
-		err := snappy.UpdateCurrentSymlink(localSnap, nil)
+		err := snappy.UpdateCurrentSymlink(localSnap.Info(), nil)
 		c.Assert(err, check.IsNil)
 	}
 

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -55,7 +55,6 @@ type managerBackend interface {
 	Rollback(name, ver string, meter progress.Meter) (string, error)
 
 	// info
-	ActiveSnap(name string) *snap.Info
 	SnapByNameAndVersion(name, version string) *snap.Info
 
 	// testing helpers
@@ -65,13 +64,6 @@ type managerBackend interface {
 type defaultBackend struct{}
 
 func (b *defaultBackend) Candidate(*snap.SideInfo) {}
-
-func (b *defaultBackend) ActiveSnap(name string) *snap.Info {
-	if snap := snappy.ActiveSnapByName(name); snap != nil {
-		return snap.Info()
-	}
-	return nil
-}
 
 func (b *defaultBackend) SnapByNameAndVersion(name, version string) *snap.Info {
 	// XXX: use snapstate stuff!

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -35,7 +35,7 @@ type managerBackend interface {
 	Download(name, channel string, meter progress.Meter) (*snap.Info, string, error)
 	CheckSnap(snapFilePath string, flags int) error
 	SetupSnap(snapFilePath string, si *snap.SideInfo, flags int) error
-	CopySnapData(instSnapPath string, flags int) error
+	CopySnapData(newSnap, oldSnap *snap.Info, flags int) error
 	LinkSnap(instSnapPath string) error
 	GarbageCollect(snap string, flags int, meter progress.Meter) error
 	// the undoers for install
@@ -128,13 +128,9 @@ func (b *defaultBackend) SetupSnap(snapFilePath string, sideInfo *snap.SideInfo,
 	return err
 }
 
-func (b *defaultBackend) CopySnapData(snapInstPath string, flags int) error {
-	sn, err := snappy.NewInstalledSnap(filepath.Join(snapInstPath, "meta", "snap.yaml"))
-	if err != nil {
-		return err
-	}
+func (b *defaultBackend) CopySnapData(newInfo, oldInfo *snap.Info, flags int) error {
 	meter := &progress.NullProgress{}
-	return snappy.CopyData(sn.Info(), snappy.InstallFlags(flags), meter)
+	return snappy.CopyData(newInfo, oldInfo, snappy.InstallFlags(flags), meter)
 }
 
 func (b *defaultBackend) LinkSnap(snapInstPath string) error {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -149,10 +149,10 @@ func (f *fakeSnappyBackend) CopySnapData(newInfo, oldInfo *snap.Info, flags int)
 	return nil
 }
 
-func (f *fakeSnappyBackend) LinkSnap(instSnapPath string) error {
+func (f *fakeSnappyBackend) LinkSnap(info *snap.Info) error {
 	f.ops = append(f.ops, fakeOp{
 		op:   "link-snap",
-		name: instSnapPath,
+		name: info.MountDir(),
 	})
 	return nil
 }
@@ -168,14 +168,6 @@ func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo) error {
 func (f *fakeSnappyBackend) UndoCopySnapData(instSnapPath string, flags int) error {
 	f.ops = append(f.ops, fakeOp{
 		op:   "undo-copy-snap-data",
-		name: instSnapPath,
-	})
-	return nil
-}
-
-func (f *fakeSnappyBackend) UndoLinkSnap(oldInstSnapPath, instSnapPath string) error {
-	f.ops = append(f.ops, fakeOp{
-		op:   "undo-link-snap",
 		name: instSnapPath,
 	})
 	return nil
@@ -204,10 +196,10 @@ func (f *fakeSnappyBackend) CanRemove(instSnapPath string) error {
 	return nil
 }
 
-func (f *fakeSnappyBackend) UnlinkSnap(instSnapPath string, meter progress.Meter) error {
+func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, meter progress.Meter) error {
 	f.ops = append(f.ops, fakeOp{
 		op:   "unlink-snap",
-		name: instSnapPath,
+		name: info.MountDir(),
 	})
 	return nil
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -44,8 +44,6 @@ type fakeSnappyBackend struct {
 
 	fakeCurrentProgress int
 	fakeTotalProgress   int
-
-	activeSnaps map[string]*snap.Info
 }
 
 func (f *fakeSnappyBackend) InstallLocal(path string, flags int, p progress.Meter) error {
@@ -171,10 +169,6 @@ func (f *fakeSnappyBackend) UndoCopySnapData(instSnapPath string, flags int) err
 		name: instSnapPath,
 	})
 	return nil
-}
-
-func (f *fakeSnappyBackend) ActiveSnap(name string) *snap.Info {
-	return f.activeSnaps[name]
 }
 
 func (f *fakeSnappyBackend) SnapByNameAndVersion(name, version string) *snap.Info {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -134,10 +134,16 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, fl
 	return nil
 }
 
-func (f *fakeSnappyBackend) CopySnapData(instSnapPath string, flags int) error {
+func (f *fakeSnappyBackend) RetrieveInfo(name string, si *snap.SideInfo) (*snap.Info, error) {
+	// naive emulation for now, always works
+	return &snap.Info{SideInfo: *si}, nil
+}
+
+func (f *fakeSnappyBackend) CopySnapData(newInfo, oldInfo *snap.Info, flags int) error {
 	f.ops = append(f.ops, fakeOp{
-		op:    "copy-data",
-		name:  instSnapPath,
+		op:   "copy-data",
+		name: newInfo.MountDir(),
+		// XXX: capture oldInfo
 		flags: flags,
 	})
 	return nil

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/ubuntu-core/snappy/overlord/state"
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 type ManagerBackend managerBackend
@@ -41,4 +42,9 @@ func (m *SnapManager) AddForeignTaskHandlers() {
 	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error { return nil }
 	m.runner.AddHandler("setup-snap-security", fakeHandler, fakeHandler)
 	m.runner.AddHandler("remove-snap-security", fakeHandler, fakeHandler)
+}
+
+func ChangeRetrieveInfo(retrieve func(name string, si *snap.SideInfo) (*snap.Info, error)) func() {
+	retrieveInfo = retrieve
+	return func() { retrieveInfo = retrieveInfoImpl }
 }

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -20,6 +20,8 @@
 package snapstate
 
 import (
+	"errors"
+
 	"gopkg.in/tomb.v2"
 
 	"github.com/ubuntu-core/snappy/overlord/state"
@@ -42,6 +44,12 @@ func (m *SnapManager) AddForeignTaskHandlers() {
 	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error { return nil }
 	m.runner.AddHandler("setup-snap-security", fakeHandler, fakeHandler)
 	m.runner.AddHandler("remove-snap-security", fakeHandler, fakeHandler)
+
+	// Add handler to test full aborting of changes
+	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
+		return errors.New("error out")
+	}
+	m.runner.AddHandler("error-trigger", erroringHandler, nil)
 }
 
 func ChangeRetrieveInfo(retrieve func(name string, si *snap.SideInfo) (*snap.Info, error)) func() {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -105,8 +105,8 @@ func Manager(s *state.State) (*SnapManager, error) {
 
 	// remove releated
 	runner.AddHandler("unlink-snap", m.doUnlinkSnap, nil)
-	runner.AddHandler("remove-snap-files", m.doRemoveSnapFiles, nil)
-	runner.AddHandler("remove-snap-data", m.doRemoveSnapData, nil)
+	runner.AddHandler("clear-snap", m.doClearSnapData, nil)
+	runner.AddHandler("discard-snap", m.doDiscardSnap, nil)
 	runner.AddHandler("forget-snap", m.doForgetSnap, nil)
 
 	// FIXME: work on those
@@ -237,7 +237,7 @@ func (m *SnapManager) doUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doRemoveSnapFiles(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
 	t.State().Unlock()
@@ -249,7 +249,7 @@ func (m *SnapManager) doRemoveSnapFiles(t *state.Task, _ *tomb.Tomb) error {
 	return m.backend.RemoveSnapFiles(ss.placeInfo(), pb)
 }
 
-func (m *SnapManager) doRemoveSnapData(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 	t.State().Lock()
 	ss, err := TaskSnapSetup(t)
 	t.State().Unlock()

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -562,16 +562,22 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// No need to undo "snaps" in state here. The only chance of
-	// having the new state there is a working doLinkSnap call.
-
 	// relinking of the old snap is done in the undo of unlink-current-snap
 
-	newInfo, err := retrieveInfo(ss.Name, snapst.Candidate)
+	n := len(snapst.Sequence)
+	cand := snapst.Sequence[n-1]
+
+	newInfo, err := retrieveInfo(ss.Name, cand)
 	if err != nil {
 		return err
 	}
 
+	snapst.Candidate = cand
+	if n == 1 {
+		snapst.Sequence = nil
+	} else {
+		snapst.Sequence = snapst.Sequence[:n-1]
+	}
 	snapst.Active = false
 
 	pb := &TaskProgressAdapter{task: t}

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -139,9 +139,9 @@ func (s *snapmgrTestSuite) TestRemoveTasks(c *C) {
 	c.Assert(err, IsNil)
 
 	i := 0
-	c.Assert(ts.Tasks(), HasLen, 5)
+	c.Assert(ts.Tasks(), HasLen, 4)
 	// all tasks are accounted
-	c.Assert(s.state.Tasks(), HasLen, 5)
+	c.Assert(s.state.Tasks(), HasLen, 4)
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "unlink-snap")
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "remove-snap-security")
@@ -149,8 +149,6 @@ func (s *snapmgrTestSuite) TestRemoveTasks(c *C) {
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "clear-snap")
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "discard-snap")
-	i++
-	c.Assert(ts.Tasks()[i].Kind(), Equals, "forget-snap")
 }
 
 func (s *snapmgrTestSuite) TestInstallIntegration(c *C) {

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -146,9 +146,11 @@ func (s *snapmgrTestSuite) TestRemoveTasks(c *C) {
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "remove-snap-security")
 	i++
-	c.Assert(ts.Tasks()[i].Kind(), Equals, "remove-snap-data")
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "clear-snap")
 	i++
-	c.Assert(ts.Tasks()[i].Kind(), Equals, "remove-snap-files")
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "discard-snap")
+	i++
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "forget-snap")
 }
 
 func (s *snapmgrTestSuite) TestInstallIntegration(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -166,9 +166,11 @@ func Remove(s *state.State, snapSpec string, flags snappy.RemoveFlags) (*state.T
 	removeFiles.Set("snap-setup-task", unlink.ID())
 	removeFiles.WaitFor(removeData)
 
-	// XXX: need a task to forget the snap
+	forget := s.NewTask("forget-snap", fmt.Sprintf(i18n.G("Forgetting removed revision of %q"), snapSpec))
+	forget.Set("snap-setup-task", unlink.ID())
+	forget.WaitFor(removeFiles)
 
-	return state.NewTaskSet(unlink, removeSecurity, removeData, removeFiles), nil
+	return state.NewTaskSet(unlink, removeSecurity, removeData, removeFiles, forget), nil
 }
 
 // Rollback returns a set of tasks for rolling back a snap.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -202,7 +202,7 @@ func Deactivate(s *state.State, snap string) (*state.TaskSet, error) {
 
 // Retrieval functions
 
-func retrieveInfo(name string, si *snap.SideInfo) (*snap.Info, error) {
+func retrieveInfoImpl(name string, si *snap.SideInfo) (*snap.Info, error) {
 	// XXX: move some of this in snap as helper?
 	snapYamlFn := filepath.Join(snap.MountDir(name, si.Revision), "meta", "snap.yaml")
 	meta, err := ioutil.ReadFile(snapYamlFn)
@@ -222,6 +222,8 @@ func retrieveInfo(name string, si *snap.SideInfo) (*snap.Info, error) {
 
 	return info, nil
 }
+
+var retrieveInfo = retrieveInfoImpl
 
 // Info returns the information about the snap with given name and revision.
 // Works also for a mounted candidate snap in the process of being installed.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -81,7 +81,7 @@ func doInstall(s *state.State, snapName, channel string, flags snappy.InstallFla
 	linkSnap.Set("snap-setup-task", prepare.ID())
 	linkSnap.WaitFor(setupSecurity)
 
-	return state.NewTaskSet(prepare, mount, copyData, setupSecurity, linkSnap), nil
+	return state.NewTaskSet(prepare, mount, unlink, copyData, setupSecurity, linkSnap), nil
 }
 
 // Install returns a set of tasks for installing snap.
@@ -165,6 +165,8 @@ func Remove(s *state.State, snapSpec string, flags snappy.RemoveFlags) (*state.T
 	removeFiles := s.NewTask("remove-snap-files", fmt.Sprintf(i18n.G("Removing files for %q"), snapSpec))
 	removeFiles.Set("snap-setup-task", unlink.ID())
 	removeFiles.WaitFor(removeData)
+
+	// XXX: need a task to forget the snap
 
 	return state.NewTaskSet(unlink, removeSecurity, removeData, removeFiles), nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -213,10 +213,10 @@ func Remove(s *state.State, snapSpec string, flags snappy.RemoveFlags) (*state.T
 	removeSecurity := s.NewTask("remove-snap-security", fmt.Sprintf(i18n.G("Remove security profile for snap %q"), snapSpec))
 	addNext(removeSecurity)
 
-	removeData := s.NewTask("remove-snap-data", fmt.Sprintf(i18n.G("Remove data for snap %q"), snapSpec))
+	removeData := s.NewTask("clear-snap", fmt.Sprintf(i18n.G("Remove data for snap %q"), snapSpec))
 	addNext(removeData)
 
-	removeFiles := s.NewTask("remove-snap-files", fmt.Sprintf(i18n.G("Remove snap %q from the system"), snapSpec))
+	removeFiles := s.NewTask("discard-snap", fmt.Sprintf(i18n.G("Remove snap %q from the system"), snapSpec))
 	addNext(removeFiles)
 
 	// forget is last

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -70,7 +70,7 @@ func doInstall(s *state.State, curActive bool, snapName, channel string, flags s
 
 	if curActive {
 		// unlink-current-snap (will stop services for copy-data)
-		unlink := s.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Unlink current revision for %q"), snapName))
+		unlink := s.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Make current revision for snap %q unavailable"), snapName))
 		addTask(unlink)
 		unlink.WaitFor(mount)
 		precopy = unlink
@@ -205,18 +205,18 @@ func Remove(s *state.State, snapSpec string, flags snappy.RemoveFlags) (*state.T
 	}
 
 	if active {
-		unlink := s.NewTask("unlink-snap", fmt.Sprintf(i18n.G("Deactivating %q"), snapSpec))
+		unlink := s.NewTask("unlink-snap", fmt.Sprintf(i18n.G("Make snap %q unavailable to the system"), snapSpec))
 
 		addNext(unlink)
 	}
 
-	removeSecurity := s.NewTask("remove-snap-security", fmt.Sprintf(i18n.G("Removing security profile for %q"), snapSpec))
+	removeSecurity := s.NewTask("remove-snap-security", fmt.Sprintf(i18n.G("Remove security profile for snap %q"), snapSpec))
 	addNext(removeSecurity)
 
-	removeData := s.NewTask("remove-snap-data", fmt.Sprintf(i18n.G("Removing data for %q"), snapSpec))
+	removeData := s.NewTask("remove-snap-data", fmt.Sprintf(i18n.G("Remove data for snap %q"), snapSpec))
 	addNext(removeData)
 
-	removeFiles := s.NewTask("remove-snap-files", fmt.Sprintf(i18n.G("Removing files for %q"), snapSpec))
+	removeFiles := s.NewTask("remove-snap-files", fmt.Sprintf(i18n.G("Remove snap %q from the system"), snapSpec))
 	addNext(removeFiles)
 
 	// forget is last

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-12 10:31+0200\n"
+        "POT-Creation-Date: 2016-04-12 21:29+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -383,6 +383,10 @@ msgid   "This command is no longer available, please use the \"list\" command"
 msgstr  ""
 
 msgid   "This command logs the given username into the store"
+msgstr  ""
+
+#, c-format
+msgid   "Unlink current revision for %q"
 msgstr  ""
 
 #, c-format

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-13 20:05+0200\n"
+        "POT-Creation-Date: 2016-04-13 20:17+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,10 +132,6 @@ msgid   "Finds packages to install"
 msgstr  ""
 
 msgid   "First boot has already run"
-msgstr  ""
-
-#, c-format
-msgid   "Forgetting removed revision of %q"
 msgstr  ""
 
 #. TRANSLATORS: the %s is a pkgname

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-12 21:29+0200\n"
+        "POT-Creation-Date: 2016-04-13 10:22+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -136,6 +136,10 @@ msgid   "Finds packages to install"
 msgstr  ""
 
 msgid   "First boot has already run"
+msgstr  ""
+
+#, c-format
+msgid   "Forgetting removed revision of %q"
 msgstr  ""
 
 #. TRANSLATORS: the %s is a pkgname

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-13 10:22+0200\n"
+        "POT-Creation-Date: 2016-04-13 20:05+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -106,10 +106,6 @@ msgid   "Deactivate an installed active snap"
 msgstr  ""
 
 #, c-format
-msgid   "Deactivating %q"
-msgstr  ""
-
-#, c-format
 msgid   "Disconnect %s:%s from %s:%s"
 msgstr  ""
 
@@ -192,7 +188,15 @@ msgid   "Login successful"
 msgstr  ""
 
 #, c-format
+msgid   "Make current revision for snap %q unavailable"
+msgstr  ""
+
+#, c-format
 msgid   "Make snap %q available to the system"
+msgstr  ""
+
+#, c-format
+msgid   "Make snap %q unavailable to the system"
 msgstr  ""
 
 #, c-format
@@ -268,21 +272,21 @@ msgstr  ""
 msgid   "Remove a snapp part"
 msgstr  ""
 
+#, c-format
+msgid   "Remove data for snap %q"
+msgstr  ""
+
+#, c-format
+msgid   "Remove security profile for snap %q"
+msgstr  ""
+
+#, c-format
+msgid   "Remove snap %q from the system"
+msgstr  ""
+
 #. TRANSLATORS: the %s is a pkgname
 #, c-format
 msgid   "Removing %s\n"
-msgstr  ""
-
-#, c-format
-msgid   "Removing data for %q"
-msgstr  ""
-
-#, c-format
-msgid   "Removing files for %q"
-msgstr  ""
-
-#, c-format
-msgid   "Removing security profile for %q"
 msgstr  ""
 
 #, c-format
@@ -387,10 +391,6 @@ msgid   "This command is no longer available, please use the \"list\" command"
 msgstr  ""
 
 msgid   "This command logs the given username into the store"
-msgstr  ""
-
-#, c-format
-msgid   "Unlink current revision for %q"
 msgstr  ""
 
 #, c-format

--- a/snappy/desktop_test.go
+++ b/snappy/desktop_test.go
@@ -104,7 +104,7 @@ Name=foo
 Icon=/snap/foo/11/foo.png`)
 
 	// unlink (deactivate) removes it again
-	err = UnlinkSnap(snap, nil)
+	err = UnlinkSnap(snap.Info(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
 }

--- a/snappy/info_test.go
+++ b/snappy/info_test.go
@@ -165,7 +165,7 @@ func (s *SnapTestSuite) TestPackageNameInstalled(c *C) {
 	c.Assert(ActivateSnap(snap, ag), IsNil)
 
 	c.Check(PackageNameActive("hello-snap"), Equals, true)
-	c.Assert(UnlinkSnap(snap, ag), IsNil)
+	c.Assert(UnlinkSnap(snap.Info(), ag), IsNil)
 	c.Check(PackageNameActive("hello-snap"), Equals, false)
 }
 

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -122,8 +122,8 @@ func extractKernelAssets(s *snap.Info, snapf snap.File, flags InstallFlags, inte
 
 // setNextBoot will schedule the given os or kernel snap to be used in
 // the next boot
-func setNextBoot(s *Snap) error {
-	if s.m.Type != snap.TypeOS && s.m.Type != snap.TypeKernel {
+func setNextBoot(s *snap.Info) error {
+	if s.Type != snap.TypeOS && s.Type != snap.TypeKernel {
 		return nil
 	}
 
@@ -133,13 +133,13 @@ func setNextBoot(s *Snap) error {
 	}
 
 	var bootvar string
-	switch s.m.Type {
+	switch s.Type {
 	case snap.TypeOS:
 		bootvar = "snappy_os"
 	case snap.TypeKernel:
 		bootvar = "snappy_kernel"
 	}
-	blobName := filepath.Base(s.Info().MountFile())
+	blobName := filepath.Base(s.MountFile())
 	if err := bootloader.SetBootVar(bootvar, blobName); err != nil {
 		return err
 	}

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -215,17 +215,17 @@ func UndoCopyData(newInfo *snap.Info, flags InstallFlags, meter progress.Meter) 
 
 }
 
-func GenerateWrappers(s *Snap, inter interacter) error {
+func GenerateWrappers(s *snap.Info, inter interacter) error {
 	// add the CLI apps from the snap.yaml
-	if err := addPackageBinaries(s.Info()); err != nil {
+	if err := addPackageBinaries(s); err != nil {
 		return err
 	}
 	// add the daemons from the snap.yaml
-	if err := addPackageServices(s.Info(), inter); err != nil {
+	if err := addPackageServices(s, inter); err != nil {
 		return err
 	}
 	// add the desktop files
-	if err := addPackageDesktopFiles(s.Info()); err != nil {
+	if err := addPackageDesktopFiles(s); err != nil {
 		return err
 	}
 
@@ -234,19 +234,19 @@ func GenerateWrappers(s *Snap, inter interacter) error {
 
 // RemoveGeneratedWrappers removes the generated services, binaries, desktop
 // wrappers
-func RemoveGeneratedWrappers(s *Snap, inter interacter) error {
+func RemoveGeneratedWrappers(s *snap.Info, inter interacter) error {
 
-	err1 := removePackageBinaries(s.Info())
+	err1 := removePackageBinaries(s)
 	if err1 != nil {
 		logger.Noticef("Failed to remove binaries for %q: %v", s.Name(), err1)
 	}
 
-	err2 := removePackageServices(s.Info(), inter)
+	err2 := removePackageServices(s, inter)
 	if err2 != nil {
 		logger.Noticef("Failed to remove services for %q: %v", s.Name(), err2)
 	}
 
-	err3 := removePackageDesktopFiles(s.Info())
+	err3 := removePackageDesktopFiles(s)
 	if err3 != nil {
 		logger.Noticef("Failed to remove desktop files for %q: %v", s.Name(), err3)
 	}
@@ -254,8 +254,8 @@ func RemoveGeneratedWrappers(s *Snap, inter interacter) error {
 	return firstErr(err1, err2, err3)
 }
 
-func UpdateCurrentSymlink(s *Snap, inter interacter) error {
-	info := s.Info()
+// XXX: would really like not to expose this but used in daemon tests atm
+func UpdateCurrentSymlink(info *snap.Info, inter interacter) error {
 	mountDir := info.MountDir()
 
 	currentActiveSymlink := filepath.Join(mountDir, "..", "current")
@@ -281,23 +281,15 @@ func UpdateCurrentSymlink(s *Snap, inter interacter) error {
 
 	// FIXME: create {Os,Kernel}Snap type instead of adding special
 	//        cases here
-	if err := setNextBoot(s); err != nil {
+	if err := setNextBoot(info); err != nil {
 		return err
 	}
 
 	return os.Symlink(filepath.Base(dataDir), currentDataSymlink)
 }
 
-func UndoUpdateCurrentSymlink(oldSnap, newSnap *Snap, inter interacter) error {
-	if err := removeCurrentSymlink(newSnap, inter); err != nil {
-		return err
-	}
-	return UpdateCurrentSymlink(oldSnap, inter)
-}
-
-func removeCurrentSymlink(s *Snap, inter interacter) error {
+func removeCurrentSymlink(info snap.PlaceInfo, inter interacter) error {
 	var err1, err2 error
-	info := s.Info()
 
 	// the snap "current" symlink
 	currentActiveSymlink := filepath.Join(info.MountDir(), "..", "current")
@@ -353,6 +345,10 @@ func ActivateSnap(s *Snap, inter interacter) error {
 
 	// security setup was done here!
 
+	return LinkSnap(s.Info(), inter)
+}
+
+func LinkSnap(s *snap.Info, inter interacter) error {
 	if err := GenerateWrappers(s, inter); err != nil {
 		return err
 	}
@@ -360,12 +356,8 @@ func ActivateSnap(s *Snap, inter interacter) error {
 	return UpdateCurrentSymlink(s, inter)
 }
 
-// actually less prechecks
-var LinkSnap = ActivateSnap
-
 // UnlinkSnap deactivates the given active snap.
-func UnlinkSnap(s *Snap, inter interacter) error {
-	info := s.Info()
+func UnlinkSnap(info *snap.Info, inter interacter) error {
 	mountDir := info.MountDir()
 
 	currentSymlink := filepath.Join(mountDir, "..", "current")
@@ -381,12 +373,12 @@ func UnlinkSnap(s *Snap, inter interacter) error {
 	}
 
 	// remove generated services, binaries, security policy
-	err1 := RemoveGeneratedWrappers(s, inter)
+	err1 := RemoveGeneratedWrappers(info, inter)
 
 	// removing security setup move here!
 
 	// and finally remove current symlink
-	err2 := removeCurrentSymlink(s, inter)
+	err2 := removeCurrentSymlink(info, inter)
 
 	// FIXME: aggregate errors instead
 	return firstErr(err1, err2)
@@ -432,13 +424,15 @@ func (o *Overlord) InstallWithSideInfo(snapFilePath string, sideInfo *snap.SideI
 	var oldInfo *snap.Info
 
 	if oldSnap != nil {
+		oldInfo = oldSnap.Info()
+
 		// we need to stop any services and make the commands unavailable
 		// so that copying data and later activating the new revision
 		// can work
-		err = UnlinkSnap(oldSnap, meter)
+		err = UnlinkSnap(oldInfo, meter)
 		defer func() {
 			if err != nil {
-				if err := LinkSnap(oldSnap, meter); err != nil {
+				if err := LinkSnap(oldInfo, meter); err != nil {
 					logger.Noticef("When linking old revision: %v", newInfo.Name(), err)
 				}
 			}
@@ -446,8 +440,6 @@ func (o *Overlord) InstallWithSideInfo(snapFilePath string, sideInfo *snap.SideI
 		if err != nil {
 			return nil, err
 		}
-
-		oldInfo = oldSnap.Info()
 	}
 
 	// deal with the data
@@ -468,19 +460,11 @@ func (o *Overlord) InstallWithSideInfo(snapFilePath string, sideInfo *snap.SideI
 		return newInfo, nil
 	}
 
-	// if get this far we know the snap is actually mounted.
-	// XXX: use infos further but anyway this is going away mostly
-	// once we simplify u-d-f
-	newSnap, err := NewInstalledSnap(filepath.Join(newInfo.MountDir(), "meta", "snap.yaml"))
-	if err != nil {
-		return nil, err
-	}
-
-	err = LinkSnap(newSnap, meter)
+	err = LinkSnap(newInfo, meter)
 	defer func() {
 		if err != nil {
-			if err := UnlinkSnap(newSnap, meter); err != nil {
-				logger.Noticef("When unlinking failed new snap revision: %v", newSnap.Name(), err)
+			if err := UnlinkSnap(newInfo, meter); err != nil {
+				logger.Noticef("When unlinking failed new snap revision: %v", newInfo.Name(), err)
 			}
 		}
 	}()
@@ -488,7 +472,7 @@ func (o *Overlord) InstallWithSideInfo(snapFilePath string, sideInfo *snap.SideI
 		return nil, err
 	}
 
-	return newSnap.Info(), nil
+	return newInfo, nil
 }
 
 // CanInstall checks whether the Snap passes a series of tests required for installation
@@ -627,7 +611,7 @@ func (o *Overlord) Uninstall(s *Snap, meter progress.Meter) error {
 		return ErrPackageNotRemovable
 	}
 
-	if err := UnlinkSnap(s, meter); err != nil && err != ErrSnapNotActive {
+	if err := UnlinkSnap(s.Info(), meter); err != nil && err != ErrSnapNotActive {
 		return err
 	}
 
@@ -645,14 +629,14 @@ func (o *Overlord) SetActive(s *Snap, active bool, meter progress.Meter) error {
 	if active {
 		// deactivate current first
 		if current := ActiveSnapByName(s.Name()); current != nil {
-			if err := UnlinkSnap(current, meter); err != nil {
+			if err := UnlinkSnap(current.Info(), meter); err != nil {
 				return err
 			}
 		}
 		return ActivateSnap(s, meter)
 	}
 
-	return UnlinkSnap(s, meter)
+	return UnlinkSnap(s.Info(), meter)
 }
 
 // Configure configures the given snap

--- a/snappy/overlord_test.go
+++ b/snappy/overlord_test.go
@@ -376,7 +376,7 @@ func (s *SnapTestSuite) TestClickSetActive(c *C) {
 	c.Assert(snaps[1].IsActive(), Equals, true)
 
 	// deactivate v2
-	err = UnlinkSnap(snaps[1], nil)
+	err = UnlinkSnap(snaps[1].Info(), nil)
 	// set v1 active
 	err = ActivateSnap(snaps[0], nil)
 	snaps, err = (&Overlord{}).Installed()

--- a/snappy/undo_test.go
+++ b/snappy/undo_test.go
@@ -137,11 +137,14 @@ version: 2.0`, 12)
 
 	c.Assert(err, IsNil)
 
+	sn1, err := NewInstalledSnap(v1)
+	c.Assert(err, IsNil)
+
 	sn, err := NewInstalledSnap(v2)
 	c.Assert(err, IsNil)
 
 	// copy data
-	err = CopyData(sn.Info(), 0, &s.meter)
+	err = CopyData(sn.Info(), sn1.Info(), 0, &s.meter)
 	c.Assert(err, IsNil)
 	v2data := filepath.Join(dirs.SnapDataDir, "hello/12")
 	l, _ := filepath.Glob(filepath.Join(v2data, "*"))

--- a/snappy/undo_test.go
+++ b/snappy/undo_test.go
@@ -172,7 +172,7 @@ apps:
 	sn, err := NewInstalledSnap(yaml)
 	c.Assert(err, IsNil)
 
-	err = GenerateWrappers(sn, &s.meter)
+	err = GenerateWrappers(sn.Info(), &s.meter)
 	c.Assert(err, IsNil)
 
 	l, err := filepath.Glob(filepath.Join(dirs.SnapBinariesDir, "*"))
@@ -183,7 +183,7 @@ apps:
 	c.Assert(l, HasLen, 1)
 
 	// undo via remove
-	err = RemoveGeneratedWrappers(sn, &s.meter)
+	err = RemoveGeneratedWrappers(sn.Info(), &s.meter)
 	l, err = filepath.Glob(filepath.Join(dirs.SnapBinariesDir, "*"))
 	c.Assert(err, IsNil)
 	c.Assert(l, HasLen, 0)
@@ -211,7 +211,7 @@ version: 2.0
 	v2, err := NewInstalledSnap(v2yaml)
 	c.Assert(err, IsNil)
 
-	err = UpdateCurrentSymlink(v2, &s.meter)
+	err = UpdateCurrentSymlink(v2.Info(), &s.meter)
 	c.Assert(err, IsNil)
 
 	v1MountDir := v1.Info().MountDir()
@@ -227,8 +227,8 @@ version: 2.0
 	c.Assert(err, IsNil)
 	c.Assert(currentDataDir, Matches, `.*/22`)
 
-	// undo sets the symlink back
-	err = UndoUpdateCurrentSymlink(v1, v2, &s.meter)
+	// undo is just update again
+	err = UpdateCurrentSymlink(v1.Info(), &s.meter)
 	currentActiveDir, err = filepath.EvalSymlinks(currentActiveSymlink)
 	c.Assert(err, IsNil)
 	c.Assert(currentActiveDir, Equals, v1MountDir)


### PR DESCRIPTION
This branch untangles the unlinking of the current snap from the copying of old data, having a separate unlink-current-snap task

this also continues trying to reduce the surface of the backend and making it a pass through to functions in snappy taking infos

also fixes remove to remove entries from sequence in SnapState.