### PR TITLE
integration-tests: add network-bind interface test

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -33,7 +33,7 @@ if [ -z "$ADT_REBOOT_MARK" ]; then
     go test -tags classiconly -c ./integration-tests/tests
 fi
 
-./tests.test  -check.vv -check.f 'snapHelloWorldExampleSuite|snapOpSuite|searchSuite|installAppSuite|authSuite|networkInterfaceSuite|homeInterfaceSuite|unity7|snapPersistsSuite'
+./tests.test  -check.vv -check.f 'snapHelloWorldExampleSuite|snapOpSuite|searchSuite|installAppSuite|authSuite|networkInterfaceSuite|networkBindInterfaceSuite|homeInterfaceSuite|unity7|snapPersistsSuite'
 
 if [ -e ${NEEDS_REBOOT} ]; then
     mark=`cat ${NEEDS_REBOOT}`

--- a/integration-tests/data/snaps/network-bind-consumer/bin/consumer
+++ b/integration-tests/data/snaps/network-bind-consumer/bin/consumer
@@ -3,7 +3,7 @@
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-class testHTTPServer_RequestHandler(BaseHTTPRequestHandler):
+class testRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
 
@@ -16,7 +16,7 @@ class testHTTPServer_RequestHandler(BaseHTTPRequestHandler):
 
 def run():
     server_address = ('localhost', 8081)
-    httpd = HTTPServer(server_address, testHTTPServer_RequestHandler)
+    httpd = HTTPServer(server_address, testRequestHandler)
     httpd.serve_forever()
 
 if __name__ == '__main__':

--- a/integration-tests/data/snaps/network-bind-consumer/bin/consumer
+++ b/integration-tests/data/snaps/network-bind-consumer/bin/consumer
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class testHTTPServer_RequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+
+        self.send_header('Content-type','text/html')
+        self.end_headers()
+
+        message = "<!doctype html>ok\n"
+        self.wfile.write(bytes(message, "utf8"))
+        return
+
+def run():
+    server_address = ('localhost', 8081)
+    httpd = HTTPServer(server_address, testHTTPServer_RequestHandler)
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+  sys.exit(run())

--- a/integration-tests/data/snaps/network-bind-consumer/meta/snap.yaml
+++ b/integration-tests/data/snaps/network-bind-consumer/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: network-bind-consumer
+version: 1.0
+summary: Basic network-bind consumer snap
+description: A basic snap declaring a plug on network-bind
+
+apps:
+  network-consumer:
+    command: bin/consumer
+    daemon: simple
+    plugs: [network-bind]

--- a/integration-tests/data/snaps/network-consumer/bin/consumer
+++ b/integration-tests/data/snaps/network-consumer/bin/consumer
@@ -1,10 +1,20 @@
 #! /usr/bin/env python3
 
+import sys
+from socket import timeout
 import urllib.request
 
+
+if len(sys.argv) > 1:
+  url = sys.argv[1]
+else:
+  url = 'http://www.ubuntu.com'
+
 try:
-  response = urllib.request.urlopen('http://www.ubuntu.com')
+  response = urllib.request.urlopen(url, timeout=3)
   if '<!doctype html>' in response.read().decode('utf-8'):
     print('ok')
 except urllib.error.URLError as e:
   print("Error, reason: ", e.reason)
+except timeout:
+  print("request timeout")

