### PR TITLE
overlord: handle ensureNext being in the past

### DIFF
--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -45,6 +45,10 @@ func MockPruneInterval(prunei, prunew, abortw time.Duration) (restore func()) {
 	}
 }
 
+func MockEnsureNext(o *Overlord, t time.Time) {
+	o.ensureNext = t
+}
+
 // Engine exposes the state engine in an Overlord for tests.
 func (o *Overlord) Engine() *StateEngine {
 	return o.stateEng

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -140,7 +140,7 @@ func (o *Overlord) ensureBefore(d time.Duration) {
 	}
 	now := time.Now()
 	next := now.Add(d)
-	if next.Before(o.ensureNext) {
+	if next.Before(o.ensureNext) || o.ensureNext.Before(now) {
 		o.ensureTimer.Reset(d)
 		o.ensureNext = next
 	}


### PR DESCRIPTION
`ensureNext` can be in the past when waking from suspend for example.