### PR TITLE
daemon/api,overlord/auth: rework authenticated users information in state

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -222,9 +222,11 @@ func loginUser(c *Command, r *http.Request) Response {
 
 	overlord := c.d.overlord
 	state := overlord.State()
+	state.Lock()
 	_, err = auth.NewUser(state, loginData.Username, macaroon, []string{discharge})
+	state.Unlock()
 	if err != nil {
-		return InternalError("cannot persist authentication details")
+		return InternalError("cannot persist authentication details: %v", err)
 	}
 
 	result := loginResponseData{

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -493,14 +493,16 @@ func (s *apiSuite) TestLoginUser(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
-	expectedUser := auth.AuthUser{
+	expectedUser := auth.UserState{
 		ID:         1,
 		Username:   "username",
 		Macaroon:   "the-macaroon-serialized-data",
 		Discharges: []string{"the-discharge-macaroon-serialized-data"},
 	}
 	state := snapCmd.d.overlord.State()
+	state.Lock()
 	user, err := auth.User(state, 1)
+	state.Unlock()
 	c.Check(err, check.IsNil)
 	c.Check(*user, check.DeepEquals, expectedUser)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ubuntu-core/snappy/asserts"
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/overlord/auth"
 	"github.com/ubuntu-core/snappy/overlord/snapstate"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/release"
@@ -492,17 +493,16 @@ func (s *apiSuite) TestLoginUser(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
-	var auth authState
-	expectedState := userAuthState{
+	expectedUser := auth.AuthUser{
+		ID:         1,
 		Username:   "username",
 		Macaroon:   "the-macaroon-serialized-data",
 		Discharges: []string{"the-discharge-macaroon-serialized-data"},
 	}
 	state := snapCmd.d.overlord.State()
-	state.Lock()
-	state.Get("auth", &auth)
-	state.Unlock()
-	c.Check(auth, check.DeepEquals, authState{Users: []userAuthState{expectedState}})
+	user, err := auth.User(state, 1)
+	c.Check(err, check.IsNil)
+	c.Check(*user, check.DeepEquals, expectedUser)
 }
 
 func (s *apiSuite) TestLoginUserBadRequest(c *check.C) {

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -27,12 +27,12 @@ import (
 
 // AuthState represents current authenticated users as tracked in state
 type AuthState struct {
-	LastID int        `json:"lastId"`
-	Users  []AuthUser `json:"users"`
+	LastID int         `json:"last-id"`
+	Users  []UserState `json:"users"`
 }
 
-// AuthUser represents an authenticated user
-type AuthUser struct {
+// UserState represents an authenticated user
+type UserState struct {
 	ID         int      `json:"id"`
 	Username   string   `json:"username,omitempty"`
 	Macaroon   string   `json:"macaroon,omitempty"`
@@ -40,42 +40,44 @@ type AuthUser struct {
 }
 
 // NewUser tracks a new authenticated user and saves its details in the state
-func NewUser(st *state.State, username, macaroon string, discharges []string) (*AuthUser, error) {
-	authenticatedUser := AuthUser{
-		ID:         1,
+func NewUser(st *state.State, username, macaroon string, discharges []string) (*UserState, error) {
+	var authStateData AuthState
+
+	err := st.Get("auth", &authStateData)
+	if err == state.ErrNoState {
+		authStateData = AuthState{}
+	} else if err != nil {
+		return nil, err
+	}
+
+	authStateData.LastID++
+	authenticatedUser := UserState{
+		ID:         authStateData.LastID,
 		Username:   username,
 		Macaroon:   macaroon,
 		Discharges: discharges,
 	}
+	authStateData.Users = append(authStateData.Users, authenticatedUser)
 
-	// TODO Handle the multi-user case.
-	authStateData := AuthState{
-		LastID: 1,
-		Users:  []AuthUser{authenticatedUser},
-	}
-
-	st.Lock()
 	st.Set("auth", authStateData)
-	st.Unlock()
 
 	return &authenticatedUser, nil
 }
 
 // User returns a user from the state given its ID
-func User(st *state.State, id int) (*AuthUser, error) {
+func User(st *state.State, id int) (*UserState, error) {
 	var authStateData AuthState
 
-	st.Lock()
 	err := st.Get("auth", &authStateData)
-	st.Unlock()
 
 	if err != nil {
 		return nil, err
 	}
 
-	authenticatedUser := authStateData.Users[0]
-	if authenticatedUser.ID != id {
-		return nil, fmt.Errorf("invalid user")
+	for _, user := range authStateData.Users {
+		if user.ID == id {
+			return &user, nil
+		}
 	}
-	return &authenticatedUser, nil
+	return nil, fmt.Errorf("invalid user")
 }

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -1,0 +1,81 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package auth
+
+import (
+	"fmt"
+
+	"github.com/ubuntu-core/snappy/overlord/state"
+)
+
+// AuthState represents current authenticated users as tracked in state
+type AuthState struct {
+	LastID int        `json:"lastId"`
+	Users  []AuthUser `json:"users"`
+}
+
+// AuthUser represents an authenticated user
+type AuthUser struct {
+	ID         int      `json:"id"`
+	Username   string   `json:"username,omitempty"`
+	Macaroon   string   `json:"macaroon,omitempty"`
+	Discharges []string `json:"discharges,omitempty"`
+}
+
+// NewUser tracks a new authenticated user and saves its details in the state
+func NewUser(st *state.State, username, macaroon string, discharges []string) (*AuthUser, error) {
+	authenticatedUser := AuthUser{
+		ID:         1,
+		Username:   username,
+		Macaroon:   macaroon,
+		Discharges: discharges,
+	}
+
+	// TODO Handle the multi-user case.
+	authStateData := AuthState{
+		LastID: 1,
+		Users:  []AuthUser{authenticatedUser},
+	}
+
+	st.Lock()
+	st.Set("auth", authStateData)
+	st.Unlock()
+
+	return &authenticatedUser, nil
+}
+
+// User returns a user from the state given its ID
+func User(st *state.State, id int) (*AuthUser, error) {
+	var authStateData AuthState
+
+	st.Lock()
+	err := st.Get("auth", &authStateData)
+	st.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
+
+	authenticatedUser := authStateData.Users[0]
+	if authenticatedUser.ID != id {
+		return nil, fmt.Errorf("invalid user")
+	}
+	return &authenticatedUser, nil
+}

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -1,0 +1,103 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package auth_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/overlord/auth"
+	"github.com/ubuntu-core/snappy/overlord/state"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type authSuite struct {
+	state *state.State
+}
+
+var _ = Suite(&authSuite{})
+
+func (as *authSuite) SetUpTest(c *C) {
+	as.state = state.New(nil)
+}
+
+func (as *authSuite) TestNewUser(c *C) {
+	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+
+	expected := &auth.AuthUser{
+		ID:         1,
+		Username:   "username",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	}
+	c.Check(err, IsNil)
+	c.Check(user, DeepEquals, expected)
+
+	userFromState, err := auth.User(as.state, 1)
+	c.Check(err, IsNil)
+	c.Check(userFromState, DeepEquals, expected)
+}
+
+func (as *authSuite) TestNewUserOverridesExistent(c *C) {
+	_, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	c.Check(err, IsNil)
+
+	// adding a new one
+	user, err := auth.NewUser(as.state, "new_username", "new_macaroon", []string{"new_discharge"})
+	expected := &auth.AuthUser{
+		ID:         1,
+		Username:   "new_username",
+		Macaroon:   "new_macaroon",
+		Discharges: []string{"new_discharge"},
+	}
+	c.Check(err, IsNil)
+	c.Check(user, DeepEquals, expected)
+
+	userFromState, err := auth.User(as.state, 1)
+	c.Check(err, IsNil)
+	c.Check(userFromState, DeepEquals, expected)
+}
+
+func (as *authSuite) TestUserForNoAuthInState(c *C) {
+	userFromState, err := auth.User(as.state, 42)
+	c.Check(err, NotNil)
+	c.Check(userFromState, IsNil)
+}
+
+func (as *authSuite) TestUserForNonExistent(c *C) {
+	_, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	c.Check(err, IsNil)
+
+	userFromState, err := auth.User(as.state, 42)
+	c.Check(err, ErrorMatches, "invalid user")
+	c.Check(userFromState, IsNil)
+}
+
+func (as *authSuite) TestUser(c *C) {
+	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	c.Check(err, IsNil)
+
+	userFromState, err := auth.User(as.state, 1)
+	c.Check(err, IsNil)
+	c.Check(userFromState, DeepEquals, user)
+}


### PR DESCRIPTION
Refactoring how authenticated user(s) information is stored in the state helping for future updates related to authenticating store requests.