### PR TITLE
overlord/ifacestate: fix setup-profiles to use new snap revision for setup

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -683,8 +683,8 @@ func (r *Repository) AutoConnectBlacklist(snapName string) map[string]bool {
 
 // DisconnectSnap disconnects all the connections to and from a given snap.
 //
-// The return value is a list of snap.Info's that were affected.
-func (r *Repository) DisconnectSnap(snapName string) ([]*snap.Info, error) {
+// The return value is a list of names that were affected.
+func (r *Repository) DisconnectSnap(snapName string) ([]string, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
@@ -706,10 +706,11 @@ func (r *Repository) DisconnectSnap(snapName string) ([]*snap.Info, error) {
 		}
 	}
 
-	result := make([]*snap.Info, 0, len(seen))
+	result := make([]string, 0, len(seen))
 	for info := range seen {
-		result = append(result, info)
+		result = append(result, info.Name())
 	}
+	sort.Strings(result)
 	return result, nil
 }
 

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1081,8 +1081,8 @@ func (s *DisconnectSnapSuite) TestOutgoingConnection(c *C) {
 	// Disconnect s1 with which has an outgoing connection to s2
 	affected, err := s.repo.DisconnectSnap("s1")
 	c.Assert(err, IsNil)
-	c.Check(affected, testutil.Contains, s.s1)
-	c.Check(affected, testutil.Contains, s.s2)
+	c.Check(affected, testutil.Contains, "s1")
+	c.Check(affected, testutil.Contains, "s2")
 }
 
 func (s *DisconnectSnapSuite) TestIncomingConnection(c *C) {
@@ -1091,8 +1091,8 @@ func (s *DisconnectSnapSuite) TestIncomingConnection(c *C) {
 	// Disconnect s1 with which has an incoming connection from s2
 	affected, err := s.repo.DisconnectSnap("s1")
 	c.Assert(err, IsNil)
-	c.Check(affected, testutil.Contains, s.s1)
-	c.Check(affected, testutil.Contains, s.s2)
+	c.Check(affected, testutil.Contains, "s1")
+	c.Check(affected, testutil.Contains, "s2")
 }
 
 func (s *DisconnectSnapSuite) TestCrossConnection(c *C) {
@@ -1104,7 +1104,7 @@ func (s *DisconnectSnapSuite) TestCrossConnection(c *C) {
 		c.Assert(err, IsNil)
 		affected, err := s.repo.DisconnectSnap(snapName)
 		c.Assert(err, IsNil)
-		c.Check(affected, testutil.Contains, s.s1)
-		c.Check(affected, testutil.Contains, s.s2)
+		c.Check(affected, testutil.Contains, "s1")
+		c.Check(affected, testutil.Contains, "s2")
 	}
 }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -95,11 +95,14 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	if err := m.autoConnect(task, snapName, blacklist); err != nil {
 		return err
 	}
-	if len(affectedSnaps) == 0 {
-		affectedSnaps = append(affectedSnaps, snapName)
+	if err := setupSnapSecurity(task, snapInfo, m.repo); err != nil {
+		return state.Retry
 	}
 	for _, snapName := range affectedSnaps {
-
+		// The affected snap is setup explicitly so skip it here.
+		if snapName == snapInfo.Name() {
+			continue
+		}
 		snapInfo, err := snapstate.Current(task.State(), snapName)
 		if err != nil {
 			return err

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -616,12 +616,12 @@ func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 	// Ensure that both snaps were setup correctly.
 	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
-	// The OS snap was setup (because it was affected).
-	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Name(), Equals, coreSnapInfo.Name())
-	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Revision, Equals, coreSnapInfo.Revision)
 	// The sample snap was setup, with the correct new revision.
-	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Name(), Equals, newSnapInfo.Name())
-	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Revision, Equals, newSnapInfo.Revision)
+	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Name(), Equals, newSnapInfo.Name())
+	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Revision, Equals, newSnapInfo.Revision)
+	// The OS snap was setup (because it was affected).
+	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Name(), Equals, coreSnapInfo.Name())
+	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Revision, Equals, coreSnapInfo.Revision)
 }
 
 // The undo handler of the setup-profiles task will honor `old-devmode` that

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -1013,6 +1013,18 @@ func (s *snapmgrQuerySuite) TestInfo(c *C) {
 	c.Check(info.Description(), Equals, "Lots of text")
 }
 
+func (s *snapmgrQuerySuite) TestCurrent(c *C) {
+	st := s.st
+	st.Lock()
+	defer st.Unlock()
+
+	info, err := snapstate.Current(st, "name1")
+	c.Assert(err, IsNil)
+
+	c.Check(info.Name(), Equals, "name1")
+	c.Check(info.Revision, Equals, 12)
+}
+
 func (s *snapmgrQuerySuite) TestActiveInfos(c *C) {
 	st := s.st
 	st.Lock()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -300,6 +300,23 @@ func Info(s *state.State, name string, revision int) (*snap.Info, error) {
 	return nil, fmt.Errorf("cannot find snap %q at revision %d", name, revision)
 }
 
+// Current returns the information about the current revision of a snap with the given name.
+func Current(s *state.State, name string) (*snap.Info, error) {
+	var snapst SnapState
+	err := Get(s, name, &snapst)
+	if err == state.ErrNoState {
+		return nil, fmt.Errorf("cannot find snap %q", name)
+	}
+	if err != nil {
+		return nil, err
+	}
+	sideInfo := snapst.Current()
+	if sideInfo != nil {
+		return readInfo(name, sideInfo)
+	}
+	return nil, fmt.Errorf("cannot find snap %q", name)
+}
+
 // Get retrieves the SnapState of the given snap.
 func Get(s *state.State, name string, snapst *SnapState) error {
 	var snaps map[string]*json.RawMessage

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -304,14 +304,10 @@ func Info(s *state.State, name string, revision int) (*snap.Info, error) {
 func Current(s *state.State, name string) (*snap.Info, error) {
 	var snapst SnapState
 	err := Get(s, name, &snapst)
-	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", name)
-	}
-	if err != nil {
+	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
-	sideInfo := snapst.Current()
-	if sideInfo != nil {
+	if sideInfo := snapst.Current(); sideInfo != nil {
 		return readInfo(name, sideInfo)
 	}
 	return nil, fmt.Errorf("cannot find snap %q", name)


### PR DESCRIPTION
This patch fixes a bug in setup-profiles where on snap upgrade, the
security would be still set up with the older revision of the snap.

This was caused by DisconnectSnap returning the list of snaps
(represented as snap.Info's) that are affected by the disconnect
operation. Those infos were subsequently used to setup the security of
each snap. This didn't work because snap.Info encodes the Revision which
changes on each upgrade.

Note that this bug is not a security vulnerability as apparmor uses the
revision in the actual profile so applications from both revisions are
simply unavailable.

Fixes: https://bugs.launchpad.net/snappy/+bug/1572463
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>