### PR TITLE
overlord/snapstate: start using revisions higher than 100000 for local installs (sideloads)

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -110,7 +110,7 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, fl
 
 func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info, error) {
 	// naive emulation for now, always works
-	return &snap.Info{SideInfo: *si}, nil
+	return &snap.Info{SuggestedName: name, SideInfo: *si}, nil
 }
 
 func (f *fakeSnappyBackend) CopySnapData(newInfo, oldInfo *snap.Info, flags int) error {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -58,12 +58,13 @@ func (ss *SnapSetup) MountDir() string {
 
 // SnapState holds the state for a snap installed in the system.
 type SnapState struct {
-	Sequence             []*snap.SideInfo `json:"sequence"` // Last is current
-	Candidate            *snap.SideInfo   `josn:"candidate,omitempty"`
-	Active               bool             `json:"active,omitempty"`
-	Channel              string           `json:"channel,omitempty"`
-	DevMode              bool             `json:"dev-mode,omitempty"`
-	LastSideloadRevision int              `json:"last-sideload-revision,omitempty"`
+	Sequence      []*snap.SideInfo `json:"sequence"` // Last is current
+	Candidate     *snap.SideInfo   `josn:"candidate,omitempty"`
+	Active        bool             `json:"active,omitempty"`
+	Channel       string           `json:"channel,omitempty"`
+	DevMode       bool             `json:"dev-mode,omitempty"`
+	// incremented revision used for local installs
+	LocalRevision int              `json:"local-revision,omitempty"`
 }
 
 // Current returns the side info for the current revision in the snap revision sequence if there is one.
@@ -116,7 +117,7 @@ func Manager(s *state.State) (*SnapManager, error) {
 	return m, nil
 }
 
-const firstSideloadRevision = 100000
+const firstLocalRevision = 100001
 
 func (m *SnapManager) doPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
@@ -130,15 +131,15 @@ func (m *SnapManager) doPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	if ss.Revision == 0 { // sideloading
 		// to not clash with not sideload installs
 		// and to not have clashes between them
-		// use incremental revisions starting at 100000
+		// use incremental revisions starting at 100001
 		// for sideloads
-		revision := snapst.LastSideloadRevision
+		revision := snapst.LocalRevision
 		if revision == 0 {
-			revision = firstSideloadRevision
+			revision = firstLocalRevision
 		} else {
 			revision++
 		}
-		snapst.LastSideloadRevision = revision
+		snapst.LocalRevision = revision
 		ss.Revision = revision
 	}
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -58,13 +58,13 @@ func (ss *SnapSetup) MountDir() string {
 
 // SnapState holds the state for a snap installed in the system.
 type SnapState struct {
-	Sequence      []*snap.SideInfo `json:"sequence"` // Last is current
-	Candidate     *snap.SideInfo   `josn:"candidate,omitempty"`
-	Active        bool             `json:"active,omitempty"`
-	Channel       string           `json:"channel,omitempty"`
-	DevMode       bool             `json:"dev-mode,omitempty"`
+	Sequence  []*snap.SideInfo `json:"sequence"` // Last is current
+	Candidate *snap.SideInfo   `josn:"candidate,omitempty"`
+	Active    bool             `json:"active,omitempty"`
+	Channel   string           `json:"channel,omitempty"`
+	DevMode   bool             `json:"dev-mode,omitempty"`
 	// incremented revision used for local installs
-	LocalRevision int              `json:"local-revision,omitempty"`
+	LocalRevision int `json:"local-revision,omitempty"`
 }
 
 // Current returns the side info for the current revision in the snap revision sequence if there is one.

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -675,9 +675,9 @@ version: 1.0`)
 	c.Check(s.fakeBackend.ops[0].name, Matches, `.*/mock_1.0_all.snap`)
 
 	c.Check(s.fakeBackend.ops[3].op, Equals, "candidate")
-	c.Check(s.fakeBackend.ops[3].sinfo, DeepEquals, snap.SideInfo{Revision: 100000})
+	c.Check(s.fakeBackend.ops[3].sinfo, DeepEquals, snap.SideInfo{Revision: 100001})
 	c.Check(s.fakeBackend.ops[4].op, Equals, "link-snap")
-	c.Check(s.fakeBackend.ops[4].name, Equals, "/snap/mock/100000")
+	c.Check(s.fakeBackend.ops[4].name, Equals, "/snap/mock/100001")
 
 	// verify snapSetup info
 	var ss snapstate.SnapSetup
@@ -686,7 +686,7 @@ version: 1.0`)
 	c.Assert(err, IsNil)
 	c.Assert(ss, DeepEquals, snapstate.SnapSetup{
 		Name:     "mock",
-		Revision: 100000,
+		Revision: 100001,
 		SnapPath: mockSnap,
 	})
 
@@ -700,9 +700,9 @@ version: 1.0`)
 	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
 		OfficialName: "",
 		Channel:      "",
-		Revision:     100000,
+		Revision:     100001,
 	})
-	c.Assert(snapst.LastSideloadRevision, Equals, 100000)
+	c.Assert(snapst.LocalRevision, Equals, 100001)
 }
 
 func (s *snapmgrTestSuite) TestInstallSubequentLocalIntegration(c *C) {
@@ -710,9 +710,9 @@ func (s *snapmgrTestSuite) TestInstallSubequentLocalIntegration(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "mock", &snapstate.SnapState{
-		Active:               true,
-		Sequence:             []*snap.SideInfo{{Revision: 100002}},
-		LastSideloadRevision: 100002,
+		Active:        true,
+		Sequence:      []*snap.SideInfo{{Revision: 100002}},
+		LocalRevision: 100002,
 	})
 
 	mockSnap := makeTestSnap(c, `name: mock
@@ -768,6 +768,7 @@ version: 1.0`)
 		Channel:      "",
 		Revision:     100003,
 	})
+	c.Assert(snapst.LocalRevision, Equals, 100003)
 }
 
 func (s *snapmgrTestSuite) TestRemoveIntegration(c *C) {


### PR DESCRIPTION
This also fixes InstallPath to check whether there was a previous snap of the same name and do the proper unlinking etc...