### PR TITLE
snappy: fix crash on certain snap.yaml

### DIFF
--- a/snappy/snap_yaml.go
+++ b/snappy/snap_yaml.go
@@ -157,6 +157,10 @@ func parseSnapYamlData(yamlData []byte, hasConfig bool) (*snapYaml, error) {
 	}
 
 	for name, plug := range m.Plugs {
+		if plug == nil {
+			plug = &plugYaml{}
+			m.Plugs[name] = plug
+		}
 		if plug.Interface == "" {
 			plug.Interface = name
 		}

--- a/snappy/snap_yaml_test.go
+++ b/snappy/snap_yaml_test.go
@@ -39,3 +39,14 @@ plugs:
 	c.Assert(err, IsNil)
 	sy.Plugs["old-security"].Interface = "old-security"
 }
+
+func (s *snapYamlTestSuite) TestParseEmptyPlugDef(c *C) {
+	snapYaml := []byte(`name: foo
+version: 1.0
+plugs:
+ unity7:
+`)
+	sy, err := parseSnapYamlData(snapYaml, false)
+	c.Assert(err, IsNil)
+	sy.Plugs["unity7"].Interface = "unity7"
+}


### PR DESCRIPTION
This fixes a crash on the following snap.yaml snippet:

    name: cap-test
    version: 3.0
    summary: Test snap for capability support
    architectures: [amd64]
    apps:
      xbomb:
	command: xbomb
    plugs:
	unity7:

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>