### PR TITLE
interfaces: miscellaneous policy updates

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -184,11 +184,11 @@ var defaultTemplate = []byte(`
   /sys/devices/system/cpu/** r,
   /sys/kernel/mm/transparent_hugepage/enabled r,
   /sys/kernel/mm/transparent_hugepage/defrag r,
-  # NOTE: this leaks running process and java seems to want it, but operates
-  # ok without it. Deny for now to silence the denial but we could allow
-  # owner match until AppArmor kernel var is available to solve this properly.
-  deny @{PROC}/@{pid}/cmdline r,
-  #owner @{PROC}/@{pid}/cmdline r,
+  # NOTE: this leaks running process but java seems to want it (even though it
+  # seems to operate ok without it) and SDL apps crash without it. Allow owner
+  # match until AppArmor kernel var is available to solve this properly (see
+  # LP: #1546825 for details)
+  owner @{PROC}/@{pid}/cmdline r,
 
   # Miscellaneous accesses
   /etc/mime.types r,

--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -30,7 +30,11 @@ const mountObserveConnectedPlugAppArmor = `
 # with trusted apps.
 # Usage: reserved
 # Needed by 'df'. This is an information leak
+@{PROC}/mounts r,
 owner @{PROC}/@{pid}/mounts r,
+
+# This is often out of date but some apps insist on using it
+/etc/mtab r,
 `
 
 // NewMountObserveInterface returns a new "mount-observe" interface.

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -42,6 +42,9 @@ ptrace (read),
 # distinguish between tracing other processes and other accesses. We deny the
 # trace here to silence the log.
 deny ptrace (trace),
+
+# Other miscellaneous accesses for observing the system
+@{PROC}/vmstat r,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/system-observe


### PR DESCRIPTION
* builtin/mount_observe.go: allow read on @{PROC}/vmstat (Closes: #1576358)
* builtin/system_observe.go: allow read on @{PROC}/mounts and /etc/mtab (Closes: #1576358)
* apparmor/template.go: allow owner read of @{PROC}/@{pid}/cmdline (Closes: #1578091)