### PR TITLE
docs: update meta.md and security.md for current snappy

### DIFF
--- a/docs/meta.md
+++ b/docs/meta.md
@@ -69,20 +69,9 @@ The following keys are optional:
 
 ## Interfaces
 
-The `old-security` interface is used to make porting existing snaps easier.
-It provides the following parameters:
-    * `caps`: (optional) list of additional security policies to add.
-              See `security.md` for details
-    * `security-template`: (optional) alternate security template to use
-                           instead of `default`. See `security.md` for details
-    * `security-override`: (optional) high level overrides to use when
-                           `security-template` and `caps` are not
-                           sufficient.  See security.md for details
-    * `security-policy`: (optional) hand-crafted low-level raw security
-                         policy to use instead of using default
-                         template-based  security policy. See
-                         security.md for details
-
+Interfaces allow snaps to communicate or share resources according to the
+protocol established by the interface and play an important part in security
+policy configuration. See `interfaces.md` and `security.md` for details.
 
 ## license.txt
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -82,7 +82,7 @@ the yaml as `plugs` and `slots`.
 # Working with snap security policy
 
 The `snap.yaml` need not specify anything for default confinement and may
-optionally use `plugs` and `slots` to declare additional interfaces to use.
+optionally specify `plugs` and `slots` to declare additional interfaces to use.
 When an interface is connected, the snap's security policy will be updated to
 allow access to use the interface. See `meta.md` and `interface.md` for
 details.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,12 +1,4 @@
-# Security policy
-
-Most of the security aspects of the system will be done via interfaces,
-slots and plugs. However for compatibility with the 15.04 snappy
-architecture there is a special interface called `old-security`
-that can be used to migrate using the 15.04 syntax. See the example
-below for the various ways the `old-security` interface can be used.
-
-## Security with the old-security interface
+# Snap security policy and sandboxing
 
 Snap packages run confined under a restrictive security sandbox by default.
 The security policies and store policies work together to allow developers to
@@ -15,102 +7,90 @@ quickly update their applications and to provide safety to end users.
 This document describes how to configure the security policies for snap
 packages and builds upon the packaging declaration as defined in `meta.md`.
 
-## How policy is applied
+# How policy is applied
 Application authors should not have to know about or understand the lowlevel
-implementation details on how security policy is enforced. Instead, security
-policy is typically defined by declaring a security template to use and any
-additional security caps to extend the policy provided by the template. If
-unspecified, default confinement allows the snap to run as a network client.
+implementation details on how security policy is enforced. Instead, all snaps
+run under default security policy which can be extended through the use of
+interfaces, slots and plugs and the available interfaces available on the
+device can be seen with:
 
-Applications are tracked by the system by using the concept of an
-ApplicationId. The `APP_ID is` the composition of the package name, the app's
-developer from the store if applicable -- only snaps of `type: app` (the
-default) use an developer to compose the `APP_ID`), the
-service/binary name and package version. The `APP_ID` takes the form of
-`<pkgname>.<developer>_<appname>_<version>`. For example, if this is in
-`snap.yaml`:
+    $ snap interfaces
+
+The description of these interfaces is found in `interfaces.md`.
+
+Each command declared in `apps` by the snap is tracked by the system by
+assigning a security label to the command. This security label takes the form
+of `snap.<name>.<app>` where `<name>` is the name of the snap from `meta.md`
+and `<app>` is the command name. For example, if this is in `snap.yaml`:
 
     name: foo
-    version: 0.1
     ...
     apps:
       bar:
-        start: bin/bar
+        command: ...
+        ...
 
-and the app was uploaded to the `snapdev` developer in the store, then the
-`APP_ID` for the `bar` service is `foo.snapdev_bar_0.1`. The `APP_ID` is used
-throughout the system including in the enforcement of security policy by the
-app launcher.
+then the security label for the `bar` command is `snap.foo.bar`. This security
+label is used throughout the system including in the enforcement of security
+policy by the app launcher. All snap commands declared via `apps` in `meta.md`
+are launched by the launcher. The security policy and launcher enforce
+application isolation as per the snappy FHS. Under the hood, the launcher:
 
