### PR TITLE
overlord: make SnapState.DevMode a method, store flags

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -145,7 +145,7 @@ func setupSnapSecurity(task *state.Task, snapInfo *snap.Info, repo *interfaces.R
 		return err
 	}
 	for _, backend := range securityBackends {
-		if err := backend.Setup(snapInfo, snapState.DevMode, repo); err != nil {
+		if err := backend.Setup(snapInfo, snapState.DevMode(), repo); err != nil {
 			task.Errorf("cannot setup %s for snap %q: %s", backend.Name(), snapName, err)
 			return err
 		}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
-	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // SnapManager is responsible for the installation and removal of snaps.
@@ -57,13 +56,21 @@ func (ss *SnapSetup) MountDir() string {
 	return snap.MountDir(ss.Name, ss.Revision)
 }
 
+// SnapStateFlags are flags stored in SnapState.
+type SnapStateFlags int
+
+const (
+	// DevMode switches confinement to non-enforcing mode.
+	DevMode = 1 << iota
+)
+
 // SnapState holds the state for a snap installed in the system.
 type SnapState struct {
 	Sequence  []*snap.SideInfo `json:"sequence"` // Last is current
 	Candidate *snap.SideInfo   `json:"candidate,omitempty"`
 	Active    bool             `json:"active,omitempty"`
 	Channel   string           `json:"channel,omitempty"`
-	Flags     int              `json:"flags,omitempty"`
+	Flags     SnapStateFlags   `json:"flags,omitempty"`
 	// incremented revision used for local installs
 	LocalRevision int `json:"local-revision,omitempty"`
 }
@@ -79,7 +86,7 @@ func (snapst *SnapState) Current() *snap.SideInfo {
 
 // DevMode returns true if the snap is installed in developer mode.
 func (snapst *SnapState) DevMode() bool {
-	return snapst.Flags&int(snappy.DeveloperMode) != 0
+	return snapst.Flags&DevMode != 0
 }
 
 // Manager returns a new snap manager.

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // SnapManager is responsible for the installation and removal of snaps.
@@ -62,7 +63,7 @@ type SnapState struct {
 	Candidate *snap.SideInfo   `json:"candidate,omitempty"`
 	Active    bool             `json:"active,omitempty"`
 	Channel   string           `json:"channel,omitempty"`
-	DevMode   bool             `json:"dev-mode,omitempty"`
+	Flags     int              `json:"flags,omitempty"`
 	// incremented revision used for local installs
 	LocalRevision int `json:"local-revision,omitempty"`
 }
@@ -74,6 +75,11 @@ func (snapst *SnapState) Current() *snap.SideInfo {
 		return nil
 	}
 	return snapst.Sequence[n-1]
+}
+
+// DevMode returns true if the snap is installed in developer mode.
+func (snapst *SnapState) DevMode() bool {
+	return snapst.Flags&int(snappy.DeveloperMode) != 0
 }
 
 // Manager returns a new snap manager.

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -976,3 +976,14 @@ func (s *snapmgrQuerySuite) TestAllEmptyAndEmptyNormalisation(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(snapStates, HasLen, 0)
 }
+
+type snapStateSuite struct{}
+
+var _ = Suite(&snapStateSuite{})
+
+func (s *snapStateSuite) TestSnapStateDevMode(c *C) {
+	snapst := &snapstate.SnapState{}
+	c.Check(snapst.DevMode(), Equals, false)
+	snapst.Flags = int(snappy.DeveloperMode)
+	c.Check(snapst.DevMode(), Equals, true)
+}

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -984,6 +984,6 @@ var _ = Suite(&snapStateSuite{})
 func (s *snapStateSuite) TestSnapStateDevMode(c *C) {
 	snapst := &snapstate.SnapState{}
 	c.Check(snapst.DevMode(), Equals, false)
-	snapst.Flags = int(snappy.DeveloperMode)
+	snapst.Flags = snapstate.DevMode
 	c.Check(snapst.DevMode(), Equals, true)
 }


### PR DESCRIPTION
This branch stores DevMode as a flag instead of a dedicated field.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>