### PR TITLE
snap/snaptest,daemon,overlord/ifacestate,overlord/snapstate: unify mocking snaps behind MockSnap

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -211,17 +211,13 @@ version: %s
 }
 
 func (s *apiSuite) mkGadget(c *check.C, store string) {
-	content := []byte(fmt.Sprintf(`name: test
+	yamlText := fmt.Sprintf(`name: test
 version: 1
 type: gadget
 gadget: {store: {id: %q}}
-`, store))
-
-	d := filepath.Join(dirs.SnapSnapsDir, "test")
-	m := filepath.Join(d, "1", "meta")
-	c.Assert(os.MkdirAll(m, 0755), check.IsNil)
-	c.Assert(os.Symlink("1", filepath.Join(d, "current")), check.IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(m, "snap.yaml"), content, 0644), check.IsNil)
+`, store)
+	snaptest.MockSnap(c, yamlText, &snap.SideInfo{Revision: 1})
+	c.Assert(os.Symlink("1", filepath.Join(dirs.SnapSnapsDir, "test", "current")), check.IsNil)
 }
 
 func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ubuntu-core/snappy/overlord/snapstate"
 	"github.com/ubuntu-core/snappy/overlord/state"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/snaptest"
 	"github.com/ubuntu-core/snappy/snappy"
 )
 
@@ -974,34 +975,21 @@ func (s *snapmgrQuerySuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 
 	// Write a snap.yaml with fake name
-	dname := filepath.Join(snap.MountDir("name1", 11), "meta")
-	err := os.MkdirAll(dname, 0775)
-	c.Assert(err, IsNil)
-	fname := filepath.Join(dname, "snap.yaml")
-	err = ioutil.WriteFile(fname, []byte(`
+	sideInfo11 := &snap.SideInfo{OfficialName: "name1", Revision: 11, EditedSummary: "s11"}
+	sideInfo12 := &snap.SideInfo{OfficialName: "name1", Revision: 12, EditedSummary: "s12"}
+	snaptest.MockSnap(c, `
 name: name0
 version: 1.1
 description: |
-    Lots of text`), 0644)
-	c.Assert(err, IsNil)
-
-	dname = filepath.Join(snap.MountDir("name1", 12), "meta")
-	err = os.MkdirAll(dname, 0775)
-	c.Assert(err, IsNil)
-	fname = filepath.Join(dname, "snap.yaml")
-	err = ioutil.WriteFile(fname, []byte(`
+    Lots of text`, sideInfo11)
+	snaptest.MockSnap(c, `
 name: name0
 version: 1.2
 description: |
-    Lots of text`), 0644)
-	c.Assert(err, IsNil)
-
+    Lots of text`, sideInfo12)
 	snapstate.Set(st, "name1", &snapstate.SnapState{
-		Active: true,
-		Sequence: []*snap.SideInfo{
-			{OfficialName: "name1", Revision: 11, EditedSummary: "s11"},
-			{OfficialName: "name1", Revision: 12, EditedSummary: "s12"},
-		},
+		Active:   true,
+		Sequence: []*snap.SideInfo{sideInfo11, sideInfo12},
 	})
 }
 

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -46,10 +46,9 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	// Put the YAML on disk, in the right spot.
 	dname := filepath.Join(dirs.SnapSnapsDir, snapInfo.Name(),
 		strconv.Itoa(sideInfo.Revision), "meta")
-	fname := filepath.Join(dname, "snap.yaml")
 	err = os.MkdirAll(dname, 0755)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(fname, []byte(yamlText), 0644)
+	err = ioutil.WriteFile(filepath.Join(dname, "snap.yaml"), []byte(yamlText), 0644)
 	c.Assert(err, check.IsNil)
 
 	// Triple-check that it really works by reading it back.

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -24,11 +24,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"gopkg.in/check.v1"
 
-	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/snap"
 )
 
@@ -43,9 +41,11 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(yamlText))
 	c.Assert(err, check.IsNil)
 
+	// Set SideInfo so that we can use MountDir below
+	snapInfo.SideInfo = *sideInfo
+
 	// Put the YAML on disk, in the right spot.
