### PR TITLE
store, daemon, client, cmd/snap: bubble TWOFACTOR_FAILURE up from store all the way to snap

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -211,7 +211,6 @@ func (e *Error) Error() string {
 	return e.Message
 }
 
-// these should be self-explanatory; otherwise, let us know!
 const (
 	ErrorKindTwoFactorRequired = "two-factor-required"
 	ErrorKindTwoFactorFailed   = "two-factor-failed"

--- a/client/client.go
+++ b/client/client.go
@@ -211,6 +211,21 @@ func (e *Error) Error() string {
 	return e.Message
 }
 
+// these should be self-explanatory; otherwise, let us know!
+const (
+	ErrorKindTwoFactorRequired = "two-factor-required"
+	ErrorKindTwoFactorFailed   = "two-factor-failed"
+)
+
+func IsTwoFactorError(err error) bool {
+	e, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+
+	return e.Kind == ErrorKindTwoFactorFailed || e.Kind == ErrorKindTwoFactorRequired
+}
+
 // SysInfo holds system information
 type SysInfo struct {
 	Flavor           string `json:"flavor"`

--- a/client/client.go
+++ b/client/client.go
@@ -216,6 +216,8 @@ const (
 	ErrorKindTwoFactorFailed   = "two-factor-failed"
 )
 
+// IsTwoFactorError returns whether the given error is due to problems
+// in two-factor authentication.
 func IsTwoFactorError(err error) bool {
 	e, ok := err.(*Error)
 	if !ok || e == nil {

--- a/client/client.go
+++ b/client/client.go
@@ -218,7 +218,7 @@ const (
 
 func IsTwoFactorError(err error) bool {
 	e, ok := err.(*Error)
-	if !ok {
+	if !ok || e == nil {
 		return false
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -257,3 +257,12 @@ func (cs *clientSuite) TestParseError(c *check.C) {
 	err = client.ParseErrorInTest(resp)
 	c.Check(err, check.ErrorMatches, `server error: "400 Bad Request"`)
 }
+
+func (cs *clientSuite) TestIsTwoFactor(c *check.C) {
+	c.Check(client.IsTwoFactorError(&client.Error{Kind: client.ErrorKindTwoFactorRequired}), check.Equals, true)
+	c.Check(client.IsTwoFactorError(&client.Error{Kind: client.ErrorKindTwoFactorFailed}), check.Equals, true)
+	c.Check(client.IsTwoFactorError(&client.Error{Kind: "some other kind"}), check.Equals, false)
+	c.Check(client.IsTwoFactorError(errors.New("test")), check.Equals, false)
+	c.Check(client.IsTwoFactorError(nil), check.Equals, false)
+	c.Check(client.IsTwoFactorError((*client.Error)(nil)), check.Equals, false)
+}

--- a/cmd/snap/cmd_build.go
+++ b/cmd/snap/cmd_build.go
@@ -29,7 +29,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 
 	"github.com/jessevdk/go-flags"
@@ -69,16 +68,17 @@ func (x *cmdBuild) Execute(args []string) (err error) {
 
 	_, err = exec.LookPath(clickReview)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not review package (%s not available)\n", clickReview)
+		fmt.Fprintf(Stderr, "Warning: could not review package (%s not available)\n", clickReview)
 	} else {
 		cmd := exec.Command(clickReview, snapPackage)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		cmd.Stdin = Stdin
+		cmd.Stdout = Stdout
+		cmd.Stderr = Stderr
 		// we ignore the error for now
 		_ = cmd.Run()
 	}
 
 	// TRANSLATORS: the %s is a pkgname
-	fmt.Printf(i18n.G("Generated '%s' snap\n"), snapPackage)
+	fmt.Fprintf(Stdout, i18n.G("Generated '%s' snap\n"), snapPackage)
 	return nil
 }

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -116,7 +116,7 @@ func (c *cmdChanges) showChange(id string) error {
 		fmt.Fprintln(Stdout, t.Summary)
 		fmt.Fprintln(Stdout)
 		for _, line := range t.Log {
-			fmt.Println(line)
+			fmt.Fprintln(Stdout, line)
 		}
 	}
 

--- a/cmd/snap/cmd_classic.go
+++ b/cmd/snap/cmd_classic.go
@@ -67,7 +67,7 @@ func (x *cmdEnableClassic) doEnable() (err error) {
 		return err
 	}
 
-	fmt.Println(i18n.G(`Classic dimension enabled on this snappy system.
+	fmt.Fprintln(Stdout, i18n.G(`Classic dimension enabled on this snappy system.
 Use "snap shell classic" to enter the classic dimension.`))
 	return nil
 }
@@ -85,6 +85,6 @@ func (x *cmdDestroyClassic) doDisable() (err error) {
 		return err
 	}
 
-	fmt.Println(i18n.G(`Classic dimension destroyed on this snappy system.`))
+	fmt.Fprintln(Stdout, i18n.G(`Classic dimension destroyed on this snappy system.`))
 	return nil
 }

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -86,7 +86,7 @@ func (s *SnapSuite) TestDisconnectExplicitEverything(c *C) {
 	rest, err := Parser().ParseArgs([]string{"disconnect", "producer:plug", "consumer:slot"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
-	c.Assert(s.Stdout(), Equals, "")
+	c.Assert(s.Stdout(), Equals, "\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -121,7 +121,7 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSlot(c *C) {
 	rest, err := Parser().ParseArgs([]string{"disconnect", "consumer:slot"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
-	c.Assert(s.Stdout(), Equals, "")
+	c.Assert(s.Stdout(), Equals, "\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -156,6 +156,6 @@ func (s *SnapSuite) TestDisconnectEverythingFromSpecificSnap(c *C) {
 	rest, err := Parser().ParseArgs([]string{"disconnect", "consumer"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
-	c.Assert(s.Stdout(), Equals, "")
+	c.Assert(s.Stdout(), Equals, "\n")
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -22,7 +22,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"os"
 
 	"github.com/jessevdk/go-flags"
 	"golang.org/x/crypto/ssh/terminal"
@@ -59,7 +58,7 @@ func requestLoginWith2faRetry(username, password string) error {
 	var msgs = [3]string{
 		i18n.G("Two-factor code: "),
 		i18n.G("Bad code. Try again: "),
-		i18n.G("Wrong again. Last chance: "),
+		i18n.G("Wrong again. Once more: "),
 	}
 
 	cli := Client()
@@ -72,8 +71,8 @@ func requestLoginWith2faRetry(username, password string) error {
 			return err
 		}
 
-		reader.Reset(os.Stdin)
-		fmt.Print(msgs[i])
+		reader.Reset(Stdin)
+		fmt.Fprint(Stdout, msgs[i])
 		// the browser shows it as well (and Sergio wants to see it ;)
 		otp, _, err = reader.ReadLine()
 		if err != nil {
@@ -84,9 +83,9 @@ func requestLoginWith2faRetry(username, password string) error {
 
 func (x *cmdLogin) Execute(args []string) error {
 	username := x.Positional.UserName
-	fmt.Print(i18n.G("Password: "))
+	fmt.Fprint(Stdout, i18n.G("Password: "))
 	password, err := terminal.ReadPassword(0)
-	fmt.Print("\n")
+	fmt.Fprint(Stdout, "\n")
 	if err != nil {
 		return err
 	}
@@ -95,7 +94,7 @@ func (x *cmdLogin) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(i18n.G("Login successful"))
+	fmt.Fprintln(Stdout, i18n.G("Login successful"))
 
 	return nil
 }

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -65,9 +65,9 @@ func requestLoginWith2faRetry(username, password string) error {
 	reader := bufio.NewReader(nil)
 
 	for i := 0; ; i++ {
-		// first try without otp
+		// first try is without otp
 		_, err = cli.Login(username, password, string(otp))
-		if i > 2 || !client.IsTwoFactorError(err) {
+		if i >= len(msgs) || !client.IsTwoFactorError(err) {
 			return err
 		}
 

--- a/cmd/snap/cmd_man.go
+++ b/cmd/snap/cmd_man.go
@@ -20,8 +20,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/ubuntu-core/snappy/i18n"
 
 	"github.com/jessevdk/go-flags"
@@ -45,7 +43,7 @@ func (*cmdMan) Execute([]string) error {
 	parser.LongDescription = `
 The snap tool interacts with the snapd daemon to control the snappy software platform.
 `
-	parser.WriteManPage(os.Stdout)
+	parser.WriteManPage(Stdout)
 
 	return nil
 }

--- a/cmd/snap/cmd_shell.go
+++ b/cmd/snap/cmd_shell.go
@@ -74,8 +74,8 @@ Use "sudo snap enable-classic" to enable it.`))
 			}
 		}
 
-		fmt.Println(i18n.G(`Entering classic dimension`))
-		fmt.Println(i18n.G(`
+		fmt.Fprintln(Stdout, i18n.G(`Entering classic dimension`))
+		fmt.Fprintln(Stdout, i18n.G(`
 
 The home directory is shared between snappy and the classic dimension.
 Run "exit" to leave the classic shell.

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -36,7 +36,7 @@ func wait(client *client.Client, id string) error {
 	pb := progress.NewTextProgress()
 	defer func() {
 		pb.Finished()
-		fmt.Print("\n")
+		fmt.Fprint(Stdout, "\n")
 	}()
 
 	var lastID string

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -61,7 +61,7 @@ func (s *SnapSuite) TestInstall(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "chan", "foo.bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "\n")
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(n, check.Equals, 3)
@@ -99,7 +99,7 @@ func (s *SnapSuite) TestInstallDevMode(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"install", "--channel", "chan", "--devmode", "foo.bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "\n")
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(n, check.Equals, 3)
@@ -142,7 +142,7 @@ func (s *SnapSuite) TestInstallPath(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"install", snapPath})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "\n")
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(n, check.Equals, 3)
@@ -185,7 +185,7 @@ func (s *SnapSuite) TestInstallPathDevMode(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"install", "--devmode", snapPath})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "\n")
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(n, check.Equals, 3)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -31,11 +31,12 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-// Stdout is the standard output stream, it is redirected for testing.
-var Stdout io.Writer = os.Stdout
-
-// Stderr is the standard error stream, it is redirected for testing.
-var Stderr io.Writer = os.Stderr
+// Standard streams, redirected for testing.
+var (
+	Stdin  io.Reader = os.Stdin
+	Stdout io.Writer = os.Stdout
+	Stderr io.Writer = os.Stderr
+)
 
 type options struct {
 	// No global options yet

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -38,6 +38,7 @@ func Test(t *testing.T) { TestingT(t) }
 
 type SnapSuite struct {
 	testutil.BaseTest
+	stdin  *bytes.Buffer
 	stdout *bytes.Buffer
 	stderr *bytes.Buffer
 }
@@ -46,13 +47,16 @@ var _ = Suite(&SnapSuite{})
 
 func (s *SnapSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.stdin = bytes.NewBuffer(nil)
 	s.stdout = bytes.NewBuffer(nil)
 	s.stderr = bytes.NewBuffer(nil)
+	Stdin = s.stdin
 	Stdout = s.stdout
 	Stderr = s.stderr
 }
 
 func (s *SnapSuite) TearDownTest(c *C) {
+	Stdin = os.Stdin
 	Stdout = os.Stdout
 	Stderr = os.Stderr
 	s.BaseTest.TearDownTest(c)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -198,15 +198,14 @@ func loginUser(c *Command, r *http.Request) Response {
 	discharge, err := store.DischargeAuthCaveat(loginData.Username, loginData.Password, macaroon, loginData.Otp)
 	switch err {
 	case store.ErrAuthenticationNeeds2fa:
-		twofactorRequiredResponse := &resp{
+		return SyncResponse(&resp{
 			Type: ResponseTypeError,
 			Result: &errorResult{
 				Kind:    errorKindTwoFactorRequired,
 				Message: err.Error(),
 			},
 			Status: http.StatusUnauthorized,
-		}
-		return SyncResponse(twofactorRequiredResponse, nil)
+		}, nil)
 	case store.Err2faFailed:
 		return SyncResponse(&resp{
 			Type: ResponseTypeError,
@@ -214,7 +213,7 @@ func loginUser(c *Command, r *http.Request) Response {
 				Kind:    errorKindTwoFactorFailed,
 				Message: err.Error(),
 			},
-			Status: http.StatusForbidden,
+			Status: http.StatusUnauthorized,
 		}, nil)
 	default:
 		return Unauthorized(err.Error())

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -669,7 +669,7 @@ func (s *apiSuite) TestLoginUserTwoFactorFailedError(c *check.C) {
 	rsp := loginUser(snapCmd, req).(*resp)
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Status, check.Equals, http.StatusForbidden)
+	c.Check(rsp.Status, check.Equals, http.StatusUnauthorized)
 	c.Check(rsp.Result.(*errorResult).Kind, check.Equals, errorKindTwoFactorFailed)
 }
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ubuntu-core/snappy/asserts"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/notifications"
-	"github.com/ubuntu-core/snappy/store"
 )
 
 // ResponseType is the response type
@@ -127,7 +126,8 @@ type errorKind string
 
 const (
 	errorKindLicenseRequired   = errorKind("license-required")
-	errorKindTwoFactorRequired = errorKind(store.TwoFactorErrKind)
+	errorKindTwoFactorRequired = errorKind("two-factor-required")
+	errorKindTwoFactorFailed   = errorKind("two-factor-failed")
 )
 
 type errorValue interface{}

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-28 11:03+0100\n"
+        "POT-Creation-Date: 2016-04-28 11:32+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -224,7 +224,7 @@ msgstr  ""
 msgid   "Two-factor code: "
 msgstr  ""
 
-msgid   "Wrong again. Last chance: "
+msgid   "Wrong again. Once more: "
 msgstr  ""
 
 msgid   "\n"

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-04-28 08:08+0200\n"
+        "POT-Creation-Date: 2016-04-28 11:03+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,6 +24,9 @@ msgid   "Activate %q snap"
 msgstr  ""
 
 msgid   "Adds an assertion to the system"
+msgstr  ""
+
+msgid   "Bad code. Try again: "
 msgstr  ""
 
 msgid   "Builds a snap package"
@@ -219,6 +222,9 @@ msgid   "This command logs the given username into the store"
 msgstr  ""
 
 msgid   "Two-factor code: "
+msgstr  ""
+
+msgid   "Wrong again. Last chance: "
 msgstr  ""
 
 msgid   "\n"

--- a/store/auth.go
+++ b/store/auth.go
@@ -136,6 +136,9 @@ func DischargeAuthCaveat(username, password, macaroon, otp string) (string, erro
 		if msg.Code == "TWOFACTOR_REQUIRED" {
 			return "", ErrAuthenticationNeeds2fa
 		}
+		if msg.Code == "TWOFACTOR_FAILURE" {
+			return "", Err2faFailed
+		}
 
 		if msg.Message != "" {
 			return "", fmt.Errorf(errorPrefix+"%v", msg.Message)

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -52,7 +52,7 @@ const mockStoreNeeds2fa = `
 const mockStore2faFailedHTTPCode = 403
 const mockStore2faFailedResponse = `
 {
-    "meessage": "The provided 2-factor key is not recognised.", 
+    "message": "The provided 2-factor key is not recognised.", 
     "code": "TWOFACTOR_FAILURE", 
     "extra": {}
 }

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -49,6 +49,15 @@ const mockStoreNeeds2fa = `
 }
 `
 
+const mockStore2faFailedHTTPCode = 403
+const mockStore2faFailedResponse = `
+{
+    "meessage": "The provided 2-factor key is not recognised.", 
+    "code": "TWOFACTOR_FAILURE", 
+    "extra": {}
+}
+`
+
 const mockStoreReturnMacaroon = `
 {
     "macaroon": "the-root-macaroon-serialized-data"
@@ -121,6 +130,19 @@ func (s *authTestSuite) TestDischargeAuthCaveatNeeds2fa(c *C) {
 
 	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
 	c.Assert(err, Equals, ErrAuthenticationNeeds2fa)
+	c.Assert(discharge, Equals, "")
+}
+
+func (s *authTestSuite) TestDischargeAuthCaveatFails2fa(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(mockStore2faFailedHTTPCode)
+		io.WriteString(w, mockStore2faFailedResponse)
+	}))
+	defer mockServer.Close()
+	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
+
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	c.Assert(err, Equals, Err2faFailed)
 	c.Assert(discharge, Equals, "")
 }
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -25,11 +25,6 @@ import (
 	"net/url"
 )
 
-const (
-	// TwoFactorErrKind is the error kind to be returned if 2FA is needed
-	TwoFactorErrKind = "two-factor-required"
-)
-
 var (
 	// ErrSnapNotFound is returned when a snap can not be found
 	ErrSnapNotFound = errors.New("snap not found")
@@ -39,6 +34,9 @@ var (
 
 	// ErrAuthenticationNeeds2fa is returned if the authentication needs 2factor
 	ErrAuthenticationNeeds2fa = errors.New("two factor authentication required")
+
+	// Err2faFailed is returned when 2fa failed (e.g., a bad token was given)
+	Err2faFailed = errors.New("two factor authentication failed")
 
 	// ErrInvalidCredentials is returned on login error
 	ErrInvalidCredentials = errors.New("invalid credentials")


### PR DESCRIPTION
includes a rather weird construct in `cmd/snap` that i'm not too happy about, but at least it's DRY.