### PR TITLE
daemon/api,overlord/auth: add helper to get UserState from a client request

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -241,7 +241,7 @@ func UserFromRequest(st *state.State, req *http.Request) (*auth.UserState, error
 
 	authorizationData := strings.SplitN(header, " ", 2)
 	if len(authorizationData) != 2 || authorizationData[0] != "Macaroon" {
-		return nil, fmt.Errorf("invalid authorization header")
+		return nil, fmt.Errorf("authorization header misses Macaroon prefix")
 	}
 
 	var macaroon string
@@ -257,7 +257,7 @@ func UserFromRequest(st *state.State, req *http.Request) (*auth.UserState, error
 	}
 
 	if macaroon == "" || len(discharges) == 0 {
-		return nil, fmt.Errorf("authorization header misses Macaroon prefix")
+		return nil, fmt.Errorf("invalid authorization header")
 	}
 
 	user, err := auth.CheckMacaroon(st, macaroon, discharges)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -230,6 +230,40 @@ func loginUser(c *Command, r *http.Request) Response {
 	return SyncResponse(result, nil)
 }
 
+// UserFromRequest extracts user information from request and return the respective user in state, if valid
+// It requires the state to be locked
+func UserFromRequest(st *state.State, req *http.Request) (*auth.UserState, error) {
+	// extract macaroons data from request
+	header := req.Header.Get("Authorization")
+	if header == "" {
+		return nil, nil
+	}
+
+	authorizationData := strings.SplitN(header, " ", 2)
+	if len(authorizationData) != 2 || authorizationData[0] != "Macaroon" {
+		return nil, fmt.Errorf("invalid authorization header")
+	}
+
+	var macaroon string
+	var discharges []string
+	for _, field := range strings.Split(authorizationData[1], ",") {
+		field := strings.TrimSpace(field)
+		if strings.HasPrefix(field, `root="`) {
+			macaroon = strings.TrimSuffix(field[6:], `"`)
+		}
+		if strings.HasPrefix(field, `discharge="`) {
+			discharges = append(discharges, strings.TrimSuffix(field[11:], `"`))
+		}
+	}
+
+	if macaroon == "" || len(discharges) == 0 {
+		return nil, fmt.Errorf("authorization header misses Macaroon prefix")
+	}
+
+	user, err := auth.CheckMacaroon(st, macaroon, discharges)
+	return user, err
+}
+
 type metarepo interface {
 	Snap(string, string, store.Authenticator) (*snap.Info, error)
 	FindSnaps(string, string, store.Authenticator) ([]*snap.Info, error)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -612,7 +612,7 @@ func (s *apiSuite) TestUserFromRequestHeaderNoMacaroons(c *check.C) {
 	user, err := UserFromRequest(state, req)
 	state.Unlock()
 
-	c.Check(err, check.ErrorMatches, "invalid authorization header")
+	c.Check(err, check.ErrorMatches, "authorization header misses Macaroon prefix")
 	c.Check(user, check.IsNil)
 }
 
@@ -625,7 +625,7 @@ func (s *apiSuite) TestUserFromRequestHeaderIncomplete(c *check.C) {
 	user, err := UserFromRequest(state, req)
 	state.Unlock()
 
-	c.Check(err, check.ErrorMatches, "authorization header misses Macaroon prefix")
+	c.Check(err, check.ErrorMatches, "invalid authorization header")
 	c.Check(user, check.IsNil)
 }
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -591,6 +591,93 @@ func (s *apiSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
 	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot get discharge macaroon")
 }
 
+func (s *apiSuite) TestUserFromRequestNoHeader(c *check.C) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	state := snapCmd.d.overlord.State()
+	state.Lock()
+	user, err := UserFromRequest(state, req)
+	state.Unlock()
+
+	c.Check(err, check.IsNil)
+	c.Check(user, check.IsNil)
+}
+
+func (s *apiSuite) TestUserFromRequestHeaderNoMacaroons(c *check.C) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Authorization", "Invalid")
+
+	state := snapCmd.d.overlord.State()
+	state.Lock()
+	user, err := UserFromRequest(state, req)
+	state.Unlock()
+
+	c.Check(err, check.ErrorMatches, "invalid authorization header")
+	c.Check(user, check.IsNil)
+}
+
+func (s *apiSuite) TestUserFromRequestHeaderIncomplete(c *check.C) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Authorization", `Macaroon root="macaroon"`)
+
+	state := snapCmd.d.overlord.State()
+	state.Lock()
+	user, err := UserFromRequest(state, req)
+	state.Unlock()
+
+	c.Check(err, check.ErrorMatches, "authorization header misses Macaroon prefix")
+	c.Check(user, check.IsNil)
+}
+
+func (s *apiSuite) TestUserFromRequestHeaderCorrectMissingUser(c *check.C) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Authorization", `Macaroon root="macaroon", discharge="discharge"`)
+
+	state := snapCmd.d.overlord.State()
+	state.Lock()
+	user, err := UserFromRequest(state, req)
+	state.Unlock()
+
+	c.Check(err, check.IsNil)
+	c.Check(user, check.IsNil)
+}
+
+func (s *apiSuite) TestUserFromRequestHeaderValidUser(c *check.C) {
+	state := snapCmd.d.overlord.State()
+	state.Lock()
+	expectedUser, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	state.Unlock()
+	c.Check(err, check.IsNil)
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Authorization", `Macaroon root="macaroon", discharge="discharge"`)
+
+	state.Lock()
+	user, err := UserFromRequest(state, req)
+	state.Unlock()
+
+	c.Check(err, check.IsNil)
+	c.Check(user, check.DeepEquals, expectedUser)
+}
+
+func (s *apiSuite) TestUserFromRequestHeaderValidUserMultipleDischarges(c *check.C) {
+	state := snapCmd.d.overlord.State()
+	state.Lock()
+	expectedUser, err := auth.NewUser(state, "username", "macaroon", []string{"discharge2", "discharge1"})
+	state.Unlock()
+	c.Check(err, check.IsNil)
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Authorization", `Macaroon root="macaroon", discharge="discharge1", discharge="discharge2"`)
+
+	state.Lock()
+	user, err := UserFromRequest(state, req)
+	state.Unlock()
+
+	c.Check(err, check.IsNil)
+	c.Check(user, check.DeepEquals, expectedUser)
+}
+
 func (s *apiSuite) TestSnapsInfoOnePerIntegration(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/snaps", nil)
 	c.Assert(err, check.IsNil)

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -23,6 +23,8 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 
 	"github.com/ubuntu-core/snappy/overlord/state"
 )
