### PR TITLE
overlord/ifacestate: reload snap connections when setting up security for a given snap

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -199,11 +199,9 @@ func (m *InterfaceManager) doSetupSnapSecurity(task *state.Task, _ *tomb.Tomb) e
 		affectedSnaps = append(affectedSnaps, snapInfo)
 	}
 	for _, snapInfo := range affectedSnaps {
-		for _, backend := range securityBackendsForSnap(snapInfo) {
-			developerMode := false // TODO: move this to snap.Info
-			if err := backend.Setup(snapInfo, developerMode, m.repo); err != nil {
-				return state.Retry
-			}
+		if err := m.setupSecurity(snapInfo); err != nil {
+			task.Errorf("cannot setup security of snap %q: %s", snapInfo.Name(), err)
+			return state.Retry
 		}
 	}
 	return nil

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -78,7 +78,7 @@ func (m *InterfaceManager) initialize(extra []interfaces.Interface) error {
 	if err := m.addSnaps(); err != nil {
 		return err
 	}
-	if err := m.reloadConnections(); err != nil {
+	if err := m.reloadConnections(""); err != nil {
 		return err
 	}
 	return nil
@@ -112,7 +112,10 @@ func (m *InterfaceManager) addSnaps() error {
 	return nil
 }
 
-func (m *InterfaceManager) reloadConnections() error {
+// reloadConnections reloads connections stored in the state in the repository.
+// Using non-empty snapName the operation can be scoped to connections
+// affecting a given snap.
+func (m *InterfaceManager) reloadConnections(snapName string) error {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return err
@@ -121,6 +124,9 @@ func (m *InterfaceManager) reloadConnections() error {
 		plugRef, slotRef, err := parseConnID(id)
 		if err != nil {
 			return err
+		}
+		if snapName != "" && plugRef.Snap != snapName && slotRef.Snap != snapName {
+			continue
 		}
 		err = m.repo.Connect(plugRef.Snap, plugRef.Name, slotRef.Snap, slotRef.Name)
 		if err != nil {

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -190,11 +190,12 @@ func (m *InterfaceManager) doSetupSnapSecurity(task *state.Task, _ *tomb.Tomb) e
 			return err
 		}
 	}
+	if err := m.reloadConnections(snapName); err != nil {
+		return err
+	}
 	if err := m.autoConnect(task, snapName); err != nil {
 		return err
 	}
-	// TODO: re-connect all connection affecting given snap
-	// TODO:  - removing failed connections from the state
 	if len(affectedSnaps) == 0 {
 		affectedSnaps = append(affectedSnaps, snapInfo)
 	}

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -136,6 +136,19 @@ func (m *InterfaceManager) reloadConnections(snapName string) error {
 	return nil
 }
 
+func (m *InterfaceManager) setupSecurity(snapInfo *snap.Info) error {
+	var snapState snapstate.SnapState
+	if err := snapstate.Get(m.state, snapInfo.Name(), &snapState); err != nil {
+		return err
+	}
+	for _, backend := range securityBackendsForSnap(snapInfo) {
+		if err := backend.Setup(snapInfo, snapState.DevMode, m.repo); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *InterfaceManager) doSetupSnapSecurity(task *state.Task, _ *tomb.Tomb) error {
 	task.State().Lock()
 	defer task.State().Unlock()
@@ -374,16 +387,9 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 	slot := m.repo.Slot(slotRef.Snap, slotRef.Name)
 
 	for _, snapInfo := range []*snap.Info{plug.Snap, slot.Snap} {
-		var snapState snapstate.SnapState
-		if err := snapstate.Get(st, snapInfo.Name(), &snapState); err != nil {
-			task.Errorf("cannot get state of snap %q: %s", snapInfo.Name(), err)
+		if err := m.setupSecurity(snapInfo); err != nil {
+			task.Errorf("cannot setup security of snap %q: %s", snapInfo.Name(), err)
 			return state.Retry
-		}
-		for _, backend := range securityBackendsForSnap(snapInfo) {
-			if err := backend.Setup(snapInfo, snapState.DevMode, m.repo); err != nil {
-				task.Errorf("cannot setup security of snap %q: %s", snapInfo.Name(), err)
-				return state.Retry
-			}
 		}
 	}
 
@@ -417,16 +423,9 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 	slot := m.repo.Slot(slotRef.Snap, slotRef.Name)
 
 	for _, snapInfo := range []*snap.Info{plug.Snap, slot.Snap} {
-		var snapState snapstate.SnapState
-		if err := snapstate.Get(st, snapInfo.Name(), &snapState); err != nil {
-			task.Errorf("cannot get state of snap %q: %s", snapInfo.Name(), err)
+		if err := m.setupSecurity(snapInfo); err != nil {
+			task.Errorf("cannot setup security of snap %q: %s", snapInfo.Name(), err)
 			return state.Retry
-		}
-		for _, backend := range securityBackendsForSnap(snapInfo) {
-			if err := backend.Setup(snapInfo, snapState.DevMode, m.repo); err != nil {
-				task.Errorf("cannot setup security of snap %q: %s", snapInfo.Name(), err)
-				return state.Retry
-			}
 		}
 	}
 

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -233,7 +233,7 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChange(c *C, snapName string
 	defer s.state.Unlock()
 
 	task := s.state.NewTask("setup-snap-security", "")
-	ss := snapstate.SnapSetup{Name: "snap"}
+	ss := snapstate.SnapSetup{Name: snapName}
 	task.Set("snap-setup", ss)
 	taskset := state.NewTaskSet(task)
 	change := s.state.NewChange("test", "")


### PR DESCRIPTION
This branch ensures that a connection that was established is kept around when setup-snap-security is used.