### PR TITLE
many: prepare for opengl support on classic

### DIFF
--- a/debian/snapd.dirs
+++ b/debian/snapd.dirs
@@ -1,7 +1,7 @@
 snap
 var/lib/snapd/apparmor/additional
 var/lib/snapd/snaps
-var/lib/snapd/gl
+var/lib/snapd/lib/gl
 usr/lib/snappy
 usr/lib/snapd
 var/snap

--- a/debian/snapd.dirs
+++ b/debian/snapd.dirs
@@ -1,6 +1,7 @@
 snap
 var/lib/snapd/apparmor/additional
 var/lib/snapd/snaps
+var/lib/snapd/gl
 usr/lib/snappy
 usr/lib/snapd
 var/snap

--- a/debian/snapd.install
+++ b/debian/snapd.install
@@ -7,6 +7,8 @@ data/completion/snappy /usr/share/bash-completion/completions/
 etc/profile.d
 # etc/X11/Xsession.d will add to XDG_DATA_DIRS so that we have .desktop support
 etc/X11
+# etc/ld.so.conf.d contains the SNAP_LIBRARY_PATH directories
+etc/ld.so.conf.d
 
 # systemd stuff
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -45,6 +45,13 @@ apps interfering with one another.
 Usage: reserved
 Auto-Connect: yes
 
+### opengl
+
+Can access the opengl hardware. 
+
+Usage: reserved
+Auto-Connect: yes
+
 ### home
 
 Can access non-hidden files in user's $HOME. This is restricted