-Under the hood, the launcher:
+* Sets up various environment variables:
+    * `HOME`: set to `SNAP_DATA` for daemons and `SNAP_USER_DATA` for user
+      commands
+    * `SNAP`: read-only install directory
+    * `SNAP_ARCH`: the architecture of device (eg, amd64, arm64, armhf, i386, etc)
+    * `SNAP_DATA`: writable area for the snap
+    * `SNAP_LIBRARY_PATH`: additional directories added to `LD_LIBRARY_PATH`
+    * `SNAP_NAME`: snap name (from `meta.md`)
+    * `SNAP_REVISION`: store revision of the snap
+    * `SNAP_USER_DATA`: per-user writable area for the snap
+    * `SNAP_VERSION`: snap version (from `meta.md`)
+    * `TMPDIR`: set to `/tmp`
+* When hardware is assigned to the snap, sets up a device cgroup with default
+  devices (eg, /dev/null, /dev/urandom, etc) and any devices that are assigned
+  to this snap
+* Sets up a private /tmp using a per-command private mount namespace and
+  mounting a per-command directory on /tmp
+* Sets up a per-command devpts new instance
+* Sets up the seccomp filter for the command
+* Executes the command under the command-specific AppArmor profile under a
+  default nice value
 
-* sets up various environment variables (eg, `SNAP_ARCH`,
-  `SNAP_DATA`, `SNAP`, `SNAP_USER_DATA`,
-  `SNAP_OLD_PWD`, `HOME` and `TMPDIR`. See the
-   [snappy FHS](https://developer.ubuntu.com/en/snappy/guides/filesystem-layout/) for details.
-* sets up a device cgroup with default devices (eg, /dev/null, /dev/urandom,
-  etc) and any devices which are assigned to this app via Gadget snaps or
-  `snappy hw-assign` (eg, `snappy hw-assign foo.snapdev /dev/bar`).
-* sets up the seccomp filter
-* executes the app under an AppArmor profile under a default nice value
-
-The launcher is used when launching both services and CLI binaries. The
-security policy and launcher enforce application isolation as per the snappy
-FHS.
 
 This combination of restrictive AppArmor profiles (which mediate file access,
 application execution, Linux capabilities(7), mount, ptrace, IPC, signals,
 coarse-grained networking), clearly defined application-specific filesystem
-areas, whitelist syscall filtering via seccomp and device cgroups provides for
-strong application confinement and isolation (see below for future work).
+areas, whitelist syscall filtering via seccomp, private /tmp, new instance
+devpts and device cgroups provides for strong application confinement and
+isolation.
 
-### AppArmor
+## AppArmor
 Upon snap package install, `snap.yaml` is examined and AppArmor profiles are
-generated for each service and binary to have names based on the `APP_ID`.
-As mentioned, AppArmor profiles are template based and may be extended through
-policy groups, which are expressed in the yaml as `caps`.
+generated for each command to have the appropriate security label and
+command-specific AppArmor rules. As mentioned, each command runs under an
+app-specific default policy that may be extended through declared interfaces
+which are expressed in the yaml as `plugs` and `slots`.
 
-### Seccomp
-Upon snap package install, `snap.yaml` is examined and seccomp filters are
-generated for each service and binary. Like with AppArmor, seccomp filters are
-template based and may be extended through filter groups, which are expressed
-in the yaml as `caps`.
+## Seccomp
+Like with AppArmor, upon snap package install, `snap.yaml` is examined and
+seccomp filters are generated for each command to run under a default seccomp
+filter that may be extended through declared interfaces which are expressed in
+the yaml as `plugs` and `slots`.
 
-## Defining snap policy
+# Working with snap security policy
 
-The `snap.yaml` need not specify anything for default confinement. Several
-options are available in the `old-security` interface to modify the
-confinement:
+The `snap.yaml` need not specify anything for default confinement and may
+optionally use `plugs` and `slots` to declare additional interfaces to use.
+When an interface is connected, the snap's security policy will be updated to
+allow access to use the interface. See `meta.md` and `interface.md` for
+details.
 
-* `caps`: (optional) list of (easy to understand, human readable) additional
-  security policies to add. The system will translate these to generate
-  AppArmor and seccomp policy. Note: these are separate from `capabilities(7)`.
-  Specify `caps: []` to indicate no additional `caps`.  When `caps` and
-  `security-template` are not specified, `caps` defaults to client networking.
-  Not compatible with `security-policy`.
-    * AppArmor access is deny by default and apps are restricted to
-      their app-specific directories, libraries, etc (enforcing ro,
-      rw, etc).  Additional access beyond what is allowed by the
-      declared `security-template` is declared via this option
-    * seccomp is deny by default. Enough safe syscalls are allowed so
-      that apps using the declared `security-template` should
-      work. Additional access beyond what is allowed by the
-      `security-template` is declared via this option
-* `security-template`: (optional) alternate security template to use instead of
-  `default`. When specified without `caps`, `caps` defaults to being empty. Not
-  compatible with `security-policy`.
-* `security-override`: (optional) overrides to use when `security-template` and
-  `caps` are not sufficient. Not compatible with `security-policy`. The
-  following keys are supported:
-    * `read-paths`: a list of additional paths that the app can read
-    * `write-paths`: a list of additional paths that the app can write
-    * `abstractions`: a list of additional AppArmor abstractions for the app
-    * `syscalls`: a list of additional syscalls that the app can use
-* `security-policy`: (optional) hand-crafted low-level raw security policy to
-  use instead of using default template-based security policy. Not compatible
-  with `caps`, `security-template` or `security-override`.
-    * `apparmor: path/to/profile`
-    * `seccomp: path/to/filter`
+The default AppArmor policy is deny by default and snaps are restricted to
+their app-specific directories, libraries, etc (enforcing ro, rw, etc). The
+seccomp filter is also deny by default and the default filter allows enough
+safe syscalls so that snaps using the default security policy should work.
 
 Eg, consider the following:
 
@@ -121,143 +101,99 @@ Eg, consider the following:
         command: bar
       baz:
         command: baz
-        slots: [baz-caps]
-      qux:
-        command: qux
-        slots: [qux-security]
-      quux:
-        command: quux
-        slots: [quux-policy]
-      corge:
-        command: corge
         daemon: simple
-        slots: [corge-override]
-      cli-exe:
-        command: cli-exe
-        slots: [no-caps]
-    slots:
-      baz-caps:
-        type: old-security
-        caps:
-          - network-client
-          - norf-framework_client
-      qux-security:
-        type: old-security
-        security-template: nondefault
-      quux-policy:
-        type: old-security
-        security-policy:
-          apparmor: meta/quux.profile
-          seccomp: meta/quux.filter
-      corge-override:
-        type: old-security
-        security-override:
-          apparmor: meta/corge.apparmor
-          seccomp: meta/corge.seccomp
-      no-caps:
-        type: old-security
-        caps: []
+        plugs: [network]
 
+then:
 
-If this package is uploaded to the store in the `snapdev` developer, then:
+* the security label for `bar` is `snap.foo.bar`. It uses only the default
+  policy
+* the security label for `baz` is `snap.foo.baz`. It uses the `default` policy plus the `network` interface security policy as provided by the OS snap
 
-* `APP_ID` for `bar` is `foo.snapdev_bar_1.0`. It uses the `default` template
-  and `network-client` (default) cap
-* `APP_ID` for `baz` is `foo.snapdev_baz_1.0`. It uses the `default` template
-  and the `network-client` and `norf-framework_client` caps
-* `APP_ID` for `qux` is `foo.snapdev_qux_1.0`. It uses the `nondefault`
-  template and `network-client` (default) cap
-* `APP_ID` for `quux` is `foo.snapdev_quux_1.0`. It does not use a
-  `security-template` or `caps` but instead ships its own AppArmor policy in
-  `meta/quux.profile`
-  and seccomp filters in `meta/quux.filter`
-* `APP_ID` for `corge` is `foo.snapdev_corge_1.0`. It does not use a
-  `security-template` or `caps` but instead ships the override files
-  `meta/corge.apparmor` and `meta/corge.seccomp`.
-* `APP_ID` for `cli-exe` is `foo.snapdev_cli-exe_1.0`. It uses the `default`
-  template and no `caps`
+Security policies and store policies work together to provide flexibility,
+speed and safety. Because of this, use of some interfaces may trigger a manual
+review in the official Ubuntu store and/or may need to be connected by the user
+or gadget snap developer.
 
-As mentioned, security policies and store policies work together to provide
-flexibility, speed and safety. Use of some of the above will trigger a manual
-review in the official Ubuntu store for snaps that are `type: app` (the
-default):
+The interfaces available on the system and those used by snaps can be seen with
+the `snap interfaces` command. Eg:
 
-* `security-policy` - always triggers a manual review because it allows
-  specifying access beyond the application specific areas
-* `caps` - will only trigger a manual review if specifying a `reserved` cap
-* `security-template` - will only trigger a manual review if specifying a
-  `reserved` tempate (eg, `unconfined`)
-* `security-override` - will only trigger a manual review if specifying access
-  beyond that provided by `common` access.
+    $ snap interfaces
+    Slot                 Plug
+    :firewall-control    -
+    :home                -
+    :locale-control      -
+    :log-observe         snappy-debug
+    :mount-observe       -
+    :network             xkcd-webserver
+    :network-bind        xkcd-webserver
+    :network-control     -
+    :network-observe     -
+    :snapd-control       -
+    :system-observe      -
+    :timeserver-control  -
+    :timezone-control    -
 
-Apps should typically only use common groups with `caps` and common templates
-with `security-template` and avoid `security-policy` and `security-override`.
+In the above it can be seen that the `snappy-debug` snap has the `log-observe`
+interface connected (and therefore the security policy from `log-observe` is
+added to it) and the `xkcd-webserver` has the `network` and `network-bind`
+interfaces connected. An interesting quality of interfaces is that they may
+either be either declared per-command or per-snap. If declared per-snap, all
+the commands within the snap have the interface security policy added to the
+command's security policy when the interface is connected. If declared
+per-command, only the commands within the snap that declare use of the
+interface have the interface security policy added to them.
 
-Snaps that are of `type: framework` (see frameworks.md) will use any of the
-above (since framework snaps' purpose is to extend the system and require
-additional privilege).
+Snappy may autoconnect the requested interfaces upon install or may require the
+user to manually connect them. Interface connections and disconnections are
+performed via the `snap connect` and `snap disconnect` commands. See
+`interfaces.md` for details.
 
-The available templates and policy groups of the target system can be seen by
-running `snappy-security list` on the target system.
+# Developer mode
+Sometimes it is helpful when developing a snap to not have to worry about the
+security sandbox in order to focus on developing the snap. To support this,
+snappy allows installing the snap in developer mode which puts the security
+policy in complain mode (where violations against security policy are logged,
+but permitted). Eg:
 
-## Debugging
-To check to see if you have any denials:
+    $ sudo snap install --devmode <snap>
+
+# Debugging
+To check to see if you have any policy violations:
 
     $ sudo grep audit /var/log/syslog
 
-An AppArmor denial will look something like:
+An AppArmor violation will look something like:
 
-    audit: type=1400 audit(1431384420.408:319): apparmor="DENIED" operation="mkdir" profile="foo_bar_0.1" name="/var/lib/foo" pid=637 comm="bar" requested_mask="c" denied_mask="c" fsuid=0 ouid=0
+    audit: type=1400 audit(1431384420.408:319): apparmor="DENIED" operation="mkdir" profile="snap.foo.bar" name="/var/lib/foo" pid=637 comm="bar" requested_mask="c" denied_mask="c" fsuid=0 ouid=0
 
-If there are no AppArmor denials, AppArmor isn't blocking the app.
+If there are no AppArmor denials, AppArmor shouldn't be blocking the snap.
 
-A seccomp denial will look something like:
+A seccomp violation will look something like:
 
     audit: type=1326 audit(1430766107.122:16): auid=1000 uid=1000 gid=1000 ses=15 pid=1491 comm="env" exe="/bin/bash" sig=31 arch=40000028 syscall=983045 compat=0 ip=0xb6fb0bd6 code=0x0
 
-The `syscall=983045` can be resolved with the `scmp_sys_resolver` command:
+The `syscall=983045` can be resolved with the `scmp\_sys\_resolver` command:
 
     $ scmp_sys_resolver 983045
     set_tls
 
-If there are no seccomp denials, seccomp isn't blocking the app.
+If there are no seccomp violations, seccomp isn't blocking the snap.
 
-For more information, please see
-[debugging](https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement#Debugging).
+The `snappy-debug` snap can be used to help with policy violations. To use it:
 
-## Future
-The following is planned:
+    $ sudo snap install snappy-debug
+    $ sudo /snap/bin/snappy-debug.security scanlog foo
 
-* launcher:
-    * utilize syscall argument filtering
-    * setup additional cgroups (tag network traffic, memory)
-    * setup iptables using cgroup tags (for internal app access)
-    * drop privileges to uid of service
-* fine-grained network mediation via AppArmor
-* `sockets`: (optional) `AF_UNIX` abstract socket definition for coordinated
-  snap communications. Abstract sockets will be namespaced and yaml is such
-  that (client) apps wanting to use the socket don't have to declare anything
-  extra, but they don't have access unless the (server) binary declaring the
-  socket says that app is ok).
-    * `names`: (optional) list of abstract socket names
-      (`<name>_<binaryname>` is prepended)
-    * `allowed-clients`: `<name>.<developer>` or
-     `<name>.<developer>_<binaryname>` (ie, omit version and
-     `binaryname` to allow all from snap `<name>.<developer>` or omit
-     version to allow only `binaryname` from snap `<name>`)
+This will:
 
- Eg:
+* adjust kernel log rate limiting
+* follow /var/log/syslog looking for policy violations for `foo`
+* resolve syscall names
+* make reccomendations on how to fix violations
 
-        name: foo
-        ...
-        services:
-          - name: bar
-          sockets:
-            names:
-              - sock1
-              - sock2
-              - ...
-            allowed-clients:
-              - baz
-              - norf_qux
-              - ...
+See `snappy-debug.security help` for details.
+
+If you believe there is a bug in the security policy or want to request a new
+interface, please [file a bug](https://bugs.launchpad.net/snappy/+filebug),
+adding the `snapd-interface` tag.

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,8 +4,8 @@ Snap packages run confined under a restrictive security sandbox by default.
 The security policies and store policies work together to allow developers to
 quickly update their applications and to provide safety to end users.
 
-This document describes how to configure the security policies for snap
-packages and builds upon the packaging declaration as defined in `meta.md`.
+This document describes the sandbox and how to configure and work with the security policies for snap
+packages.
 
 # How policy is applied
 Application authors should not have to know about or understand the lowlevel
@@ -33,8 +33,11 @@ and `<app>` is the command name. For example, if this is in `snap.yaml`:
 then the security label for the `bar` command is `snap.foo.bar`. This security
 label is used throughout the system including in the enforcement of security
 policy by the app launcher. All snap commands declared via `apps` in `meta.md`
-are launched by the launcher. The security policy and launcher enforce
-application isolation as per the snappy FHS. Under the hood, the launcher:
+are launched by the launcher and snaps run in the global (ie, default)
+namespace (except where noted otherwise) to facilitate communications and
+sharing between snaps and because this is more familiar for developers and
+administrators. The security policy and launcher enforce application isolation
+as per the snappy FHS. Under the hood, the launcher:
 
 * Sets up various environment variables:
     * `HOME`: set to `SNAP_DATA` for daemons and `SNAP_USER_DATA` for user
@@ -57,7 +60,6 @@ application isolation as per the snappy FHS. Under the hood, the launcher:
 * Sets up the seccomp filter for the command
 * Executes the command under the command-specific AppArmor profile under a
   default nice value
-
 
 This combination of restrictive AppArmor profiles (which mediate file access,
 application execution, Linux capabilities(7), mount, ptrace, IPC, signals,


### PR DESCRIPTION
Remove old-security from docs/meta.md and refer to interface.md and security.md

Rewrite docs/security.md with interfaces in mind, updating debugging section,
have a blurb on snappy-debug, update for changes in 16 and remove 'Future'
section