### PR TITLE
interfaecs/apparmor: remove all traces of old-security from apparmor backend

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -125,7 +125,7 @@ func (b *Backend) combineSnippets(snapInfo *snap.Info, devMode bool, snippets ma
 		policy = templatePattern.ReplaceAllFunc(policy, func(placeholder []byte) []byte {
 			switch {
 			case bytes.Equal(placeholder, placeholderVar):
-				return modernVariables(appInfo)
+				return templateVariables(appInfo)
 			case bytes.Equal(placeholder, placeholderProfileAttach):
 				return []byte(fmt.Sprintf("profile \"%s\"", appInfo.SecurityTag()))
 			case bytes.Equal(placeholder, placeholderSnippets):

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -51,24 +51,11 @@ import (
 )
 
 // Backend is responsible for maintaining apparmor profiles for ubuntu-core-launcher.
-type Backend struct {
-	// legacyTemplate exists to support old-security which goes
-	// beyond what is possible with pure security snippets.
-	//
-	// If non-empty then it overrides the built-in template.
-	legacyTemplate []byte
-}
+type Backend struct{}
 
 // Name returns the name of the backend.
 func (b *Backend) Name() string {
 	return "apparmor"
-}
-
-// UseLegacyTemplate switches from default apparmor template to a custom
-// template. This also implies that a fixed set of apparmor variables will be
-// injected into this template. The set is compatible with Ubuntu core 15.04.
-func (b *Backend) UseLegacyTemplate(template []byte) {
-	b.legacyTemplate = template
 }
 
 // Setup creates and loads apparmor profiles specific to a given snap.
@@ -131,10 +118,7 @@ var (
 // backend delegates writing those files to higher layers.
 func (b *Backend) combineSnippets(snapInfo *snap.Info, devMode bool, snippets map[string][][]byte) (content map[string]*osutil.FileState, err error) {
 	for _, appInfo := range snapInfo.Apps {
-		policy := b.legacyTemplate
-		if policy == nil {
-			policy = defaultTemplate
-		}
+		policy := defaultTemplate
 		if devMode {
 			policy = attachPattern.ReplaceAll(policy, attachComplain)
 		}

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -125,9 +125,7 @@ func (b *Backend) combineSnippets(snapInfo *snap.Info, devMode bool, snippets ma
 		policy = templatePattern.ReplaceAllFunc(policy, func(placeholder []byte) []byte {
 			switch {
 			case bytes.Equal(placeholder, placeholderVar):
-				// TODO: use modern variables when default template is compatible
-				// with them and the custom template is not used.
-				return legacyVariables(appInfo)
+				return modernVariables(appInfo)
 			case bytes.Equal(placeholder, placeholderProfileAttach):
 				return []byte(fmt.Sprintf("profile \"%s\"", appInfo.SecurityTag()))
 			case bytes.Equal(placeholder, placeholderSnippets):

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -244,9 +244,9 @@ type combineSnippetsScenario struct {
 }
 
 const commonPrefix = `
-@{APP_APPNAME}="smbd"
-@{APP_PKGNAME}="samba"
-@{APP_VERSION}="1"
+@{APP_NAME}="smbd"
+@{SNAP_NAME}="samba"
+@{SNAP_REVISION}="1"
 @{INSTALL_DIR}="/snap"`
 
 var combineSnippetsScenarios = []combineSnippetsScenario{{

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -79,7 +79,6 @@ fi
 `
 
 func (s *backendSuite) SetUpTest(c *C) {
-	s.backend.UseLegacyTemplate(nil)
 	// Isolate this test to a temporary directory
 	s.rootDir = c.MkDir()
 	dirs.SetRootDir(s.rootDir)
@@ -235,33 +234,6 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 		"/sys/class/ r,\n",
 	} {
 		c.Assert(string(data), testutil.Contains, line)
-	}
-}
-
-func (s *backendSuite) TestCustomTemplateUsedOnRequest(c *C) {
-	s.backend.UseLegacyTemplate([]byte(`
-# Description: Custom template for testing
-###VAR###
-
-###PROFILEATTACH### (attach_disconnected) {
-	###SNIPPETS###
-	FOO
-}
-`))
-	snapInfo, err := snap.InfoFromSnapYaml([]byte(sambaYaml))
-	c.Assert(err, IsNil)
-	err = s.backend.Setup(snapInfo, false, s.repo)
-	c.Assert(err, IsNil)
-	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
-	data, err := ioutil.ReadFile(profile)
-	c.Assert(err, IsNil)
-	// Our custom template was used
-	c.Assert(string(data), testutil.Contains, "FOO")
-	// Custom profile can rely on legacy variables
-	for _, legacyVarName := range []string{
-		"APP_APPNAME", "APP_PKGNAME", "APP_VERSION", "INSTALL_DIR",
-	} {
-		c.Assert(string(data), testutil.Contains, fmt.Sprintf("@{%s}=", legacyVarName))
 	}
 }
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -216,27 +216,27 @@ var defaultTemplate = []byte(`
   @{PROC}/net/dev r,
 
   # Read-only for the install directory
-  @{INSTALL_DIR}/@{APP_PKGNAME}/                   r,
-  @{INSTALL_DIR}/@{APP_PKGNAME}/@{APP_VERSION}/    r,
-  @{INSTALL_DIR}/@{APP_PKGNAME}/@{APP_VERSION}/**  mrklix,
+  @{INSTALL_DIR}/@{SNAP_NAME}/                   r,
+  @{INSTALL_DIR}/@{SNAP_NAME}/@{SNAP_REVISION}/    r,
+  @{INSTALL_DIR}/@{SNAP_NAME}/@{SNAP_REVISION}/**  mrklix,
 
   # Don't log noisy python denials (see LP: #1496895 for more details)
-  deny @{INSTALL_DIR}/@{APP_PKGNAME}/**/__pycache__/             w,
-  deny @{INSTALL_DIR}/@{APP_PKGNAME}/**/__pycache__/*.pyc.[0-9]* w,
+  deny @{INSTALL_DIR}/@{SNAP_NAME}/**/__pycache__/             w,
+  deny @{INSTALL_DIR}/@{SNAP_NAME}/**/__pycache__/*.pyc.[0-9]* w,
 
   # Read-only home area for other versions
-  owner @{HOME}/snap/@{APP_PKGNAME}/                  r,
-  owner @{HOME}/snap/@{APP_PKGNAME}/**                mrkix,
+  owner @{HOME}/snap/@{SNAP_NAME}/                  r,
+  owner @{HOME}/snap/@{SNAP_NAME}/**                mrkix,
 
   # Writable home area for this version.
-  owner @{HOME}/snap/@{APP_PKGNAME}/@{APP_VERSION}/** wl,
+  owner @{HOME}/snap/@{SNAP_NAME}/@{SNAP_REVISION}/** wl,
 
   # Read-only system area for other versions
-  /var/snap/@{APP_PKGNAME}/   r,
-  /var/snap/@{APP_PKGNAME}/** mrkix,
+  /var/snap/@{SNAP_NAME}/   r,
+  /var/snap/@{SNAP_NAME}/** mrkix,
 
   # Writable system area only for this version
-  /var/snap/@{APP_PKGNAME}/@{APP_VERSION}/** wl,
+  /var/snap/@{SNAP_NAME}/@{SNAP_REVISION}/** wl,
 
   # The ubuntu-core-launcher creates an app-specific private restricted /tmp
   # and will fail to launch the app if something goes wrong. As such, we can
@@ -245,17 +245,17 @@ var defaultTemplate = []byte(`
   /tmp/** mrwlkix,
 
   # Also do the same for shm
-  /{dev,run}/shm/snap/@{APP_PKGNAME}/                  r,
-  /{dev,run}/shm/snap/@{APP_PKGNAME}/**                rk,
-  /{dev,run}/shm/snap/@{APP_PKGNAME}/@{APP_VERSION}/   r,
-  /{dev,run}/shm/snap/@{APP_PKGNAME}/@{APP_VERSION}/** mrwlkix,
+  /{dev,run}/shm/snap/@{SNAP_NAME}/                  r,
+  /{dev,run}/shm/snap/@{SNAP_NAME}/**                rk,
+  /{dev,run}/shm/snap/@{SNAP_NAME}/@{SNAP_REVISION}/   r,
+  /{dev,run}/shm/snap/@{SNAP_NAME}/@{SNAP_REVISION}/** mrwlkix,
 
   # Allow apps from the same package to communicate with each other via an
   # abstract or anonymous socket
-  unix peer=(label=@{APP_PKGNAME}_*),
+  unix peer=(label=@{SNAP_NAME}_*),
 
   # Allow apps from the same package to signal each other via signals
-  signal peer=@{APP_PKGNAME}_*,
+  signal peer=@{SNAP_NAME}_*,
 
   # for 'udevadm trigger --verbose --dry-run --tag-match=snappy-assign'
   /{,s}bin/udevadm ixr,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -252,10 +252,10 @@ var defaultTemplate = []byte(`
 
   # Allow apps from the same package to communicate with each other via an
   # abstract or anonymous socket
-  unix peer=(label=@{SNAP_NAME}_*),
+  unix peer=(label=snap.@{SNAP_NAME}.*),
 
   # Allow apps from the same package to signal each other via signals
-  signal peer=@{SNAP_NAME}_*,
+  signal peer=snap.@{SNAP_NAME}.*,
 
   # for 'udevadm trigger --verbose --dry-run --tag-match=snappy-assign'
   /{,s}bin/udevadm ixr,

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -26,9 +26,9 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-// modernVariables returns text defining some apparmor variables that
-// work with non-legacy apparmor templates.
-func modernVariables(appInfo *snap.AppInfo) []byte {
+// templateVariables returns text defining apparmor variables that can be used in the
+// apparmor template and by apparmor snippets.
+func templateVariables(appInfo *snap.AppInfo) []byte {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
 	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name())

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -54,7 +54,6 @@ func legacyVariables(appInfo *snap.AppInfo) []byte {
 func modernVariables(appInfo *snap.AppInfo) []byte {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
-	fmt.Fprintf(&buf, "@{APP_SECURITY_TAG}=\"%s\"\n", appInfo.SecurityTag())
 	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name())
 	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%d\"\n", appInfo.Snap.Revision)
 	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/snap\"")

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -26,29 +26,6 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-// legacyVariablees returns text defining some apparmor variables that work
-// with legacy apparmor templates.
-//
-// The variables are expanded by apparmor parser. They are (currently):
-//  - APP_APPNAME
-//  - APP_PKGNAME
-//  - APP_VERSION
-//  - INSTALL_DIR
-// They can be changed but this has to match changes in template.go.
-//
-// In addition, the set of variables listed here interacts with old-security
-// interface since there the base template is provided by a particular 3rd
-// party snap, not by snappy.
-func legacyVariables(appInfo *snap.AppInfo) []byte {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "@{APP_APPNAME}=\"%s\"\n", appInfo.Name)
-	// TODO: replace with app.SecurityTag()
-	fmt.Fprintf(&buf, "@{APP_PKGNAME}=\"%s\"\n", appInfo.Snap.Name())
-	fmt.Fprintf(&buf, "@{APP_VERSION}=\"%d\"\n", appInfo.Snap.Revision)
-	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/snap\"")
-	return buf.Bytes()
-}
-
 // modernVariables returns text defining some apparmor variables that
 // work with non-legacy apparmor templates.
 func modernVariables(appInfo *snap.AppInfo) []byte {

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -49,21 +49,14 @@ func legacyVariables(appInfo *snap.AppInfo) []byte {
 	return buf.Bytes()
 }
 
-// modenVariables returns text defining some apparmor variables that
+// modernVariables returns text defining some apparmor variables that
 // work with non-legacy apparmor templates.
-//
-// XXX: Straw-man: can we just expose the following apparmor variables...
-//
-// @{APP_NAME}=app.Name
-// @{APP_SECURITY_TAG}=app.SecurityTag()
-// @{SNAP_NAME}=app.SnapName
-//
-// ...have everything work correctly?
 func modernVariables(appInfo *snap.AppInfo) []byte {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "@{APP_NAME}=\"%s\"\n", appInfo.Name)
 	fmt.Fprintf(&buf, "@{APP_SECURITY_TAG}=\"%s\"\n", appInfo.SecurityTag())
 	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", appInfo.Snap.Name())
+	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%d\"\n", appInfo.Snap.Revision)
 	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/snap\"")
 	return buf.Bytes()
 }


### PR DESCRIPTION
This branch streamlines the apparmor policy code that no longer needs to support old-security