### PR TITLE
integration-tests, debian/tests: home interface

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -26,4 +26,4 @@ cp debian/tests/testconfig.json $GOPATH/src/github.com/ubuntu-core/snappy/integr
 cd $GOPATH/src/github.com/ubuntu-core/snappy
 go test -c ./integration-tests/tests
 
-./tests.test  -check.vv -check.f 'snapHelloWorldExampleSuite|snapOpSuite|searchSuite|installAppSuite|authSuite|networkInterfaceSuite'
+./tests.test  -check.vv -check.f 'snapHelloWorldExampleSuite|snapOpSuite|searchSuite|installAppSuite|authSuite|networkInterfaceSuite|homeInterfaceSuite'

--- a/integration-tests/data/snaps/home-consumer/bin/reader
+++ b/integration-tests/data/snaps/home-consumer/bin/reader
@@ -1,0 +1,14 @@
+#! /usr/bin/env python3
+
+import sys
+
+def main(fileName):
+  try:
+    with open(fileName) as f:
+      print(f.read(), end='')
+  except PermissionError:
+    print('Access to file not allowed')
+    raise
+
+if __name__ == '__main__':
+  main(sys.argv[1])

--- a/integration-tests/data/snaps/home-consumer/bin/writer
+++ b/integration-tests/data/snaps/home-consumer/bin/writer
@@ -1,0 +1,15 @@
+#! /usr/bin/env python3
+
+import sys
+
+def main(fileName):
+  try:
+    with open(fileName, "a+") as f:
+      msg = "ok\n"
+      f.write(msg)
+  except PermissionError:
+    print('Access to file not allowed')
+    raise
+
+if __name__ == '__main__':
+  main(sys.argv[1])

--- a/integration-tests/data/snaps/home-consumer/meta/snap.yaml
+++ b/integration-tests/data/snaps/home-consumer/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: home-consumer
+version: 1.0
+summary: Basic home consumer snap
+description: A basic snap declaring a plug on home
+
+apps:
+  reader:
+    command: bin/reader
+    plugs: [home]
+  writer:
+    command: bin/writer
+    plugs: [home]

