### PR TITLE
many: add support for developer mode

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -50,8 +50,9 @@ type Config struct {
 
 // A Client knows how to talk to the snappy daemon.
 type Client struct {
-	baseURL url.URL
-	doer    doer
+	baseURL        url.URL
+	doer           doer
+	xxxHackDevMode bool
 }
 
 // New returns a new instance of Client
@@ -107,6 +108,9 @@ func (client *Client) raw(method, urlpath string, query url.Values, body io.Read
 	req, err := http.NewRequest(method, u.String(), body)
 	if err != nil {
 		return nil, err
+	}
+	if client.xxxHackDevMode {
+		req.Header.Add("X-Developer-Mode", "yes")
 	}
 
 	// set Authorization header if there are user's credentials

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -55,6 +55,8 @@ func (client *Client) InstallSnapPath(path string, devMode bool) (changeID strin
 		return "", fmt.Errorf("cannot open: %q", path)
 	}
 
+	client.xxxHackDevMode = devMode
+	defer func() { client.xxxHackDevMode = false }()
 	return client.doAsync("POST", "/v2/snaps", nil, f)
 }
 

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -20,6 +20,8 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -28,10 +30,18 @@ import (
 // InstallSnap adds the snap with the given name from the given channel (or
 // the system default channel if not), returning the UUID of the background
 // operation upon success.
-func (client *Client) InstallSnap(name, channel string) (changeID string, err error) {
+func (client *Client) InstallSnap(name, channel string, devMode bool) (changeID string, err error) {
 	path := fmt.Sprintf("/v2/snaps/%s", name)
-	body := strings.NewReader(fmt.Sprintf(`{"action":"install","channel":%q}`, channel))
-
+	req := struct {
+		Action  string `json:"action"`
+		Channel string `json:"channel"`
+		DevMode bool   `json:"devmode"`
+	}{Action: "install", Channel: channel, DevMode: devMode}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+	body := bytes.NewReader(data)
 	return client.doAsync("POST", path, nil, body)
 }
 
@@ -39,7 +49,7 @@ func (client *Client) InstallSnap(name, channel string) (changeID string, err er
 // of the background operation upon success.
 //
 // XXX: add support for "X-Allow-Unsigned"
-func (client *Client) InstallSnapPath(path string) (changeID string, err error) {
+func (client *Client) InstallSnapPath(path string, devMode bool) (changeID string, err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("cannot open: %q", path)
@@ -60,10 +70,18 @@ func (client *Client) RemoveSnap(name string) (changeID string, err error) {
 // RefreshSnap refreshes the snap with the given name (switching it to track
 // the given channel if given), returning the UUID of the background operation
 // upon success.
-func (client *Client) RefreshSnap(name, channel string) (changeID string, err error) {
+func (client *Client) RefreshSnap(name, channel string, devMode bool) (changeID string, err error) {
 	path := fmt.Sprintf("/v2/snaps/%s", name)
-	body := strings.NewReader(fmt.Sprintf(`{"action":"refresh","channel":%q}`, channel))
-
+	req := struct {
+		Action  string `json:"action"`
+		Channel string `json:"channel"`
+		DevMode bool   `json:"devmode"`
+	}{Action: "refresh", Channel: channel, DevMode: devMode}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+	body := bytes.NewReader(data)
 	return client.doAsync("POST", path, nil, body)
 }
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -144,6 +144,7 @@ func (x *cmdOp) Execute([]string) error {
 
 type cmdInstall struct {
 	Channel    string `long:"channel" description:"Install from this channel instead of the device's default"`
+	DevMode    bool   `long:"devmode" description:"Install the snap with non-enforcing security"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -156,9 +157,9 @@ func (x *cmdInstall) Execute([]string) error {
 	cli := Client()
 	name := x.Positional.Snap
 	if strings.Contains(name, "/") || strings.HasSuffix(name, ".snap") || strings.Contains(name, ".snap.") {
-		changeID, err = cli.InstallSnapPath(name)
+		changeID, err = cli.InstallSnapPath(name, x.DevMode)
 	} else {
-		changeID, err = cli.InstallSnap(name, x.Channel)
+		changeID, err = cli.InstallSnap(name, x.Channel, x.DevMode)
 	}
 	if err != nil {
 		return err
@@ -169,6 +170,7 @@ func (x *cmdInstall) Execute([]string) error {
 
 type cmdRefresh struct {
 	Channel    string `long:"channel" description:"Refresh to the latest on this channel, and track this channel henceforth"`
+	DevMode    bool   `long:"devmode" description:"Refresh the snap with non-enforcing security"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -176,7 +178,7 @@ type cmdRefresh struct {
 
 func (x *cmdRefresh) Execute([]string) error {
 	cli := Client()
-	changeID, err := cli.RefreshSnap(x.Positional.Snap, x.Channel)
+	changeID, err := cli.RefreshSnap(x.Positional.Snap, x.Channel, x.DevMode)
 	if err != nil {
 		return err
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -517,6 +517,7 @@ type snapInstruction struct {
 	progress.NullProgress
 	Action   string       `json:"action"`
 	Channel  string       `json:"channel"`
+	DevMode  bool         `json:"devmode"`
 	LeaveOld bool         `json:"leave-old"`
 	License  *licenseData `json:"license"`
 	pkg      string
@@ -595,7 +596,9 @@ func (inst *snapInstruction) install() (*state.Change, error) {
 	if inst.Channel != "stable" {
 		msg = fmt.Sprintf(i18n.G("Install %q snap from %q channel"), inst.pkg, inst.Channel)
 	}
-
+	if inst.DevMode {
+		flags |= snappy.DeveloperMode
+	}
 	st := inst.overlord.State()
 	st.Lock()
 	chg := st.NewChange("install-snap", msg)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -800,6 +800,7 @@ func sideloadSnap(c *Command, r *http.Request) Response {
 
 	body := r.Body
 	unsignedOk := false
+	devMode := false
 	contentType := r.Header.Get("Content-Type")
 
 	if strings.HasPrefix(contentType, "multipart/") {
@@ -840,6 +841,7 @@ func sideloadSnap(c *Command, r *http.Request) Response {
 
 		// If x-allow-unsigned is present, unsigned is OK
 		_, unsignedOk = r.Header["X-Allow-Unsigned"]
+		_, devMode = r.Header["X-Developer-Mode"]
 	}
 
 	tmpf, err := ioutil.TempFile("", "snapd-sideload-pkg-")
@@ -855,6 +857,9 @@ func sideloadSnap(c *Command, r *http.Request) Response {
 	var flags snappy.InstallFlags
 	if unsignedOk {
 		flags |= snappy.AllowUnauthenticated
+	}
+	if devMode {
+		flags |= snappy.DeveloperMode
 	}
 
 	snap := tmpf.Name()

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // SnapManager is responsible for the installation and removal of snaps.
@@ -130,6 +131,9 @@ func (m *SnapManager) doPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	st.Lock()
 	snapst.Candidate = &snap.SideInfo{}
+	if ss.Flags&int(snappy.DeveloperMode) != 0 {
+		snapst.DevMode = true
+	}
 	Set(st, ss.Name, snapst)
 	st.Unlock()
 	return nil
@@ -170,6 +174,9 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	t.Set("snap-setup", ss)
 	snapst.Candidate = &storeInfo.SideInfo
+	if ss.Flags&int(snappy.DeveloperMode) != 0 {
+		snapst.DevMode = true
+	}
 	Set(st, ss.Name, snapst)
 	st.Unlock()
 


### PR DESCRIPTION
This branch adds support for ``$ snap install --devmode`` and ``$ snap refresh --devmode`` that translate to setting DevMode in the snap state.

I've tested this locally with *ubuntu-calculator-app* from the store and a side-loaded custom snap. Both had the security in non-enforcing mode.

NOTE: There's a very ugly client hack to set the X-Developer-Mode header for side-loaded snaps.