### PR TITLE
overlord: keep tasks unlinked from a change hidden, prune them

### DIFF
--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -39,3 +39,8 @@ func MockChangeTimes(chg *Change, spawnTime, readyTime time.Time) {
 	chg.spawnTime = spawnTime
 	chg.readyTime = readyTime
 }
+
+func MockTaskTimes(t *Task, spawnTime, readyTime time.Time) {
+	t.spawnTime = spawnTime
+	t.readyTime = readyTime
+}


### PR DESCRIPTION
With this tasks not linked to a Change are hidden from State.Task and State.Tasks (used by taskrunner), and they are also pruned. Usually they are the result of the setting up of a Change that failed early.