### PR TITLE
interfaces: add TestSecurityBackend

### DIFF
--- a/interfaces/testbackend.go
+++ b/interfaces/testbackend.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"github.com/ubuntu-core/snappy/snap"
+)
+
+// TestSecurityBackend is a security backend intended for testing.
+type TestSecurityBackend struct {
+	// SetupCalls stores information about all calls to Setup
+	SetupCalls []SetupCall
+	// RemoveCalls stores information about all calls to Remove
+	RemoveCalls []string
+	// SetupCallback is an callback that is optionally called in Setup
+	SetupCallback func(snapInfo *snap.Info, developerMode bool, repo *Repository) error
+	// RemoveCallback is a callback that is optionally called in Remove
+	RemoveCallback func(snapName string) error
+}
+
+// SetupCall stores details about calls to TestSecurityBackend.Setup
+type SetupCall struct {
+	// SnapInfo is a copy of the snapInfo argument to a particular call to Setup
+	SnapInfo *snap.Info
+	// DeveloperMode is a copy of the developerMode argument to a particular call to Setup
+	DeveloperMode bool
+}
+
+// Name returns the name of the security backend.
+func (b *TestSecurityBackend) Name() string {
+	return "test"
+}
+
+// Setup records information about the call and calls the setup callback if one is defined.
+func (b *TestSecurityBackend) Setup(snapInfo *snap.Info, developerMode bool, repo *Repository) error {
+	b.SetupCalls = append(b.SetupCalls, SetupCall{SnapInfo: snapInfo, DeveloperMode: developerMode})
+	if b.SetupCallback == nil {
+		return nil
+	}
+	return b.SetupCallback(snapInfo, developerMode, repo)
+}
+
+// Remove records information about the call and calls the remove callback if one is defined
+func (b *TestSecurityBackend) Remove(snapName string) error {
+	b.RemoveCalls = append(b.RemoveCalls, snapName)
+	if b.RemoveCallback == nil {
+		return nil
+	}
+	return b.RemoveCallback(snapName)
+}

--- a/interfaces/testbackend.go
+++ b/interfaces/testbackend.go
@@ -26,7 +26,7 @@ import (
 // TestSecurityBackend is a security backend intended for testing.
 type TestSecurityBackend struct {
 	// SetupCalls stores information about all calls to Setup
-	SetupCalls []SetupCall
+	SetupCalls []TestSetupCall
 	// RemoveCalls stores information about all calls to Remove
 	RemoveCalls []string
 	// SetupCallback is an callback that is optionally called in Setup
@@ -35,8 +35,8 @@ type TestSecurityBackend struct {
 	RemoveCallback func(snapName string) error
 }
 
-// SetupCall stores details about calls to TestSecurityBackend.Setup
-type SetupCall struct {
+// TestSetupCall stores details about calls to TestSecurityBackend.Setup
+type TestSetupCall struct {
 	// SnapInfo is a copy of the snapInfo argument to a particular call to Setup
 	SnapInfo *snap.Info
 	// DeveloperMode is a copy of the developerMode argument to a particular call to Setup
@@ -50,7 +50,7 @@ func (b *TestSecurityBackend) Name() string {
 
 // Setup records information about the call and calls the setup callback if one is defined.
 func (b *TestSecurityBackend) Setup(snapInfo *snap.Info, developerMode bool, repo *Repository) error {
-	b.SetupCalls = append(b.SetupCalls, SetupCall{SnapInfo: snapInfo, DeveloperMode: developerMode})
+	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SnapInfo: snapInfo, DeveloperMode: developerMode})
 	if b.SetupCallback == nil {
 		return nil
 	}

--- a/interfaces/testbackend.go
+++ b/interfaces/testbackend.go
@@ -39,8 +39,8 @@ type TestSecurityBackend struct {
 type TestSetupCall struct {
 	// SnapInfo is a copy of the snapInfo argument to a particular call to Setup
 	SnapInfo *snap.Info
-	// DeveloperMode is a copy of the developerMode argument to a particular call to Setup
-	DeveloperMode bool
+	// DevMode is a copy of the developerMode argument to a particular call to Setup
+	DevMode bool
 }
 
 // Name returns the name of the security backend.
@@ -49,12 +49,12 @@ func (b *TestSecurityBackend) Name() string {
 }
 
 // Setup records information about the call and calls the setup callback if one is defined.
-func (b *TestSecurityBackend) Setup(snapInfo *snap.Info, developerMode bool, repo *Repository) error {
-	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SnapInfo: snapInfo, DeveloperMode: developerMode})
+func (b *TestSecurityBackend) Setup(snapInfo *snap.Info, devMode bool, repo *Repository) error {
+	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SnapInfo: snapInfo, DevMode: devMode})
 	if b.SetupCallback == nil {
 		return nil
 	}
-	return b.SetupCallback(snapInfo, developerMode, repo)
+	return b.SetupCallback(snapInfo, devMode, repo)
 }
 
 // Remove records information about the call and calls the remove callback if one is defined


### PR DESCRIPTION
This patch adds a security backend that is intended for testing. As with
the test interface it is public because it has to be used in other
packages.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>