### PR TITLE
state: log do/undo status too when a task is run

### DIFF
--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -231,7 +231,7 @@ func (r *TaskRunner) Ensure() {
 			// Dependencies still unhandled.
 			continue
 		}
-		logger.Debugf("Running task %s: %q %s", t.ID(), t.Status(), t.Summary())
+		logger.Debugf("Running task %s on %s: %s", t.ID(), t.Status(), t.Summary())
 		r.run(t)
 	}
 }

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -231,7 +231,7 @@ func (r *TaskRunner) Ensure() {
 			// Dependencies still unhandled.
 			continue
 		}
-		logger.Debugf("Running task %s: %s", t.ID(), t.Summary())
+		logger.Debugf("Running task %s: %q %s", t.ID(), t.Status(), t.Summary())
 		r.run(t)
 	}
 }


### PR DESCRIPTION
Trivial branch that just adds the information if the task is in "do" or "undo" mode when it is run. The log is confusing without this extra bit because it will appear as if snappy is running the failed tasks again (which it is, but in undo mode :)