### PR TITLE
cmd/snap: improve UX of snap interfaces when there are no results

### DIFF
--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -63,6 +63,9 @@ func init() {
 func (x *cmdInterfaces) Execute(args []string) error {
 	ifaces, err := Client().Interfaces()
 	if err == nil {
+		if len(ifaces.Plugs) == 0 && len(ifaces.Slots) == 0 {
+			return fmt.Errorf(i18n.G("no interfaces found"))
+		}
 		w := tabwriter.NewWriter(Stdout, 0, 4, 1, ' ', 0)
 		fmt.Fprintln(w, i18n.G("slot\tplug"))
 		defer w.Flush()

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -485,3 +485,24 @@ func (s *SnapSuite) TestInterfacesOfSpecificSnapAndSlot(c *C) {
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
+
+func (s *SnapSuite) TestInterfacesNothingAtAll(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v2/interfaces")
+		body, err := ioutil.ReadAll(r.Body)
+		c.Check(err, IsNil)
+		c.Check(body, DeepEquals, []byte{})
+		EncodeResponseBody(c, w, map[string]interface{}{
+			"type":   "sync",
+			"result": client.Interfaces{},
+		})
+	})
+	rest, err := Parser().ParseArgs([]string{"interfaces"})
+	c.Assert(err, ErrorMatches, "no interfaces found")
+	// XXX: not sure why this is returned, I guess that's what happens when a
+	// command Execute returns an error.
+	c.Assert(rest, DeepEquals, []string{"interfaces"})
+	c.Assert(s.Stdout(), Equals, "")
+	c.Assert(s.Stderr(), Equals, "")
+}

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-15 18:01-0300\n"
+        "POT-Creation-Date: 2016-04-16 13:58+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -307,6 +307,9 @@ msgid   "\n"
         "\n"
         "The home directory is shared between snappy and the classic dimension.\n"
         "Run \"exit\" to leave the classic shell.\n"
+msgstr  ""
+
+msgid   "no interfaces found"
 msgstr  ""
 
 msgid   "no snaps found"


### PR DESCRIPTION
Before the user installs the first snap the output of "snap interfaces"
is literally "slot plug" which is rather meaningless to an inexperienced
user. This patch changes that to behave the same way as "snap list"
does, by printing a simple message.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>