### PR TITLE
snap: validate similarly to what we did with old snapYaml info from squashfs snaps

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -120,7 +120,17 @@ func (s *Snap) Info() (*snap.Info, error) {
 		return nil, fmt.Errorf("info failed for %s: %s", s.path, err)
 	}
 
-	return snap.InfoFromSnapYaml(snapYaml)
+	info, err := snap.InfoFromSnapYaml(snapYaml)
+	if err != nil {
+		return nil, err
+	}
+
+	err = snap.Validate(info)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }
 
 // HashDigest computes a hash digest of the snap file using the given hash.

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -160,3 +160,13 @@ type: gadget`
 	c.Assert(info.Version, Equals, "1.0")
 	c.Assert(info.Type, Equals, snap.TypeGadget)
 }
+
+func (s *SquashfsTestSuite) TestInfoValidates(c *C) {
+	manifest := `name: foo.bar
+version: 1.0
+type: gadget`
+	snapF := makeSnap(c, manifest, "")
+
+	_, err := snapF.Info()
+	c.Assert(err, ErrorMatches, "invalid snap name.*")
+}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -38,6 +38,22 @@ func ValidateName(name string) error {
 
 // Validate verifies the content in the info.
 func Validate(info *Info) error {
+	name := info.Name()
+	if name == "" {
+		return fmt.Errorf("snap name cannot be empty")
+	}
+	err := ValidateName(name)
+	if err != nil {
+		return err
+	}
+
+	// validate app entries
+	for _, app := range info.Apps {
+		err := ValidateApp(app)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -91,3 +91,52 @@ func (s *ValidateSuite) TestAppWhitelistError(c *C) {
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, `app description field 'name' contains illegal "x\n" (legal: '^[A-Za-z0-9/. _#:-]*$')`)
 }
+
+// Validate
+
+func (s *ValidateSuite) TestDetectIllegalYamlBinaries(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+apps:
+ tes!me:
+   command: someething
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, NotNil)
+}
+
+func (s *ValidateSuite) TestDetectIllegalYamlService(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+apps:
+ tes!me:
+   command: something
+   daemon: forking
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, NotNil)
+}
+
+func (s *ValidateSuite) TestIllegalSnapName(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo.something
+version: 1.0
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, `invalid snap name: "foo.something"`)
+}
+
+func (s *ValidateSuite) TestValidateChecksName(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`
+version: 1.0
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, `snap name cannot be empty`)
+}

--- a/snappy/snap_yaml_test.go
+++ b/snappy/snap_yaml_test.go
@@ -21,6 +21,8 @@ package snappy
 
 import (
 	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 type snapYamlTestSuite struct {
@@ -38,6 +40,9 @@ plugs:
 	sy, err := parseSnapYamlData(snapYaml, false)
 	c.Assert(err, IsNil)
 	sy.Plugs["old-security"].Interface = "old-security"
+
+	_, err = snap.InfoFromSnapYaml(snapYaml)
+	c.Assert(err, IsNil)
 }
 
 func (s *snapYamlTestSuite) TestParseEmptyPlugDef(c *C) {
@@ -49,4 +54,8 @@ plugs:
 	sy, err := parseSnapYamlData(snapYaml, false)
 	c.Assert(err, IsNil)
 	sy.Plugs["unity7"].Interface = "unity7"
+
+	info, err := snap.InfoFromSnapYaml(snapYaml)
+	c.Assert(err, IsNil)
+	c.Check(info.Plugs["unity7"].Interface, Equals, "unity7")
 }


### PR DESCRIPTION
the tests are copies/ports of tests for parseSnapYamlData from snapp_test.go.

we can decide later to always validate in InfoFromSnapYaml itself.