### PR TITLE
many: add store authenticator parameter

### DIFF
--- a/cmd/snappy/cmd_info.go
+++ b/cmd/snappy/cmd_info.go
@@ -75,7 +75,7 @@ func snapInfo(pkgname string, includeStore, verbose bool) error {
 	snap := snappy.ActiveSnapByName(pkgname)
 	if snap == nil && includeStore {
 		m := snappy.NewConfiguredUbuntuStoreSnapRepository()
-		remote, err := m.Snap(pkgname, release.Get().Channel)
+		remote, err := m.Snap(pkgname, release.Get().Channel, nil)
 		if err != nil {
 			return fmt.Errorf("cannot get details for snap %q: %s", pkgname, err)
 		}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -237,8 +237,8 @@ func loginUser(c *Command, r *http.Request) Response {
 }
 
 type metarepo interface {
-	Snap(string, string) (*snap.Info, error)
-	FindSnaps(string, string) ([]*snap.Info, error)
+	Snap(string, string, store.Authenticator) (*snap.Info, error)
+	FindSnaps(string, string, store.Authenticator) ([]*snap.Info, error)
 }
 
 var newRemoteRepo = func() metarepo {
@@ -258,7 +258,7 @@ func getSnapInfo(c *Command, r *http.Request) Response {
 	defer lock.Unlock()
 
 	channel := ""
-	remoteSnap, _ := newRemoteRepo().Snap(name, channel)
+	remoteSnap, _ := newRemoteRepo().Snap(name, channel, nil)
 
 	installed, err := (&snappy.Overlord{}).Installed()
 	if err != nil {
@@ -362,7 +362,7 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 		//   * if there are no results, return an error response.
 		//   * If there are results at all (perhaps local), include a
 		//     warning in the response
-		found, _ := newRemoteRepo().FindSnaps(searchTerm, "")
+		found, _ := newRemoteRepo().FindSnaps(searchTerm, "", nil)
 
 		sources = append(sources, "store")
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -62,14 +62,14 @@ type apiSuite struct {
 
 var _ = check.Suite(&apiSuite{})
 
-func (s *apiSuite) Snap(string, string) (*snap.Info, error) {
+func (s *apiSuite) Snap(string, string, store.Authenticator) (*snap.Info, error) {
 	if len(s.rsnaps) > 0 {
 		return s.rsnaps[0], s.err
 	}
 	return nil, s.err
 }
 
-func (s *apiSuite) FindSnaps(searchTerm, channel string) ([]*snap.Info, error) {
+func (s *apiSuite) FindSnaps(searchTerm, channel string, auther store.Authenticator) ([]*snap.Info, error) {
 	s.searchTerm = searchTerm
 	s.channel = channel
 

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -23,11 +23,12 @@ import (
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snappy"
+	"github.com/ubuntu-core/snappy/store"
 )
 
 type managerBackend interface {
 	// install releated
-	Download(name, channel string, meter progress.Meter) (*snap.Info, string, error)
+	Download(name, channel string, meter progress.Meter, auther store.Authenticator) (*snap.Info, string, error)
 	CheckSnap(snapFilePath string, curInfo *snap.Info, flags int) error
 	SetupSnap(snapFilePath string, si *snap.SideInfo, flags int) error
 	CopySnapData(newSnap, oldSnap *snap.Info, flags int) error
@@ -74,14 +75,14 @@ func (b *defaultBackend) Activate(name string, active bool, meter progress.Meter
 	return snappy.SetActive(name, active, meter)
 }
 
-func (b *defaultBackend) Download(name, channel string, meter progress.Meter) (*snap.Info, string, error) {
+func (b *defaultBackend) Download(name, channel string, meter progress.Meter, auther store.Authenticator) (*snap.Info, string, error) {
 	mStore := snappy.NewConfiguredUbuntuStoreSnapRepository()
-	snap, err := mStore.Snap(name, channel)
+	snap, err := mStore.Snap(name, channel, auther)
 	if err != nil {
 		return nil, "", err
 	}
 
-	downloadedSnapFile, err := mStore.Download(snap, meter)
+	downloadedSnapFile, err := mStore.Download(snap, meter, auther)
 	if err != nil {
 		return nil, "", err
 	}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/store"
 )
 
 type fakeOp struct {
@@ -57,7 +58,7 @@ func (f *fakeSnappyBackend) InstallLocal(path string, flags int, p progress.Mete
 	return nil
 }
 
-func (f *fakeSnappyBackend) Download(name, channel string, p progress.Meter) (*snap.Info, string, error) {
+func (f *fakeSnappyBackend) Download(name, channel string, p progress.Meter, auther store.Authenticator) (*snap.Info, string, error) {
 	f.ops = append(f.ops, fakeOp{
 		op:      "download",
 		name:    name,

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -176,7 +176,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	pb := &TaskProgressAdapter{task: t}
-	storeInfo, downloadedSnapFile, err := m.backend.Download(ss.Name, ss.Channel, pb)
+	storeInfo, downloadedSnapFile, err := m.backend.Download(ss.Name, ss.Channel, pb, nil)
 	if err != nil {
 		return err
 	}

--- a/snappy/install.go
+++ b/snappy/install.go
@@ -49,7 +49,7 @@ const (
 )
 
 func installRemote(mStore *store.SnapUbuntuStoreRepository, remoteSnap *snap.Info, flags InstallFlags, meter progress.Meter) (string, error) {
-	downloadedSnap, err := mStore.Download(remoteSnap, meter)
+	downloadedSnap, err := mStore.Download(remoteSnap, meter, nil)
 	if err != nil {
 		return "", fmt.Errorf("cannot download %s: %s", remoteSnap.Name(), err)
 	}
@@ -118,7 +118,7 @@ func snapUpdates(repo *store.SnapUbuntuStoreRepository) (snaps []*snap.Info, err
 		return nil, err
 	}
 
-	rsnaps, err := repo.Updates(installed)
+	rsnaps, err := repo.Updates(installed, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func doInstall(name, channel string, flags InstallFlags, meter progress.Meter) (
 		return "", err
 	}
 
-	snap, err := mStore.Snap(name, channel)
+	snap, err := mStore.Snap(name, channel, nil)
 	if err != nil {
 		return "", err
 	}

--- a/snappy/snapp_test.go
+++ b/snappy/snapp_test.go
@@ -518,7 +518,7 @@ type: gadget
 	c.Assert(repo, NotNil)
 
 	// we just ensure that the right header is set
-	repo.Snap("xkcd", "edge")
+	repo.Snap("xkcd", "edge", nil)
 }
 
 func (s *SnapTestSuite) TestUninstallBuiltIn(c *C) {

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -229,7 +229,7 @@ func (s *SnapUbuntuStoreRepository) checkStoreResponse(resp *http.Response) {
 }
 
 // Snap returns the snap.Info for the store hosted snap with the given name or an error.
-func (s *SnapUbuntuStoreRepository) Snap(name, channel string) (*snap.Info, error) {
+func (s *SnapUbuntuStoreRepository) Snap(name, channel string, auther Authenticator) (*snap.Info, error) {
 
 	u := *s.searchURI // make a copy, so we can mutate it
 
@@ -284,7 +284,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string) (*snap.Info, erro
 
 // FindSnaps finds  (installable) snaps from the store, matching the
 // given search term.
-func (s *SnapUbuntuStoreRepository) FindSnaps(searchTerm string, channel string) ([]*snap.Info, error) {
+func (s *SnapUbuntuStoreRepository) FindSnaps(searchTerm string, channel string, auther Authenticator) ([]*snap.Info, error) {
 	if channel == "" {
 		channel = release.Get().Channel
 	}
@@ -330,7 +330,7 @@ func (s *SnapUbuntuStoreRepository) FindSnaps(searchTerm string, channel string)
 }
 
 // Updates returns the available updates for a list of snap identified by fullname with channel.
-func (s *SnapUbuntuStoreRepository) Updates(installed []string) (snaps []*snap.Info, err error) {
+func (s *SnapUbuntuStoreRepository) Updates(installed []string, auther Authenticator) (snaps []*snap.Info, err error) {
 	// XXX: uses obsolete end point!
 
 	jsonData, err := json.Marshal(map[string][]string{"name": installed})
@@ -372,7 +372,7 @@ func (s *SnapUbuntuStoreRepository) Updates(installed []string) (snaps []*snap.I
 // Download downloads the given snap and returns its filename.
 // The file is saved in temporary storage, and should be removed
 // after use to prevent the disk from running out of space.
-func (s *SnapUbuntuStoreRepository) Download(remoteSnap *snap.Info, pbar progress.Meter) (path string, err error) {
+func (s *SnapUbuntuStoreRepository) Download(remoteSnap *snap.Info, pbar progress.Meter, auther Authenticator) (path string, err error) {
 	w, err := ioutil.TempFile("", remoteSnap.Name())
 	if err != nil {
 		return "", err
@@ -388,7 +388,7 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *snap.Info, pbar progres
 	}()
 
 	url := remoteSnap.AnonDownloadURL
-	if url == "" {
+	if url == "" || auther != nil {
 		url = remoteSnap.DownloadURL
 	}
 
@@ -439,7 +439,7 @@ type assertionSvcError struct {
 }
 
 // Assertion retrivies the assertion for the given type and primary key.
-func (s *SnapUbuntuStoreRepository) Assertion(assertType *asserts.AssertionType, primaryKey ...string) (asserts.Assertion, error) {
+func (s *SnapUbuntuStoreRepository) Assertion(assertType *asserts.AssertionType, primaryKey []string, auther Authenticator) (asserts.Assertion, error) {
 	url, err := s.assertionsURI.Parse(path.Join(assertType.Name, path.Join(primaryKey...)))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Update store API in snap repository to expect an extra authenticator argument that will be used to add authorization headers to the requests to the store. Keeping it nil as placeholder for now.