### PR TITLE
client,daemon,overlord: don't guess snap file vs. name

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -35,11 +35,11 @@ func (client *Client) InstallSnap(name, channel string) (string, error) {
 	return client.doAsync("POST", path, nil, body)
 }
 
-// InstallSnapFile sideloads the snap with the given path, returning the UUID
+// InstallSnapPath sideloads the snap with the given path, returning the UUID
 // of the background operation upon success.
 //
 // XXX: add support for "X-Allow-Unsigned"
-func (client *Client) InstallSnapFile(path string) (string, error) {
+func (client *Client) InstallSnapPath(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("cannot open: %q", path)

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -218,7 +218,7 @@ func (cs *clientSuite) TestClientOpSideload(c *check.C) {
 	err := ioutil.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
-	id, err := (*client.Client).InstallSnapFile(cs.cli, snap)
+	id, err := (*client.Client).InstallSnapPath(cs.cli, snap)
 	c.Assert(err, check.IsNil)
 
 	body, err := ioutil.ReadAll(cs.req.Body)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -130,7 +130,7 @@ func (x *cmdInstall) Execute([]string) error {
 	cli := Client()
 	name := x.Positional.Snap
 	if strings.Contains(name, "/") || strings.HasSuffix(name, ".snap") || strings.Contains(name, ".snap.") {
-		uuid, err = cli.InstallSnapFile(name)
+		uuid, err = cli.InstallSnapPath(name)
 	} else {
 		uuid, err = cli.InstallSnap(name, x.Channel)
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -476,6 +476,7 @@ func (inst *snapInstruction) Agreed(intro, license string) bool {
 }
 
 var snapstateInstall = snapstate.Install
+var snapstateInstallPath = snapstate.InstallPath
 var snapstateGet = snapstate.Get
 
 func waitChange(chg *state.Change) error {
@@ -806,7 +807,7 @@ func sideloadSnap(c *Command, r *http.Request) Response {
 	state.Lock()
 	msg := fmt.Sprintf(i18n.G("Install local %q snap"), snap)
 	chg := state.NewChange("install-snap", msg)
-	ts, err := snapstateInstall(state, snap, "", flags)
+	ts, err := snapstateInstallPath(state, snap, "", flags)
 	if err == nil {
 		chg.AddAll(ts)
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -379,6 +379,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"pkgActionDispatch",
 		// snapInstruction vars:
 		"snapstateInstall",
+		"snapstateInstallPath",
 		"snapstateGet",
 	}
 	c.Check(found, check.Equals, len(api)+len(exceptions),
@@ -938,7 +939,7 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, unsignedExpected bo
 		expectedFlags |= snappy.AllowUnauthenticated
 	}
 
-	snapstateInstall = func(s *state.State, name, channel string, flags snappy.InstallFlags) (*state.TaskSet, error) {
+	snapstateInstallPath = func(s *state.State, name, channel string, flags snappy.InstallFlags) (*state.TaskSet, error) {
 		c.Check(flags, check.Equals, expectedFlags)
 
 		bs, err := ioutil.ReadFile(name)

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -578,7 +578,7 @@ func (s *snapmgrTestSuite) TestInstallLocalIntegration(c *C) {
 	mockSnap := makeTestSnap(c, `name: mock
 version: 1.0`)
 	chg := s.state.NewChange("install", "install a local snap")
-	ts, err := snapstate.Install(s.state, mockSnap, "", 0)
+	ts, err := snapstate.InstallPath(s.state, mockSnap, "", 0)
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/logger"
-	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snappy"
@@ -39,18 +38,18 @@ import (
 // allow exchange in the tests
 var backend managerBackend = &defaultBackend{}
 
-func doInstall(s *state.State, curActive bool, snapName, channel string, flags snappy.InstallFlags) (*state.TaskSet, error) {
+func doInstall(s *state.State, curActive bool, snapName, snapPath, channel string, flags snappy.InstallFlags) (*state.TaskSet, error) {
 	// download
 	var prepare *state.Task
 	ss := SnapSetup{
 		Channel: channel,
 		Flags:   int(flags),
 	}
-	if osutil.FileExists(snapName) {
-		ss.SnapPath = snapName
-		prepare = s.NewTask("prepare-snap", fmt.Sprintf(i18n.G("Prepare snap %q"), snapName))
+	ss.Name = snapName
+	ss.SnapPath = snapPath
+	if snapPath != "" {
+		prepare = s.NewTask("prepare-snap", fmt.Sprintf(i18n.G("Prepare snap %q"), snapPath))
 	} else {
-		ss.Name = snapName
 		prepare = s.NewTask("download-snap", fmt.Sprintf(i18n.G("Download snap %q"), snapName))
 	}
 	prepare.Set("snap-setup", ss)
@@ -105,7 +104,13 @@ func Install(s *state.State, name, channel string, flags snappy.InstallFlags) (*
 		return nil, fmt.Errorf("snap %q already installed", name)
 	}
 
-	return doInstall(s, false, name, channel, flags)
+	return doInstall(s, false, name, "", channel, flags)
+}
+
+// InstallPath returns a set of tasks for installing snap from a file path.
+// Note that the state must be locked by the caller.
+func InstallPath(s *state.State, path, channel string, flags snappy.InstallFlags) (*state.TaskSet, error) {
+	return doInstall(s, false, "", path, channel, flags)
 }
 
 // Update initiates a change updating a snap.
@@ -120,7 +125,7 @@ func Update(s *state.State, name, channel string, flags snappy.InstallFlags) (*s
 		return nil, fmt.Errorf("cannot find snap %q", name)
 	}
 
-	return doInstall(s, snapst.Active, name, channel, flags)
+	return doInstall(s, snapst.Active, name, "", channel, flags)
 }
 
 // parseSnapspec parses a string like: name[.developer][=version]


### PR DESCRIPTION
Also rename Client.InstallFile to InstallPath, opening
up InstallFile for an actual os.File or io.Reader.