### PR TITLE
cmd: don't perform type assertion when we know error to be nil

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -145,10 +145,10 @@ func run() error {
 	parser := Parser()
 	_, err := parser.Parse()
 	if err != nil {
+		if _, ok := err.(*flags.Error); !ok {
+			logger.Debugf("cannot parse arguments: %v: %v", os.Args, err)
+		}
 		return err
-	}
-	if _, ok := err.(*flags.Error); !ok {
-		logger.Debugf("cannot parse arguments: %v: %v", os.Args, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Saw this beauty in my syslog when running `snap list`:
```
Apr 22 09:13:50 localhost /usr/lib/snapd/snapd[1332]: daemon.go:170: DEBUG: uid=1000;@ GET /v2/snaps?sources=local 9.332204ms 200
Apr 22 09:13:50 localhost snap[1329]: main.go:151: DEBUG: cannot parse arguments: [snap list]: <nil>
```