### PR TITLE
overlord/snapstate,overlord/snapstate/backend,snappy: start backend porting LinkSnap and UnlinkSnap

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -20,6 +20,7 @@
 package snapstate
 
 import (
+	"github.com/ubuntu-core/snappy/overlord/snapstate/backend"
 	"github.com/ubuntu-core/snappy/progress"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snappy"
@@ -48,7 +49,10 @@ type managerBackend interface {
 	Candidate(sideInfo *snap.SideInfo)
 }
 
-type defaultBackend struct{}
+type defaultBackend struct {
+	// XXX defaultBackend will go away and be replaced by this in the end.
+	backend.Backend
+}
 
 func (b *defaultBackend) Candidate(*snap.SideInfo) {}
 
@@ -88,11 +92,6 @@ func (b *defaultBackend) CopySnapData(newInfo, oldInfo *snap.Info, flags int) er
 	return snappy.CopyData(newInfo, oldInfo, snappy.InstallFlags(flags), meter)
 }
 
-func (b *defaultBackend) LinkSnap(info *snap.Info) error {
-	meter := &progress.NullProgress{}
-	return snappy.LinkSnap(info, meter)
-}
-
 func (b *defaultBackend) UndoSetupSnap(s snap.PlaceInfo) error {
 	meter := &progress.NullProgress{}
 	snappy.UndoSetupSnap(s, meter)
@@ -107,10 +106,6 @@ func (b *defaultBackend) UndoCopySnapData(newInfo *snap.Info, flags int) error {
 
 func (b *defaultBackend) CanRemove(info *snap.Info, active bool) bool {
 	return snappy.CanRemove(info, active)
-}
-
-func (b *defaultBackend) UnlinkSnap(info *snap.Info, meter progress.Meter) error {
-	return snappy.UnlinkSnap(info, meter)
 }
 
 func (b *defaultBackend) RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error {

--- a/overlord/snapstate/backend/backend.go
+++ b/overlord/snapstate/backend/backend.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package backend implements the low-level primitives to manage the snaps and their installation on disk.
+package backend
+
+// Backend exposes all the low-level primitives to manage snaps and their installation on disk.
+type Backend struct{}

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -1,0 +1,154 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ubuntu-core/snappy/logger"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snap"
+	// XXX: eventually not needed
+	"github.com/ubuntu-core/snappy/snappy"
+	"github.com/ubuntu-core/snappy/wrappers"
+)
+
+func updateCurrentSymlinks(info *snap.Info) error {
+	mountDir := info.MountDir()
+
+	currentActiveSymlink := filepath.Join(mountDir, "..", "current")
+	if err := os.Remove(currentActiveSymlink); err != nil && !os.IsNotExist(err) {
+		logger.Noticef("Failed to remove %q: %v", currentActiveSymlink, err)
+	}
+
+	dataDir := info.DataDir()
+	dbase := filepath.Dir(dataDir)
+	currentDataSymlink := filepath.Join(dbase, "current")
+	if err := os.Remove(currentDataSymlink); err != nil && !os.IsNotExist(err) {
+		logger.Noticef("Failed to remove %q: %v", currentDataSymlink, err)
+	}
+
+	// symlink is relative to parent dir
+	if err := os.Symlink(filepath.Base(mountDir), currentActiveSymlink); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(info.DataDir(), 0755); err != nil {
+		return err
+	}
+
+	// XXX: should migrate to a different package/form
+	if err := snappy.SetNextBoot(info); err != nil {
+		return err
+	}
+
+	return os.Symlink(filepath.Base(dataDir), currentDataSymlink)
+}
+
+// LinkSnap makes the snap available by generating wrappers and setting the current symlinks
+func (b Backend) LinkSnap(info *snap.Info) error {
+	if err := generateWrappers(info); err != nil {
+		return err
+	}
+
+	return updateCurrentSymlinks(info)
+}
+
+func generateWrappers(s *snap.Info) error {
+	// add the CLI apps from the snap.yaml
+	if err := wrappers.AddSnapBinaries(s); err != nil {
+		return err
+	}
+	// add the daemons from the snap.yaml
+	if err := wrappers.AddSnapServices(s, &progress.NullProgress{}); err != nil {
+		return err
+	}
+	// add the desktop files
+	if err := wrappers.AddSnapDesktopFiles(s); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func removeGeneratedWrappers(s *snap.Info, meter progress.Meter) error {
+	err1 := wrappers.RemoveSnapBinaries(s)
+	if err1 != nil {
+		logger.Noticef("Failed to remove binaries for %q: %v", s.Name(), err1)
+	}
+
+	err2 := wrappers.RemoveSnapServices(s, meter)
+	if err2 != nil {
+		logger.Noticef("Failed to remove services for %q: %v", s.Name(), err2)
+	}
+
+	err3 := wrappers.RemoveSnapDesktopFiles(s)
+	if err3 != nil {
+		logger.Noticef("Failed to remove desktop files for %q: %v", s.Name(), err3)
+	}
+
+	return firstErr(err1, err2, err3)
+}
+
+// UnlinkSnap makes the snap unavailable to the system removing wrappers and symlinks.
+func (b Backend) UnlinkSnap(info *snap.Info, meter progress.Meter) error {
+	// remove generated services, binaries etc
+	err1 := removeGeneratedWrappers(info, meter)
+
+	// and finally remove current symlinks
+	err2 := removeCurrentSymlinks(info)
+
+	// FIXME: aggregate errors instead
+	return firstErr(err1, err2)
+}
+
+func removeCurrentSymlinks(info snap.PlaceInfo) error {
+	var err1, err2 error
+
+	// the snap "current" symlink
+	currentActiveSymlink := filepath.Join(info.MountDir(), "..", "current")
+	err1 = os.Remove(currentActiveSymlink)
+	if err1 != nil && !os.IsNotExist(err1) {
+		logger.Noticef("Failed to remove %q: %v", currentActiveSymlink, err1)
+	} else {
+		err1 = nil
+	}
+
+	// the data "current" symlink
+	currentDataSymlink := filepath.Join(filepath.Dir(info.DataDir()), "current")
+	err2 = os.Remove(currentDataSymlink)
+	if err2 != nil && !os.IsNotExist(err2) {
+		logger.Noticef("Failed to remove %q: %v", currentDataSymlink, err2)
+	} else {
+		err2 = nil
+	}
+
+	if err1 != nil && err2 != nil {
+		return fmt.Errorf("cannot remove snap current symlink: %v and %v", err1, err2)
+	} else if err1 != nil {
+		return fmt.Errorf("cannot remove snap current symlink: %v", err1)
+	} else if err2 != nil {
+		return fmt.Errorf("cannot remove snap current symlink: %v", err2)
+	}
+
+	return nil
+}

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -91,17 +91,17 @@ func generateWrappers(s *snap.Info) error {
 func removeGeneratedWrappers(s *snap.Info, meter progress.Meter) error {
 	err1 := wrappers.RemoveSnapBinaries(s)
 	if err1 != nil {
-		logger.Noticef("Failed to remove binaries for %q: %v", s.Name(), err1)
+		logger.Noticef("Cannot remove binaries for %q: %v", s.Name(), err1)
 	}
 
 	err2 := wrappers.RemoveSnapServices(s, meter)
 	if err2 != nil {
-		logger.Noticef("Failed to remove services for %q: %v", s.Name(), err2)
+		logger.Noticef("Cannot remove services for %q: %v", s.Name(), err2)
 	}
 
 	err3 := wrappers.RemoveSnapDesktopFiles(s)
 	if err3 != nil {
-		logger.Noticef("Failed to remove desktop files for %q: %v", s.Name(), err3)
+		logger.Noticef("Cannot remove desktop files for %q: %v", s.Name(), err3)
 	}
 
 	return firstErr(err1, err2, err3)
@@ -126,7 +126,7 @@ func removeCurrentSymlinks(info snap.PlaceInfo) error {
 	currentActiveSymlink := filepath.Join(info.MountDir(), "..", "current")
 	err1 = os.Remove(currentActiveSymlink)
 	if err1 != nil && !os.IsNotExist(err1) {
-		logger.Noticef("Failed to remove %q: %v", currentActiveSymlink, err1)
+		logger.Noticef("Cannot remove %q: %v", currentActiveSymlink, err1)
 	} else {
 		err1 = nil
 	}
@@ -135,7 +135,7 @@ func removeCurrentSymlinks(info snap.PlaceInfo) error {
 	currentDataSymlink := filepath.Join(info.DataDir(), "..", "current")
 	err2 = os.Remove(currentDataSymlink)
 	if err2 != nil && !os.IsNotExist(err2) {
-		logger.Noticef("Failed to remove %q: %v", currentDataSymlink, err2)
+		logger.Noticef("Cannot remove %q: %v", currentDataSymlink, err2)
 	} else {
 		err2 = nil
 	}

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -57,7 +57,7 @@ func updateCurrentSymlinks(info *snap.Info) error {
 	return os.Symlink(filepath.Base(mountDir), currentActiveSymlink)
 }
 
-// LinkSnap makes the snap available by generating wrappers and setting the current symlinks
+// LinkSnap makes the snap available by generating wrappers and setting the current symlinks.
 func (b Backend) LinkSnap(info *snap.Info) error {
 	if err := generateWrappers(info); err != nil {
 		return err

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -63,7 +63,7 @@ func (b Backend) LinkSnap(info *snap.Info) error {
 		return err
 	}
 
-	// XXX: should migrate to a different package/form
+	// XXX/TODO: this needs to be a task with proper undo and tests!
 	if err := snappy.SetNextBoot(info); err != nil {
 		return err
 	}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -1,0 +1,124 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/dirs"
+	"github.com/ubuntu-core/snappy/osutil"
+	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/snaptest"
+	"github.com/ubuntu-core/snappy/systemd"
+
+	"github.com/ubuntu-core/snappy/overlord/snapstate/backend"
+)
+
+func TestBackend(t *testing.T) { TestingT(t) }
+
+type linkSuite struct {
+	be           backend.Backend
+	nullProgress progress.NullProgress
+	prevctlCmd   func(...string) ([]byte, error)
+}
+
+var _ = Suite(&linkSuite{})
+
+func (s *linkSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+
+	s.prevctlCmd = systemd.SystemctlCmd
+	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+		return []byte("ActiveState=inactive\n"), nil
+	}
+}
+
+func (s *linkSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+	systemd.SystemctlCmd = s.prevctlCmd
+}
+
+func (s *linkSuite) TestLinkDoUndoGenerateWrappers(c *C) {
+	const yaml = `name: hello
+version: 1.0
+apps:
+ bin:
+   command: bin
+ svc:
+   command: svc
+   daemon: simple
+`
+
+	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: 11})
+
+	err := s.be.LinkSnap(info)
+	c.Assert(err, IsNil)
+
+	l, err := filepath.Glob(filepath.Join(dirs.SnapBinariesDir, "*"))
+	c.Assert(err, IsNil)
+	c.Assert(l, HasLen, 1)
+	l, err = filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.service"))
+	c.Assert(err, IsNil)
+	c.Assert(l, HasLen, 1)
+
+	// undo will remove
+	err = s.be.UnlinkSnap(info, &s.nullProgress)
+	l, err = filepath.Glob(filepath.Join(dirs.SnapBinariesDir, "*"))
+	c.Assert(err, IsNil)
+	c.Assert(l, HasLen, 0)
+	l, err = filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.service"))
+	c.Assert(err, IsNil)
+	c.Assert(l, HasLen, 0)
+}
+
+func (s *linkSuite) TestLinkDoUndoCurrentSymlink(c *C) {
+	const yaml = `name: hello
+version: 1.0
+`
+
+	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: 11})
+
+	err := s.be.LinkSnap(info)
+	c.Assert(err, IsNil)
+
+	mountDir := info.MountDir()
+	dataDir := info.DataDir()
+	currentActiveSymlink := filepath.Join(mountDir, "..", "current")
+	currentActiveDir, err := filepath.EvalSymlinks(currentActiveSymlink)
+	c.Assert(err, IsNil)
+	c.Assert(currentActiveDir, Equals, mountDir)
+
+	currentDataSymlink := filepath.Join(filepath.Dir(dataDir), "current")
+	currentDataDir, err := filepath.EvalSymlinks(currentDataSymlink)
+	c.Assert(err, IsNil)
+	c.Assert(currentDataDir, Equals, dataDir)
+
+	// undo will remove the symlinks
+	err = s.be.UnlinkSnap(info, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	c.Check(osutil.FileExists(currentActiveSymlink), Equals, false)
+	c.Check(osutil.FileExists(currentDataSymlink), Equals, false)
+
+}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -84,6 +84,8 @@ apps:
 
 	// undo will remove
 	err = s.be.UnlinkSnap(info, &s.nullProgress)
+	c.Assert(err, IsNil)
+
 	l, err = filepath.Glob(filepath.Join(dirs.SnapBinariesDir, "*"))
 	c.Assert(err, IsNil)
 	c.Assert(l, HasLen, 0)
@@ -109,7 +111,7 @@ version: 1.0
 	c.Assert(err, IsNil)
 	c.Assert(currentActiveDir, Equals, mountDir)
 
-	currentDataSymlink := filepath.Join(filepath.Dir(dataDir), "current")
+	currentDataSymlink := filepath.Join(dataDir, "..", "current")
 	currentDataDir, err := filepath.EvalSymlinks(currentDataSymlink)
 	c.Assert(err, IsNil)
 	c.Assert(currentDataDir, Equals, dataDir)
@@ -158,12 +160,11 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(currentActiveDir, Equals, mountDir)
 
-	currentDataSymlink := filepath.Join(filepath.Dir(dataDir), "current")
+	currentDataSymlink := filepath.Join(dataDir, "..", "current")
 	currentDataDir, err := filepath.EvalSymlinks(currentDataSymlink)
 	c.Assert(err, IsNil)
 	c.Assert(currentDataDir, Equals, dataDir)
 }
-
 
 func (s *linkSuite) TestLinkUnoIdempotent(c *C) {
 	// make sure that a retry wouldn't stumble on partial work
@@ -198,10 +199,8 @@ apps:
 	c.Assert(l, HasLen, 0)
 
 	// no symlinks
-	mountDir := info.MountDir()
-	dataDir := info.DataDir()
-	currentActiveSymlink := filepath.Join(mountDir, "..", "current")
-	currentDataSymlink := filepath.Join(filepath.Dir(dataDir), "current")
+	currentActiveSymlink := filepath.Join(info.MountDir(), "..", "current")
+	currentDataSymlink := filepath.Join(info.DataDir(), "..", "current")
 	c.Check(osutil.FileExists(currentActiveSymlink), Equals, false)
 	c.Check(osutil.FileExists(currentDataSymlink), Equals, false)
 }

--- a/overlord/snapstate/backend/utils.go
+++ b/overlord/snapstate/backend/utils.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+// firstErr returns the first error of the given error list
+func firstErr(err ...error) error {
+	for _, e := range err {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -35,7 +35,7 @@ func SetSnapManagerBackend(s *SnapManager, b ManagerBackend) {
 }
 
 func SetSnapstateBackend(b ManagerBackend) {
-	backend = b
+	be = b
 }
 
 type ForeignTaskTracker interface {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -32,7 +32,8 @@ import (
 )
 
 // allow exchange in the tests
-var backend managerBackend = &defaultBackend{}
+// XXX once we reimplent CanRemove directly here, this goes away
+var be managerBackend = &defaultBackend{}
 
 func doInstall(s *state.State, curActive bool, snapName, snapPath, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
 	if err := checkChangeConflict(s, snapName); err != nil {
@@ -204,7 +205,8 @@ func Remove(s *state.State, name string, flags snappy.RemoveFlags) (*state.TaskS
 	}
 
 	// check if this is something that can be removed
-	if !backend.CanRemove(info, active) {
+	// XXX: move CanRemove impl directly in snapstate
+	if !be.CanRemove(info, active) {
 		return nil, fmt.Errorf("snap %q is not removable", name)
 	}
 

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -116,9 +116,9 @@ func extractKernelAssets(s *snap.Info, snapf snap.File, flags InstallFlags, inte
 	return dir.Sync()
 }
 
-// setNextBoot will schedule the given os or kernel snap to be used in
+// SetNextBoot will schedule the given os or kernel snap to be used in
 // the next boot
-func setNextBoot(s *snap.Info) error {
+func SetNextBoot(s *snap.Info) error {
 	if s.Type != snap.TypeOS && s.Type != snap.TypeKernel {
 		return nil
 	}

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -292,7 +292,7 @@ func UpdateCurrentSymlink(info *snap.Info, inter interacter) error {
 
 	// FIXME: create {Os,Kernel}Snap type instead of adding special
 	//        cases here
-	if err := setNextBoot(info); err != nil {
+	if err := SetNextBoot(info); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This starts snapstate/backend where all the low-level primitives to manage snaps and their installations on disk should move (from snappy/). It moves Link/UnlinkSnap.

There is more work in the area to check that the corresponding do/undo methods in snapstate itself are also idempotent but the branch is already big enough for a start.

Also this exercise made clear that SetNextBoot needs to be a proper task as well.

Another general todo is to move away from logging to logger to logging into the tasks I suppose...