### PR TITLE
client,daemon,overlord: fix authentication

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -158,8 +158,10 @@ func (client *Client) doSync(method, path string, query url.Values, headers map[
 		return nil, fmt.Errorf("expected sync response, got %q", rsp.Type)
 	}
 
-	if err := json.Unmarshal(rsp.Result, v); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal: %v", err)
+	if v != nil {
+		if err := json.Unmarshal(rsp.Result, v); err != nil {
+			return nil, fmt.Errorf("cannot unmarshal: %v", err)
+		}
 	}
 
 	return &rsp.ResultInfo, nil

--- a/client/login.go
+++ b/client/login.go
@@ -103,3 +103,9 @@ func readAuthData() (*User, error) {
 
 	return &user, nil
 }
+
+// removeAuthData removes any previously written authentication details.
+func removeAuthData() error {
+	filename := storeAuthDataFilename()
+	return os.Remove(filename)
+}

--- a/client/logout.go
+++ b/client/logout.go
@@ -19,8 +19,11 @@
 
 package client
 
-// Logout logs the user out
+// Logout logs the user out.
 func (client *Client) Logout() error {
 	_, err := client.doSync("POST", "/v2/logout", nil, nil, nil, nil)
-	return err
+	if err != nil {
+		return err
+	}
+	return removeAuthData()
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -250,7 +250,7 @@ func UserFromRequest(st *state.State, req *http.Request) (*auth.UserState, error
 	// extract macaroons data from request
 	header := req.Header.Get("Authorization")
 	if header == "" {
-		return nil, errNoAuth
+		return nil, auth.ErrInvalidAuth
 	}
 
 	authorizationData := strings.SplitN(header, " ", 2)
@@ -308,7 +308,7 @@ func getSnapInfo(c *Command, r *http.Request) Response {
 	}
 
 	auther, err := c.d.auther(r)
-	if err != nil && err != errNoAuth {
+	if err != nil && err != auth.ErrInvalidAuth {
 		return InternalError("%v", err)
 	}
 
@@ -404,7 +404,7 @@ func getSnapsInfo(c *Command, r *http.Request) Response {
 		remoteRepo := newRemoteRepo()
 
 		auther, err := c.d.auther(r)
-		if err != nil && err != errNoAuth {
+		if err != nil && err != auth.ErrInvalidAuth {
 			return InternalError("%v", err)
 		}
 
@@ -775,7 +775,7 @@ func postSnap(c *Command, r *http.Request) Response {
 
 	if err == nil {
 		inst.userID = user.ID
-	} else if err != errNoAuth {
+	} else if err != auth.ErrInvalidAuth {
 		return InternalError("%v", err)
 	}
 
@@ -867,7 +867,7 @@ out:
 	user, err := UserFromRequest(state, r)
 	if err == nil {
 		userID = user.ID
-	} else if err != errNoAuth {
+	} else if err != auth.ErrInvalidAuth {
 		return InternalError("%v", err)
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -679,7 +679,7 @@ func (s *apiSuite) TestUserFromRequestNoHeader(c *check.C) {
 	user, err := UserFromRequest(state, req)
 	state.Unlock()
 
-	c.Check(err, check.Equals, errNoAuth)
+	c.Check(err, check.Equals, auth.ErrInvalidAuth)
 	c.Check(user, check.IsNil)
 }
 
@@ -718,7 +718,7 @@ func (s *apiSuite) TestUserFromRequestHeaderCorrectMissingUser(c *check.C) {
 	user, err := UserFromRequest(state, req)
 	state.Unlock()
 
-	c.Check(err, check.IsNil)
+	c.Check(err, check.Equals, auth.ErrInvalidAuth)
 	c.Check(user, check.IsNil)
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -20,7 +20,6 @@
 package daemon
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -235,21 +234,16 @@ func (d *Daemon) Dying() <-chan struct{} {
 	return d.tomb.Dying()
 }
 
-var errNoAuth = errors.New("no authorization data provided")
-
 func (d *Daemon) auther(r *http.Request) (store.Authenticator, error) {
 	overlord := d.overlord
 	state := overlord.State()
 	state.Lock()
 	user, err := UserFromRequest(state, r)
 	state.Unlock()
-
-	if err == nil {
-		return user.Authenticator(), nil
-	} else if err != errNoAuth {
+	if err != nil {
 		return nil, err
 	}
-	return nil, errNoAuth
+	return user.Authenticator(), nil
 }
 
 // New Daemon

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -214,7 +214,7 @@ func (s *daemonSuite) TestAutherNoAuth(c *check.C) {
 	d := newTestDaemon(c)
 	user, err := d.auther(req)
 
-	c.Check(err, check.ErrorMatches, errNoAuth.Error())
+	c.Check(err, check.Equals, auth.ErrInvalidAuth)
 	c.Check(user, check.IsNil)
 }
 

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -101,7 +101,6 @@ func User(st *state.State, id int) (*UserState, error) {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
-
 	if err != nil {
 		return nil, err
 	}
@@ -114,12 +113,14 @@ func User(st *state.State, id int) (*UserState, error) {
 	return nil, fmt.Errorf("invalid user")
 }
 
+var ErrInvalidAuth = fmt.Errorf("invalid authentication")
+
 // CheckMacaroon returns the UserState for the given macaroon/discharges credentials
 func CheckMacaroon(st *state.State, macaroon string, discharges []string) (*UserState, error) {
 	var authStateData AuthState
 	err := st.Get("auth", &authStateData)
 	if err != nil {
-		return nil, nil
+		return nil, ErrInvalidAuth
 	}
 
 NextUser:
@@ -139,7 +140,7 @@ NextUser:
 		}
 		return &user, nil
 	}
-	return nil, fmt.Errorf("invalid authentication")
+	return nil, ErrInvalidAuth
 }
 
 // Authenticator returns MacaroonAuthenticator for current authenticated user represented by UserState

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -128,21 +128,28 @@ func (as *authSuite) TestCheckMacaroonNoAuthData(c *C) {
 	user, err := auth.CheckMacaroon(as.state, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 
-	c.Check(err, IsNil)
+	c.Check(err, Equals, auth.ErrInvalidAuth)
 	c.Check(user, IsNil)
 }
 
-func (as *authSuite) TestCheckMacaroonNoValidUser(c *C) {
-	as.state.Lock()
-	_, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
-	as.state.Unlock()
-	c.Check(err, IsNil)
-
+func (as *authSuite) TestCheckMacaroonInvalidAuth(c *C) {
 	as.state.Lock()
 	user, err := auth.CheckMacaroon(as.state, "other-macaroon", []string{"discharge"})
 	as.state.Unlock()
 
-	c.Check(err, ErrorMatches, "invalid authentication")
+	c.Check(err, Equals, auth.ErrInvalidAuth)
+	c.Check(user, IsNil)
+
+	as.state.Lock()
+	_, err = auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	as.state.Unlock()
+	c.Check(err, IsNil)
+
+	as.state.Lock()
+	user, err = auth.CheckMacaroon(as.state, "other-macaroon", []string{"discharge"})
+	as.state.Unlock()
+
+	c.Check(err, Equals, auth.ErrInvalidAuth)
 	c.Check(user, IsNil)
 }
 


### PR DESCRIPTION
Due to a bug in overlord/auth, the daemon was blindly accepting
the authentication of anyone with an authentication header if
there was no auth state at all (nobody ever logged in).

This also includes a clean up of Logout, making it remove the
previously stored authentication details on success.