--- a/integration-tests/tests/home_interface_test.go
+++ b/integration-tests/tests/home_interface_test.go
@@ -33,9 +33,9 @@ import (
 
 var _ = check.Suite(&homeInterfaceSuite{
 	interfaceSuite: interfaceSuite{
-		sampleSnap: data.HomeConsumerSnapName,
-		slot:       "home",
-		plug:       "home-consumer"}})
+		sampleSnaps: []string{data.HomeConsumerSnapName},
+		slot:        "home",
+		plug:        "home-consumer"}})
 
 type homeInterfaceSuite struct {
 	interfaceSuite

--- a/integration-tests/tests/interfaces_test.go
+++ b/integration-tests/tests/interfaces_test.go
@@ -49,26 +49,32 @@ const (
 
 type interfaceSuite struct {
 	common.SnappySuite
-	snapPath, sampleSnap string
-	slot, plug           string
-	autoconnect          bool
+	snapPaths, sampleSnaps []string
+	slot, plug             string
+	autoconnect            bool
 }
 
 func (s *interfaceSuite) SetUpTest(c *check.C) {
 	s.SnappySuite.SetUpTest(c)
 
 	var err error
-	s.snapPath, err = build.LocalSnap(c, s.sampleSnap)
-	c.Assert(err, check.IsNil)
 
-	common.InstallSnap(c, s.snapPath)
+	s.snapPaths = make([]string, len(s.sampleSnaps))
+	for i := 0; i < len(s.sampleSnaps); i++ {
+		s.snapPaths[i], err = build.LocalSnap(c, s.sampleSnaps[i])
+		c.Assert(err, check.IsNil)
+
+		common.InstallSnap(c, s.snapPaths[i])
+	}
 }
 
 func (s *interfaceSuite) TearDownTest(c *check.C) {
 	s.SnappySuite.TearDownTest(c)
 
-	os.Remove(s.snapPath)
-	common.RemoveSnap(c, s.sampleSnap)
+	for i := 0; i < len(s.snapPaths); i++ {
+		os.Remove(s.snapPaths[i])
+		common.RemoveSnap(c, s.sampleSnaps[i])
+	}
 }
 
 func (s *interfaceSuite) TestPlugAutoconnect(c *check.C) {

--- a/integration-tests/tests/network_bind_interface_test.go
+++ b/integration-tests/tests/network_bind_interface_test.go
@@ -42,7 +42,7 @@ type networkBindInterfaceSuite struct {
 
 func (s *networkBindInterfaceSuite) TestPlugDisconnectionDisablesClientConnection(c *check.C) {
 	output := cli.ExecCommand(c, "network-consumer", providerURL)
-	c.Assert(output, check.Equals, okOutput)
+	c.Assert(output, check.Equals, "ok\n")
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
 		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
@@ -51,5 +51,5 @@ func (s *networkBindInterfaceSuite) TestPlugDisconnectionDisablesClientConnectio
 	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))
 
 	output = cli.ExecCommand(c, "network-consumer", providerURL)
-	c.Assert(output, check.Not(check.Equals), okOutput)
+	c.Assert(output, check.Equals, "request timeout\n")
 }

--- a/integration-tests/tests/network_bind_interface_test.go
+++ b/integration-tests/tests/network_bind_interface_test.go
@@ -21,25 +21,27 @@
 package tests
 
 import (
+	"gopkg.in/check.v1"
+
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/data"
-
-	"gopkg.in/check.v1"
 )
 
-var _ = check.Suite(&networkInterfaceSuite{
+const providerURL = "http://127.0.0.1:8081"
+
+var _ = check.Suite(&networkBindInterfaceSuite{
 	interfaceSuite: interfaceSuite{
-		sampleSnaps: []string{data.NetworkConsumerSnapName},
-		slot:        "network",
-		plug:        "network-consumer",
+		sampleSnaps: []string{data.NetworkBindConsumerSnapName, data.NetworkConsumerSnapName},
+		slot:        "network-bind",
+		plug:        "network-bind-consumer",
 		autoconnect: true}})
 
-type networkInterfaceSuite struct {
+type networkBindInterfaceSuite struct {
 	interfaceSuite
 }
 
-func (s *networkInterfaceSuite) TestPlugDisconnectionDisablesFunctionality(c *check.C) {
-	output := cli.ExecCommand(c, "network-consumer")
+func (s *networkBindInterfaceSuite) TestPlugDisconnectionDisablesClientConnection(c *check.C) {
+	output := cli.ExecCommand(c, "network-consumer", providerURL)
 	c.Assert(output, check.Equals, okOutput)
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
@@ -48,6 +50,6 @@ func (s *networkInterfaceSuite) TestPlugDisconnectionDisablesFunctionality(c *ch
 	output = cli.ExecCommand(c, "snap", "interfaces")
 	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))
 
-	output = cli.ExecCommand(c, "network-consumer")
-	c.Assert(output == okOutput, check.Equals, false)
+	output = cli.ExecCommand(c, "network-consumer", providerURL)
+	c.Assert(output, check.Not(check.Equals), okOutput)
 }

--- a/integration-tests/tests/network_interface_test.go
+++ b/integration-tests/tests/network_interface_test.go
@@ -42,7 +42,7 @@ func (s *networkInterfaceSuite) TestPlugDisconnectionDisablesFunctionality(c *ch
 	providerURL := "http://127.0.0.1:8081"
 
 	output := cli.ExecCommand(c, "network-consumer", providerURL)
-	c.Assert(output, check.Equals, okOutput)
+	c.Assert(output, check.Equals, "ok\n")
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
 		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)

--- a/integration-tests/tests/network_interface_test.go
+++ b/integration-tests/tests/network_interface_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = check.Suite(&networkInterfaceSuite{
 	interfaceSuite: interfaceSuite{
-		sampleSnaps: []string{data.NetworkConsumerSnapName},
+		sampleSnaps: []string{data.NetworkBindConsumerSnapName, data.NetworkConsumerSnapName},
 		slot:        "network",
 		plug:        "network-consumer",
 		autoconnect: true}})
@@ -39,7 +39,9 @@ type networkInterfaceSuite struct {
 }
 
 func (s *networkInterfaceSuite) TestPlugDisconnectionDisablesFunctionality(c *check.C) {
-	output := cli.ExecCommand(c, "network-consumer")
+	providerURL := "http://127.0.0.1:8081"
+
+	output := cli.ExecCommand(c, "network-consumer", providerURL)
 	c.Assert(output, check.Equals, okOutput)
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
@@ -48,6 +50,6 @@ func (s *networkInterfaceSuite) TestPlugDisconnectionDisablesFunctionality(c *ch
 	output = cli.ExecCommand(c, "snap", "interfaces")
 	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))
 
-	output = cli.ExecCommand(c, "network-consumer")
-	c.Assert(output == okOutput, check.Equals, false)
+	output = cli.ExecCommand(c, "network-consumer", providerURL)
+	c.Assert(output, check.Equals, "Error, reason:  [Errno 13] Permission denied\n")
 }

--- a/integration-tests/testutils/data/data.go
+++ b/integration-tests/testutils/data/data.go
@@ -35,6 +35,8 @@ const (
 	BasicDesktopSnapName = "basic-desktop"
 	// NetworkConsumerSnapName is the name of the snap with network plug
 	NetworkConsumerSnapName = "network-consumer"
+	// NetworkBindConsumerSnapName is the name of the snap with network plug
+	NetworkBindConsumerSnapName = "network-bind-consumer"
 	// HomeConsumerSnapName is the name of the snap with home plug
 	HomeConsumerSnapName = "home-consumer"
 	// WrongYamlSnapName is the name of a snap with an invalid meta yaml


### PR DESCRIPTION
The test reuses the previous network-consumer snap as client and introduces a network-bind-consumer snap. It's been included in the autopkgtest suite.