### PR TITLE
interfaces/builtin: make snapd-control autoconnect

### DIFF
--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -55,5 +55,6 @@ func NewSnapdControlInterface() interfaces.Interface {
 		connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  snapdControlConnectedPlugSecComp,
 		reservedForOS:         true,
+		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -128,5 +128,5 @@ func (s *SnapdControlInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 }
 
 func (s *SnapdControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.AutoConnect(), Equals, true)
 }


### PR DESCRIPTION
Using snapd-control forces manual review, so autoconnect is fine.