### PR TITLE
interfaces,overlord/ifacestate: fix abbreviated for of disconnect  operations 

### DIFF
--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -33,6 +33,11 @@ type Plug struct {
 	Connections []SlotRef `json:"connections,omitempty"`
 }
 
+// Ref returns reference to a plug
+func (plug *Plug) Ref() PlugRef {
+	return PlugRef{Snap: plug.Snap.Name(), Name: plug.Name}
+}
+
 // PlugRef is a reference to a plug.
 type PlugRef struct {
 	Snap string `json:"snap"`
@@ -43,6 +48,11 @@ type PlugRef struct {
 type Slot struct {
 	*snap.SlotInfo
 	Connections []PlugRef `json:"connections,omitempty"`
+}
+
+// Ref returns reference to a slot
+func (slot *Slot) Ref() SlotRef {
+	return SlotRef{Snap: slot.Snap.Name(), Name: slot.Name}
 }
 
 // SlotRef is a reference to a slot.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -67,6 +67,17 @@ type Interfaces struct {
 	Slots []*Slot `json:"slots"`
 }
 
+// ConnRef holds information about plug and slot reference that form a particular connection.
+type ConnRef struct {
+	PlugRef PlugRef
+	SlotRef SlotRef
+}
+
+// ID returns a string identifying a given connection.
+func (conn *ConnRef) ID() string {
+	return fmt.Sprintf("%s:%s %s:%s", conn.PlugRef.Snap, conn.PlugRef.Name, conn.SlotRef.Snap, conn.SlotRef.Name)
+}
+
 // Interface describes a group of interchangeable capabilities with common features.
 // Interfaces act as a contract between system builders, application developers
 // and end users.

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -83,3 +83,12 @@ func (s *CoreSuite) TestSlotRef(c *C) {
 	c.Check(ref.Snap, Equals, "producer")
 	c.Check(ref.Name, Equals, "slot")
 }
+
+// ConnRef.ID works as expected
+func (s *CoreSuite) TestConnRefID(c *C) {
+	conn := &ConnRef{
+		PlugRef: PlugRef{Snap: "consumer", Name: "plug"},
+		SlotRef: SlotRef{Snap: "producer", Name: "slot"},
+	}
+	c.Check(conn.ID(), Equals, "consumer:plug producer:slot")
+}

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -25,6 +25,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	. "github.com/ubuntu-core/snappy/interfaces"
+	"github.com/ubuntu-core/snappy/snap"
 )
 
 func Test(t *testing.T) {
@@ -65,4 +66,20 @@ func (s *CoreSuite) TestValidateName(c *C) {
 		err := ValidateName(name)
 		c.Assert(err, ErrorMatches, `invalid interface name: ".*"`)
 	}
+}
+
+// Plug.Ref works as expected
+func (s *CoreSuite) TestPlugRef(c *C) {
+	plug := &Plug{PlugInfo: &snap.PlugInfo{Snap: &snap.Info{SuggestedName: "consumer"}, Name: "plug"}}
+	ref := plug.Ref()
+	c.Check(ref.Snap, Equals, "consumer")
+	c.Check(ref.Name, Equals, "plug")
+}
+
+// Slot.Ref works as expected
+func (s *CoreSuite) TestSlotRef(c *C) {
+	slot := &Slot{SlotInfo: &snap.SlotInfo{Snap: &snap.Info{SuggestedName: "producer"}, Name: "slot"}}
+	ref := slot.Ref()
+	c.Check(ref.Snap, Equals, "producer")
+	c.Check(ref.Name, Equals, "slot")
 }


### PR DESCRIPTION
This branch allows user to use disconnect as advertised by `snap disconnect --help`.

In general, disconnect can affect more than one pair of snaps and more than one connection. Using abbreviated forms one can disconnect all plugs from a specific slot or even all plugs from all slots of a specific snap.