### PR TITLE
cmd/snap,daemon,overlord/ifacestate: add support for developer mode

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -147,7 +147,6 @@ func (x *cmdInstall) Execute([]string) error {
 
 type cmdRefresh struct {
 	Channel    string `long:"channel" description:"Refresh to the latest on this channel, and track this channel henceforth"`
-	DevMode    bool   `long:"devmode" description:"Refresh the snap with non-enforcing security"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -156,7 +155,7 @@ type cmdRefresh struct {
 func (x *cmdRefresh) Execute([]string) error {
 	cli := Client()
 	name := x.Positional.Snap
-	opts := &client.SnapOptions{Channel: x.Channel, DevMode: x.DevMode}
+	opts := &client.SnapOptions{Channel: x.Channel}
 	changeID, err := cli.Refresh(name, opts)
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -120,6 +120,7 @@ func (x *cmdRemove) Execute([]string) error {
 
 type cmdInstall struct {
 	Channel    string `long:"channel" description:"Install from this channel instead of the device's default"`
+	DevMode    bool   `long:"devmode" description:"Install the snap with non-enforcing security"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -131,7 +132,7 @@ func (x *cmdInstall) Execute([]string) error {
 
 	cli := Client()
 	name := x.Positional.Snap
-	opts := &client.SnapOptions{Channel: x.Channel}
+	opts := &client.SnapOptions{Channel: x.Channel, DevMode: x.DevMode}
 	if strings.Contains(name, "/") || strings.HasSuffix(name, ".snap") || strings.Contains(name, ".snap.") {
 		changeID, err = cli.InstallPath(name, opts)
 	} else {
@@ -146,6 +147,7 @@ func (x *cmdInstall) Execute([]string) error {
 
 type cmdRefresh struct {
 	Channel    string `long:"channel" description:"Refresh to the latest on this channel, and track this channel henceforth"`
+	DevMode    bool   `long:"devmode" description:"Refresh the snap with non-enforcing security"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes" required:"yes"`
@@ -154,7 +156,7 @@ type cmdRefresh struct {
 func (x *cmdRefresh) Execute([]string) error {
 	cli := Client()
 	name := x.Positional.Snap
-	opts := &client.SnapOptions{Channel: x.Channel}
+	opts := &client.SnapOptions{Channel: x.Channel, DevMode: x.DevMode}
 	changeID, err := cli.Refresh(name, opts)
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -67,6 +67,44 @@ func (s *SnapSuite) TestInstall(c *check.C) {
 	c.Check(n, check.Equals, 3)
 }
 
+func (s *SnapSuite) TestInstallDevMode(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo.bar")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action":  "install",
+				"name":    "foo.bar",
+				"devmode": true,
+				"channel": "chan",
+			})
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+		default:
+			c.Fatalf("expected to get 3 requests, now on %d", n)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "chan", "--devmode", "foo.bar"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(n, check.Equals, 3)
+}
+
 func (s *SnapSuite) TestInstallPath(c *check.C) {
 	n := 0
 	snapBody := []byte("snap-data")
@@ -80,6 +118,7 @@ func (s *SnapSuite) TestInstallPath(c *check.C) {
 			c.Assert(err, check.IsNil)
 			c.Assert(string(postData), check.Matches, "(?s).*\r\nsnap-data\r\n.*")
 			c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"action\"\r\n\r\ninstall\r\n.*")
+			c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"devmode\"\r\n\r\nfalse\r\n.*")
 			w.WriteHeader(http.StatusAccepted)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 1:
@@ -101,6 +140,49 @@ func (s *SnapSuite) TestInstallPath(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser().ParseArgs([]string{"install", snapPath})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(n, check.Equals, 3)
+}
+
+func (s *SnapSuite) TestInstallPathDevMode(c *check.C) {
+	n := 0
+	snapBody := []byte("snap-data")
+
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			postData, err := ioutil.ReadAll(r.Body)
+			c.Assert(err, check.IsNil)
+			c.Assert(string(postData), check.Matches, "(?s).*\r\nsnap-data\r\n.*")
+			c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"action\"\r\n\r\ninstall\r\n.*")
+			c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"devmode\"\r\n\r\ntrue\r\n.*")
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+		default:
+			c.Fatalf("expected to get 3 requests, now on %d", n)
+		}
+
+		n++
+	})
+	snapPath := filepath.Join(c.MkDir(), "foo.snap")
+	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	c.Assert(err, check.IsNil)
+
+	rest, err := snap.Parser().ParseArgs([]string{"install", "--devmode", snapPath})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "")

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -799,13 +799,9 @@ func sideloadSnap(c *Command, r *http.Request) Response {
 	}
 
 	var flags snappy.InstallFlags
-	for _, value := range form.Value["devmode"] {
-		switch value {
-		case "true":
-			flags = snappy.DeveloperMode
-		case "false":
-			flags = 0
-		}
+
+	if len(form.Value["devmode"]) > 0 && form.Value["devmode"][0] == "true" {
+		flags |= snappy.DeveloperMode
 	}
 
 	// form.File is a map of arrays of *FileHeader things

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -610,9 +610,6 @@ func (inst *snapInstruction) update() (*state.Change, error) {
 	if inst.Channel != "stable" {
 		msg = fmt.Sprintf(i18n.G("Update %q snap from %q channel"), inst.pkg, inst.Channel)
 	}
-	if inst.DevMode {
-		flags |= snappy.DeveloperMode
-	}
 	chg := state.NewChange("update-snap", msg)
 	ts, err := snapstate.Update(state, inst.pkg, inst.Channel, flags)
 	if err == nil {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1135,10 +1135,33 @@ func (o *fakeOverlord) Configure(s *snappy.Snap, c []byte) ([]byte, error) {
 
 func (s *apiSuite) TestSideloadSnap(c *check.C) {
 	// try a multipart/form-data upload
-	s.sideloadCheck(c, "----hello--\r\nContent-Disposition: form-data; name=\"x\"; filename=\"x\"\r\n\r\nxyzzy\r\n----hello----\r\n", map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"})
+	body := "" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"x\"; filename=\"x\"\r\n" +
+		"\r\n" +
+		"xyzzy\r\n" +
+		"----hello--\r\n"
+	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+	s.sideloadCheck(c, body, head, 0)
 }
 
-func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]string) {
+func (s *apiSuite) TestSideloadSnapDevMode(c *check.C) {
+	body := "" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"x\"; filename=\"x\"\r\n" +
+		"\r\n" +
+		"xyzzy\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"devmode\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n"
+	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+	// try a multipart/form-data upload
+	s.sideloadCheck(c, body, head, snappy.DeveloperMode)
+}
+
+func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]string, expectedFlags snappy.InstallFlags) {
 	d := newTestDaemon(c)
 	d.overlord.Loop()
 	defer d.overlord.Stop()
@@ -1151,14 +1174,14 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]str
 	c.Check(err, check.IsNil)
 
 	// setup done
-	var expectedFlags snappy.InstallFlags
-
 	installQueue := []string{}
 	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
 		// pretend we do not have a state for ubuntu-core
 		return state.ErrNoState
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
+		// NOTE: ubuntu-core is not installed in developer mode
+		c.Check(flags, check.Equals, snappy.InstallFlags(0))
 		installQueue = append(installQueue, name)
 
 		t := s.NewTask("fake-install-snap", "Doing a fake install")
@@ -1185,9 +1208,9 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]str
 
 	rsp := sideloadSnap(snapsCmd, req).(*resp)
 	c.Check(rsp.Type, check.Equals, ResponseTypeAsync)
-	c.Check(installQueue, check.HasLen, 2)
-	c.Assert(installQueue[0], check.Equals, "ubuntu-core")
-	c.Assert(installQueue[1], check.Matches, ".*/snapd-sideload-pkg-.*")
+	c.Assert(installQueue, check.HasLen, 2)
+	c.Check(installQueue[0], check.Equals, "ubuntu-core")
+	c.Check(installQueue[1], check.Matches, ".*/snapd-sideload-pkg-.*")
 }
 
 func (s *apiSuite) TestAppIconGet(c *check.C) {
@@ -1422,6 +1445,33 @@ func (s *apiSuite) TestInstallLeaveOld(c *check.C) {
 
 	c.Check(calledFlags, check.Equals, snappy.InstallFlags(0))
 	c.Check(err, check.IsNil)
+}
+
+func (s *apiSuite) TestInstallDevMode(c *check.C) {
+	var calledFlags snappy.InstallFlags
+
+	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
+		calledFlags = flags
+
+		t := s.NewTask("fake-install-snap", "Doing a fake install")
+		return state.NewTaskSet(t), nil
+	}
+
+	d := s.daemon(c)
+	inst := &snapInstruction{
+		overlord: d.overlord,
+		Action:   "install",
+		// Install the snap in developer mode
+		DevMode: true,
+	}
+
+	d.overlord.Loop()
+	defer d.overlord.Stop()
+	_, err := inst.dispatch()()
+	c.Check(err, check.IsNil)
+
+	// DevMode was converted to the snappy.DeveloperMode flag
+	c.Check(calledFlags&snappy.DeveloperMode, check.Equals, snappy.DeveloperMode)
 }
 
 func snapList(rawSnaps interface{}) []map[string]interface{} {

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -187,7 +187,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 
 	// Set DevMode flag if SnapSetup.Flags indicates it should be done
 	// but remember the old value in the task in case we undo.
-	task.Set("old-dev-mode", snapState.DevMode())
+	task.Set("old-devmode", snapState.DevMode())
 	if ss.Flags&int(snappy.DeveloperMode) != 0 {
 		snapState.Flags |= snapstate.DevMode
 	} else {
@@ -312,14 +312,14 @@ func (m *InterfaceManager) doRemoveProfiles(task *state.Task, _ *tomb.Tomb) erro
 		return err
 	}
 
-	// Get the old-dev-mode flag from the task.
+	// Get the old-devmode flag from the task.
 	// This flag is set by setup-profiles in case we have to undo.
 	var oldDevMode bool
-	err = task.Get("old-dev-mode", &oldDevMode)
+	err = task.Get("old-devmode", &oldDevMode)
 	if err != nil && err != state.ErrNoState {
 		return err
 	}
-	// Restore the state of DevMode flag if old-dev-mode was saved in the task.
+	// Restore the state of DevMode flag if old-devmode was saved in the task.
 	if err == nil {
 		if oldDevMode {
 			snapState.Flags |= snapstate.DevMode

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -38,7 +38,6 @@ import (
 	"github.com/ubuntu-core/snappy/overlord/snapstate"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
-	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // InterfaceManager is responsible for the maintenance of interfaces in
@@ -188,7 +187,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	// Set DevMode flag if SnapSetup.Flags indicates it should be done
 	// but remember the old value in the task in case we undo.
 	task.Set("old-devmode", snapState.DevMode())
-	if ss.Flags&int(snappy.DeveloperMode) != 0 {
+	if ss.DevMode() {
 		snapState.Flags |= snapstate.DevMode
 	} else {
 		snapState.Flags &= ^snapstate.DevMode

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ubuntu-core/snappy/overlord/snapstate"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 // InterfaceManager is responsible for the maintenance of interfaces in
@@ -178,6 +179,21 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	}
 	snap.AddImplicitSlots(snapInfo)
 	snapName := snapInfo.Name()
+	var snapState snapstate.SnapState
+	if err := snapstate.Get(task.State(), snapName, &snapState); err != nil {
+		task.Errorf("cannot get state of snap %q: %s", snapName, err)
+		return err
+	}
+
+	// Set DevMode flag if SnapSetup.Flags indicates it should be done
+	// but remember the old value in the task in case we undo.
+	task.Set("old-dev-mode", snapState.DevMode())
+	if ss.Flags&int(snappy.DeveloperMode) != 0 {
+		snapState.Flags |= snapstate.DevMode
+	} else {
+		snapState.Flags &= ^snapstate.DevMode
+	}
+	snapstate.Set(task.State(), snapName, &snapState)
 
 	// The snap may have been updated so perform the following operation to
 	// ensure that we are always working on the correct state:
@@ -278,21 +294,54 @@ func (m *InterfaceManager) autoConnect(task *state.Task, snapName string, blackl
 }
 
 func (m *InterfaceManager) doRemoveProfiles(task *state.Task, _ *tomb.Tomb) error {
-	task.State().Lock()
-	defer task.State().Unlock()
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
 
+	// Get SnapSetup for this snap. This is gives us the name of the snap.
 	snapSetup, err := snapstate.TaskSnapSetup(task)
 	if err != nil {
 		return err
 	}
 	snapName := snapSetup.Name
 
+	// Get SnapState for this snap
+	var snapState snapstate.SnapState
+	err = snapstate.Get(st, snapName, &snapState)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+
+	// Get the old-dev-mode flag from the task.
+	// This flag is set by setup-profiles in case we have to undo.
+	var oldDevMode bool
+	err = task.Get("old-dev-mode", &oldDevMode)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	// Restore the state of DevMode flag if old-dev-mode was saved in the task.
+	if err == nil {
+		if oldDevMode {
+			snapState.Flags |= snapstate.DevMode
+		} else {
+			snapState.Flags &= ^snapstate.DevMode
+		}
+		snapstate.Set(st, snapName, &snapState)
+	}
+
+	// Disconnect the snap entirely.
+	// This is required to remove the snap from the interface repository.
+	// The returned list of affected snaps will need to have its security setup
+	// to reflect the change.
 	affectedSnaps, err := m.repo.DisconnectSnap(snapName)
 	if err != nil {
 		return err
 	}
+
+	// Setup security of the affected snaps.
 	for _, snapInfo := range affectedSnaps {
 		if snapInfo.Name() == snapName {
+			// Skip setup for the snap being removed as this is handled below.
 			continue
 		}
 		if err := setupSnapSecurity(task, snapInfo, m.repo); err != nil {
@@ -300,9 +349,13 @@ func (m *InterfaceManager) doRemoveProfiles(task *state.Task, _ *tomb.Tomb) erro
 		}
 	}
 
+	// Remove the snap from the interface repository.
+	// This discards all the plugs and slots belonging to that snap.
 	if err := m.repo.RemoveSnap(snapName); err != nil {
 		return err
 	}
+
+	// Remove security artefacts of the snap.
 	if err := removeSnapSecurity(task, snapName); err != nil {
 		return state.Retry
 	}

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -494,7 +494,7 @@ func (s *interfaceManagerSuite) testDoSetupSnapSecuirtyReloadsConnectionsWhenInv
 // The setup-profiles task will honor snappy.DeveloperMode flag by storing it
 // in the SnapState.Flags (as DevMode) and by actually setting up security
 // using that flag. Old copy of SnapState.Flag's DevMode is saved for the undo
-// handler under `old-dev-mode`.
+// handler under `old-devmode`.
 func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 	// Put the OS snap in place.
 	mgr := s.manager(c)
@@ -530,12 +530,12 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 	// The old value of DevMode was saved in the task in case undo is needed.
 	task := change.Tasks()[0]
 	var oldDevMode bool
-	err = task.Get("old-dev-mode", &oldDevMode)
+	err = task.Get("old-devmode", &oldDevMode)
 	c.Assert(err, IsNil)
 	c.Check(oldDevMode, Equals, false)
 }
 
-// The undo handler of the setup-profiles task will honor `old-dev-mode` that
+// The undo handler of the setup-profiles task will honor `old-devmode` that
 // is optionally stored in the task state and use it to set the DevMode flag in
 // the SnapState.
 //
@@ -544,7 +544,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesUndoDevModeTrue(c *C) {
 	s.undoDevModeCheck(c, snappy.InstallFlags(0), true)
 }
 
-// The undo handler of the setup-profiles task will honor `old-dev-mode` that
+// The undo handler of the setup-profiles task will honor `old-devmode` that
 // is optionally stored in the task state and use it to set the DevMode flag in
 // the SnapState.
 //
@@ -566,7 +566,7 @@ func (s *interfaceManagerSuite) undoDevModeCheck(c *C, flags snappy.InstallFlags
 	s.state.Lock()
 	task := change.Tasks()[0]
 	// Inject the old value of DevMode flag for the task handler to restore
-	task.Set("old-dev-mode", devMode)
+	task.Set("old-devmode", devMode)
 	task.SetStatus(state.UndoStatus)
 	s.state.Unlock()
 	mgr.Ensure()

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ubuntu-core/snappy/overlord/snapstate"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snappy"
 )
 
 func TestInterfaceManager(t *testing.T) { TestingT(t) }
@@ -224,12 +225,12 @@ func (s *interfaceManagerSuite) mockSnap(c *C, yamlText string) *snap.Info {
 	return snapInfo
 }
 
-func (s *interfaceManagerSuite) addSetupSnapSecurityChange(c *C, snapName string) *state.Change {
+func (s *interfaceManagerSuite) addSetupSnapSecurityChange(c *C, snapName string, flags snappy.InstallFlags) *state.Change {
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	task := s.state.NewTask("setup-profiles", "")
-	ss := snapstate.SnapSetup{Name: snapName}
+	ss := snapstate.SnapSetup{Name: snapName, Flags: int(flags)}
 	task.Set("snap-setup", ss)
 	taskset := state.NewTaskSet(task)
 	change := s.state.NewChange("test", "")
@@ -308,7 +309,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsDisconnect(c *C) {
 	mgr := s.manager(c)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, snapInfo.Name())
+	change := s.addSetupSnapSecurityChange(c, snapInfo.Name(), snappy.InstallFlags(0))
 	mgr.Ensure()
 	mgr.Wait()
 	mgr.Stop()
@@ -344,7 +345,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyAutoConnects(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, snapInfo.Name())
+	change := s.addSetupSnapSecurityChange(c, snapInfo.Name(), snappy.InstallFlags(0))
 	mgr.Ensure()
 	mgr.Wait()
 	mgr.Stop()
@@ -394,7 +395,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyKeepsExistingConnectionSt
 	s.state.Unlock()
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, snapInfo.Name())
+	change := s.addSetupSnapSecurityChange(c, snapInfo.Name(), snappy.InstallFlags(0))
 	mgr.Ensure()
 	mgr.Wait()
 	mgr.Stop()
@@ -430,7 +431,7 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
 	snapInfo := s.mockSnap(c, osSnapYaml)
 
 	// Run the setup-profiles task and let it finish.
-	change := s.addSetupSnapSecurityChange(c, snapInfo.Name())
+	change := s.addSetupSnapSecurityChange(c, snapInfo.Name(), snappy.InstallFlags(0))
 	mgr.Ensure()
 	mgr.Wait()
 	mgr.Stop()
@@ -469,7 +470,7 @@ func (s *interfaceManagerSuite) testDoSetupSnapSecuirtyReloadsConnectionsWhenInv
 	mgr := s.manager(c)
 
 	// Run the setup-profiles task
-	change := s.addSetupSnapSecurityChange(c, snapName)
+	change := s.addSetupSnapSecurityChange(c, snapName, snappy.InstallFlags(0))
 	mgr.Ensure()
 	mgr.Wait()
 	mgr.Stop()

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ubuntu-core/snappy/overlord/auth"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snappy"
 	"github.com/ubuntu-core/snappy/store"
 )
 
@@ -57,6 +58,10 @@ func (ss *SnapSetup) placeInfo() snap.PlaceInfo {
 
 func (ss *SnapSetup) MountDir() string {
 	return snap.MountDir(ss.Name, ss.Revision)
+}
+
+func (ss *SnapSetup) DevMode() bool {
+	return ss.Flags&int(snappy.DeveloperMode) != 0
 }
 
 // SnapStateFlags are flags stored in SnapState.

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -1050,3 +1050,14 @@ func (s *snapStateSuite) TestSnapStateDevMode(c *C) {
 	snapst.Flags = snapstate.DevMode
 	c.Check(snapst.DevMode(), Equals, true)
 }
+
+type snapSetupSuite struct{}
+
+var _ = Suite(&snapSetupSuite{})
+
+func (s *snapSetupSuite) TestDevMode(c *C) {
+	ss := &snapstate.SnapSetup{}
+	c.Check(ss.DevMode(), Equals, false)
+	ss.Flags = int(snappy.DeveloperMode)
+	c.Check(ss.DevMode(), Equals, true)
+}


### PR DESCRIPTION
This branch adds support for installing or refreshing a snap with --devmode. This switches all security to non-enforcing mode which is useful for development.
