### PR TITLE
integration-tests: re-enable a bunch of integration tests

### DIFF
--- a/integration-tests/tests/installDesktopApp_test.go
+++ b/integration-tests/tests/installDesktopApp_test.go
@@ -42,8 +42,6 @@ type installDesktopAppSuite struct {
 }
 
 func (s *installDesktopAppSuite) TestInstallsDesktopFile(c *check.C) {
-	c.Skip("port to snapd")
-
 	snapPath, err := build.LocalSnap(c, data.BasicDesktopSnapName)
 	defer os.Remove(snapPath)
 	c.Assert(err, check.IsNil, check.Commentf("Error building local snap: %s", err))

--- a/integration-tests/tests/list_test.go
+++ b/integration-tests/tests/list_test.go
@@ -39,12 +39,10 @@ type listSuite struct {
 var verRegexp = `(\d{2}\.\d{2}.*|\w{12})`
 
 func (s *listSuite) TestListMustPrintCoreVersion(c *check.C) {
-	c.Skip("port to snapd")
-
-	listOutput := cli.ExecCommand(c, "snappy", "list")
+	listOutput := cli.ExecCommand(c, "snap", "list")
 
 	expected := "(?ms)" +
-		"Name +Date +Version +Developer *\n" +
+		"Name +Version +Developer *\n" +
 		".*" +
 		fmt.Sprintf("^%s +.* +%s +(canonical|sideload) *\n", partition.OSSnapName(c), verRegexp) +
 		".*"
@@ -52,18 +50,16 @@ func (s *listSuite) TestListMustPrintCoreVersion(c *check.C) {
 }
 
 func (s *listSuite) TestListMustPrintAppVersion(c *check.C) {
-	c.Skip("port to snapd")
-
-	common.InstallSnap(c, "hello-world/edge")
+	common.InstallSnap(c, "hello-world")
 	s.AddCleanup(func() {
 		common.RemoveSnap(c, "hello-world")
 	})
 
-	listOutput := cli.ExecCommand(c, "snappy", "list")
+	listOutput := cli.ExecCommand(c, "snap", "list")
 	expected := "(?ms)" +
-		"Name +Date +Version +Developer *\n" +
+		"Name +Version +Developer *\n" +
 		".*" +
-		"^hello-world +.* +(\\d+)(\\.\\d+)* +.* +.* *\n" +
+		"^hello-world +(\\d+)(\\.\\d+)* +.* +.* *\n" +
 		".*"
 
 	c.Assert(listOutput, check.Matches, expected)

--- a/integration-tests/tests/snap_example_test.go
+++ b/integration-tests/tests/snap_example_test.go
@@ -39,7 +39,7 @@ type snapHelloWorldExampleSuite struct {
 }
 
 func installSnap(c *check.C, packageName string) string {
-	cli.ExecCommand(c, "sudo", "snap", "install", "--channel", "edge", packageName)
+	cli.ExecCommand(c, "sudo", "snap", "install", packageName)
 	// FIXME: should `snap install` shold show a list afterards?
 	//        like `snappy install`?
 	// right now "snap list" on freshly booted is empty
@@ -99,10 +99,7 @@ type snapPythonWebserverExampleSuite struct {
 }
 
 func (s *snapPythonWebserverExampleSuite) TestNetworkingServiceMustBeStarted(c *check.C) {
-	c.Skip("FIXME: re-enable when new-security supports auto-connect")
-
-	baseAppName := "xkcd-webserver"
-	appName := baseAppName + ".canonical"
+	appName := "xkcd-webserver"
 	installSnap(c, appName)
 	defer removeSnap(c, appName)
 
@@ -122,8 +119,6 @@ type snapGoWebserverExampleSuite struct {
 }
 
 func (s *snapGoWebserverExampleSuite) TestGetRootPathMustPrintMessage(c *check.C) {
-	c.Skip("FIXME: re-enable when new-security supports auto-connect")
-
 	appName := "go-example-webserver"
 	output := installSnap(c, appName)
 	defer removeSnap(c, appName)

--- a/integration-tests/tests/snap_update_app_test.go
+++ b/integration-tests/tests/snap_update_app_test.go
@@ -40,7 +40,7 @@ type snapRefreshAppSuite struct {
 }
 
 func (s *snapRefreshAppSuite) TestAppUpdate(c *check.C) {
-	c.Skip("port to snapd")
+	c.Skip("port the buildin fake store to support the new refresh")
 
 	snap := "hello-world.canonical"
 	storeSnap := fmt.Sprintf("%s", snap)

--- a/integration-tests/tests/snapd_2_0_snaps_test.go
+++ b/integration-tests/tests/snapd_2_0_snaps_test.go
@@ -33,16 +33,14 @@ import (
 var _ = check.Suite(&snapd20SnapsTestSuite{})
 
 type pkgsResponse struct {
-	Result pkgContainer
+	Result pkgItems
 	response
+	Paging            map[string]interface{}
+	Sources           interface{}
+	SuggestedCurrency string `json:"suggested-currency"`
 }
 
-type pkgContainer struct {
-	Snaps  pkgItems
-	Paging map[string]interface{}
-}
-
-type pkgItems map[string]pkgItem
+type pkgItems []pkgItem
 
 type pkgItem struct {
 	Description   string

--- a/integration-tests/tests/snapd_2_0_test.go
+++ b/integration-tests/tests/snapd_2_0_test.go
@@ -38,5 +38,5 @@ func (s *snapd20TestSuite) resource() string {
 
 func (s *snapd20TestSuite) getInteractions() apiInteractions {
 	return []apiInteraction{{
-		responsePattern: `(?U){"result":{"api-compat":"\d+","default-channel":".*","flavor":".*","release":".*"},"status":"OK","status-code":200,"type":"sync"}`}}
+		responsePattern: `(?U){"type":"sync","status-code":200,"status":"OK","result":{"flavor":"core","series":"\d+"}}`}}
 }

--- a/integration-tests/tests/snapd_test.go
+++ b/integration-tests/tests/snapd_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	baseURL        = "snapd://"
-	httpClientSnap = "http.chipaca"
+	httpClientSnap = "http"
 )
 
 var _ = check.Suite(&snapdTestSuite{})
@@ -47,10 +47,7 @@ type snapdTestSuite struct {
 
 func (s *snapdTestSuite) SetUpTest(c *check.C) {
 	s.SnappySuite.SetUpTest(c)
-
-	c.Skip("FIXME: we need to update http.chipaca to new-security *and* land  auto-connect support in snapd")
-
-	common.InstallSnap(c, httpClientSnap+"/edge")
+	common.InstallSnap(c, httpClientSnap)
 }
 
 func (s *snapdTestSuite) TearDownTest(c *check.C) {
@@ -211,7 +208,7 @@ func doMethodNotAllowed(c *check.C, resource, verb string) {
 
 // makeRequest makes a request to the API according to the provided options.
 func makeRequest(options *requestOptions) (body []byte, err error) {
-	cmd := []string{"sudo", "http.do",
+	cmd := []string{"sudo", "http",
 		"--pretty", "none",
 		"--body",
 		"--ignore-stdin",

--- a/integration-tests/tests/snapd_test.go
+++ b/integration-tests/tests/snapd_test.go
@@ -195,7 +195,7 @@ func do404(c *check.C, resource string) {
 		resource+path,
 		"GET",
 		apiInteraction{
-			responsePattern: `{"result":{"message":".*"},"status":"Not Found","status-code":404,"type":"error"}`})
+			responsePattern: `{"type":"error","status-code":404,"status":"Not Found","result":{"message":".*"}}`})
 }
 
 func doMethodNotAllowed(c *check.C, resource, verb string) {
@@ -203,7 +203,7 @@ func doMethodNotAllowed(c *check.C, resource, verb string) {
 		resource,
 		verb,
 		apiInteraction{
-			responsePattern: `{"result":{"message":"method \S+ not allowed"},"status":"Method Not Allowed","status-code":405,"type":"error"}`})
+			responsePattern: `{"type":"error","status-code":405,"status":"Method Not Allowed","result":{"message":"method \\\"` + verb + `\\\" not allowed"}}`})
 }
 
 // makeRequest makes a request to the API according to the provided options.
@@ -211,8 +211,7 @@ func makeRequest(options *requestOptions) (body []byte, err error) {
 	cmd := []string{"sudo", "http",
 		"--pretty", "none",
 		"--body",
-		"--ignore-stdin",
-		options.verb, options.resource}
+		"--ignore-stdin"}
 
 	if options.payload != "" {
 		payload, err := determinePayload(options.payload)
@@ -222,7 +221,11 @@ func makeRequest(options *requestOptions) (body []byte, err error) {
 		if strings.HasPrefix(payload, "@") {
 			defer os.Remove(payload[1:])
 		}
-		cmd = append(cmd, payload)
+		cmd = append(cmd, "--form",
+			options.verb, options.resource, payload)
+	} else {
+		cmd = append(cmd,
+			options.verb, options.resource)
 	}
 
 	bodyString, err := cli.ExecCommandErr(append(cmd, "X-Allow-Unsigned:1")...)
@@ -233,7 +236,7 @@ func makeRequest(options *requestOptions) (body []byte, err error) {
 func determinePayload(payload string) (string, error) {
 	if _, err := os.Stat(payload); err == nil {
 		// payload is a file, in order to make the snap file available to http we need to move it to its $SNAP_DATA path
-		snapAppDataPath := filepath.Join("/var/lib/snapd", strings.Split(httpClientSnap, ".")[0], "current")
+		snapAppDataPath := filepath.Join("/var/snap", strings.Split(httpClientSnap, ".")[0], "current")
 		if _, err := cli.ExecCommandErr("sudo", "cp", payload, snapAppDataPath); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
This PR closes #1052 authored by @mvo5 putting its changes on top of the current master (819378df7e78 with integration tests fixed) in order to get them in ASAP.
