### PR TITLE
asserts: extend tests to cover mandatory and empty headers

### DIFF
--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -104,12 +104,19 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 
 	invalidHeaderTests := []struct{ original, invalid, expectedErr string }{
 		{"account-id: acc-id1\n", "", `"account-id" header is mandatory`},
-		{aks.sinceLine, "", `"since" header is mandatory`},
-		{aks.untilLine, "", `"until" header is mandatory`},
-		{aks.sinceLine, "since: 12:30\n", `"since" header is not a RFC3339 date: .*`},
-		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
+		{"account-id: acc-id1\n", "account-id: \n", `"account-id" header should not be empty`},
 		{"public-key-id: " + aks.keyid + "\n", "", `"public-key-id" header is mandatory`},
+		{"public-key-id: " + aks.keyid + "\n", "public-key-id: \n", `"public-key-id" header should not be empty`},
 		{"public-key-fingerprint: " + aks.fp + "\n", "", `"public-key-fingerprint" header is mandatory`},
+		{"public-key-fingerprint: " + aks.fp + "\n", "public-key-fingerprint: \n", `"public-key-fingerprint" header should not be empty`},
+		{aks.sinceLine, "", `"since" header is mandatory`},
+		{aks.sinceLine, "since: \n", `"since" header should not be empty`},
+		{aks.sinceLine, "since: 12:30\n", `"since" header is not a RFC3339 date: .*`},
+		{aks.sinceLine, "since: \n", `"since" header should not be empty`},
+		{aks.untilLine, "", `"until" header is mandatory`},
+		{aks.untilLine, "until: \n", `"until" header should not be empty`},
+		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
+		{aks.untilLine, "until: \n", `"until" header should not be empty`},
 	}
 
 	for _, test := range invalidHeaderTests {

--- a/asserts/identity_test.go
+++ b/asserts/identity_test.go
@@ -99,8 +99,13 @@ func (ids *identitySuite) TestDecodeInvalid(c *C) {
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"account-id: abc-123\n", "", `"account-id" header is mandatory`},
+		{"account-id: abc-123\n", "account-id: \n", `"account-id" header should not be empty`},
 		{"display-name: Display Name\n", "", `"display-name" header is mandatory`},
+		{"display-name: Display Name\n", "display-name: \n", `"display-name" header should not be empty`},
 		{"validation: certified\n", "", `"validation" header is mandatory`},
+		{"validation: certified\n", "validation: \n", `"validation" header should not be empty`},
+		{ids.tsLine, "", `"timestamp" header is mandatory`},
+		{ids.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{ids.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}
 

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -89,12 +89,18 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"series: 16\n", "", `"series" header is mandatory`},
+		{"series: 16\n", "series: \n", `"series" header should not be empty`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
+		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
 		{"snap-name: first\n", "", `"snap-name" header is mandatory`},
+		{"snap-name: first\n", "snap-name: \n", `"snap-name" header should not be empty`},
 		{"publisher-id: dev-id1\n", "", `"publisher-id" header is mandatory`},
+		{"publisher-id: dev-id1\n", "publisher-id: \n", `"publisher-id" header should not be empty`},
+		{sds.tsLine, "", `"timestamp" header is mandatory`},
+		{sds.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
+		{sds.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 		{"gates: snap-id-3,snap-id-4\n", "", `\"gates\" header is mandatory`},
 		{"gates: snap-id-3,snap-id-4\n", "gates: foo,\n", `empty entry in comma separated "gates" header: "foo,"`},
-		{sds.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}
 
 	for _, test := range invalidTests {
@@ -159,12 +165,18 @@ func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"series: 16\n", "", `"series" header is mandatory`},
+		{"series: 16\n", "series: \n", `"series" header should not be empty`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
+		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
-		{"grade: stable\n", "", `"grade" header is mandatory`},
+		{"snap-digest: sha256 ...\n", "snap-digest: \n", `"snap-digest" header should not be empty`},
 		{"snap-size: 10000\n", "", `"snap-size" header is mandatory`},
 		{"snap-size: 10000\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},
 		{"snap-size: 10000\n", "snap-size: zzz\n", `"snap-size" header is not an unsigned integer: zzz`},
+		{"grade: stable\n", "", `"grade" header is mandatory`},
+		{"grade: stable\n", "grade: \n", `"grade" header should not be empty`},
+		{sbs.tsLine, "", `"timestamp" header is mandatory`},
+		{sbs.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{sbs.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}
 
@@ -331,15 +343,23 @@ func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 	encoded := srs.makeValidEncoded()
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"series: 16\n", "", `"series" header is mandatory`},
+		{"series: 16\n", "series: \n", `"series" header should not be empty`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
+		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
+		{"snap-digest: sha256 ...\n", "snap-digest: \n", `"snap-digest" header should not be empty`},
 		{"snap-size: 123\n", "", `"snap-size" header is mandatory`},
+		{"snap-size: 123\n", "snap-size: \n", `"snap-size" header should not be empty`},
 		{"snap-size: 123\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},
 		{"snap-size: 123\n", "snap-size: zzz\n", `"snap-size" header is not an unsigned integer: zzz`},
 		{"snap-revision: 1\n", "", `"snap-revision" header is mandatory`},
+		{"snap-revision: 1\n", "snap-revision: \n", `"snap-revision" header should not be empty`},
 		{"snap-revision: 1\n", "snap-revision: -1\n", `"snap-revision" header is not an unsigned integer: -1`},
 		{"snap-revision: 1\n", "snap-revision: zzz\n", `"snap-revision" header is not an unsigned integer: zzz`},
 		{"developer-id: dev-id1\n", "", `"developer-id" header is mandatory`},
+		{"developer-id: dev-id1\n", "developer-id: \n", `"developer-id" header should not be empty`},
+		{srs.tsLine, "", `"timestamp" header is mandatory`},
+		{srs.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{srs.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}
 


### PR DESCRIPTION
All (I think) headers were checked when missing. They're now also
checked for present but empty.

Invalid header test tables were also sorted in documented order for
easier future maintenance.