### PR TITLE
interfaces/builtin: quote apparmor label

### DIFF
--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -73,7 +73,7 @@ func (s *BluezInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
 	}
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, "peer=(label=snap.bluez.*),")
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.bluez.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the bluez slot
@@ -94,7 +94,7 @@ func (s *BluezInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) {
 	}
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, "peer=(label=snap.bluez.{app1,app2}),")
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.bluez.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the bluez slot
@@ -113,7 +113,7 @@ func (s *BluezInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
 	}
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, "peer=(label=snap.bluez.app),")
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.bluez.app"),`)
 }
 
 func (s *BluezInterfaceSuite) TestUnusedSecuritySystems(c *C) {

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -36,7 +36,7 @@ import (
 // - "snap.$snap.*" if all apps are bound to the slot
 func slotAppLabelExpr(slot *interfaces.Slot) []byte {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "snap.%s.", slot.Snap.Name())
+	fmt.Fprintf(&buf, `"snap.%s.`, slot.Snap.Name())
 	if len(slot.Apps) == 1 {
 		for appName := range slot.Apps {
 			buf.WriteString(appName)
@@ -57,5 +57,6 @@ func slotAppLabelExpr(slot *interfaces.Slot) []byte {
 		buf.Truncate(buf.Len() - 1)
 		buf.WriteByte('}')
 	}
+	buf.WriteByte('"')
 	return buf.Bytes()
 }


### PR DESCRIPTION
This patch adds double quotes around the apparmor label. Testing
uncovered that we should do this to make apparmor_parser happy.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>