### PR TITLE
intefaces/builtin: allow getsockname on connected x11 plugs

### DIFF
--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -39,6 +39,7 @@ const x11ConnectedPlugSecComp = `
 # Usage: reserved
 
 getpeername
+getsockname
 recvfrom
 recvmsg
 shutdown

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ubuntu-core/snappy/interfaces"
 	"github.com/ubuntu-core/snappy/interfaces/builtin"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/testutil"
 )
 
 type X11InterfaceSuite struct {
@@ -129,4 +130,11 @@ func (s *X11InterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 
 func (s *X11InterfaceSuite) TestAutoConnect(c *C) {
 	c.Check(s.iface.AutoConnect(), Equals, true)
+}
+
+// The getsockname system call is allowed
+func (s *X11InterfaceSuite) TestLP1574526(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Check(string(snippet), testutil.Contains, "getsockname\n")
 }


### PR DESCRIPTION
This patch allows application using a connected x11 plug to use the
"getsockname" system call. This seems to be required by xeyes.

Closes:LP#1574526
Fixes: https://bugs.launchpad.net/snappy/+bug/1574526
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>