--- a/etc/ld.so.conf.d/snappy.conf
+++ b/etc/ld.so.conf.d/snappy.conf
@@ -1,0 +1,2 @@
+# snappy looks for additional gl drivers here
+/var/lib/snapd/lib/gl

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -175,6 +175,14 @@ var defaultTemplate = []byte(`
   # specific gl libs
   /var/lib/snapd/gl/** rm,
 
+  # nvidia
+  /proc/driver/nvidia/params r,
+  /sys/bus/pci/devices/** r,
+  /dev/nvidiactl rw,
+  /proc/modules r,
+  /dev/nvidia-modeset rw,
+  /dev/nvidia0 rw,
+
   # java
   @{PROC}/@{pid}/ r,
   @{PROC}/@{pid}/fd/ r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -172,6 +172,9 @@ var defaultTemplate = []byte(`
   # this is an information leak
   deny /{,var/}run/utmp r,
 
+  # specific gl libs
+  /var/lib/snapd/gl/** rm,
+
   # java
   @{PROC}/@{pid}/ r,
   @{PROC}/@{pid}/fd/ r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -172,17 +172,6 @@ var defaultTemplate = []byte(`
   # this is an information leak
   deny /{,var/}run/utmp r,
 
-  # specific gl libs
-  /var/lib/snapd/gl/** rm,
-
-  # nvidia
-  /proc/driver/nvidia/params r,
-  /sys/bus/pci/devices/** r,
-  /dev/nvidiactl rw,
-  /proc/modules r,
-  /dev/nvidia-modeset rw,
-  /dev/nvidia0 rw,
-
   # java
   @{PROC}/@{pid}/ r,
   @{PROC}/@{pid}/fd/ r,

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -48,4 +48,5 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewTimezoneControlInterface())
 	c.Check(all, DeepContains, builtin.NewUnity7Interface())
 	c.Check(all, DeepContains, builtin.NewX11Interface())
+	c.Check(all, DeepContains, builtin.NewOpenglInterface())
 }

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -23,27 +23,36 @@ import (
 	"github.com/ubuntu-core/snappy/interfaces"
 )
 
-var allInterfaces = []interfaces.Interface{
-	&BoolFileInterface{},
-	NewFirewallControlInterface(),
-	NewHomeInterface(),
-	NewLocaleControlInterface(),
-	NewLogObserveInterface(),
-	NewMountObserveInterface(),
-	NewNetworkInterface(),
-	NewNetworkBindInterface(),
-	NewNetworkControlInterface(),
-	NewNetworkObserveInterface(),
-	NewSnapdControlInterface(),
-	NewSystemObserveInterface(),
-	NewTimeserverControlInterface(),
-	NewTimezoneControlInterface(),
-	NewUnity7Interface(),
-	NewX11Interface(),
-	NewOpenglInterface(),
-}
+const openglConnectedPlugAppArmor = `
+# Description: Can access opengl. 
+# Usage: reserved
 
-// Interfaces returns all of the built-in interfaces.
-func Interfaces() []interfaces.Interface {
-	return allInterfaces
+  # specific gl libs
+  /var/lib/snapd/lib/gl/** rm,
+
+  # nvidia
+  /proc/driver/nvidia/params r,
+  /sys/bus/pci/devices/** r,
+  /dev/nvidiactl rw,
+  /proc/modules r,
+  /dev/nvidia-modeset rw,
+  /dev/nvidia* rw,
+`
+
+const openglConnectedPlugSecComp = `
+# Description: Can access opengl. 
+# Usage: reserved
+
+getsockopt
+`
+
+// NewOpenglInterface returns a new "opengl" interface.
+func NewOpenglInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "opengl",
+		connectedPlugAppArmor: openglConnectedPlugAppArmor,
+		connectedPlugSecComp:  openglConnectedPlugSecComp,
+		reservedForOS:         true,
+		autoConnect:           true,
+	}
 }

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -131,6 +131,7 @@ getpeername
 recvfrom
 recvmsg
 shutdown
+getsockopt
 
 # dbus
 connect

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -36,6 +36,7 @@ var implicitSlots = []string{
 	// TODO Disable these on devices:
 	"unity7",
 	"x11",
+	"opengl",
 }
 
 // AddImplicitSlots adds implicitly defined slots to a given snap.

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -38,7 +38,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlots(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 15)
+	c.Assert(info.Slots, HasLen, 16)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -66,6 +66,7 @@ func GetBasicSnapEnvVars(desc interface{}) []string {
 		"SNAP_NAME={{.SnapName}}",
 		"SNAP_VERSION={{.Version}}",
 		"SNAP_ARCH={{.SnapArch}}",
+		"SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:",
 	})
 }
 

--- a/snappy/binaries_test.go
+++ b/snappy/binaries_test.go
@@ -46,6 +46,7 @@ export SNAP_DATA="/var/snap/pastebinit/1.4.0.0.1/"
 export SNAP_NAME="pastebinit"
 export SNAP_VERSION="1.4.0.0.1"
 export SNAP_ARCH="%[1]s"
+export SNAP_LIBRARY_PATH="/var/lib/snapd/lib/gl:"
 export SNAP_USER_DATA="$HOME/snap/pastebinit/1.4.0.0.1/"
 
 if [ ! -d "$SNAP_USER_DATA" ]; then

--- a/snappy/services_test.go
+++ b/snappy/services_test.go
@@ -94,7 +94,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/0.3.4/bin/foo start
 Restart=on-failure
 WorkingDirectory=/var/snap/xkcd-webserver/0.3.4/
-Environment="SNAP=/snap/xkcd-webserver/0.3.4/" "SNAP_DATA=/var/snap/xkcd-webserver/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ARCH=%[3]s" "SNAP_USER_DATA=/root/snap/xkcd-webserver/0.3.4/" "SNAP_APP_PATH=/snap/xkcd-webserver/0.3.4/" "SNAP_APP_DATA_PATH=/var/snap/xkcd-webserver/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snap/xkcd-webserver/0.3.4/"
+Environment="SNAP=/snap/xkcd-webserver/0.3.4/" "SNAP_DATA=/var/snap/xkcd-webserver/0.3.4/" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_ARCH=%[3]s" "SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:" "SNAP_USER_DATA=/root/snap/xkcd-webserver/0.3.4/" "SNAP_APP_PATH=/snap/xkcd-webserver/0.3.4/" "SNAP_APP_DATA_PATH=/var/snap/xkcd-webserver/0.3.4/" "SNAP_APP_USER_DATA_PATH=/root/snap/xkcd-webserver/0.3.4/"
 ExecStop=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/0.3.4/bin/foo stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/0.3.4/bin/foo post-stop
 TimeoutStopSec=30

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -221,7 +221,7 @@ X-Snappy=yes
 ExecStart=/usr/bin/ubuntu-core-launcher app aa-profile /apps/app/1.0/bin/start
 Restart=on-failure
 WorkingDirectory=/var/apps/app/1.0/
-Environment="SNAP=/apps/app/1.0/" "SNAP_DATA=/var/apps/app/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ARCH=%[3]s" "SNAP_USER_DATA=/root/apps/app/1.0/" "SNAP_APP_PATH=/apps/app/1.0/" "SNAP_APP_DATA_PATH=/var/apps/app/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app/1.0/"
+Environment="SNAP=/apps/app/1.0/" "SNAP_DATA=/var/apps/app/1.0/" "SNAP_NAME=app" "SNAP_VERSION=1.0" "SNAP_ARCH=%[3]s" "SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:" "SNAP_USER_DATA=/root/apps/app/1.0/" "SNAP_APP_PATH=/apps/app/1.0/" "SNAP_APP_DATA_PATH=/var/apps/app/1.0/" "SNAP_APP_USER_DATA_PATH=/root/apps/app/1.0/"
 ExecStop=/usr/bin/ubuntu-core-launcher app aa-profile /apps/app/1.0/bin/stop
 ExecStopPost=/usr/bin/ubuntu-core-launcher app aa-profile /apps/app/1.0/bin/stop --post
 TimeoutStopSec=10


### PR DESCRIPTION
This branch prepare the snappy side of opengl support on classic. The idea is that the ubuntu-core-launcher bind mounts the hosts libgl directory into /var/lib/snapd/lib/gl and via the ld.so.conf.d mechanism and SNAP_LIBRARY_PATH (that will get picked up by snapcraft) the apps can link to that libgl. The code also adds an opengl interface so that the apps can get the permission to access the device.