@@ -82,6 +84,51 @@ func User(st *state.State, id int) (*UserState, error) {
 		}
 	}
 	return nil, fmt.Errorf("invalid user")
+}
+
+// GetUserFromRequest extracts user information from request and return the respective user in state, if valid
+func GetUserFromRequest(st *state.State, req *http.Request) (*UserState, error) {
+	// extract macaroons data from request
+	header := req.Header.Get("Authorization")
+	if header == "" {
+		return nil, nil
+	}
+
+	const errorMsg = "unauthorized"
+	auth := strings.SplitN(header, " ", 2)
+	if len(auth) != 2 || auth[0] != "Macaroon" {
+		return nil, fmt.Errorf(errorMsg)
+	}
+
+	var macaroon string
+	var discharges []string
+	for _, field := range strings.Split(auth[1], ",") {
+		field := strings.TrimSpace(field)
+		if strings.HasPrefix(field, `root="`) {
+			macaroon = field[6 : len(field)-1]
+		}
+		if strings.HasPrefix(field, `discharge="`) {
+			discharges = append(discharges, field[11:len(field)-1])
+		}
+	}
+
+	if macaroon == "" || len(discharges) == 0 {
+		return nil, fmt.Errorf(errorMsg)
+	}
+
+	var authStateData AuthState
+	err := st.Get("auth", &authStateData)
+
+	if err != nil {
+		return nil, fmt.Errorf(errorMsg)
+	}
+
+	for _, user := range authStateData.Users {
+		if user.Macaroon == macaroon && reflect.DeepEqual(discharges, user.Discharges) {
+			return &user, nil
+		}
+	}
+	return nil, fmt.Errorf(errorMsg)
 }
 
 // Authenticator returns MacaroonAuthenticator for current authenticated user represented by UserState


### PR DESCRIPTION
Extract macaroons information from Authorization header in a request and return the respective UserState if header is well-formed and valid.