--- a/integration-tests/tests/home_interface_test.go
+++ b/integration-tests/tests/home_interface_test.go
@@ -1,0 +1,146 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !excludeintegration
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/data"
+
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&homeInterfaceSuite{
+	interfaceSuite: interfaceSuite{
+		sampleSnap: data.HomeConsumerSnapName,
+		slot:       "home",
+		plug:       "home-consumer"}})
+
+type homeInterfaceSuite struct {
+	interfaceSuite
+}
+
+func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesRead(c *check.C) {
+	cli.ExecCommand(c, "sudo", "snap", "connect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	fileName, err := createHomeFile("readable", okOutput)
+	c.Assert(err, check.IsNil)
+	defer os.Remove(fileName)
+
+	output := cli.ExecCommand(c, "home-consumer.reader", fileName)
+	c.Assert(output, check.Equals, okOutput)
+
+	cli.ExecCommand(c, "sudo", "snap", "disconnect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	output, err = cli.ExecCommandErr("home-consumer.reader", fileName)
+	c.Assert(err, check.NotNil)
+	c.Assert(output == okOutput, check.Equals, false)
+}
+
+func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesAppend(c *check.C) {
+	cli.ExecCommand(c, "sudo", "snap", "connect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	previousContent := "previous content\n"
+	fileName, err := createHomeFile("writable", previousContent)
+	c.Assert(err, check.IsNil)
+
+	cli.ExecCommand(c, "home-consumer.writer", fileName)
+
+	dat, err := ioutil.ReadFile(fileName)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(dat), check.Equals, previousContent+okOutput)
+
+	err = os.Remove(fileName)
+	c.Assert(err, check.IsNil)
+
+	cli.ExecCommand(c, "sudo", "snap", "disconnect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	_, err = cli.ExecCommandErr("home-consumer.writer", fileName)
+	c.Assert(err, check.NotNil)
+}
+
+func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesCreate(c *check.C) {
+	cli.ExecCommand(c, "sudo", "snap", "connect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	home := os.Getenv("HOME")
+	fileName := filepath.Join(home, "writable")
+
+	cli.ExecCommand(c, "home-consumer.writer", fileName)
+
+	dat, err := ioutil.ReadFile(fileName)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(dat), check.Equals, okOutput)
+
+	err = os.Remove(fileName)
+	c.Assert(err, check.IsNil)
+
+	cli.ExecCommand(c, "sudo", "snap", "disconnect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	_, err = cli.ExecCommandErr("home-consumer.writer", fileName)
+	c.Assert(err, check.NotNil)
+}
+
+func (s *homeInterfaceSuite) TestReadHiddenFilesForbidden(c *check.C) {
+	cli.ExecCommand(c, "sudo", "snap", "connect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	fileName, err := createHomeFile(".readable", okOutput)
+	c.Assert(err, check.IsNil)
+	defer os.Remove(fileName)
+
+	output, err := cli.ExecCommandErr("home-consumer.reader", fileName)
+	c.Assert(err, check.NotNil)
+	c.Assert(output == okOutput, check.Equals, false)
+}
+
+func (s *homeInterfaceSuite) TestWriteHiddenFilesForbidden(c *check.C) {
+	cli.ExecCommand(c, "sudo", "snap", "connect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	previousContent := "previous content\n"
+	fileName, err := createHomeFile(".writable", previousContent)
+	c.Assert(err, check.IsNil)
+	defer os.Remove(fileName)
+
+	_, err = cli.ExecCommandErr("home-consumer.writer", fileName)
+	c.Assert(err, check.NotNil)
+
+	dat, err := ioutil.ReadFile(fileName)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(dat), check.Equals, previousContent)
+}
+
+func createHomeFile(name, content string) (path string, err error) {
+	home := os.Getenv("HOME")
+	path = filepath.Join(home, name)
+	err = ioutil.WriteFile(path, []byte(content), 0644)
+
+	return path, err
+}

--- a/integration-tests/tests/network_interface_test.go
+++ b/integration-tests/tests/network_interface_test.go
@@ -1,0 +1,53 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !excludeintegration
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/data"
+
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&networkInterfaceSuite{
+	interfaceSuite: interfaceSuite{
+		sampleSnap:  data.NetworkConsumerSnapName,
+		slot:        "network",
+		plug:        "network-consumer",
+		autoconnect: true}})
+
+type networkInterfaceSuite struct {
+	interfaceSuite
+}
+
+func (s *networkInterfaceSuite) TestPlugDisconnectionDisablesFunctionality(c *check.C) {
+	output := cli.ExecCommand(c, "network-consumer")
+	c.Assert(output, check.Equals, okOutput)
+
+	cli.ExecCommand(c, "sudo", "snap", "disconnect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	output = cli.ExecCommand(c, "snap", "interfaces")
+	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))
+
+	output = cli.ExecCommand(c, "network-consumer")
+	c.Assert(output == okOutput, check.Equals, false)
+}

--- a/integration-tests/testutils/data/data.go
+++ b/integration-tests/testutils/data/data.go
@@ -37,6 +37,8 @@ const (
 	BasicDesktopSnapName = "basic-desktop"
 	// NetworkConsumerSnapName is the name of the snap with network plug
 	NetworkConsumerSnapName = "network-consumer"
+	// HomeConsumerSnapName is the name of the snap with home plug
+	HomeConsumerSnapName = "home-consumer"
 	// WrongYamlSnapName is the name of a snap with an invalid meta yaml
 	WrongYamlSnapName = "wrong-yaml"
 )


### PR DESCRIPTION
* Integration tests:
    * reading, appending and creating text in files under the home directory with a sample snap using the home plug. 
    * inability to work with hidden files
* networkInterfaceSuite refactored, there's a common interfaceSuite embedded in both network and home interface suites, with common methods, fields and tests.
* homeInterfaceSuite added to autopkgtest