### PR TITLE
client: send authorization header in client requests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -133,11 +133,11 @@ func (cs *clientSuite) TestClientSetsAuthorization(c *check.C) {
 	os.Setenv("HOME", tmpdir)
 	defer os.Setenv("HOME", home)
 
-	mockUserData := client.AuthenticatedUser{
+	mockUserData := client.User{
 		Macaroon:   "macaroon",
 		Discharges: []string{"discharge"},
 	}
-	err := client.WriteAuthData(mockUserData)
+	err := client.TestWriteAuth(mockUserData)
 	c.Assert(err, check.IsNil)
 
 	var v string

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -115,6 +115,37 @@ func (cs *clientSuite) TestClientWorks(c *check.C) {
 	c.Check(cs.req.URL.Path, check.Equals, "/this")
 }
 
+func (cs *clientSuite) TestClientDefaultsToNoAuthorization(c *check.C) {
+	home := os.Getenv("HOME")
+	tmpdir := c.MkDir()
+	os.Setenv("HOME", tmpdir)
+	defer os.Setenv("HOME", home)
+
+	var v string
+	_ = cs.cli.Do("GET", "/this", nil, nil, &v)
+	authorization := cs.req.Header.Get("Authorization")
+	c.Check(authorization, check.Equals, "")
+}
+
+func (cs *clientSuite) TestClientSetsAuthorization(c *check.C) {
+	home := os.Getenv("HOME")
+	tmpdir := c.MkDir()
+	os.Setenv("HOME", tmpdir)
+	defer os.Setenv("HOME", home)
+
+	mockUserData := client.AuthenticatedUser{
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	}
+	err := client.WriteAuthData(mockUserData)
+	c.Assert(err, check.IsNil)
+
+	var v string
+	_ = cs.cli.Do("GET", "/this", nil, nil, &v)
+	authorization := cs.req.Header.Get("Authorization")
+	c.Check(authorization, check.Equals, `Macaroon root="macaroon", discharge="discharge"`)
+}
+
 func (cs *clientSuite) TestClientSysInfo(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"flavor": "f",

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -36,3 +36,7 @@ func (client *Client) Do(method, path string, query url.Values, body io.Reader, 
 
 // expose parseError for testing
 var ParseErrorInTest = parseError
+
+// expose read and write auth helpers for testing
+var TestWriteAuth = writeAuthData
+var TestReadAuth = readAuthData

--- a/client/login.go
+++ b/client/login.go
@@ -29,8 +29,8 @@ import (
 	"github.com/ubuntu-core/snappy/osutil"
 )
 
-// AuthenticatedUser holds logged in user information.
-type AuthenticatedUser struct {
+// User holds logged in user information.
+type User struct {
 	Macaroon   string   `json:"macaroon,omitempty"`
 	Discharges []string `json:"discharges,omitempty"`
 }
@@ -42,7 +42,7 @@ type loginData struct {
 }
 
 // Login logs user in.
-func (client *Client) Login(username, password, otp string) (*AuthenticatedUser, error) {
+func (client *Client) Login(username, password, otp string) (*User, error) {
 	postData := loginData{
 		Username: username,
 		Password: password,
@@ -53,12 +53,12 @@ func (client *Client) Login(username, password, otp string) (*AuthenticatedUser,
 		return nil, err
 	}
 
-	var user AuthenticatedUser
+	var user User
 	if _, err := client.doSync("POST", "/v2/login", nil, &body, &user); err != nil {
 		return nil, err
 	}
 
-	if err := WriteAuthData(user); err != nil {
+	if err := writeAuthData(user); err != nil {
 		return nil, fmt.Errorf("cannot persist login information: %v", err)
 	}
 	return &user, nil
@@ -72,13 +72,13 @@ func storeAuthDataFilename() string {
 	return filepath.Join(homeDir, ".snap", "auth.json")
 }
 
-// WriteAuthData saves authentication details for later reuse through ReadAuthData
-func WriteAuthData(userData AuthenticatedUser) error {
+// writeAuthData saves authentication details for later reuse through ReadAuthData
+func writeAuthData(user User) error {
 	targetFile := storeAuthDataFilename()
 	if err := os.MkdirAll(filepath.Dir(targetFile), 0700); err != nil {
 		return err
 	}
-	outStr, err := json.Marshal(userData)
+	outStr, err := json.Marshal(user)
 	if err != nil {
 		return nil
 	}
@@ -86,19 +86,20 @@ func WriteAuthData(userData AuthenticatedUser) error {
 	return osutil.AtomicWriteFile(targetFile, []byte(outStr), 0600, 0)
 }
 
-// ReadAuthData reads previously written authentication details
-func ReadAuthData() (*AuthenticatedUser, error) {
+// readAuthData reads previously written authentication details
+func readAuthData() (*User, error) {
 	sourceFile := storeAuthDataFilename()
 	f, err := os.Open(sourceFile)
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
-	var userData AuthenticatedUser
+	var user User
 	dec := json.NewDecoder(f)
-	if err := dec.Decode(&userData); err != nil {
+	if err := dec.Decode(&user); err != nil {
 		return nil, err
 	}
 
-	return &userData, nil
+	return &user, nil
 }

--- a/client/login_test.go
+++ b/client/login_test.go
@@ -75,3 +75,41 @@ func (cs *clientSuite) TestClientLoginError(c *check.C) {
 	outFile := filepath.Join(tmpdir, ".snap", "auth.json")
 	c.Check(osutil.FileExists(outFile), check.Equals, false)
 }
+
+func (cs *clientSuite) TestWriteAuthData(c *check.C) {
+	home := os.Getenv("HOME")
+	tmpdir := c.MkDir()
+	os.Setenv("HOME", tmpdir)
+	defer os.Setenv("HOME", home)
+
+	authData := client.AuthenticatedUser{
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	}
+	err := client.WriteAuthData(authData)
+	c.Assert(err, check.IsNil)
+
+	outFile := filepath.Join(tmpdir, ".snap", "auth.json")
+	c.Check(osutil.FileExists(outFile), check.Equals, true)
+	content, err := ioutil.ReadFile(outFile)
+	c.Check(err, check.IsNil)
+	c.Check(string(content), check.Equals, `{"macaroon":"macaroon","discharges":["discharge"]}`)
+}
+
+func (cs *clientSuite) TestReadAuthData(c *check.C) {
+	home := os.Getenv("HOME")
+	tmpdir := c.MkDir()
+	os.Setenv("HOME", tmpdir)
+	defer os.Setenv("HOME", home)
+
+	authData := client.AuthenticatedUser{
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	}
+	err := client.WriteAuthData(authData)
+	c.Assert(err, check.IsNil)
+
+	readUser, err := client.ReadAuthData()
+	c.Assert(err, check.IsNil)
+	c.Check(readUser, check.DeepEquals, &authData)
+}

--- a/client/login_test.go
+++ b/client/login_test.go
@@ -44,7 +44,7 @@ func (cs *clientSuite) TestClientLogin(c *check.C) {
 	user, err := cs.cli.Login("username", "pass", "")
 
 	c.Check(err, check.IsNil)
-	c.Check(user, check.DeepEquals, &client.AuthenticatedUser{
+	c.Check(user, check.DeepEquals, &client.User{
 		Macaroon:   "the-root-macaroon",
 		Discharges: []string{"discharge-macaroon"}})
 
@@ -82,11 +82,11 @@ func (cs *clientSuite) TestWriteAuthData(c *check.C) {
 	os.Setenv("HOME", tmpdir)
 	defer os.Setenv("HOME", home)
 
-	authData := client.AuthenticatedUser{
+	authData := client.User{
 		Macaroon:   "macaroon",
 		Discharges: []string{"discharge"},
 	}
-	err := client.WriteAuthData(authData)
+	err := client.TestWriteAuth(authData)
 	c.Assert(err, check.IsNil)
 
 	outFile := filepath.Join(tmpdir, ".snap", "auth.json")
@@ -102,14 +102,14 @@ func (cs *clientSuite) TestReadAuthData(c *check.C) {
 	os.Setenv("HOME", tmpdir)
 	defer os.Setenv("HOME", home)
 
-	authData := client.AuthenticatedUser{
+	authData := client.User{
 		Macaroon:   "macaroon",
 		Discharges: []string{"discharge"},
 	}
-	err := client.WriteAuthData(authData)
+	err := client.TestWriteAuth(authData)
 	c.Assert(err, check.IsNil)
 
-	readUser, err := client.ReadAuthData()
+	readUser, err := client.TestReadAuth()
 	c.Assert(err, check.IsNil)
 	c.Check(readUser, check.DeepEquals, &authData)
 }


### PR DESCRIPTION
If there are logged in user details available, make client requests include the authorization header with the macaroons information.