### PR TITLE
systemd: use native systemctl enable instead of our own implementation

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -208,17 +207,8 @@ func (*systemd) DaemonReload() error {
 
 // Enable the given service
 func (s *systemd) Enable(serviceName string) error {
-	enableSymlink := filepath.Join(s.rootDir, snapServicesDir, servicesSystemdTarget+".wants", serviceName)
-
-	// already enabled
-	if _, err := os.Lstat(enableSymlink); err == nil {
-		return nil
-	}
-
-	// Do not use s.rootDir here. The link must point to the
-	// real (internal) path.
-	serviceFilename := filepath.Join(snapServicesDir, serviceName)
-	return os.Symlink(serviceFilename, enableSymlink)
+	_, err := SystemctlCmd("--root", s.rootDir, "enable", serviceName)
+	return err
 }
 
 // Disable the given service

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -197,19 +197,10 @@ func (s *SystemdTestSuite) TestDisable(c *C) {
 }
 
 func (s *SystemdTestSuite) TestEnable(c *C) {
-	sysd := New("xyzzy", s.rep)
-	sysd.(*systemd).rootDir = c.MkDir()
-	err := os.MkdirAll(filepath.Join(sysd.(*systemd).rootDir, "/etc/systemd/system/multi-user.target.wants"), 0755)
+	err := New("xyzzy", s.rep).Enable("foo")
 	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "enable", "foo"}})
 
-	err = sysd.Enable("foo")
-	c.Assert(err, IsNil)
-
-	// check symlink
-	enableLink := filepath.Join(sysd.(*systemd).rootDir, "/etc/systemd/system/multi-user.target.wants/foo")
-	target, err := os.Readlink(enableLink)
-	c.Assert(err, IsNil)
-	c.Assert(target, Equals, "/etc/systemd/system/foo")
 }
 
 const expectedServiceFmt = `[Unit]


### PR DESCRIPTION
This branch fixes a bug that I see on my system when doing real-world snap install testing. I get:
```
- Mount snap "ubuntu-clock-app" ([start snap-ubuntu\x2dclock\x2dapp-2.mount] failed with exit status 5: Failed to start snap-ubuntu\x2dclock\x2dapp-2.mount: Unit snap-ubuntu\x2dclock\x2dapp-2.mount not found.
```
quite often. This branch fixes this. The background:

We had our own implementation of systemd.Enable() in the past
because ubuntu-device-flash was using this code when the user
installed additional snaps. Because u-d-f could run on pre-systemd
systems we did not want to depend on systemctl for enable.

However it looks like our version is buggy. Plus with 16.04
systemd is everywhere and we will also change the way that
u-d-f --install works for 16.