### PR TITLE
asserts: allow empty snap-name for snap-declaration

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -73,14 +73,14 @@ func checkPublicKey(ab *assertionBase, fingerprintName, keyIDName string) (Publi
 	if err != nil {
 		return nil, err
 	}
-	fp, err := checkMandatory(ab.headers, fingerprintName)
+	fp, err := checkNotEmpty(ab.headers, fingerprintName)
 	if err != nil {
 		return nil, err
 	}
 	if fp != pubKey.Fingerprint() {
 		return nil, fmt.Errorf("public key does not match provided fingerprint")
 	}
-	keyID, err := checkMandatory(ab.headers, keyIDName)
+	keyID, err := checkNotEmpty(ab.headers, keyIDName)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -104,12 +104,19 @@ func (aks *accountKeySuite) TestDecodeInvalidHeaders(c *C) {
 
 	invalidHeaderTests := []struct{ original, invalid, expectedErr string }{
 		{"account-id: acc-id1\n", "", `"account-id" header is mandatory`},
-		{aks.sinceLine, "", `"since" header is mandatory`},
-		{aks.untilLine, "", `"until" header is mandatory`},
-		{aks.sinceLine, "since: 12:30\n", `"since" header is not a RFC3339 date: .*`},
-		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
+		{"account-id: acc-id1\n", "account-id: \n", `"account-id" header should not be empty`},
 		{"public-key-id: " + aks.keyid + "\n", "", `"public-key-id" header is mandatory`},
+		{"public-key-id: " + aks.keyid + "\n", "public-key-id: \n", `"public-key-id" header should not be empty`},
 		{"public-key-fingerprint: " + aks.fp + "\n", "", `"public-key-fingerprint" header is mandatory`},
+		{"public-key-fingerprint: " + aks.fp + "\n", "public-key-fingerprint: \n", `"public-key-fingerprint" header should not be empty`},
+		{aks.sinceLine, "", `"since" header is mandatory`},
+		{aks.sinceLine, "since: \n", `"since" header should not be empty`},
+		{aks.sinceLine, "since: 12:30\n", `"since" header is not a RFC3339 date: .*`},
+		{aks.sinceLine, "since: \n", `"since" header should not be empty`},
+		{aks.untilLine, "", `"until" header is mandatory`},
+		{aks.untilLine, "until: \n", `"until" header should not be empty`},
+		{aks.untilLine, "until: " + aks.since.Format(time.RFC3339) + "\n", `invalid 'since' and 'until' times \(no gap after 'since' till 'until'\)`},
+		{aks.untilLine, "until: \n", `"until" header should not be empty`},
 	}
 
 	for _, test := range invalidHeaderTests {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -472,11 +472,11 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 		return nil, fmt.Errorf("assertion body length and declared body-length don't match: %v != %v", len(body), length)
 	}
 
-	if _, err := checkMandatory(headers, "authority-id"); err != nil {
+	if _, err := checkNotEmpty(headers, "authority-id"); err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
 	}
 
-	typ, err := checkMandatory(headers, "type")
+	typ, err := checkNotEmpty(headers, "type")
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
 	}
@@ -486,7 +486,7 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 	}
 
 	for _, primKey := range assertType.PrimaryKey {
-		if _, err := checkMandatory(headers, primKey); err != nil {
+		if _, err := checkNotEmpty(headers, primKey); err != nil {
 			return nil, fmt.Errorf("assertion %s: %v", assertType.Name, err)
 		}
 	}
@@ -543,7 +543,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]string, body 
 	finalHeaders["type"] = assertType.Name
 	finalHeaders["body-length"] = strconv.Itoa(bodyLength)
 