-	dname := filepath.Join(dirs.SnapSnapsDir, snapInfo.Name(),
-		strconv.Itoa(sideInfo.Revision), "meta")
+	dname := filepath.Join(snapInfo.MountDir(), "meta")
 	err = os.MkdirAll(dname, 0755)
 	c.Assert(err, check.IsNil)
 	err = ioutil.WriteFile(filepath.Join(dname, "snap.yaml"), []byte(yamlText), 0644)

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package snaptest contains helper functions for mocking snaps.
+package snaptest
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/snap"
+)
+
+// MockSnap puts a snap.yaml file on disk, based on the provided arguments.
+//
+// The caller is responsible for mocking root directory with dirs.SetRootDir()
+// and for altering the overlord state if required.
+func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
+	c.Assert(sideInfo, check.Not(check.IsNil))
+
+	// Parse the yaml (we need the Name).
+	snapInfo, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, check.IsNil)
+
+	// Put the YAML on disk, in the right spot.
+	dname := filepath.Join(dirs.SnapSnapsDir, snapInfo.Name(),
+		strconv.Itoa(sideInfo.Revision), "meta")
+	fname := filepath.Join(dname, "snap.yaml")
+	err = os.MkdirAll(dname, 0755)
+	c.Assert(err, check.IsNil)
+	err = ioutil.WriteFile(fname, []byte(yamlText), 0644)
+	c.Assert(err, check.IsNil)
+
+	// Triple-check that it really works by reading it back.
+	snapInfo, err = snap.ReadInfo(snapInfo.Name(), sideInfo)
+	c.Assert(err, check.IsNil)
+	return snapInfo
+}

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -45,10 +45,10 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	snapInfo.SideInfo = *sideInfo
 
 	// Put the YAML on disk, in the right spot.
-	dname := filepath.Join(snapInfo.MountDir(), "meta")
-	err = os.MkdirAll(dname, 0755)
+	metaDir := filepath.Join(snapInfo.MountDir(), "meta")
+	err = os.MkdirAll(metaDir, 0755)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(dname, "snap.yaml"), []byte(yamlText), 0644)
+	err = ioutil.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(yamlText), 0644)
 	c.Assert(err, check.IsNil)
 
 	// Triple-check that it really works by reading it back.

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -46,6 +46,8 @@ plugs:
 
 type snapTestSuite struct{}
 
+var _ = Suite(&snapTestSuite{})
+
 func (s *snapTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 }
@@ -61,6 +63,7 @@ func (s *snapTestSuite) TestMockSnap(c *C) {
 	// Data from SideInfo is used
 	c.Check(snapInfo.Revision, Equals, 42)
 	// The YAML is placed on disk
-	_, err := os.Stat(filepath.Join(dirs.SnapSnapsDir, "sample", "43", "meta", "snap.yaml"))
-	c.Check(err, IsNil)
+	stat, err := os.Stat(filepath.Join(dirs.SnapSnapsDir, "sample", "42", "meta", "snap.yaml"))
+	c.Assert(err, IsNil)
+	c.Check(stat.Size(), Equals, int64(len(sampleYaml)))
 }

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snaptest_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/snaptest"
+)
+
+func TestSnapTest(t *testing.T) { TestingT(t) }
+
+const sampleYaml = `
+name: sample
+version: 1
+apps:
+ app:
+   command: foo
+plugs:
+ network:
+  interface: network
+`
+
+type snapTestSuite struct{}
+
+func (s *snapTestSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *snapTestSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+}
+
+func (s *snapTestSuite) TestMockSnap(c *C) {
+	snapInfo := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: 42})
+	// Data from YAML is used
+	c.Check(snapInfo.Name(), Equals, "sample")
+	// Data from SideInfo is used
+	c.Check(snapInfo.Revision, Equals, 42)
+	// The YAML is placed on disk
+	_, err := os.Stat(filepath.Join(dirs.SnapSnapsDir, "sample", "43", "meta", "snap.yaml"))
+	c.Check(err, IsNil)
+}


### PR DESCRIPTION
This branch adds snap/snaptest.MockSnap with the intent of using it throughout the code to mock installed snap and cut the amount of repeated boilerplate.