### PR TITLE
daemon: don't install ubuntu-core twice

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -570,10 +570,13 @@ func (inst *snapInstruction) install() (*state.Change, error) {
 	st := inst.overlord.State()
 	st.Lock()
 	chg := st.NewChange("install-snap", msg)
-	err := ensureUbuntuCore(chg, inst.userID)
-	if err == nil {
-		err = installSnap(chg, inst.pkg, inst.Channel, inst.userID, flags)
+	if inst.pkg != "ubuntu-core" {
+		if err := ensureUbuntuCore(chg, inst.userID); err != nil {
+			st.Unlock()
+			return nil, err
+		}
 	}
+	err := installSnap(chg, inst.pkg, inst.Channel, inst.userID, flags)
 	st.Unlock()
 	if err != nil {
 		return nil, err

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1374,6 +1374,43 @@ func (s *apiSuite) TestInstallMissingUbuntuCore(c *check.C) {
 	c.Check(installQueue[3].WaitTasks(), check.HasLen, 2)
 }
 
+// Installing ubuntu-core when not having ubuntu-core doesn't misbehave and try
+// to install ubuntu-core twice.
+func (s *apiSuite) TestInstallUbuntuCoreWhenMissing(c *check.C) {
+	installQueue := []*state.Task{}
+
+	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
+		// pretend we do not have a state for ubuntu-core
+		return state.ErrNoState
+	}
+	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
+		t1 := s.NewTask("fake-install-snap", name)
+		t2 := s.NewTask("fake-install-snap", "second task is just here so that we can check that the wait is correctly added to all tasks")
+		installQueue = append(installQueue, t1, t2)
+		return state.NewTaskSet(t1, t2), nil
+	}
+
+	d := s.daemon(c)
+	inst := &snapInstruction{
+		overlord: d.overlord,
+		Action:   "install",
+		pkg:      "ubuntu-core",
+	}
+
+	d.overlord.Loop()
+	defer d.overlord.Stop()
+	_, err := inst.dispatch()()
+	c.Check(err, check.IsNil)
+
+	d.overlord.State().Lock()
+	defer d.overlord.State().Unlock()
+	c.Check(installQueue, check.HasLen, 2)
+	// the only "ubuntu-core" install tasks
+	c.Check(installQueue[0].Summary(), check.Equals, "ubuntu-core")
+	c.Check(installQueue[0].WaitTasks(), check.HasLen, 0)
+	c.Check(installQueue[1].WaitTasks(), check.HasLen, 0)
+}
+
 func (s *apiSuite) TestInstallFails(c *check.C) {
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
 		t := s.NewTask("fake-install-snap-error", "Install task")


### PR DESCRIPTION
This patch fixes a bug that would render snappy inoperable if the user
tried to install ubuntu-core as the fist snap on the system. Before this
patch the logic in the daemon would enqueue the install twice which
would break all other install/remove operations.

Tested locally with unit tests and real clean-state install.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>