-	if _, err := checkMandatory(finalHeaders, "authority-id"); err != nil {
+	if _, err := checkNotEmpty(finalHeaders, "authority-id"); err != nil {
 		return nil, err
 	}
 
@@ -568,7 +568,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]string, body 
 		"body-length":  true,
 	}
 	for _, primKey := range assertType.PrimaryKey {
-		if _, err := checkMandatory(finalHeaders, primKey); err != nil {
+		if _, err := checkNotEmpty(finalHeaders, primKey); err != nil {
 			return nil, err
 		}
 		writeHeader(buf, finalHeaders, primKey)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -225,7 +225,7 @@ func (db *Database) PublicKey(authorityID string, keyID string) (PublicKey, erro
 // Sign assembles an assertion with the provided information and signs it
 // with the private key from `headers["authority-id"]` that has the provided key id.
 func (db *Database) Sign(assertType *AssertionType, headers map[string]string, body []byte, keyID string) (Assertion, error) {
-	authorityID, err := checkMandatory(headers, "authority-id")
+	authorityID, err := checkNotEmpty(headers, "authority-id")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -111,7 +111,7 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 	}
 
 	for _, mandatory := range modelMandatory {
-		if _, err := checkMandatory(assert.headers, mandatory); err != nil {
+		if _, err := checkNotEmpty(assert.headers, mandatory); err != nil {
 			return nil, err
 		}
 	}
@@ -181,7 +181,7 @@ func (ds *DeviceSerial) Timestamp() time.Time {
 func assembleDeviceSerial(assert assertionBase) (Assertion, error) {
 	// TODO: authority-id can only == canonical or brand-id
 
-	encodedKey, err := checkMandatory(assert.headers, "device-key")
+	encodedKey, err := checkNotEmpty(assert.headers, "device-key")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -28,7 +28,7 @@ import (
 
 // common checks used when decoding/assembling assertions
 
-func checkMandatory(headers map[string]string, name string) (string, error) {
+func checkNotEmpty(headers map[string]string, name string) (string, error) {
 	value, ok := headers[name]
 	if !ok {
 		return "", fmt.Errorf("%q header is mandatory", name)
@@ -70,7 +70,7 @@ func checkInteger(headers map[string]string, name string, defl int) (int, error)
 }
 
 func checkRFC3339Date(headers map[string]string, name string) (time.Time, error) {
-	dateStr, err := checkMandatory(headers, name)
+	dateStr, err := checkNotEmpty(headers, name)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -82,7 +82,7 @@ func checkRFC3339Date(headers map[string]string, name string) (time.Time, error)
 }
 
 func checkUint(headers map[string]string, name string, bitSize int) (uint64, error) {
-	valueStr, err := checkMandatory(headers, name)
+	valueStr, err := checkNotEmpty(headers, name)
 	if err != nil {
 		return 0, err
 	}

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -28,7 +28,7 @@ import (
 
 // common checks used when decoding/assembling assertions
 
-func checkMandatory(headers map[string]string, name string) (string, error) {
+func checkExists(headers map[string]string, name string) (string, error) {
 	value, ok := headers[name]
 	if !ok {
 		return "", fmt.Errorf("%q header is mandatory", name)
@@ -37,7 +37,7 @@ func checkMandatory(headers map[string]string, name string) (string, error) {
 }
 
 func checkNotEmpty(headers map[string]string, name string) (string, error) {
-	value, err := checkMandatory(headers, name)
+	value, err := checkExists(headers, name)
 	if err != nil {
 		return "", err
 	}

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -28,10 +28,18 @@ import (
 
 // common checks used when decoding/assembling assertions
 
-func checkNotEmpty(headers map[string]string, name string) (string, error) {
+func checkMandatory(headers map[string]string, name string) (string, error) {
 	value, ok := headers[name]
 	if !ok {
 		return "", fmt.Errorf("%q header is mandatory", name)
+	}
+	return value, nil
+}
+
+func checkNotEmpty(headers map[string]string, name string) (string, error) {
+	value, err := checkMandatory(headers, name)
+	if err != nil {
+		return "", err
 	}
 	if len(value) == 0 {
 		return "", fmt.Errorf("%q header should not be empty", name)

--- a/asserts/identity.go
+++ b/asserts/identity.go
@@ -54,12 +54,12 @@ func (id *Identity) Timestamp() time.Time {
 }
 
 func assembleIdentity(assert assertionBase) (Assertion, error) {
-	_, err := checkMandatory(assert.headers, "display-name")
+	_, err := checkNotEmpty(assert.headers, "display-name")
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = checkMandatory(assert.headers, "validation")
+	_, err = checkNotEmpty(assert.headers, "validation")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/identity_test.go
+++ b/asserts/identity_test.go
@@ -99,8 +99,13 @@ func (ids *identitySuite) TestDecodeInvalid(c *C) {
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"account-id: abc-123\n", "", `"account-id" header is mandatory`},
+		{"account-id: abc-123\n", "account-id: \n", `"account-id" header should not be empty`},
 		{"display-name: Display Name\n", "", `"display-name" header is mandatory`},
+		{"display-name: Display Name\n", "display-name: \n", `"display-name" header should not be empty`},
 		{"validation: certified\n", "", `"validation" header is mandatory`},
+		{"validation: certified\n", "validation: \n", `"validation" header should not be empty`},
+		{ids.tsLine, "", `"timestamp" header is mandatory`},
+		{ids.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{ids.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}
 

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -65,7 +65,7 @@ func (snapdcl *SnapDeclaration) Timestamp() time.Time {
 // XXX: consistency check is signed by canonical
 
 func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
-	_, err := checkNotEmpty(assert.headers, "snap-name")
+	_, err := checkMandatory(assert.headers, "snap-name")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -65,7 +65,7 @@ func (snapdcl *SnapDeclaration) Timestamp() time.Time {
 // XXX: consistency check is signed by canonical
 
 func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
-	_, err := checkMandatory(assert.headers, "snap-name")
+	_, err := checkExists(assert.headers, "snap-name")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -65,12 +65,12 @@ func (snapdcl *SnapDeclaration) Timestamp() time.Time {
 // XXX: consistency check is signed by canonical
 
 func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
-	_, err := checkMandatory(assert.headers, "snap-name")
+	_, err := checkNotEmpty(assert.headers, "snap-name")
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = checkMandatory(assert.headers, "publisher-id")
+	_, err = checkNotEmpty(assert.headers, "publisher-id")
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (snapbld *SnapBuild) Timestamp() time.Time {
 func assembleSnapBuild(assert assertionBase) (Assertion, error) {
 	// TODO: more parsing/checking of snap-digest
 
-	_, err := checkMandatory(assert.headers, "grade")
+	_, err := checkNotEmpty(assert.headers, "grade")
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
-	_, err = checkMandatory(assert.headers, "developer-id")
+	_, err = checkNotEmpty(assert.headers, "developer-id")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -70,6 +70,24 @@ func (sds *snapDeclSuite) TestDecodeOK(c *C) {
 	c.Check(snapDecl.Gates(), DeepEquals, []string{"snap-id-3", "snap-id-4"})
 }
 
+func (sds *snapDeclSuite) TestEmptySnapName(c *C) {
+	encoded := "type: snap-declaration\n" +
+		"authority-id: canonical\n" +
+		"series: 16\n" +
+		"snap-id: snap-id-1\n" +
+		"snap-name: \n" +
+		"publisher-id: dev-id1\n" +
+		"gates: snap-id-3,snap-id-4\n" +
+		sds.tsLine +
+		"body-length: 0" +
+		"\n\n" +
+		"openpgp c2ln"
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	snapDecl := a.(*asserts.SnapDeclaration)
+	c.Check(snapDecl.SnapName(), Equals, "")
+}
+
 const (
 	snapDeclErrPrefix = "assertion snap-declaration: "
 )
@@ -93,7 +111,6 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
 		{"snap-name: first\n", "", `"snap-name" header is mandatory`},
-		{"snap-name: first\n", "snap-name: \n", `"snap-name" header should not be empty`},
 		{"publisher-id: dev-id1\n", "", `"publisher-id" header is mandatory`},
 		{"publisher-id: dev-id1\n", "publisher-id: \n", `"publisher-id" header should not be empty`},
 		{sds.tsLine, "", `"timestamp" header is mandatory`},

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -89,12 +89,18 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"series: 16\n", "", `"series" header is mandatory`},
+		{"series: 16\n", "series: \n", `"series" header should not be empty`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
+		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
 		{"snap-name: first\n", "", `"snap-name" header is mandatory`},
+		{"snap-name: first\n", "snap-name: \n", `"snap-name" header should not be empty`},
 		{"publisher-id: dev-id1\n", "", `"publisher-id" header is mandatory`},
+		{"publisher-id: dev-id1\n", "publisher-id: \n", `"publisher-id" header should not be empty`},
+		{sds.tsLine, "", `"timestamp" header is mandatory`},
+		{sds.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
+		{sds.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 		{"gates: snap-id-3,snap-id-4\n", "", `\"gates\" header is mandatory`},
 		{"gates: snap-id-3,snap-id-4\n", "gates: foo,\n", `empty entry in comma separated "gates" header: "foo,"`},
-		{sds.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}
 
 	for _, test := range invalidTests {
@@ -159,12 +165,18 @@ func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"series: 16\n", "", `"series" header is mandatory`},
+		{"series: 16\n", "series: \n", `"series" header should not be empty`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
+		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
-		{"grade: stable\n", "", `"grade" header is mandatory`},
+		{"snap-digest: sha256 ...\n", "snap-digest: \n", `"snap-digest" header should not be empty`},
 		{"snap-size: 10000\n", "", `"snap-size" header is mandatory`},
 		{"snap-size: 10000\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},
 		{"snap-size: 10000\n", "snap-size: zzz\n", `"snap-size" header is not an unsigned integer: zzz`},
+		{"grade: stable\n", "", `"grade" header is mandatory`},
+		{"grade: stable\n", "grade: \n", `"grade" header should not be empty`},
+		{sbs.tsLine, "", `"timestamp" header is mandatory`},
+		{sbs.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{sbs.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}
 
@@ -331,15 +343,23 @@ func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 	encoded := srs.makeValidEncoded()
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"series: 16\n", "", `"series" header is mandatory`},
+		{"series: 16\n", "series: \n", `"series" header should not be empty`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
+		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
 		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
+		{"snap-digest: sha256 ...\n", "snap-digest: \n", `"snap-digest" header should not be empty`},
 		{"snap-size: 123\n", "", `"snap-size" header is mandatory`},
+		{"snap-size: 123\n", "snap-size: \n", `"snap-size" header should not be empty`},
 		{"snap-size: 123\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},
 		{"snap-size: 123\n", "snap-size: zzz\n", `"snap-size" header is not an unsigned integer: zzz`},
 		{"snap-revision: 1\n", "", `"snap-revision" header is mandatory`},
+		{"snap-revision: 1\n", "snap-revision: \n", `"snap-revision" header should not be empty`},
 		{"snap-revision: 1\n", "snap-revision: -1\n", `"snap-revision" header is not an unsigned integer: -1`},
 		{"snap-revision: 1\n", "snap-revision: zzz\n", `"snap-revision" header is not an unsigned integer: zzz`},
 		{"developer-id: dev-id1\n", "", `"developer-id" header is mandatory`},
+		{"developer-id: dev-id1\n", "developer-id: \n", `"developer-id" header should not be empty`},
+		{srs.tsLine, "", `"timestamp" header is mandatory`},
+		{srs.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{srs.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
 	}
 


### PR DESCRIPTION
The empty snap-name is used to indicate that this snap-id should not be
published for the series, and is used to revoke any previous name
assigned to the snap-id.