### PR TITLE
overlord/ifacestate: don't crash if connection cannot be reloaded

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -124,7 +124,7 @@ func (m *InterfaceManager) reloadConnections() error {
 		}
 		err = m.repo.Connect(plugRef.Snap, plugRef.Name, slotRef.Snap, slotRef.Name)
 		if err != nil {
-			return err
+			logger.Noticef("%s", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
This patch changes the interface manager to gracefully ignore errors
when trying to reload connections. This can fail if the snap in question
does not get mounted (for any reason) and the resulting system will
appear not to have that snap installed.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>