### PR TITLE
wrappers,snappy: move binary wrapper generation to new package wrappers

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -249,6 +249,12 @@ func (app *AppInfo) WrapperPath() string {
 	return filepath.Join(dirs.SnapBinariesDir, binName)
 }
 
+// Invocation returns the launcher command line to use when invoking the app binary.
+func (app *AppInfo) Invocation() string {
+	securityTag := app.SecurityTag()
+	return fmt.Sprintf("ubuntu-core-launcher %s %s %s", securityTag, securityTag, filepath.Join(app.Snap.MountDir(), app.Command))
+}
+
 // ServiceFile returns the systemd service file path for the daemon app.
 func (app *AppInfo) ServiceFile() string {
 	return filepath.Join(dirs.SnapServicesDir, app.SecurityTag()+".service")

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -83,6 +83,23 @@ apps:
 	c.Check(info.Apps["foo"].WrapperPath(), Equals, filepath.Join(dirs.SnapBinariesDir, "foo"))
 }
 
+func (s *infoSuite) TestAppInfoInvocation(c *C) {
+	dirs.SetRootDir("")
+
+	info, err := snap.InfoFromSnapYaml([]byte(`name: foo
+apps:
+   foo:
+     command: foo-bin
+   bar:
+     command: bar-bin -x
+`))
+	c.Assert(err, IsNil)
+	info.Revision = 42
+
+	c.Check(info.Apps["bar"].Invocation(), Equals, "ubuntu-core-launcher snap.foo.bar snap.foo.bar /snap/foo/42/bar-bin -x")
+	c.Check(info.Apps["foo"].Invocation(), Equals, "ubuntu-core-launcher snap.foo.foo snap.foo.foo /snap/foo/42/foo-bin")
+}
+
 const sampleYaml = `
 name: sample
 version: 1

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/systemd"
+	"github.com/ubuntu-core/snappy/wrappers"
 )
 
 // Overlord is responsible for the overall system state.
@@ -225,7 +226,7 @@ func UndoCopyData(newInfo *snap.Info, flags InstallFlags, meter progress.Meter) 
 
 func GenerateWrappers(s *snap.Info, inter interacter) error {
 	// add the CLI apps from the snap.yaml
-	if err := addPackageBinaries(s); err != nil {
+	if err := wrappers.AddSnapBinaries(s); err != nil {
 		return err
 	}
 	// add the daemons from the snap.yaml
@@ -244,7 +245,7 @@ func GenerateWrappers(s *snap.Info, inter interacter) error {
 // wrappers
 func RemoveGeneratedWrappers(s *snap.Info, inter interacter) error {
 
-	err1 := removePackageBinaries(s)
+	err1 := wrappers.RemoveSnapBinaries(s)
 	if err1 != nil {
 		logger.Noticef("Failed to remove binaries for %q: %v", s.Name(), err1)
 	}

--- a/snappy/services_test.go
+++ b/snappy/services_test.go
@@ -62,29 +62,6 @@ func (s *SnapTestSuite) TestAddPackageServicesStripsGlobalRootdir(c *C) {
 	}
 }
 
-func (s *SnapTestSuite) TestAddPackageBinariesStripsGlobalRootdir(c *C) {
-	// ensure that even with a global rootdir the paths in the generated
-	// .services file are setup correctly (i.e. that the global root
-	// is stripped)
-	c.Assert(dirs.GlobalRootDir, Not(Equals), "/")
-
-	yamlFile, err := makeInstalledMockSnap("", 11)
-	c.Assert(err, IsNil)
-	snap, err := NewInstalledSnap(yamlFile)
-	c.Assert(err, IsNil)
-
-	err = addPackageBinaries(snap.Info())
-	c.Assert(err, IsNil)
-
-	content, err := ioutil.ReadFile(filepath.Join(s.tempdir, "/snap/bin/hello-snap.hello"))
-	c.Assert(err, IsNil)
-
-	needle := `
-ubuntu-core-launcher snap.hello-snap.hello snap.hello-snap.hello /snap/hello-snap/11/bin/hello "$@"
-`
-	c.Assert(string(content), Matches, "(?ms).*"+regexp.QuoteMeta(needle)+".*")
-}
-
 var (
 	expectedServiceWrapperFmt = `[Unit]
 # Auto-generated, DO NO EDIT

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -17,7 +17,8 @@
  *
  */
 
