### PR TITLE
integration-tests: add store login test

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -244,3 +244,14 @@ the top of the file:
 // +build !excludeintegration,classiconly
 ...
 ```
+
+### Store tests
+
+We have marked some of the tests that execise the different endpoints of the store so that they can be
+executed separately, for trying them you should use the `TestStore` filter:
+
+    $ go run ./integration-tests/main.go -filter TestStore
+
+There are tests that needs authentication against the store, for instance those that check the login and
+logout functionalities. For them to work the `TEST_USER_NAME` and `TEST_USER_PASSWORD` environment variables
+must be defined, otherwise they will be skipped.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -247,11 +247,10 @@ the top of the file:
 
 ### Store tests
 
-We have marked some of the tests that execise the different endpoints of the store so that they can be
+We have marked some of the tests that exercise the different endpoints of the store so that they can be
 executed separately, for trying them you should use the `TestStore` filter:
 
     $ go run ./integration-tests/main.go -filter TestStore
 
-There are tests that needs authentication against the store, for instance those that check the login and
-logout functionalities. For them to work the `TEST_USER_NAME` and `TEST_USER_PASSWORD` environment variables
-must be defined, otherwise they will be skipped.
+Tests that depend on authentication are skipped unless the `TEST_USER_NAME` and `TEST_USER_PASSWORD`
+environment variables are defined.

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -116,9 +116,11 @@ func main() {
 		IntegrationTestName: build.IntegrationTestName,
 		ShellOnFail:         *shellOnFail,
 		Env: map[string]string{
-			"http_proxy":  *httpProxy,
-			"https_proxy": *httpProxy,
-			"no_proxy":    "127.0.0.1,127.0.1.1,localhost,login.ubuntu.com",
+			"http_proxy":         *httpProxy,
+			"https_proxy":        *httpProxy,
+			"no_proxy":           "127.0.0.1,127.0.1.1,localhost,login.ubuntu.com",
+			"TEST_USER_NAME":     os.Getenv("TEST_USER_NAME"),
+			"TEST_USER_PASSWORD": os.Getenv("TEST_USER_PASSWORD"),
 		},
 	}
 	if !remoteTestbed {

--- a/integration-tests/tests/login_test.go
+++ b/integration-tests/tests/login_test.go
@@ -186,7 +186,7 @@ func (s *storeSuite) TestStoreLoginLogout(c *check.C) {
 	password := os.Getenv("TEST_USER_PASSWORD")
 
 	if username == "" || password == "" {
-		c.Skip("Test user credentials not available in current environment, skipping store tests")
+		c.Skip("$TEST_USER_NAME or $TEST_USER_PASSWORD not defined")
 	}
 
 	err := authenticate(username, password)


### PR DESCRIPTION
Currently the test exercises an actual login and logout against the production store. 

The execution of the test is controlled by the `TEST_USER_NAME` and `TEST_USER_PASSWORD` environment variables, if they don't exist the test is skipped.

Also, all the tests that exercise the store have been renamed to `TestStore...` to ease filtering.