### PR TITLE
snappy: fix openSnapFile's handling of sideInfo

### DIFF
--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -37,12 +37,9 @@ func openSnapFile(snapPath string, unsignedOk bool, sideInfo *snap.SideInfo) (*s
 	if err != nil {
 		return nil, nil, err
 	}
-
-	var snapInfo snap.Info
-	snapInfo = *info
 	if sideInfo != nil {
-		snapInfo.SideInfo = *sideInfo
+		info.SideInfo = *sideInfo
 	}
 
-	return &snapInfo, snapf, nil
+	return info, snapf, nil
 }


### PR DESCRIPTION
This patch fixes a subtle bug in openSnapFile. The returned snap.Info
would have inconsistent snap.Info identity across its data structure.

This could be observed by loading a file with at least one application,
plug or slot. The .Snap reference from those objects would be different
from the top-level snap.Info object itself. As a result the sideInfo
would only be available from the top-level object.

In the end this would result in mysterious Revision-0 bugs if those apps
were used for certain things.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>