### PR TITLE
daemon,store: plug in authentication for store search/details

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -234,9 +234,6 @@ func loginUser(c *Command, r *http.Request) Response {
 // It requires the state to be locked
 func UserFromRequest(st *state.State, req *http.Request) (*auth.UserState, error) {
 	// extract macaroons data from request
-	if req == nil {
-		return nil, nil
-	}
 	header := req.Header.Get("Authorization")
 	if header == "" {
 		return nil, nil
@@ -296,7 +293,7 @@ func getSnapInfo(c *Command, r *http.Request) Response {
 		channel = localSnap.Channel
 	}
 
-	var authenticator store.Authenticator
+	var auther store.Authenticator
 	overlord := c.d.overlord
 	state := overlord.State()
 	state.Lock()
@@ -306,10 +303,10 @@ func getSnapInfo(c *Command, r *http.Request) Response {
 		return InternalError("%v", err)
 	}
 	if user != nil {
-		authenticator = user.Authenticator()
+		auther = user.Authenticator()
 	}
 
-	remoteSnap, _ := remoteRepo.Snap(name, channel, authenticator)
+	remoteSnap, _ := remoteRepo.Snap(name, channel, auther)
 
 	if localSnap == nil && remoteSnap == nil {
 		return NotFound("cannot find snap %q", name)
@@ -400,7 +397,7 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 
 		remoteRepo := newRemoteRepo()
 
-		var authenticator store.Authenticator
+		var auther store.Authenticator
 		overlord := c.d.overlord
 		state := overlord.State()
 		state.Lock()
@@ -410,7 +407,7 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 			return InternalError("%v", err)
 		}
 		if user != nil {
-			authenticator = user.Authenticator()
+			auther = user.Authenticator()
 		}
 
 		// repo.Find("") finds all
@@ -419,7 +416,7 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 		//   * if there are no results, return an error response.
 		//   * If there are results at all (perhaps local), include a
 		//     warning in the response
-		found, _ := remoteRepo.FindSnaps(searchTerm, "", authenticator)
+		found, _ := remoteRepo.FindSnaps(searchTerm, "", auther)
 		suggestedCurrency = remoteRepo.SuggestedCurrency()
 
 		sources = append(sources, "store")

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -433,6 +433,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 	exceptions := []string{ // keep sorted, for scanning ease
 		"apiCompatLevel",
 		"api",
+		"errNoAuth",
 		"maxReadBuflen",
 		"muxVars",
 		"newRemoteRepo",

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -433,7 +433,6 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 	exceptions := []string{ // keep sorted, for scanning ease
 		"apiCompatLevel",
 		"api",
-		"errNoAuth",
 		"maxReadBuflen",
 		"muxVars",
 		"newRemoteRepo",

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -662,7 +662,7 @@ func (s *apiSuite) TestUserFromRequestNoHeader(c *check.C) {
 	user, err := UserFromRequest(state, req)
 	state.Unlock()
 
-	c.Check(err, check.IsNil)
+	c.Check(err, check.Equals, errNoAuth)
 	c.Check(user, check.IsNil)
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/overlord/auth"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -176,4 +178,43 @@ func (s *daemonSuite) TestAddRoutes(c *check.C) {
 	// XXX: still waiting to know how to check d.router.NotFoundHandler has been set to NotFound
 	//      the old test relied on undefined behaviour:
 	//      c.Check(fmt.Sprintf("%p", d.router.NotFoundHandler), check.Equals, fmt.Sprintf("%p", NotFound))
+}
+
+func (s *daemonSuite) TestAutherNoAuth(c *check.C) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	d := newTestDaemon(c)
+	user, err := d.auther(req)
+
+	c.Check(err, check.ErrorMatches, errNoAuth.Error())
+	c.Check(user, check.IsNil)
+}
+
+func (s *daemonSuite) TestAutherInvalidAuth(c *check.C) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Authorization", `Macaroon root="macaroon"`)
+
+	d := newTestDaemon(c)
+	user, err := d.auther(req)
+
+	c.Check(err, check.ErrorMatches, "invalid authorization header")
+	c.Check(user, check.IsNil)
+}
+
+func (s *daemonSuite) TestAutherValidUser(c *check.C) {
+	d := newTestDaemon(c)
+
+	state := d.overlord.State()
+	state.Lock()
+	expectedUser, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	state.Unlock()
+	c.Check(err, check.IsNil)
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Authorization", `Macaroon root="macaroon", discharge="discharge"`)
+
+	user, err := d.auther(req)
+
+	c.Check(err, check.IsNil)
+	c.Check(user, check.DeepEquals, expectedUser.Authenticator())
 }

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -202,7 +202,11 @@ func NewUbuntuStoreSnapRepository(cfg *SnapUbuntuStoreConfig, storeID string) *S
 }
 
 // small helper that sets the correct http headers for the ubuntu store
-func (s *SnapUbuntuStoreRepository) applyUbuntuStoreHeaders(req *http.Request, accept string) {
+func (s *SnapUbuntuStoreRepository) applyUbuntuStoreHeaders(req *http.Request, accept string, auther Authenticator) {
+	if auther != nil {
+		auther.Authenticate(req)
+	}
+
 	if accept == "" {
 		accept = "application/hal+json"
 	}
@@ -244,10 +248,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, auther Authentica
 	}
 
 	// set headers
-	if auther != nil {
-		auther.Authenticate(req)
-	}
-	s.applyUbuntuStoreHeaders(req, "")
+	s.applyUbuntuStoreHeaders(req, "", auther)
 	req.Header.Set("X-Ubuntu-Device-Channel", channel)
 
 	resp, err := s.client.Do(req)
@@ -319,10 +320,7 @@ func (s *SnapUbuntuStoreRepository) FindSnaps(searchTerm string, channel string,
 	}
 
 	// set headers
-	if auther != nil {
-		auther.Authenticate(req)
-	}
-	s.applyUbuntuStoreHeaders(req, "")
+	s.applyUbuntuStoreHeaders(req, "", auther)
 	req.Header.Set("X-Ubuntu-Device-Channel", channel)
 
 	resp, err := s.client.Do(req)
@@ -362,12 +360,9 @@ func (s *SnapUbuntuStoreRepository) Updates(installed []string, auther Authentic
 		return nil, err
 	}
 	// set headers
-	if auther != nil {
-		auther.Authenticate(req)
-	}
 	// the updates call is a special snowflake right now
 	// (see LP: #1427155)
-	s.applyUbuntuStoreHeaders(req, "application/json")
+	s.applyUbuntuStoreHeaders(req, "application/json", auther)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -418,10 +413,7 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *snap.Info, pbar progres
 	if err != nil {
 		return "", err
 	}
-	if auther != nil {
-		auther.Authenticate(req)
-	}
-	s.applyUbuntuStoreHeaders(req, "")
+	s.applyUbuntuStoreHeaders(req, "", auther)
 
 	if err := download(remoteSnap.Name(), w, req, pbar); err != nil {
 		return "", err

--- a/store/snap_remote_repo.go
+++ b/store/snap_remote_repo.go
@@ -244,6 +244,9 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, auther Authentica
 	}
 
 	// set headers
+	if auther != nil {
+		auther.Authenticate(req)
+	}
 	s.applyUbuntuStoreHeaders(req, "")
 	req.Header.Set("X-Ubuntu-Device-Channel", channel)
 
@@ -316,6 +319,9 @@ func (s *SnapUbuntuStoreRepository) FindSnaps(searchTerm string, channel string,
 	}
 
 	// set headers
+	if auther != nil {
+		auther.Authenticate(req)
+	}
 	s.applyUbuntuStoreHeaders(req, "")
 	req.Header.Set("X-Ubuntu-Device-Channel", channel)
 
@@ -356,6 +362,9 @@ func (s *SnapUbuntuStoreRepository) Updates(installed []string, auther Authentic
 		return nil, err
 	}
 	// set headers
+	if auther != nil {
+		auther.Authenticate(req)
+	}
 	// the updates call is a special snowflake right now
 	// (see LP: #1427155)
 	s.applyUbuntuStoreHeaders(req, "application/json")
@@ -408,6 +417,9 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *snap.Info, pbar progres
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
+	}
+	if auther != nil {
+		auther.Authenticate(req)
 	}
 	s.applyUbuntuStoreHeaders(req, "")
 
@@ -463,6 +475,9 @@ func (s *SnapUbuntuStoreRepository) Assertion(assertType *asserts.AssertionType,
 		return nil, err
 	}
 
+	if auther != nil {
+		auther.Authenticate(req)
+	}
 	req.Header.Set("Accept", asserts.MediaType)
 
 	resp, err := s.client.Do(req)

--- a/store/snap_remote_repo_test.go
+++ b/store/snap_remote_repo_test.go
@@ -161,12 +161,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryHeaders(c *C) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	c.Assert(err, IsNil)
 
-	t.store.applyUbuntuStoreHeaders(req, "")
+	t.store.applyUbuntuStoreHeaders(req, "", nil)
 
 	c.Assert(req.Header.Get("X-Ubuntu-Release"), Equals, release.String())
 	c.Check(req.Header.Get("Accept"), Equals, "application/hal+json")
 
-	t.store.applyUbuntuStoreHeaders(req, "application/json")
+	t.store.applyUbuntuStoreHeaders(req, "application/json", nil)
 
 	c.Check(req.Header.Get("Accept"), Equals, "application/json")
 	c.Assert(req.Header.Get("Authorization"), Equals, "")

--- a/store/snap_remote_repo_test.go
+++ b/store/snap_remote_repo_test.go
@@ -91,6 +91,10 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 
 func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 	download = func(name string, w io.Writer, req *http.Request, pbar progress.Meter) error {
+		// check authorization is set
+		authorization := req.Header.Get("Authorization")
+		c.Check(authorization, Equals, "Authorization-details")
+
 		c.Check(req.URL.String(), Equals, "AUTH-URL")
 		w.Write([]byte("I was downloaded"))
 		return nil
@@ -276,6 +280,31 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(repo.SuggestedCurrency(), Equals, "GBP")
 }
 
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsSetsAuth(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// check authorization is set
+		authorization := r.Header.Get("Authorization")
+		c.Check(authorization, Equals, "Authorization-details")
+
+		io.WriteString(w, MockDetailsJSON)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	searchURI, err := url.Parse(mockServer.URL + "/search")
+	c.Assert(err, IsNil)
+	cfg := SnapUbuntuStoreConfig{
+		SearchURI: searchURI,
+	}
+	repo := NewUbuntuStoreSnapRepository(&cfg, "")
+	c.Assert(repo, NotNil)
+
+	authenticator := &fakeAuthenticator{}
+	_, err = repo.Snap("hello-world", "edge", authenticator)
+	c.Assert(err, IsNil)
+}
+
 /*
 acquired via
 curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: rolling-core" -H "X-Ubuntu-Device-Channel: edge" 'https://search.apps.ubuntu.com/api/v1/search?q=package_name:""&fields=channel,publisher,package_name,origin,description,summary,title,icon_url,prices,content,ratings_average,version,anon_download_url,download_url,download_sha512,last_updated,binary_filesize,support_url,revision' | python -m json.tool
@@ -407,6 +436,32 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFind(c *C) {
 	c.Check(snaps[0].Name(), Equals, funkyAppName)
 }
 
+func (t *remoteRepoTestSuite) TestUbuntuStoreFindSetsAuth(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// check authorization is set
+		authorization := r.Header.Get("Authorization")
+		c.Check(authorization, Equals, "Authorization-details")
+
+		c.Check(r.URL.RawQuery, Equals, "q=name%3Afoo")
+		io.WriteString(w, MockSearchJSON)
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	var err error
+	searchURI, err := url.Parse(mockServer.URL)
+	c.Assert(err, IsNil)
+	cfg := SnapUbuntuStoreConfig{
+		SearchURI: searchURI,
+	}
+	repo := NewUbuntuStoreSnapRepository(&cfg, "")
+	c.Assert(repo, NotNil)
+
+	authenticator := &fakeAuthenticator{}
+	_, err = repo.FindSnaps("foo", "", authenticator)
+	c.Assert(err, IsNil)
+}
+
 /* acquired via:
 curl -s --data-binary '{"name":["8nzc1x4iim2xj1g2ul64.chipaca"]}'  -H 'content-type: application/json' https://search.apps.ubuntu.com/api/v1/click-metadata
 */
@@ -455,6 +510,35 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdates(c *C) {
 	c.Assert(results[0].Name(), Equals, funkyAppName)
 	c.Assert(results[0].Revision, Equals, 3)
 	c.Assert(results[0].Version, Equals, "42")
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdatesSetsAuth(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// check authorization is set
+		authorization := r.Header.Get("Authorization")
+		c.Check(authorization, Equals, "Authorization-details")
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		c.Assert(string(jsonReq), Equals, `{"name":["`+funkyAppName+`"]}`)
+		io.WriteString(w, MockUpdatesJSON)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	var err error
+	bulkURI, err := url.Parse(mockServer.URL + "/updates/")
+	c.Assert(err, IsNil)
+	cfg := SnapUbuntuStoreConfig{
+		BulkURI: bulkURI,
+	}
+	repo := NewUbuntuStoreSnapRepository(&cfg, "")
+	c.Assert(repo, NotNil)
+
+	authenticator := &fakeAuthenticator{}
+	_, err = repo.Updates([]string{funkyAppName}, authenticator)
+	c.Assert(err, IsNil)
 }
 
 func (t *remoteRepoTestSuite) TestStructFieldsSurvivesNoTag(c *C) {
@@ -553,6 +637,33 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(a, NotNil)
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionSetsAuth(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// check authorization is set
+		authorization := r.Header.Get("Authorization")
+		c.Check(authorization, Equals, "Authorization-details")
+
+		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
+		c.Check(r.URL.Path, Equals, "/assertions/snap-declaration/16/snapidfoo")
+		io.WriteString(w, testAssertion)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	var err error
+	assertionsURI, err := url.Parse(mockServer.URL + "/assertions/")
+	c.Assert(err, IsNil)
+	cfg := SnapUbuntuStoreConfig{
+		AssertionsURI: assertionsURI,
+	}
+	repo := NewUbuntuStoreSnapRepository(&cfg, "")
+
+	authenticator := &fakeAuthenticator{}
+	_, err = repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, authenticator)
+	c.Assert(err, IsNil)
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNotFound(c *C) {


### PR DESCRIPTION
Get user from client request, if authorization was provided, and pass authenticator to the remote snap repository to make authenticated requests against the store.