### PR TITLE
overlord/ifacestate: add implicit slots in setup-profiles

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -176,6 +176,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	if err != nil {
 		return err
 	}
+	snap.AddImplicitSlots(snapInfo)
 	snapName := snapInfo.Name()
 
 	// The snap may have been updated so perform the following operation to

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -421,6 +421,32 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyKeepsExistingConnectionSt
 	})
 }
 
+// The setup-profiles task will add implicit slots necessary for the OS snap.
+func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
+	// Initialize the manager. This registers the two snaps.
+	mgr := s.manager(c)
+
+	// Add an OS snap.
+	snapInfo := s.mockSnap(c, osSnapYaml)
+
+	// Run the setup-snap-security task and let it finish.
+	change := s.addSetupSnapSecurityChange(c, snapInfo.Name())
+	mgr.Ensure()
+	mgr.Wait()
+	mgr.Stop()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Ensure that the task succeeded.
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	// Ensure that we have slots on the OS snap.
+	repo := mgr.Repository()
+	slots := repo.Slots(snapInfo.Name())
+	c.Assert(slots, HasLen, 16)
+}
+
 func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyReloadsConnectionsWhenInvokedOnPlugSide(c *C) {
 	s.testDoSetupSnapSecuirtyReloadsConnectionsWhenInvokedOn(c, "consumer")
 }

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -423,13 +423,13 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyKeepsExistingConnectionSt
 
 // The setup-profiles task will add implicit slots necessary for the OS snap.
 func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
-	// Initialize the manager. This registers the two snaps.
+	// Initialize the manager.
 	mgr := s.manager(c)
 
 	// Add an OS snap.
 	snapInfo := s.mockSnap(c, osSnapYaml)
 
-	// Run the setup-snap-security task and let it finish.
+	// Run the setup-profiles task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, snapInfo.Name())
 	mgr.Ensure()
 	mgr.Wait()


### PR DESCRIPTION
This patch ensures that setup-profile adds implicit slots. This allows
the bundled installation of the OS snap to succeed in adding the associated interfaces.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>