### PR TITLE
snap: add certain implicit slots only on classic

### DIFF
--- a/snap/export_test.go
+++ b/snap/export_test.go
@@ -19,4 +19,7 @@
 
 package snap
 
-var ImplicitSlotsForTests = implicitSlots
+var (
+	ImplicitSlotsForTests        = implicitSlots
+	ImplicitClassicSlotsForTests = implicitClassicSlots
+)

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -19,6 +19,8 @@
 
 package snap
 
+import "github.com/ubuntu-core/snappy/release"
+
 var implicitSlots = []string{
 	"firewall-control",
 	"home",
@@ -33,7 +35,9 @@ var implicitSlots = []string{
 	"system-observe",
 	"timeserver-control",
 	"timezone-control",
-	// TODO Disable these on devices:
+}
+
+var implicitClassicSlots = []string{
 	"unity7",
 	"x11",
 	"opengl",
@@ -51,11 +55,23 @@ func AddImplicitSlots(snapInfo *Info) {
 	}
 	for _, ifaceName := range implicitSlots {
 		if _, ok := snapInfo.Slots[ifaceName]; !ok {
-			snapInfo.Slots[ifaceName] = &SlotInfo{
-				Name:      ifaceName,
-				Snap:      snapInfo,
-				Interface: ifaceName,
-			}
+			snapInfo.Slots[ifaceName] = makeImplicitSlot(snapInfo, ifaceName)
 		}
+	}
+	if !release.OnClassic {
+		return
+	}
+	for _, ifaceName := range implicitClassicSlots {
+		if _, ok := snapInfo.Slots[ifaceName]; !ok {
+			snapInfo.Slots[ifaceName] = makeImplicitSlot(snapInfo, ifaceName)
+		}
+	}
+}
+
+func makeImplicitSlot(snapInfo *Info, ifaceName string) *SlotInfo {
+	return &SlotInfo{
+		Name:      ifaceName,
+		Snap:      snapInfo,
+		Interface: ifaceName,
 	}
 }

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -21,6 +21,7 @@ package snap_test
 
 import (
 	"github.com/ubuntu-core/snappy/interfaces/builtin"
+	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/snap"
 
 	. "gopkg.in/check.v1"
@@ -30,7 +31,10 @@ type SpecialSuite struct{}
 
 var _ = Suite(&SpecialSuite{})
 
-func (s *InfoSnapYamlTestSuite) TestAddImplicitSlots(c *C) {
+func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
 	osYaml := []byte("name: ubuntu-core\ntype: os\n")
 	info, err := snap.InfoFromSnapYaml(osYaml)
 	c.Assert(err, IsNil)
@@ -38,6 +42,20 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlots(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
+	c.Assert(info.Slots, HasLen, 13)
+}
+
+func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	osYaml := []byte("name: ubuntu-core\ntype: os\n")
+	info, err := snap.InfoFromSnapYaml(osYaml)
+	c.Assert(err, IsNil)
+	snap.AddImplicitSlots(info)
+	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
+	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
+	c.Assert(info.Slots["unity7"].Snap, Equals, info)
 	c.Assert(info.Slots, HasLen, 16)
 }
 
@@ -47,6 +65,9 @@ func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {
 		known[iface.Name()] = true
 	}
 	for _, ifaceName := range snap.ImplicitSlotsForTests {
+		c.Check(known[ifaceName], Equals, true)
+	}
+	for _, ifaceName := range snap.ImplicitClassicSlotsForTests {
 		c.Check(known[ifaceName], Equals, true)
 	}
 }


### PR DESCRIPTION
This patch changes snap.AddImplicitSlots to differentiate between
classic and all-snaps environments. Certain slots, like unity7, x11 and
opengl are now only added in when running on classic.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>