### PR TITLE
integration-tests: add coverage flags to snapd.service ExecStart setting when building from branch

### DIFF
--- a/integration-tests/tests/base_test.go
+++ b/integration-tests/tests/base_test.go
@@ -123,7 +123,7 @@ ExecStart=
 ExecStart=%s
 `, strings.Join(cmd, " ")))
 
-	fmt.Println(string(cfgContent))
+	fmt.Println("snapd coverage.conf:\n", string(cfgContent))
 
 	tmpFile := "/tmp/snapd." + cfgFileName
 	if err = ioutil.WriteFile(tmpFile, cfgContent, os.ModeExclusive); err != nil {

--- a/integration-tests/tests/base_test.go
+++ b/integration-tests/tests/base_test.go
@@ -118,6 +118,8 @@ func writeCoverageConfig() error {
 	cmd, err := cli.AddOptionsToCommand([]string{filepath.Base(binPath)})
 	cmd[0] = binPath
 
+	// the first ExecStart= is needed to reset the setting value according to
+	// https://www.freedesktop.org/software/systemd/man/systemd.service.html
 	cfgContent := []byte(fmt.Sprintf(`[Service]
 ExecStart=
 ExecStart=%s

--- a/integration-tests/tests/snap_update_app_test.go
+++ b/integration-tests/tests/snap_update_app_test.go
@@ -61,10 +61,10 @@ func (s *snapRefreshAppSuite) TestAppUpdate(c *check.C) {
 	env := fmt.Sprintf(`SNAPPY_FORCE_CPI_URL=%s`, fakeStore.URL())
 	cfg, _ := config.ReadConfig(config.DefaultFileName)
 
-	tearDownSnapd(c, cfg.FromBranch)
+	tearDownSnapd(c)
 	defer setUpSnapd(c, cfg.FromBranch, "")
 	setUpSnapd(c, cfg.FromBranch, env)
-	defer tearDownSnapd(c, cfg.FromBranch)
+	defer tearDownSnapd(c)
 
 	// run the fake update
 	output := updates.CallFakeSnapRefresh(c, snap, updates.NoOp, fakeStore)

--- a/integration-tests/tests/snap_update_app_test.go
+++ b/integration-tests/tests/snap_update_app_test.go
@@ -61,10 +61,10 @@ func (s *snapRefreshAppSuite) TestAppUpdate(c *check.C) {
 	env := fmt.Sprintf(`SNAPPY_FORCE_CPI_URL=%s`, fakeStore.URL())
 	cfg, _ := config.ReadConfig(config.DefaultFileName)
 
-	tearDownSnapd(cfg.FromBranch)
+	tearDownSnapd(c, cfg.FromBranch)
 	defer setUpSnapd(c, cfg.FromBranch, "")
 	setUpSnapd(c, cfg.FromBranch, env)
-	defer tearDownSnapd(cfg.FromBranch)
+	defer tearDownSnapd(c, cfg.FromBranch)
 
 	// run the fake update
 	output := updates.CallFakeSnapRefresh(c, snap, updates.NoOp, fakeStore)


### PR DESCRIPTION
A new conf file is written in `/etc/systemd/system/snapd.service.d` with the ExecStart reset and override, adding the options for recording the coverage reports.
Also the `tearDownSnapd` signature has been modified to match `setUpSnapd`, including a `*check.C` as first parameter to ease error handling.