### PR TITLE
snap list should return 0 even when no snaps are present

### DIFF
--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -67,11 +67,9 @@ func listSnaps(args []string) error {
 		return err
 	}
 
-	if len(snaps) == 0 {
-		return fmt.Errorf(i18n.G("no snaps found"))
+	if len(snaps) > 0 {
+		sort.Sort(snapsByName(snaps))
 	}
-
-	sort.Sort(snapsByName(snaps))
 
 	w := tabWriter()
 	defer w.Flush()

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-05-10 22:32-0700\n"
+        "POT-Creation-Date: 2016-05-11 18:25-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -344,9 +344,6 @@ msgid   "no changes found"
 msgstr  ""
 
 msgid   "no interfaces found"
-msgstr  ""
-
-msgid   "no snaps found"
 msgstr  ""
 
 msgid   "produces manpage"


### PR DESCRIPTION
Currently, 'snap list' returns 1 when no snaps are present on a system.
This patch changes this behavior to return 0 even if no snaps are present yet
retains the message.

Signed-off-by: Chris J Arges <chris.j.arges@canonical.com>