### PR TITLE
overlord, snap: add firstboot state sync

### DIFF
--- a/cmd/snap/cmd_first_boot.go
+++ b/cmd/snap/cmd_first_boot.go
@@ -20,13 +20,9 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/jessevdk/go-flags"
 
-	"github.com/ubuntu-core/snappy/i18n"
 	"github.com/ubuntu-core/snappy/overlord"
-	"github.com/ubuntu-core/snappy/snappy"
 )
 
 type cmdInternalFirstBoot struct{}
@@ -41,11 +37,5 @@ func init() {
 }
 
 func (x *cmdInternalFirstBoot) Execute(args []string) error {
-	err := overlord.FirstBoot()
-	if err == snappy.ErrNotFirstBoot {
-		fmt.Println(i18n.G("First boot has already run"))
-		return nil
-	}
-
-	return err
+	return overlord.FirstBoot()
 }

--- a/cmd/snap/cmd_first_boot.go
+++ b/cmd/snap/cmd_first_boot.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/ubuntu-core/snappy/i18n"
+	"github.com/ubuntu-core/snappy/overlord"
 	"github.com/ubuntu-core/snappy/snappy"
 )
 
@@ -40,7 +41,7 @@ func init() {
 }
 
 func (x *cmdInternalFirstBoot) Execute(args []string) error {
-	err := snappy.FirstBoot()
+	err := overlord.FirstBoot()
 	if err == snappy.ErrNotFirstBoot {
 		fmt.Println(i18n.G("First boot has already run"))
 		return nil

--- a/debian/snapd.firstboot.service
+++ b/debian/snapd.firstboot.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Run snappy firstboot setup
 After=local-fs.target
-Before=network-pre.target
+Before=network-pre.target snapd.service
 DefaultDependencies=false
 # NOTE: this is hardcoded in `snappy firstboot`; keep in sync
-ConditionPathExists=!/var/lib/snappy/firstboot/stamp
+ConditionPathExists=!/var/lib/snapd/firstboot/stamp
 
 
 [Service]

--- a/debian/ubuntu-core-snapd-units.dirs
+++ b/debian/ubuntu-core-snapd-units.dirs
@@ -1,0 +1,1 @@
+var/lib/snapd/firstboot

--- a/overlord/firstboot.go
+++ b/overlord/firstboot.go
@@ -45,6 +45,7 @@ func populateStateFromInstalled() error {
 		var snapst snapstate.SnapState
 		snapst.Sequence = append(snapst.Sequence, &info.SideInfo)
 		snapst.Channel = info.Channel
+		snapst.Active = sn.IsActive()
 		snapstate.Set(st, sn.Name(), &snapst)
 	}
 

--- a/overlord/firstboot.go
+++ b/overlord/firstboot.go
@@ -20,7 +20,10 @@
 package overlord
 
 import (
+	"fmt"
+
 	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/overlord/snapstate"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snappy"
@@ -30,6 +33,10 @@ func populateStateFromInstalled() error {
 	all, err := (&snappy.Overlord{}).Installed()
 	if err != nil {
 		return err
+	}
+
+	if osutil.FileExists(dirs.SnapStateFile) {
+		return fmt.Errorf("cannot create state: state %q already exists", dirs.SnapStateFile)
 	}
 
 	st := state.New(&overlordStateBackend{

--- a/overlord/firstboot.go
+++ b/overlord/firstboot.go
@@ -59,6 +59,10 @@ func populateStateFromInstalled() error {
 	return nil
 }
 
+// FIXME:
+// This is not the final way we will do the state sync. This is just
+// an intermediate step to have working images again. We need to
+// figure out how we want first-boot to look like.
 func FirstBoot() error {
 	if err := snappy.FirstBoot(); err != nil {
 		return err

--- a/overlord/firstboot.go
+++ b/overlord/firstboot.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package overlord
+
+import (
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/overlord/snapstate"
+	"github.com/ubuntu-core/snappy/overlord/state"
+	"github.com/ubuntu-core/snappy/snappy"
+)
+
+func populateStateFromInstalled() error {
+	all, err := (&snappy.Overlord{}).Installed()
+	if err != nil {
+		return err
+	}
+
+	st := state.New(&overlordStateBackend{
+		path: dirs.SnapStateFile,
+	})
+	st.Lock()
+	defer st.Unlock()
+
+	for _, sn := range all {
+		// no need to do a snapstate.Get() because this is firstboot
+		info := sn.Info()
+
+		var snapst snapstate.SnapState
+		snapst.Sequence = append(snapst.Sequence, &info.SideInfo)
+		snapst.Channel = info.Channel
+		snapstate.Set(st, sn.Name(), &snapst)
+	}
+
+	return nil
+}
+
+func FirstBoot() error {
+	if err := snappy.FirstBoot(); err != nil {
+		return err
+	}
+
+	return populateStateFromInstalled()
+}

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-16 16:39-0300\n"
+        "POT-Creation-Date: 2016-04-18 17:13+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -83,9 +83,6 @@ msgid   "Entering classic dimension"
 msgstr  ""
 
 msgid   "Finds packages to install"
-msgstr  ""
-
-msgid   "First boot has already run"
 msgstr  ""
 
 #. TRANSLATORS: the %s is a pkgname

--- a/snappy/firstboot.go
+++ b/snappy/firstboot.go
@@ -168,7 +168,7 @@ func FirstBoot() error {
 
 // NOTE: if you change stampFile, update the condition in
 // snapd.firstboot.service to match
-var stampFile = "/var/lib/snappy/firstboot/stamp"
+var stampFile = "/var/lib/snapd/firstboot/stamp"
 
 func stampFirstBoot() error {
 	// filepath.Dir instead of firstbootDir directly to ease testing


### PR DESCRIPTION
This branch makes our images work again. It will take what is installed on the system and populate the state with that. This is an intermediate step until we know better how to represent state when using u-d-f. As long as we keep the manifests on disk this will work and is a cheap way for us to unbreak the images and to let people play with snappy 2.0 on devices and images.