### PR TITLE
overlord: don't hold locks when callling backends

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -52,15 +52,8 @@ type fakeSnappyBackend struct {
 	linkSnapFailTrigger string
 }
 
-func (f *fakeSnappyBackend) InstallLocal(path string, flags int, p progress.Meter) error {
-	f.ops = append(f.ops, fakeOp{
-		op:   "install-local",
-		name: path,
-	})
-	return nil
-}
-
 func (f *fakeSnappyBackend) Download(name, channel string, checker func(*snap.Info) error, p progress.Meter, auther store.Authenticator) (*snap.Info, string, error) {
+	p.Notify("download")
 	var macaroon string
 	if auther != nil {
 		macaroon = auther.(*auth.MacaroonAuthenticator).Macaroon
@@ -186,6 +179,7 @@ func (f *fakeSnappyBackend) CanRemove(info *snap.Info, active bool) bool {
 }
 
 func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, meter progress.Meter) error {
+	meter.Notify("unlink")
 	f.ops = append(f.ops, fakeOp{
 		op:   "unlink-snap",
 		name: info.MountDir(),
@@ -194,6 +188,7 @@ func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, meter progress.Meter) er
 }
 
 func (f *fakeSnappyBackend) RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error {
+	meter.Notify("remove-snap-files")
 	f.ops = append(f.ops, fakeOp{
 		op:   "remove-snap-files",
 		name: s.MountDir(),
@@ -205,15 +200,6 @@ func (f *fakeSnappyBackend) RemoveSnapData(info *snap.Info) error {
 	f.ops = append(f.ops, fakeOp{
 		op:   "remove-snap-data",
 		name: info.MountDir(),
-	})
-	return nil
-}
-
-func (f *fakeSnappyBackend) GarbageCollect(name string, flags int, meter progress.Meter) error {
-	f.ops = append(f.ops, fakeOp{
-		op:    "garbage-collect",
-		name:  name,
-		flags: flags,
 	})
 	return nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -247,9 +247,6 @@ func (m *SnapManager) doUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	st := t.State()
 
-	// Hold the lock for the full duration of the task here so
-	// nobody observes a world where the state engine and
-	// the file system are reporting different things.
 	st.Lock()
 	defer st.Unlock()
 
@@ -264,7 +261,9 @@ func (m *SnapManager) doUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	pb := &TaskProgressAdapter{task: t}
+	st.Unlock() // pb itself will ask for locking
 	err = m.backend.UnlinkSnap(info, pb)
+	st.Lock()
 	if err != nil {
 		return err
 	}
@@ -303,7 +302,6 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	st.Lock()
 	if len(snapst.Sequence) == 1 {
 		snapst.Sequence = nil
 	} else {
@@ -317,7 +315,6 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		}
 		snapst.Sequence = newSeq
 	}
-	st.Unlock()
 
 	pb := &TaskProgressAdapter{task: t}
 	err = m.backend.RemoveSnapFiles(ss.placeInfo(), pb)
@@ -425,9 +422,6 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 
-	// Hold the lock for the full duration of the task here so
-	// nobody observes a world where the state engine and
-	// the file system are reporting different things.
 	st.Lock()
 	defer st.Unlock()
 
@@ -442,7 +436,9 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	snapst.Active = true
+	st.Unlock()
 	err = m.backend.LinkSnap(oldInfo)
+	st.Lock()
 	if err != nil {
 		return err
 	}
@@ -456,9 +452,6 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 
-	// Hold the lock for the full duration of the task here so
-	// nobody observes a world where the state engine and
-	// the file system are reporting different things.
 	st.Lock()
 	defer st.Unlock()
 
@@ -475,7 +468,9 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.Active = false
 
 	pb := &TaskProgressAdapter{task: t}
+	st.Unlock() // pb itself will ask for locking
 	err = m.backend.UnlinkSnap(oldInfo, pb)
+	st.Lock()
 	if err != nil {
 		return err
 	}
@@ -530,9 +525,6 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 
-	// Hold the lock for the full duration of the task here so
-	// nobody observes a world where the state engine and
-	// the file system are reporting different things.
 	st.Lock()
 	defer st.Unlock()
 
@@ -557,7 +549,9 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	st.Unlock()
 	err = m.backend.LinkSnap(newInfo)
+	st.Lock()
 	if err != nil {
 		return err
 	}
@@ -571,9 +565,6 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 
-	// Hold the lock for the full duration of the task here so
-	// nobody observes a world where the state engine and
-	// the file system are reporting different things.
 	st.Lock()
 	defer st.Unlock()
 
@@ -601,7 +592,9 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	pb := &TaskProgressAdapter{task: t}
+	st.Unlock() // pb itself will ask for locking
 	err = m.backend.UnlinkSnap(newInfo, pb)
+	st.Lock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes some actual deadlock when the backend where trying to notify/use the TaskProgressAdapter.