### PR TITLE
store: change applyUbuntuStoreHeaders to not take accept, and to take a channel

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -211,19 +211,19 @@ func NewUbuntuStoreSnapRepository(cfg *SnapUbuntuStoreConfig, storeID string) *S
 }
 
 // small helper that sets the correct http headers for the ubuntu store
-func (s *SnapUbuntuStoreRepository) applyUbuntuStoreHeaders(req *http.Request, accept string, auther Authenticator) {
+func (s *SnapUbuntuStoreRepository) setUbuntuStoreHeaders(req *http.Request, channel string, auther Authenticator) {
 	if auther != nil {
 		auther.Authenticate(req)
 	}
 
-	if accept == "" {
-		accept = "application/hal+json"
-	}
-	req.Header.Set("Accept", accept)
-
+	req.Header.Set("Accept", "application/hal+json,application/json")
 	req.Header.Set("X-Ubuntu-Architecture", string(arch.UbuntuArchitecture()))
 	req.Header.Set("X-Ubuntu-Release", release.Series)
 	req.Header.Set("X-Ubuntu-Wire-Protocol", UbuntuCoreWireProtocol)
+
+	if channel != "" {
+		req.Header.Set("X-Ubuntu-Device-Channel", channel)
+	}
 
 	if s.storeID != "" {
 		req.Header.Set("X-Ubuntu-Store", s.storeID)
@@ -294,8 +294,7 @@ func (s *SnapUbuntuStoreRepository) getPurchasesFromURL(url *url.URL, channel st
 		return nil, err
 	}
 
-	s.applyUbuntuStoreHeaders(req, "", auther)
-	req.Header.Set("X-Ubuntu-Device-Channel", channel)
+	s.setUbuntuStoreHeaders(req, channel, auther)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -423,8 +422,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, auther Authentica
 	}
 
 	// set headers
-	s.applyUbuntuStoreHeaders(req, "", auther)
-	req.Header.Set("X-Ubuntu-Device-Channel", channel)
+	s.setUbuntuStoreHeaders(req, channel, auther)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -485,8 +483,7 @@ func (s *SnapUbuntuStoreRepository) FindSnaps(searchTerm string, channel string,
 	}
 
 	// set headers
-	s.applyUbuntuStoreHeaders(req, "", auther)
-	req.Header.Set("X-Ubuntu-Device-Channel", channel)
+	s.setUbuntuStoreHeaders(req, channel, auther)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -535,7 +532,7 @@ func (s *SnapUbuntuStoreRepository) Updates(installed []string, auther Authentic
 	// set headers
 	// the updates call is a special snowflake right now
 	// (see LP: #1427155)
-	s.applyUbuntuStoreHeaders(req, "application/json", auther)
+	s.setUbuntuStoreHeaders(req, "", auther)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -586,7 +583,7 @@ func (s *SnapUbuntuStoreRepository) Download(remoteSnap *snap.Info, pbar progres
 	if err != nil {
 		return "", err
 	}
-	s.applyUbuntuStoreHeaders(req, "", auther)
+	s.setUbuntuStoreHeaders(req, "", auther)
 
 	if err := download(remoteSnap.Name(), w, req, pbar); err != nil {
 		return "", err

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -160,15 +160,15 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryHeaders(c *C) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	c.Assert(err, IsNil)
 
-	t.store.applyUbuntuStoreHeaders(req, "", nil)
+	t.store.setUbuntuStoreHeaders(req, "", nil)
 
-	c.Assert(req.Header.Get("X-Ubuntu-Release"), Equals, "16")
-	c.Check(req.Header.Get("Accept"), Equals, "application/hal+json")
+	c.Check(req.Header.Get("X-Ubuntu-Release"), Equals, "16")
+	c.Check(req.Header.Get("X-Ubuntu-Device-Channel"), Equals, "")
 
-	t.store.applyUbuntuStoreHeaders(req, "application/json", nil)
+	t.store.setUbuntuStoreHeaders(req, "chan", nil)
 
-	c.Check(req.Header.Get("Accept"), Equals, "application/json")
-	c.Assert(req.Header.Get("Authorization"), Equals, "")
+	c.Check(req.Header.Get("Authorization"), Equals, "")
+	c.Check(req.Header.Get("X-Ubuntu-Device-Channel"), Equals, "chan")
 }
 
 const (


### PR DESCRIPTION
I renamed it to `setUbuntuStoreHeaders` to catch the unwary, because the arity is the same.