### PR TITLE
tests: remove hashes.yaml

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -186,7 +186,6 @@ name: %s
 version: %s
 %s`, name, version, extraYaml)
 	c.Check(ioutil.WriteFile(yamlPath, []byte(content), 0644), check.IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(metadir, "hashes.yaml"), []byte(nil), 0644), check.IsNil)
 
 	err := snappy.SaveManifest(skelInfo)
 	c.Assert(err, check.IsNil)
@@ -227,7 +226,6 @@ gadget: {store: {id: %q}}
 	c.Assert(os.MkdirAll(m, 0755), check.IsNil)
 	c.Assert(os.Symlink("1", filepath.Join(d, "current")), check.IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(m, "snap.yaml"), content, 0644), check.IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(m, "hashes.yaml"), []byte(nil), 0644), check.IsNil)
 }
 
 func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {

--- a/snappy/common_test.go
+++ b/snappy/common_test.go
@@ -102,11 +102,6 @@ apps:
 		return "", err
 	}
 
-	hashFile := filepath.Join(metaDir, "hashes.yaml")
-	if err := ioutil.WriteFile(hashFile, []byte("{}"), 0644); err != nil {
-		return "", err
-	}
-
 	si := snap.SideInfo{
 		OfficialName:      m.Name,
 		Revision:          revno,


### PR DESCRIPTION
The meta/hashes.yaml file is a leftover from 15.04, we can safely remove it.