### PR TITLE
overlord/auth,store/auth: add macaroon authenticator to UserState

### DIFF
--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -20,6 +20,7 @@
 package auth
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 
@@ -103,9 +104,10 @@ func newMacaroonAuthenticator(macaroon string, discharges []string) *MacaroonAut
 
 // Authenticate will add the store expected Authorization header for macaroons
 func (ma *MacaroonAuthenticator) Authenticate(r *http.Request) {
-	value := fmt.Sprintf(`Macaroon root="%s"`, ma.Macaroon)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, `Macaroon root="%s"`, ma.Macaroon)
 	for _, discharge := range ma.Discharges {
-		value = fmt.Sprintf(`%s, discharge="%s"`, value, discharge)
+		fmt.Fprintf(&buf, `, discharge="%s"`, discharge)
 	}
-	r.Header.Set("Authorization", value)
+	r.Header.Set("Authorization", buf.String())
 }

--- a/store/auth.go
+++ b/store/auth.go
@@ -41,6 +41,11 @@ var (
 	UbuntuoneDischargeAPI = ubuntuoneAPIBase + "/tokens/discharge"
 )
 
+// Authenticator interface to set required authorization headers for requests to the store
+type Authenticator interface {
+	Authenticate(r *http.Request)
+}
+
 // StoreToken contains the personal token to access the store
 type StoreToken struct {
 	OpenID      string `json:"openid"`


### PR DESCRIPTION
The authenticator will be passed to the snap repository interacting with store. It will be used to set authorization headers (built from the user's macaroons) in the requests to the store.