### PR TITLE
snappy,systemd: move GenServiceFile, GetSocketFile from systemd/

### DIFF
--- a/snappy/services.go
+++ b/snappy/services.go
@@ -301,7 +301,7 @@ WantedBy={{.ServiceSystemdTarget}}
 		filepath.Join(desc.SnapPath, desc.Start),
 		filepath.Join(desc.SnapPath, desc.Stop),
 		filepath.Join(desc.SnapPath, desc.PostStop),
-		systemd.ServicesSystemdTarget,
+		systemd.ServicesTarget,
 		arch.UbuntuArchitecture(),
 		// systemd runs as PID 1 so %h will not work.
 		"/root",
@@ -351,7 +351,7 @@ WantedBy={{.SocketSystemdTarget}}
 		desc.ServiceFileName,
 		desc.ListenStream,
 		desc.SocketMode,
-		systemd.SocketsSystemdTarget,
+		systemd.SocketsTarget,
 	}
 
 	if err := t.Execute(&templateOut, wrapperData); err != nil {

--- a/snappy/services.go
+++ b/snappy/services.go
@@ -51,14 +51,6 @@ type interacter interface {
 // wait this time between TERM and KILL
 var killWait = 5 * time.Second
 
-const (
-	// the default target for systemd units that we generate
-	servicesSystemdTarget = "multi-user.target"
-
-	// the default target for systemd units that we generate
-	socketsSystemdTarget = "sockets.target"
-)
-
 // servicesBinariesStringsWhitelist is the whitelist of legal chars
 // in the "binaries" and "services" section of the snap.yaml
 var servicesBinariesStringsWhitelist = regexp.MustCompile(`^[A-Za-z0-9/. _#:-]*$`)
@@ -309,7 +301,7 @@ WantedBy={{.ServiceSystemdTarget}}
 		filepath.Join(desc.SnapPath, desc.Start),
 		filepath.Join(desc.SnapPath, desc.Stop),
 		filepath.Join(desc.SnapPath, desc.PostStop),
-		servicesSystemdTarget,
+		systemd.ServicesSystemdTarget,
 		arch.UbuntuArchitecture(),
 		// systemd runs as PID 1 so %h will not work.
 		"/root",
@@ -359,7 +351,7 @@ WantedBy={{.SocketSystemdTarget}}
 		desc.ServiceFileName,
 		desc.ListenStream,
 		desc.SocketMode,
-		socketsSystemdTarget,
+		systemd.SocketsSystemdTarget,
 	}
 
 	if err := t.Execute(&templateOut, wrapperData); err != nil {

--- a/snappy/services.go
+++ b/snappy/services.go
@@ -20,16 +20,21 @@
 package snappy
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
+	"text/template"
 	"time"
 
+	"github.com/ubuntu-core/snappy/arch"
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/snapenv"
 	"github.com/ubuntu-core/snappy/systemd"
 	"github.com/ubuntu-core/snappy/timeout"
 )
@@ -45,6 +50,14 @@ type interacter interface {
 
 // wait this time between TERM and KILL
 var killWait = 5 * time.Second
+
+const (
+	// the default target for systemd units that we generate
+	servicesSystemdTarget = "multi-user.target"
+
+	// the default target for systemd units that we generate
+	socketsSystemdTarget = "sockets.target"
+)
 
 // servicesBinariesStringsWhitelist is the whitelist of legal chars
 // in the "binaries" and "services" section of the snap.yaml
@@ -70,26 +83,25 @@ func generateSnapServicesFile(app *snap.AppInfo, baseDir string) (string, error)
 		socketFileName = filepath.Base(app.ServiceSocketFile())
 	}
 
-	return systemd.New(dirs.GlobalRootDir, nil).GenServiceFile(
-		&systemd.ServiceDescription{
-			SnapName:       app.Snap.Name(),
-			AppName:        app.Name,
-			Version:        app.Snap.Version,
-			Revision:       app.Snap.Revision,
-			Description:    desc,
-			SnapPath:       baseDir,
-			Start:          app.Command,
-			Stop:           app.Stop,
-			PostStop:       app.PostStop,
-			StopTimeout:    serviceStopTimeout(app),
-			AaProfile:      app.SecurityTag(),
-			BusName:        app.BusName,
-			Type:           app.Daemon,
-			UdevAppName:    app.SecurityTag(),
-			Socket:         app.Socket,
-			SocketFileName: socketFileName,
-			Restart:        app.RestartCond,
-		}), nil
+	return GenServiceFile(&ServiceDescription{
+		SnapName:       app.Snap.Name(),
+		AppName:        app.Name,
+		Version:        app.Snap.Version,
+		Revision:       app.Snap.Revision,
+		Description:    desc,
+		SnapPath:       baseDir,
+		Start:          app.Command,
+		Stop:           app.Stop,
+		PostStop:       app.PostStop,
+		StopTimeout:    serviceStopTimeout(app),
+		AaProfile:      app.SecurityTag(),
+		BusName:        app.BusName,
+		Type:           app.Daemon,
+		UdevAppName:    app.SecurityTag(),
+		Socket:         app.Socket,
+		SocketFileName: socketFileName,
+		Restart:        app.RestartCond,
+	}), nil
 }
 
 func generateSnapSocketFile(app *snap.AppInfo, baseDir string) (string, error) {
@@ -105,12 +117,11 @@ func generateSnapSocketFile(app *snap.AppInfo, baseDir string) (string, error) {
 
 	serviceFileName := filepath.Base(app.ServiceFile())
 
-	return systemd.New(dirs.GlobalRootDir, nil).GenSocketFile(
-		&systemd.ServiceDescription{
-			ServiceFileName: serviceFileName,
-			ListenStream:    app.ListenStream,
-			SocketMode:      app.SocketMode,
-		}), nil
+	return GenSocketFile(&ServiceDescription{
+		ServiceFileName: serviceFileName,
+		ListenStream:    app.ListenStream,
+		SocketMode:      app.SocketMode,
+	}), nil
 }
 
 func addPackageServices(s *snap.Info, inter interacter) error {
@@ -224,4 +235,137 @@ func removePackageServices(s *snap.Info, inter interacter) error {
 	}
 
 	return nil
+}
+
+// ServiceDescription describes a snappy systemd service
+type ServiceDescription struct {
+	SnapName        string
+	AppName         string
+	Version         string
+	Revision        int
+	Description     string
+	SnapPath        string
+	Start           string
+	Stop            string
+	PostStop        string
+	StopTimeout     time.Duration
+	Restart         systemd.RestartCondition
+	Type            string
+	AaProfile       string
+	BusName         string
+	UdevAppName     string
+	Socket          bool
+	SocketFileName  string
+	ListenStream    string
+	SocketMode      string
+	ServiceFileName string
+}
+
+func GenServiceFile(desc *ServiceDescription) string {
+	serviceTemplate := `[Unit]
+Description={{.Description}}
+After=snapd.frameworks.target{{ if .Socket }} {{.SocketFileName}}{{end}}
+Requires=snapd.frameworks.target{{ if .Socket }} {{.SocketFileName}}{{end}}
+X-Snappy=yes
+
+[Service]
+ExecStart=/usr/bin/ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.FullPathStart}}
+Restart={{.Restart}}
+WorkingDirectory=/var{{.SnapPath}}
+Environment={{.EnvVars}}
+{{if .Stop}}ExecStop=/usr/bin/ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.FullPathStop}}{{end}}
+{{if .PostStop}}ExecStopPost=/usr/bin/ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.FullPathPostStop}}{{end}}
+{{if .StopTimeout}}TimeoutStopSec={{.StopTimeout.Seconds}}{{end}}
+Type={{.Type}}
+{{if .BusName}}BusName={{.BusName}}{{end}}
+
+[Install]
+WantedBy={{.ServiceSystemdTarget}}
+`
+	var templateOut bytes.Buffer
+	t := template.Must(template.New("wrapper").Parse(serviceTemplate))
+
+	restartCond := desc.Restart.String()
+	if restartCond == "" {
+		restartCond = systemd.RestartOnFailure.String()
+	}
+
+	wrapperData := struct {
+		// the service description
+		ServiceDescription
+		// and some composed values
+		FullPathStart        string
+		FullPathStop         string
+		FullPathPostStop     string
+		ServiceSystemdTarget string
+		SnapArch             string
+		Home                 string
+		EnvVars              string
+		SocketFileName       string
+		Restart              string
+		Type                 string
+	}{
+		*desc,
+		filepath.Join(desc.SnapPath, desc.Start),
+		filepath.Join(desc.SnapPath, desc.Stop),
+		filepath.Join(desc.SnapPath, desc.PostStop),
+		servicesSystemdTarget,
+		arch.UbuntuArchitecture(),
+		// systemd runs as PID 1 so %h will not work.
+		"/root",
+		"",
+		desc.SocketFileName,
+		restartCond,
+		desc.Type,
+	}
+	allVars := snapenv.GetBasicSnapEnvVars(wrapperData)
+	allVars = append(allVars, snapenv.GetUserSnapEnvVars(wrapperData)...)
+	wrapperData.EnvVars = "\"" + strings.Join(allVars, "\" \"") + "\"" // allVars won't be empty
+
+	if err := t.Execute(&templateOut, wrapperData); err != nil {
+		// this can never happen, except we forget a variable
+		logger.Panicf("Unable to execute template: %v", err)
+	}
+
+	return templateOut.String()
+}
+
+func GenSocketFile(desc *ServiceDescription) string {
+	serviceTemplate := `[Unit]
+Description={{.Description}} Socket Unit File
+PartOf={{.ServiceFileName}}
+X-Snappy=yes
+
+[Socket]
+ListenStream={{.ListenStream}}
+{{if .SocketMode}}SocketMode={{.SocketMode}}{{end}}
+
+[Install]
+WantedBy={{.SocketSystemdTarget}}
+`
+	var templateOut bytes.Buffer
+	t := template.Must(template.New("wrapper").Parse(serviceTemplate))
+
+	wrapperData := struct {
+		// the service description
+		ServiceDescription
+		// and some composed values
+		ServiceFileName,
+		ListenStream string
+		SocketMode          string
+		SocketSystemdTarget string
+	}{
+		*desc,
+		desc.ServiceFileName,
+		desc.ListenStream,
+		desc.SocketMode,
+		socketsSystemdTarget,
+	}
+
+	if err := t.Execute(&templateOut, wrapperData); err != nil {
+		// this can never happen, except we forget a variable
+		logger.Panicf("Unable to execute template: %v", err)
+	}
+
+	return templateOut.String()
 }

--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -26,7 +26,6 @@ import (
 var (
 	SystemdRun = run // NOTE: plain Run clashes with check.v1
 	Jctl       = jctl
-	RestartMap = restartMap
 )
 
 func MockStopStepsStopDelay() func() {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -146,10 +146,10 @@ func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) err
 
 const (
 	// the default target for systemd units that we generate
-	ServicesSystemdTarget = "multi-user.target"
+	ServicesTarget = "multi-user.target"
 
 	// the default target for systemd units that we generate
-	SocketsSystemdTarget = "sockets.target"
+	SocketsTarget = "sockets.target"
 
 	// the location to put system services
 	snapServicesDir = "/etc/systemd/system"

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -29,15 +29,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
-	"text/template"
 	"time"
 
-	"github.com/ubuntu-core/snappy/arch"
 	"github.com/ubuntu-core/snappy/dirs"
-	"github.com/ubuntu-core/snappy/logger"
 	"github.com/ubuntu-core/snappy/osutil"
-	"github.com/ubuntu-core/snappy/snap/snapenv"
 )
 
 var (
@@ -93,8 +88,6 @@ type Systemd interface {
 	Stop(service string, timeout time.Duration) error
 	Kill(service, signal string) error
 	Restart(service string, timeout time.Duration) error
-	GenServiceFile(desc *ServiceDescription) string
-	GenSocketFile(desc *ServiceDescription) string
 	Status(service string) (string, error)
 	ServiceStatus(service string) (*ServiceStatus, error)
 	Logs(services []string) ([]Log, error)
@@ -117,7 +110,7 @@ const (
 	RestartAlways     RestartCondition = "always"
 )
 
-var restartMap = map[string]RestartCondition{
+var RestartMap = map[string]RestartCondition{
 	"never":       RestartNever,
 	"on-success":  RestartOnSuccess,
 	"on-failure":  RestartOnFailure,
@@ -141,7 +134,7 @@ func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) err
 		return err
 	}
 
-	nrc, ok := restartMap[v]
+	nrc, ok := RestartMap[v]
 	if !ok {
 		return ErrUnknownRestartCondition
 	}
@@ -151,37 +144,7 @@ func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) err
 	return nil
 }
 
-// ServiceDescription describes a snappy systemd service
-type ServiceDescription struct {
-	SnapName        string
-	AppName         string
-	Version         string
-	Revision        int
-	Description     string
-	SnapPath        string
-	Start           string
-	Stop            string
-	PostStop        string
-	StopTimeout     time.Duration
-	Restart         RestartCondition
-	Type            string
-	AaProfile       string
-	BusName         string
-	UdevAppName     string
-	Socket          bool
-	SocketFileName  string
-	ListenStream    string
-	SocketMode      string
-	ServiceFileName string
-}
-
 const (
-	// the default target for systemd units that we generate
-	servicesSystemdTarget = "multi-user.target"
-
-	// the default target for systemd units that we generate
-	socketsSystemdTarget = "sockets.target"
-
 	// the location to put system services
 	snapServicesDir = "/etc/systemd/system"
 )
@@ -332,115 +295,6 @@ func (s *systemd) Stop(serviceName string, timeout time.Duration) error {
 	}
 
 	return &Timeout{action: "stop", service: serviceName}
-}
-
-func (s *systemd) GenServiceFile(desc *ServiceDescription) string {
-	serviceTemplate := `[Unit]
-Description={{.Description}}
-After=snapd.frameworks.target{{ if .Socket }} {{.SocketFileName}}{{end}}
-Requires=snapd.frameworks.target{{ if .Socket }} {{.SocketFileName}}{{end}}
-X-Snappy=yes
-
-[Service]
-ExecStart=/usr/bin/ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.FullPathStart}}
-Restart={{.Restart}}
-WorkingDirectory=/var{{.SnapPath}}
-Environment={{.EnvVars}}
-{{if .Stop}}ExecStop=/usr/bin/ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.FullPathStop}}{{end}}
-{{if .PostStop}}ExecStopPost=/usr/bin/ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.FullPathPostStop}}{{end}}
-{{if .StopTimeout}}TimeoutStopSec={{.StopTimeout.Seconds}}{{end}}
-Type={{.Type}}
-{{if .BusName}}BusName={{.BusName}}{{end}}
-
-[Install]
-WantedBy={{.ServiceSystemdTarget}}
-`
-	var templateOut bytes.Buffer
-	t := template.Must(template.New("wrapper").Parse(serviceTemplate))
-
-	restartCond := desc.Restart.String()
-	if restartCond == "" {
-		restartCond = RestartOnFailure.String()
-	}
-
-	wrapperData := struct {
-		// the service description
-		ServiceDescription
-		// and some composed values
-		FullPathStart        string
-		FullPathStop         string
-		FullPathPostStop     string
-		ServiceSystemdTarget string
-		SnapArch             string
-		Home                 string
-		EnvVars              string
-		SocketFileName       string
-		Restart              string
-		Type                 string
-	}{
-		*desc,
-		filepath.Join(desc.SnapPath, desc.Start),
-		filepath.Join(desc.SnapPath, desc.Stop),
-		filepath.Join(desc.SnapPath, desc.PostStop),
-		servicesSystemdTarget,
-		arch.UbuntuArchitecture(),
-		// systemd runs as PID 1 so %h will not work.
-		"/root",
-		"",
-		desc.SocketFileName,
-		restartCond,
-		desc.Type,
-	}
-	allVars := snapenv.GetBasicSnapEnvVars(wrapperData)
-	allVars = append(allVars, snapenv.GetUserSnapEnvVars(wrapperData)...)
-	wrapperData.EnvVars = "\"" + strings.Join(allVars, "\" \"") + "\"" // allVars won't be empty
-
-	if err := t.Execute(&templateOut, wrapperData); err != nil {
-		// this can never happen, except we forget a variable
-		logger.Panicf("Unable to execute template: %v", err)
-	}
-
-	return templateOut.String()
-}
-
-func (s *systemd) GenSocketFile(desc *ServiceDescription) string {
-	serviceTemplate := `[Unit]
-Description={{.Description}} Socket Unit File
-PartOf={{.ServiceFileName}}
-X-Snappy=yes
-
-[Socket]
-ListenStream={{.ListenStream}}
-{{if .SocketMode}}SocketMode={{.SocketMode}}{{end}}
-
-[Install]
-WantedBy={{.SocketSystemdTarget}}
-`
-	var templateOut bytes.Buffer
-	t := template.Must(template.New("wrapper").Parse(serviceTemplate))
-
-	wrapperData := struct {
-		// the service description
-		ServiceDescription
-		// and some composed values
-		ServiceFileName,
-		ListenStream string
-		SocketMode          string
-		SocketSystemdTarget string
-	}{
-		*desc,
-		desc.ServiceFileName,
-		desc.ListenStream,
-		desc.SocketMode,
-		socketsSystemdTarget,
-	}
-
-	if err := t.Execute(&templateOut, wrapperData); err != nil {
-		// this can never happen, except we forget a variable
-		logger.Panicf("Unable to execute template: %v", err)
-	}
-
-	return templateOut.String()
 }
 
 // Kill all processes of the unit with the given signal

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -145,6 +145,12 @@ func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) err
 }
 
 const (
+	// the default target for systemd units that we generate
+	ServicesSystemdTarget = "multi-user.target"
+
+	// the default target for systemd units that we generate
+	SocketsSystemdTarget = "sockets.target"
+
 	// the location to put system services
 	snapServicesDir = "/etc/systemd/system"
 )


### PR DESCRIPTION
This patch moves functions that take ServiceDescription to services.go.
The rationale is that ServiceDescription will decay to little (if
anything) more than just snap.AppInfo and to avoid circular dependencies
we don't want to import snap.Info from systemd/. In addition this has a
nice feature of being symmetric with binaries.go

The code can be refactored further, there's some duplication in
services_test.go and ServiceDescription is now mostly a useless
pass-throuh. Those will be addressed by subsequent branches.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>