### PR TITLE
snappy: fail early when we can not update the current symlink

### DIFF
--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -269,6 +269,7 @@ func UpdateCurrentSymlink(info *snap.Info, inter interacter) error {
 	currentActiveSymlink := filepath.Join(mountDir, "..", "current")
 	if err := os.Remove(currentActiveSymlink); err != nil && !os.IsNotExist(err) {
 		logger.Noticef("Failed to remove %q: %v", currentActiveSymlink, err)
+		return err
 	}
 
 	dataDir := info.DataDir()
@@ -276,6 +277,7 @@ func UpdateCurrentSymlink(info *snap.Info, inter interacter) error {
 	currentDataSymlink := filepath.Join(dbase, "current")
 	if err := os.Remove(currentDataSymlink); err != nil && !os.IsNotExist(err) {
 		logger.Noticef("Failed to remove %q: %v", currentDataSymlink, err)
+		return err
 	}
 
 	// symlink is relative to parent dir


### PR DESCRIPTION
Trivial branch that will fail early if the current symlink can not be updated. Now that we have `undo` for tasks we should fail early. The only situation this can happy is if there is some corruption.