### PR TITLE
many: add support for developer mode

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -120,6 +120,7 @@ func (x *cmdRemove) Execute([]string) error {
 
 type cmdInstall struct {
 	Channel    string `long:"channel" description:"Install from this channel instead of the device's default"`
+	DevMode    bool   `long:"devmode" description:"Install the snap with non-enforcing security"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -131,7 +132,7 @@ func (x *cmdInstall) Execute([]string) error {
 
 	cli := Client()
 	name := x.Positional.Snap
-	opts := &client.SnapOptions{Channel: x.Channel}
+	opts := &client.SnapOptions{Channel: x.Channel, DevMode: x.DevMode}
 	if strings.Contains(name, "/") || strings.HasSuffix(name, ".snap") || strings.Contains(name, ".snap.") {
 		changeID, err = cli.InstallPath(name, opts)
 	} else {
@@ -146,6 +147,7 @@ func (x *cmdInstall) Execute([]string) error {
 
 type cmdRefresh struct {
 	Channel    string `long:"channel" description:"Refresh to the latest on this channel, and track this channel henceforth"`
+	DevMode    bool   `long:"devmode" description:"Refresh the snap with non-enforcing security"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -154,7 +156,7 @@ type cmdRefresh struct {
 func (x *cmdRefresh) Execute([]string) error {
 	cli := Client()
 	name := x.Positional.Snap
-	opts := &client.SnapOptions{Channel: x.Channel}
+	opts := &client.SnapOptions{Channel: x.Channel, DevMode: x.DevMode}
 	changeID, err := cli.Refresh(name, opts)
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -67,6 +67,44 @@ func (s *SnapSuite) TestInstall(c *check.C) {
 	c.Check(n, check.Equals, 3)
 }
 
+func (s *SnapSuite) TestInstallDevMode(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo.bar")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action":  "install",
+				"name":    "foo.bar",
+				"devmode": true,
+				"channel": "chan",
+			})
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+		default:
+			c.Fatalf("expected to get 3 requests, now on %d", n)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "chan", "--devmode", "foo.bar"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(n, check.Equals, 3)
+}
+
 func (s *SnapSuite) TestInstallPath(c *check.C) {
 	n := 0
 	snapBody := []byte("snap-data")
@@ -101,6 +139,49 @@ func (s *SnapSuite) TestInstallPath(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser().ParseArgs([]string{"install", snapPath})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(n, check.Equals, 3)
+}
+
+func (s *SnapSuite) TestInstallPathDevMode(c *check.C) {
+	n := 0
+	snapBody := []byte("snap-data")
+
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			postData, err := ioutil.ReadAll(r.Body)
+			c.Assert(err, check.IsNil)
+			c.Assert(string(postData), check.Matches, "(?s).*\r\nsnap-data\r\n.*")
+			c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"action\"\r\n\r\ninstall\r\n.*")
+			c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"devmode\"\r\n.*")
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+		default:
+			c.Fatalf("expected to get 3 requests, now on %d", n)
+		}
+
+		n++
+	})
+	snapPath := filepath.Join(c.MkDir(), "foo.snap")
+	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	c.Assert(err, check.IsNil)
+
+	rest, err := snap.Parser().ParseArgs([]string{"install", "--devmode", snapPath})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "")

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ubuntu-core/snappy/overlord/snapstate"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // InterfaceManager is responsible for the maintenance of interfaces in
@@ -178,6 +179,21 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	}
 	snap.AddImplicitSlots(snapInfo)
 	snapName := snapInfo.Name()
+	var snapState snapstate.SnapState
+	if err := snapstate.Get(task.State(), snapName, &snapState); err != nil {
+		task.Errorf("cannot get state of snap %q: %s", snapName, err)
+		return err
+	}
+
+	// Set DevMode flag if SnapSetup.Flags indicates it should be done
+	// but remember the old value in the task in case we undo.
+	task.Set("old-dev-mode", snapState.DevMode())
+	if ss.Flags&int(snappy.DeveloperMode) != 0 {
+		snapState.Flags |= snapstate.DevMode
+	} else {
+		snapState.Flags &= ^snapstate.DevMode
+	}
+	snapstate.Set(task.State(), snapName, &snapState)
 
 	// The snap may have been updated so perform the following operation to
 	// ensure that we are always working on the correct state:
@@ -278,21 +294,54 @@ func (m *InterfaceManager) autoConnect(task *state.Task, snapName string, blackl
 }
 
 func (m *InterfaceManager) doRemoveProfiles(task *state.Task, _ *tomb.Tomb) error {
-	task.State().Lock()
-	defer task.State().Unlock()
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
 
+	// Get SnapSetup for this snap. This is gives us the name of the snap.
 	snapSetup, err := snapstate.TaskSnapSetup(task)
 	if err != nil {
 		return err
 	}
 	snapName := snapSetup.Name
 
+	// Get SnapState for this snap
+	var snapState snapstate.SnapState
+	err = snapstate.Get(st, snapName, &snapState)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+
+	// Get the old-dev-mode flag from the task.
+	// This flag is set by setup-profiles in case we have to undo.
+	var oldDevMode bool
+	err = task.Get("old-dev-mode", &oldDevMode)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	// Restore the state of DevMode flag if old-dev-mode was saved in the task.
+	if err == nil {
+		if oldDevMode {
+			snapState.Flags |= snapstate.DevMode
+		} else {
+			snapState.Flags &= ^snapstate.DevMode
+		}
+		snapstate.Set(st, snapName, &snapState)
+	}
+
+	// Disconnect the snap entirely.
+	// This is required to remove the snap from the interface repository.
+	// The returned list of affected snaps will need to have its security setup
+	// to reflect the change.
 	affectedSnaps, err := m.repo.DisconnectSnap(snapName)
 	if err != nil {
 		return err
 	}
+
+	// Setup security of the affected snaps.
 	for _, snapInfo := range affectedSnaps {
 		if snapInfo.Name() == snapName {
+			// Skip setup for the snap being removed as this is handled below.
 			continue
 		}
 		if err := setupSnapSecurity(task, snapInfo, m.repo); err != nil {
@@ -300,9 +349,13 @@ func (m *InterfaceManager) doRemoveProfiles(task *state.Task, _ *tomb.Tomb) erro
 		}
 	}
 
+	// Remove the snap from the interface repository.
+	// This discards all the plugs and slots belonging to that snap.
 	if err := m.repo.RemoveSnap(snapName); err != nil {
 		return err
 	}
+
+	// Remove security artefacts of the snap.
 	if err := removeSnapSecurity(task, snapName); err != nil {
 		return state.Retry
 	}


### PR DESCRIPTION
This branch adds support for installing or refreshing a snap with ``--devmode``. This switches all security to non-enforcing mode which is useful for development.