### PR TITLE
debian: make autopkgtest use the right env vars

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -1,4 +1,17 @@
 #!/bin/sh
+
+# make debian autopkgtest host happy
+mkdir -p /etc/systemd/system/snapd.service.d/
+cat <EOF>/etc/systemd/system/snapd.service.d/proxy.conf
+[Service]
+Environment=http_proxy=$http_proxy
+Environment=https_proxy=$http_proxy
+EOF
+systemctl daemon-reload
+
+# ensure our PATH is right
+. /etc/profile.d/apps-bin-path.sh
+
 tmp="$(mktemp -d)"
 export GOPATH=$tmp
 ./get-deps.sh


### PR DESCRIPTION
This works around the issue that the autopkgtest system has no direct access. We need to set a proxy via an override.