### PR TITLE
client, cmd, daemon, snap, snappy: add buy command 

### DIFF
--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -86,20 +86,20 @@ func hasPrices(snaps []*client.Snap) bool {
 }
 
 func printWithPrices(w *tabwriter.Writer, snaps []*client.Snap, suggestedCurrency string) {
-	fmt.Fprintln(w, i18n.G("Name\tVersion\tPrice\tSummary"))
+	fmt.Fprintln(w, i18n.G("Name\tVersion\tStatus\tPrice\tSummary"))
 
 	for _, snap := range snaps {
 		price := getPrice(snap.Prices, suggestedCurrency)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", snap.Name, snap.Version, price, snap.Summary)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", snap.Name, snap.Version, snap.Status, price, snap.Summary)
 
 	}
 }
 
 func printNoPrices(w *tabwriter.Writer, snaps []*client.Snap) {
-	fmt.Fprintln(w, i18n.G("Name\tVersion\tSummary"))
+	fmt.Fprintln(w, i18n.G("Name\tVersion\tStatus\tSummary"))
 
 	for _, snap := range snaps {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", snap.Name, snap.Version, snap.Summary)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", snap.Name, snap.Version, snap.Status, snap.Summary)
 	}
 }
 

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -131,6 +131,9 @@ func mapSnap(localSnap *snap.Info, active bool, remoteSnap *snap.Info) map[strin
 	var prices map[string]float64
 
 	if remoteSnap != nil {
+		if remoteSnap.RequiresPurchase {
+			status = "priced"
+		}
 		prices = remoteSnap.Prices
 	}
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -330,7 +330,7 @@ See `sources` for `/v2/snaps`.
 
 ### POST
 
-* Description: Install, refresh, or remove
+* Description: Install, refresh, remove or buy
 * Access: trusted
 * Operation: async
 * Return: background operation or standard error
@@ -347,7 +347,7 @@ See `sources` for `/v2/snaps`.
 
 field      | ignored except in action | description
 -----------|-------------------|------------
-`action`   |                   | Required; a string, one of `install`, `refresh`, or `remove`
+`action`   |                   | Required; a string, one of `install`, `refresh`, `remove`, or `buy`
 `channel`  | `install` `update` | From which channel to pull the new package (and track henceforth). Channels are a means to discern the maturity of a package or the software it contains, although the exact meaning is left to the application developer. One of `edge`, `beta`, `candidate`, and `stable` which is the default.
 
 #### A note on licenses

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -214,7 +214,7 @@ Sample result:
       "name": "ubuntu-core",
       "developer": "canonical",
       "resource": "/v2/snaps/ubuntu-core",
-      "status": "active",
+      "status": "priced",
       "type": "os",
       "update-available": 247,
       "version": "241",
@@ -226,8 +226,8 @@ Sample result:
 
 #### Fields
 
-* `status`: can be either `available`, `installed`, `active` (i.e. is
-  current).
+* `status`: may transition as `available` => `installed` => `active`. For paid snaps,
+  the initial state is `priced` and once bought it becomes `available`.
 * `name`: the snap name.
 * `version`: a string representing the version.
 * `revision`: a number representing the revision.

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -38,7 +38,7 @@ func (s *searchSuite) TestSearchMustPrintMatch(c *check.C) {
 
 	// XXX: Summary is empty atm, waiting for store support
 	expected := "(?ms)" +
-		"Name +Version +Summary *\n" +
+		"Name +Version +Status +Summary *\n" +
 		".*" +
 		"^hello-world +.* *\n" +
 		".*"

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-18 17:13+0200\n"
+        "POT-Creation-Date: 2016-04-20 14:51+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -145,10 +145,10 @@ msgstr  ""
 msgid   "Name\tVersion\tDeveloper"
 msgstr  ""
 
-msgid   "Name\tVersion\tPrice\tSummary"
+msgid   "Name\tVersion\tStatus\tPrice\tSummary"
 msgstr  ""
 
-msgid   "Name\tVersion\tSummary"
+msgid   "Name\tVersion\tStatus\tSummary"
 msgstr  ""
 
 msgid   "Password: "

--- a/snap/info.go
+++ b/snap/info.go
@@ -98,9 +98,10 @@ type Info struct {
 	SideInfo
 
 	// The information in these fields is ephemeral, available only from the store.
-	AnonDownloadURL string
-	DownloadURL     string
-	Prices          map[string]float64 `yaml:"prices,omitempty" json:"prices,omitempty"`
+	AnonDownloadURL  string
+	DownloadURL      string
+	Prices           map[string]float64 `yaml:"prices,omitempty" json:"prices,omitempty"`
+	RequiresPurchase bool               `yaml:"requires-purchase,omitempty" json:"requires-purchase,omitempty"`
 }
 
 // Name returns the blessed name for the snap.

--- a/snappy/buy.go
+++ b/snappy/buy.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snappy
+
+import (
+	"fmt"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/store"
+)
+
+// Buy the given snap name.
+func Buy(fullName string, meter progress.Meter) error {
+	mStore := NewConfiguredUbuntuStoreSnapRepository()
+	state, redirect, err := mStore.Buy(fullName, store.BuyOptions{}, meter, nil)
+
+	fmt.Printf("Purchase state: %s\n", state)
+	if redirect != nil {
+		fmt.Printf("  Redirect to: %s\n", redirect.RedirectTo)
+	}
+
+	return err
+}

--- a/store/authError.go
+++ b/store/authError.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store
+
+/*
+authError contains the reason behind an authentication failure
+*/
+type authError struct {
+	Threshold int64  `json:"threshold"`
+	Error     string `json:"error"`
+}

--- a/store/errors.go
+++ b/store/errors.go
@@ -40,8 +40,14 @@ var (
 	// ErrAuthenticationNeeds2fa is returned if the authentication needs 2factor
 	ErrAuthenticationNeeds2fa = errors.New("two factor authentication required")
 
+	// ErrNeedsAuthorization is returned if the store rejects our authorization attempt
+	ErrNeedsAuthorization = errors.New("store rejected authorization attempt")
+
 	// ErrInvalidCredentials is returned on login error
 	ErrInvalidCredentials = errors.New("invalid credentials")
+
+	// ErrTokenNeedsRefresh is returned when the store token has expired, and needs refreshing
+	ErrTokenNeedsRefresh = errors.New("store token needs refresh")
 )
 
 // ErrDownload represents a download error

--- a/store/purchase.go
+++ b/store/purchase.go
@@ -22,6 +22,14 @@ package store
 /*
 purchase encapsulates the purchase data sent to us from the software center agent.
 
+This object type can be received in response to requests about the user's current
+purchases, and also when making purchase requests.
+
+When making a purchase request, the State "InProgress", together with a RedirectTo
+URL may be received. In-this case, the user must be directed to that webpage.
+Additionally, Partner ID may be recieved as an extended header "X-Partner-Id",
+this should be included in the follow-on requests to the redirect URL.
+
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 
@@ -55,6 +63,7 @@ type purchase struct {
 	State           string `json:"state"`
 	ItemSKU         string `json:"item_sku,omitempty"`
 	PurchaseID      string `json:"purchase_id,omitempty"`
+	RedirectTo      string `json:"redirect_to,omitempty"`
 }
 
 type purchaseList []purchase

--- a/store/purchase.go
+++ b/store/purchase.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store
+
+/*
+purchase encapsulates the purchase data sent to us from the software center agent.
+
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+[
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "com.ubuntu.developer.dev.appname",
+    "refundable_until": "2015-07-15 18:46:21",
+    "state": "Complete"
+  },
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "com.ubuntu.developer.dev.appname",
+    "item_sku": "item-1-sku",
+    "purchase_id": "1",
+    "refundable_until": null,
+    "state": "Complete"
+  },
+  {
+    "open_id": "https://login.staging.ubuntu.com/+id/open_id",
+    "package_name": "com.ubuntu.developer.dev.otherapp",
+    "refundable_until": "2015-07-17 11:33:29",
+    "state": "Complete"
+  }
+]
+*/
+type purchase struct {
+	OpenID          string `json:"open_id"`
+	PackageName     string `json:"package_name"`
+	RefundableUntil string `json:"refundable_until"`
+	State           string `json:"state"`
+	ItemSKU         string `json:"item_sku,omitempty"`
+	PurchaseID      string `json:"purchase_id,omitempty"`
+}
+
+type purchaseList []purchase

--- a/store/purchaseInstruction.go
+++ b/store/purchaseInstruction.go
@@ -1,0 +1,35 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store
+
+/*
+PurchaseInstruction encapsulates the data that must be sent in order to make a purchase from the store.
+
+The Device ID can be sent in the extended header "X-Device-Id".
+The Partner ID (e.g. "bq") can be sent in the extended header "X-Partner-Id".
+*/
+type PurchaseInstruction struct {
+	Name      string  `json:"name"`
+	ItemSKU   string  `json:"item_sku,omitempty"`
+	Amount    float64 `json:"amount,omitempty"`
+	Currency  string  `json:"currency,omitempty"`
+	BackendID string  `json:"backend_id,omitempty"`
+	MethodID  int64   `json:"method_id,omitempty"`
+}


### PR DESCRIPTION
The beginnings of doing actual purchases.

Depends on #1058

Note: This doesn't integrate the code that talks to the store with the snappy REST API.