### PR TITLE
cmd: don't include the unit tests when building with go test -c for integration tests

### DIFF
--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !integrationcoverage
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !integrationcoverage
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !integrationcoverage
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !integrationcoverage
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/cmd/snap/interfaces_common_test.go
+++ b/cmd/snap/interfaces_common_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !integrationcoverage
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !integrationcoverage
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/run-checks
+++ b/run-checks
@@ -105,6 +105,22 @@ if [ ! -z "$STATIC" ]; then
         # don't exit 1
     fi
 
+    # cmd/* test sources are tagged so they are not included in
+    # special integration test builds
+    echo Checking 'cmd/*/*_test.go' build tagging
+    bad=""
+    for cmd in cmd/* ; do
+        nottagged=$(ls ${cmd}/*_test.go|grep -v integration_coverage_test|grep -v -F "$(grep -l '!integrationcoverage' ${cmd}/*_test.go)" || true)
+
+        if [ -n "${nottagged}" ] ; then
+            echo these ${cmd} test files miss the '!integrationcoverage' tag: ${nottagged}
+            bad=1
+        fi
+    done
+    if [ -n "${bad}" ] ; then
+        exit 1
+    fi
+
     # pot file
     echo Checking translations
     TMPF="$(mktemp)"


### PR DESCRIPTION
Also adds a check to "run-check --static" to keep it so.