### PR TITLE
store: add workaround for misbehaving store

### DIFF
--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -219,7 +219,7 @@ func (s *SnapTestSuite) TestInstallAppPackageNameFails(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	_, err = Install("hello-snap.potato", "ch", 0, ag)
+	_, err = Install("hello-snap", "ch", 0, ag)
 	c.Assert(err, ErrorMatches, ".*"+ErrPackageNameAlreadyInstalled.Error())
 }
 

--- a/store/snap_remote_repo_test.go
+++ b/store/snap_remote_repo_test.go
@@ -238,7 +238,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 		c.Check(r.URL.Path, Equals, "/search")
 
 		q := r.URL.Query()
-		c.Check(q.Get("q"), Equals, "package_name:\"hello-world\"")
+		c.Check(q.Get("q"), Equals, "package_name:hello-world")
 		c.Check(r.Header.Get("X-Ubuntu-Device-Channel"), Equals, "edge")
 
 		w.Header().Set("X-Suggested-Currency", "GBP")
@@ -307,7 +307,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 		c.Check(r.URL.Path, Equals, "/search")
 
 		q := r.URL.Query()
-		c.Check(q.Get("q"), Equals, "package_name:\"no-such-pkg\"")
+		c.Check(q.Get("q"), Equals, "package_name:no-such-pkg")
 		c.Check(r.Header.Get("X-Ubuntu-Device-Channel"), Equals, "edge")
 		w.WriteHeader(404)
 		io.WriteString(w, MockNoDetailsJSON)
@@ -604,7 +604,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
 	c.Check(repo.SuggestedCurrency(), Equals, "USD")
 
 	// we should soon have a suggested currency
-	result, err := repo.Snap(funkyAppName, "edge", nil)
+	result, err := repo.Snap("hello-world", "edge", nil)
 	c.Assert(err, IsNil)
 	c.Assert(result, NotNil)
 	c.Check(repo.SuggestedCurrency(), Equals, "GBP")
@@ -612,7 +612,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
 	suggestedCurrency = "EUR"
 
 	// checking the currency updates
-	result, err = repo.Snap(funkyAppName, "edge", nil)
+	result, err = repo.Snap("hello-world", "edge", nil)
 	c.Assert(err, IsNil)
 	c.Assert(result, NotNil)
 	c.Check(repo.SuggestedCurrency(), Equals, "EUR")


### PR DESCRIPTION
SHORT LIVED OMG HACK TO WORKAROUND SERVER BREAKAGE

We should get only a single result when using a search with
a quoted package name. We get totally incorrect results from
the store if we do that. As a workaround we do a search on
the package_name without quotes. This will mean 'http' will
return http,http-server,http-client etc. So we need to manually
filter for exact matches.

Note that this will break once the results are bigger than
the servers page size. Because we have not many snaps in the
store this is not a concern right now.