### PR TITLE
daemon,snap,snappy: have one helper to read info from snap file (parallel to ReadInfo)

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -870,7 +870,7 @@ func readSnapInfoImpl(snapPath string) (*snap.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	return snapf.Info()
+	return snap.ReadInfoFromSnapFile(snapf, nil)
 }
 
 var readSnapInfo = readSnapInfoImpl

--- a/snap/info.go
+++ b/snap/info.go
@@ -249,15 +249,15 @@ func infoFromSnapYamlWithSideInfo(meta []byte, si *SideInfo, validate bool) (*In
 		return nil, err
 	}
 
+	if si != nil {
+		info.SideInfo = *si
+	}
+
 	if validate {
 		err := Validate(info)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if si != nil {
-		info.SideInfo = *si
 	}
 
 	return info, nil

--- a/snap/info.go
+++ b/snap/info.go
@@ -243,7 +243,7 @@ func (app *AppInfo) ServiceSocketFile() string {
 	return filepath.Join(dirs.SnapServicesDir, app.SecurityTag()+".socket")
 }
 
-func infoFromSnapYamlWithSideInfo(meta []byte, si *SideInfo, validate bool) (*Info, error) {
+func infoFromSnapYamlWithSideInfo(meta []byte, si *SideInfo) (*Info, error) {
 	info, err := InfoFromSnapYaml(meta)
 	if err != nil {
 		return nil, err
@@ -251,13 +251,6 @@ func infoFromSnapYamlWithSideInfo(meta []byte, si *SideInfo, validate bool) (*In
 
 	if si != nil {
 		info.SideInfo = *si
-	}
-
-	if validate {
-		err := Validate(info)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return info, nil
@@ -274,7 +267,7 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 		return nil, err
 	}
 
-	return infoFromSnapYamlWithSideInfo(meta, si, false)
+	return infoFromSnapYamlWithSideInfo(meta, si)
 }
 
 // ReadInfoFromSnapFile reads the snap information from the given File
@@ -285,5 +278,15 @@ func ReadInfoFromSnapFile(snapf File, si *SideInfo) (*Info, error) {
 		return nil, err
 	}
 
-	return infoFromSnapYamlWithSideInfo(meta, si, true)
+	info, err := infoFromSnapYamlWithSideInfo(meta, si)
+	if err != nil {
+		return nil, err
+	}
+
+	err = Validate(info)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }

--- a/snappy/snap_file.go
+++ b/snappy/snap_file.go
@@ -33,12 +33,9 @@ func openSnapFile(snapPath string, unsignedOk bool, sideInfo *snap.SideInfo) (*s
 		return nil, nil, err
 	}
 
-	info, err := snapf.Info()
+	info, err := snap.ReadInfoFromSnapFile(snapf, sideInfo)
 	if err != nil {
 		return nil, nil, err
-	}
-	if sideInfo != nil {
-		info.SideInfo = *sideInfo
 	}
 
 	return info, snapf, nil


### PR DESCRIPTION
Introduces ReadInfoFromSnapFile. Reasons for this:
* as uncovered by the revision 0 bug, overriding SideInfo is slightly delicate, better to make it the task of code under snap/
* more symmetry with ReadInfo
* this seems more a task to be built on top of snap.File primitives than to be redone by each snap.File, plan is to remove File.Info actually. If we grew more snap.File impls which we might they would need to repeat code with the previous approach