### PR TITLE
integration-tests: snap list on fresh boot is good again

### DIFF
--- a/integration-tests/tests/snap_example_test.go
+++ b/integration-tests/tests/snap_example_test.go
@@ -50,7 +50,7 @@ func removeSnap(c *check.C, packageName string) string {
 	cli.ExecCommand(c, "sudo", "snap", "remove", packageName)
 	// FIXME: should `snap remove` shold show a list afterards?
 	//        like `snappy install`?
-	out_ := cli.ExecCommand(c, "snap", "list")
+	out := cli.ExecCommand(c, "snap", "list")
 	return out
 }
 

--- a/integration-tests/tests/snap_example_test.go
+++ b/integration-tests/tests/snap_example_test.go
@@ -42,9 +42,7 @@ func installSnap(c *check.C, packageName string) string {
 	cli.ExecCommand(c, "sudo", "snap", "install", "--channel", "edge", packageName)
 	// FIXME: should `snap install` shold show a list afterards?
 	//        like `snappy install`?
-	// right now "snap list" on freshly booted is empty
-	// because u-d-f installed aren't in state
-	out, _ := cli.ExecCommandErr("snap", "list")
+	out := cli.ExecCommand(c, "snap", "list")
 	return out
 }
 
@@ -52,9 +50,7 @@ func removeSnap(c *check.C, packageName string) string {
 	cli.ExecCommand(c, "sudo", "snap", "remove", packageName)
 	// FIXME: should `snap remove` shold show a list afterards?
 	//        like `snappy install`?
-	// right now "snap list" on freshly booted is empty
-	// because u-d-f installed aren't in state
-	out, _ := cli.ExecCommandErr("snap", "list")
+	out_ := cli.ExecCommand(c, "snap", "list")
 	return out
 }
 

--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -123,12 +123,7 @@ func (s *SnappySuite) SetUpTest(c *check.C) {
 
 // GetCurrentVersion returns the version of the installed and active package.
 func GetCurrentVersion(c *check.C, packageName string) string {
-	output, err := cli.ExecCommandErr("snap", "list")
-	if err != nil {
-		// XXX: right now "snap list" on freshly booted is empty
-		// because u-d-f installed aren't in state
-		return "verUnknown"
-	}
+	output := cli.ExecCommand(c, "snap", "list")
 	pattern := "(?mU)^" + packageName + " +(.*)$"
 	re := regexp.MustCompile(pattern)
 	match := re.FindStringSubmatch(string(output))
@@ -220,17 +215,13 @@ func getVersionFile() string {
 // InstallSnap executes the required command to install the specified snap
 func InstallSnap(c *check.C, packageName string) string {
 	cli.ExecCommand(c, "sudo", "snap", "install", packageName)
-	// XXX: right now "snap list" on freshly booted is empty
-	// because u-d-f installed aren't in state
-	out, _ := cli.ExecCommandErr("snap", "list")
+	out := cli.ExecCommand(c, "snap", "list")
 	return out
 }
 
 // RemoveSnap executes the required command to remove the specified snap
 func RemoveSnap(c *check.C, packageName string) string {
 	cli.ExecCommand(c, "sudo", "snap", "remove", packageName)
-	// XXX: right now "snap list" on freshly booted is empty
-	// because u-d-f installed aren't in state
-	out, _ := cli.ExecCommandErr("snap", "list")
+	out := cli.ExecCommand(c, "snap", "list")
 	return out
 }


### PR DESCRIPTION
This branch removes workarounds that were needed when fresh images did not have any `snap list` output. We sync the installed state on first boot into the state engine now, so these workarounds are no longer needed.

Please only merge if the integration tests are actually agreeing with this theory :)