### PR TITLE
debian: disable autopilot

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,11 +22,11 @@ override_dh_systemd_enable:
 		-pubuntu-core-snapd-units \
 		snapd.firstboot.service
 	# we want the autopilot timer enabled by default
-	dh_systemd_enable \
+#	dh_systemd_enable \
 		-psnapd \
 		snappy-autopilot.timer
 	# but the autopilot service disabled
-	dh_systemd_enable \
+#	dh_systemd_enable \
 		--no-enable \
 		-psnapd \
 		snappy-autopilot.service
@@ -41,11 +41,11 @@ override_dh_systemd_start:
 		-pubuntu-core-snapd-units \
 		snapd.boot-ok.service
 	# we want to start the autopilot timer
-	dh_systemd_start \
+#	dh_systemd_start \
 		-psnapd \
 		snappy-autopilot.timer
 	# but not start the service
-	dh_systemd_start \
+#	dh_systemd_start \
 		--no-start \
 		-psnapd \
 		snappy-autopilot.service


### PR DESCRIPTION
This patch disables autopilot. Currently autopilot runs "snap refresh"
but the implementation requires "snap refresh <snap-name>".

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>