-package snappy
+// Package wrappers is used to generate wrappers and service units for snap applications.
+package wrappers
 
 import (
 	"bytes"
@@ -109,7 +110,8 @@ ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
 	return templateOut.String(), nil
 }
 
-func addPackageBinaries(s *snap.Info) error {
+// AddSnapBinaries writes the wrapper binaries for the applications from the snap which aren't services.
+func AddSnapBinaries(s *snap.Info) error {
 	if err := os.MkdirAll(dirs.SnapBinariesDir, 0755); err != nil {
 		return err
 	}
@@ -125,7 +127,8 @@ func addPackageBinaries(s *snap.Info) error {
 		// service file, this ensures that /snap/foo/1.0/bin/start
 		// is in the service file when the SetRoot() option
 		// is used
-		realBaseDir := stripGlobalRootDir(baseDir)
+		// realBaseDir := stripGlobalRootDir(baseDir)
+		realBaseDir := baseDir
 		content, err := generateSnapBinaryWrapper(app, realBaseDir)
 		if err != nil {
 			return err
@@ -139,7 +142,8 @@ func addPackageBinaries(s *snap.Info) error {
 	return nil
 }
 
-func removePackageBinaries(s *snap.Info) error {
+// RemoveSnapBinaries removes the wrapper binaries for the applications from the snap which aren't services from.
+func RemoveSnapBinaries(s *snap.Info) error {
 	for _, app := range s.Apps {
 		os.Remove(app.WrapperPath())
 	}

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -23,7 +23,6 @@ package wrappers
 import (
 	"bytes"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -34,76 +33,64 @@ import (
 	"github.com/ubuntu-core/snappy/snap/snapenv"
 )
 
-// TODO: => AppInfo.CommandLine
-func binPathForBinary(pkgPath string, app *snap.AppInfo) string {
-	return filepath.Join(pkgPath, app.Command)
-}
-
 // Doesn't need to handle complications like internal quotes, just needs to
 // wrap right side of an env variable declaration with quotes for the shell.
 func quoteEnvVar(envVar string) string {
 	return "export " + strings.Replace(envVar, "=", "=\"", 1) + "\""
 }
 
-func generateSnapBinaryWrapper(app *snap.AppInfo, pkgPath string) (string, error) {
+func generateSnapBinaryWrapper(app *snap.AppInfo) (string, error) {
 	wrapperTemplate := `#!/bin/sh
 set -e
 
 # snap info
-{{.NewAppVars}}
+{{.EnvVars}}
 
 if [ ! -d "$SNAP_USER_DATA" ]; then
    mkdir -p "$SNAP_USER_DATA"
 fi
 export HOME="$SNAP_USER_DATA"
 
-# Snap name is: {{.SnapName}}
-# App name is: {{.AppName}}
+# Snap name is: {{.App.Snap.Name}}
+# App name is: {{.App.Name}}
 
-ubuntu-core-launcher {{.UdevAppName}} {{.AaProfile}} {{.Target}} "$@"
+{{.App.Invocation}} "$@"
 `
 
 	if err := snap.ValidateApp(app); err != nil {
 		return "", err
 	}
 
-	actualBinPath := binPathForBinary(pkgPath, app)
-
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("wrapper").Parse(wrapperTemplate))
 	wrapperData := struct {
-		SnapName    string
-		AppName     string
-		SnapArch    string
-		SnapPath    string
-		Version     string
-		Revision    int
-		UdevAppName string
-		Home        string
-		Target      string
-		AaProfile   string
-		OldAppVars  string
-		NewAppVars  string
+		App     *snap.AppInfo
+		EnvVars string
+		// XXX: needed by snapenv
+		SnapName string
+		SnapArch string
+		SnapPath string
+		Version  string
+		Revision int
+		Home     string
 	}{
-		SnapName:    app.Snap.Name(),
-		AppName:     app.Name,
-		SnapArch:    arch.UbuntuArchitecture(),
-		SnapPath:    pkgPath,
-		Version:     app.Snap.Version,
-		Revision:    app.Snap.Revision,
-		UdevAppName: app.SecurityTag(),
-		Home:        "$HOME",
-		Target:      actualBinPath,
-		AaProfile:   app.SecurityTag(),
+		App: app,
+		// XXX: needed by snapenv
+		SnapName: app.Snap.Name(),
+		SnapArch: arch.UbuntuArchitecture(),
+		SnapPath: app.Snap.MountDir(),
+		Version:  app.Snap.Version,
+		Revision: app.Snap.Revision,
+		Home:     "$HOME",
 	}
 
-	newVars := []string{}
+	envVars := []string{}
 	for _, envVar := range append(
 		snapenv.GetBasicSnapEnvVars(wrapperData),
 		snapenv.GetUserSnapEnvVars(wrapperData)...) {
-		newVars = append(newVars, quoteEnvVar(envVar))
+		envVars = append(envVars, quoteEnvVar(envVar))
 	}
-	wrapperData.NewAppVars = strings.Join(newVars, "\n")
+	wrapperData.EnvVars = strings.Join(envVars, "\n")
 
 	t.Execute(&templateOut, wrapperData)
 
@@ -116,20 +103,12 @@ func AddSnapBinaries(s *snap.Info) error {
 		return err
 	}
 
-	baseDir := s.MountDir()
-
 	for _, app := range s.Apps {
 		if app.Daemon != "" {
 			continue
 		}
 
-		// this will remove the global base dir when generating the
-		// service file, this ensures that /snap/foo/1.0/bin/start
-		// is in the service file when the SetRoot() option
-		// is used
-		// realBaseDir := stripGlobalRootDir(baseDir)
-		realBaseDir := baseDir
-		content, err := generateSnapBinaryWrapper(app, realBaseDir)
+		content, err := generateSnapBinaryWrapper(app)
 		if err != nil {
 			return err
 		}

--- a/wrappers/binaries_gen_test.go
+++ b/wrappers/binaries_gen_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package snappy
+package wrappers
 
 import (
 	"fmt"
@@ -28,9 +28,9 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
-type binariesTestSuite struct{}
+type binariesWrapperGenSuite struct{}
 
-var _ = Suite(&binariesTestSuite{})
+var _ = Suite(&binariesWrapperGenSuite{})
 
 const expectedWrapper = `#!/bin/sh
 set -e
@@ -56,7 +56,7 @@ export HOME="$SNAP_USER_DATA"
 ubuntu-core-launcher snap.pastebinit.pastebinit snap.pastebinit.pastebinit /snap/pastebinit/44/bin/pastebinit "$@"
 `
 
-func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
+func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 	pkgPath := "/snap/pastebinit/44"
 	info := &snap.Info{}
 	info.SuggestedName = "pastebinit"
@@ -75,7 +75,7 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 	c.Assert(generatedWrapper, Equals, expected)
 }
 
-func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
+func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
 	pkgPath := "/snap/pastebinit/44"
 	info := &snap.Info{}
 	info.SuggestedName = "pastebinit"
@@ -89,13 +89,13 @@ func (s *SnapTestSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *SnapTestSuite) TestSnappyBinPathForBinaryNoExec(c *C) {
+func (s *binariesWrapperGenSuite) TestSnappyBinPathForBinaryNoExec(c *C) {
 	binary := &snap.AppInfo{Name: "pastebinit", Command: "bin/pastebinit"}
 	pkgPath := "/snap/pastebinit/44"
 	c.Assert(binPathForBinary(pkgPath, binary), Equals, "/snap/pastebinit/44/bin/pastebinit")
 }
 
-func (s *SnapTestSuite) TestSnappyBinPathForBinaryWithExec(c *C) {
+func (s *binariesWrapperGenSuite) TestSnappyBinPathForBinaryWithExec(c *C) {
 	binary := &snap.AppInfo{Name: "pastebinit", Command: "bin/random-pastebin"}
 	pkgPath := "/snap/pastebinit/44"
 	c.Assert(binPathForBinary(pkgPath, binary), Equals, "/snap/pastebinit/44/bin/random-pastebin")

--- a/wrappers/binaries_gen_test.go
+++ b/wrappers/binaries_gen_test.go
@@ -57,7 +57,6 @@ ubuntu-core-launcher snap.pastebinit.pastebinit snap.pastebinit.pastebinit /snap
 `
 
 func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
-	pkgPath := "/snap/pastebinit/44"
 	info := &snap.Info{}
 	info.SuggestedName = "pastebinit"
 	info.Version = "1.4.0.0.1"
@@ -70,13 +69,12 @@ func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 
 	expected := fmt.Sprintf(expectedWrapper, arch.UbuntuArchitecture())
 
-	generatedWrapper, err := generateSnapBinaryWrapper(binary, pkgPath)
+	generatedWrapper, err := generateSnapBinaryWrapper(binary)
 	c.Assert(err, IsNil)
 	c.Assert(generatedWrapper, Equals, expected)
 }
 
 func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChars(c *C) {
-	pkgPath := "/snap/pastebinit/44"
 	info := &snap.Info{}
 	info.SuggestedName = "pastebinit"
 	info.Version = "1.4.0.0.1"
@@ -85,18 +83,6 @@ func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapperIllegalChar
 		Name: "bin/pastebinit\nSomething nasty",
 	}
 
-	_, err := generateSnapBinaryWrapper(binary, pkgPath)
+	_, err := generateSnapBinaryWrapper(binary)
 	c.Assert(err, NotNil)
-}
-
-func (s *binariesWrapperGenSuite) TestSnappyBinPathForBinaryNoExec(c *C) {
-	binary := &snap.AppInfo{Name: "pastebinit", Command: "bin/pastebinit"}
-	pkgPath := "/snap/pastebinit/44"
-	c.Assert(binPathForBinary(pkgPath, binary), Equals, "/snap/pastebinit/44/bin/pastebinit")
-}
-
-func (s *binariesWrapperGenSuite) TestSnappyBinPathForBinaryWithExec(c *C) {
-	binary := &snap.AppInfo{Name: "pastebinit", Command: "bin/random-pastebin"}
-	pkgPath := "/snap/pastebinit/44"
-	c.Assert(binPathForBinary(pkgPath, binary), Equals, "/snap/pastebinit/44/bin/random-pastebin")
 }

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package wrappers_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/osutil"
+	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/snaptest"
+	"github.com/ubuntu-core/snappy/wrappers"
+)
+
+func TestWrappers(t *testing.T) { TestingT(t) }
+
+type binariesTestSuite struct {
+	tempdir string
+}
+
+var _ = Suite(&binariesTestSuite{})
+
+func (s *binariesTestSuite) SetUpTest(c *C) {
+	s.tempdir = c.MkDir()
+	dirs.SetRootDir(s.tempdir)
+}
+
+func (s *binariesTestSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+}
+
+const packageHello = `name: hello-snap
+version: 1.10
+summary: hello
+description: Hello...
+apps:
+ hello:
+   command: bin/hello
+ svc1:
+  command: bin/hello
+  stop-command: bin/goodbye
+  post-stop-command: bin/missya
+  daemon: forking
+`
+
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: 11})
+
+	err := wrappers.AddSnapBinaries(info)
+	c.Assert(err, IsNil)
+
+	wrapper := filepath.Join(s.tempdir, "/snap/bin/hello-snap.hello")
+
+	content, err := ioutil.ReadFile(wrapper)
+	c.Assert(err, IsNil)
+
+	needle := fmt.Sprintf(`
+ubuntu-core-launcher snap.hello-snap.hello snap.hello-snap.hello %s/snap/hello-snap/11/bin/hello "$@"
+`, s.tempdir)
+
+	c.Assert(string(content), Matches, "(?ms).*"+regexp.QuoteMeta(needle)+".*")
+
+	err = wrappers.RemoveSnapBinaries(info)
+	c.Assert(err, IsNil)
+
+	c.Check(osutil.FileExists(wrapper), Equals, false)
+}


### PR DESCRIPTION
This introduces a new package wrappers to host wrapper, service unit etc generation and starts moving binary wrapper generation to it

Also stops caring about stripGlobalRootDir given that wrapper generation is not done in u-d-f anymore, simplifies templating using AppInfo and introduces AppInfo.Invocation to produce the ubuntu-core-launcher incantation for further simplification.