### PR TITLE
interfaces/apparmor: remove unused apparmor variables

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -259,8 +259,7 @@ func (s *backendSuite) TestCustomTemplateUsedOnRequest(c *C) {
 	c.Assert(string(data), testutil.Contains, "FOO")
 	// Custom profile can rely on legacy variables
 	for _, legacyVarName := range []string{
-		"APP_APPNAME", "APP_ID_DBUS", "APP_PKGNAME_DBUS",
-		"APP_PKGNAME", "APP_VERSION", "INSTALL_DIR",
+		"APP_APPNAME", "APP_PKGNAME", "APP_VERSION", "INSTALL_DIR",
 	} {
 		c.Assert(string(data), testutil.Contains, fmt.Sprintf("@{%s}=", legacyVarName))
 	}
@@ -274,8 +273,6 @@ type combineSnippetsScenario struct {
 
 const commonPrefix = `
 @{APP_APPNAME}="smbd"
-@{APP_ID_DBUS}="samba_2eacme_5fsmbd_5f1"
-@{APP_PKGNAME_DBUS}="samba_2eacme"
 @{APP_PKGNAME}="samba"
 @{APP_VERSION}="1"
 @{INSTALL_DIR}="/snap"`

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/ubuntu-core/snappy/interfaces/dbus"
 	"github.com/ubuntu-core/snappy/snap"
 )
 
@@ -32,8 +31,6 @@ import (
 //
 // The variables are expanded by apparmor parser. They are (currently):
 //  - APP_APPNAME
-//  - APP_ID_DBUS
-//  - APP_PKGNAME_DBUS
 //  - APP_PKGNAME
 //  - APP_VERSION
 //  - INSTALL_DIR
@@ -46,12 +43,6 @@ func legacyVariables(appInfo *snap.AppInfo) []byte {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "@{APP_APPNAME}=\"%s\"\n", appInfo.Name)
 	// TODO: replace with app.SecurityTag()
-	fmt.Fprintf(&buf, "@{APP_ID_DBUS}=\"%s\"\n",
-		dbus.SafePath(fmt.Sprintf("%s.%s_%s_%d",
-			appInfo.Snap.Name(), appInfo.Snap.Developer, appInfo.Name, appInfo.Snap.Revision)))
-	// XXX: How is this different from APP_ID_DBUS?
-	fmt.Fprintf(&buf, "@{APP_PKGNAME_DBUS}=\"%s\"\n",
-		dbus.SafePath(fmt.Sprintf("%s.%s", appInfo.Snap.Name(), appInfo.Snap.Developer)))
 	fmt.Fprintf(&buf, "@{APP_PKGNAME}=\"%s\"\n", appInfo.Snap.Name())
 	fmt.Fprintf(&buf, "@{APP_VERSION}=\"%d\"\n", appInfo.Snap.Revision)
 	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/snap\"")


### PR DESCRIPTION
This patch removes unused apparmor variables APP_ID_DBUS and
APP_PKGNAME_DBUS which also removes the need to use .Developer in any
apparmor profile content.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>