### PR TITLE
interfaces: remove 'audit deny' rules from network_control.go

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -68,11 +68,9 @@ network sna,
 /{,usr/}{,s}bin/bridge ixr,
 /{,usr/}{,s}bin/dhclient Pxr,             # use ixr instead if want to limit to snap dirs
 /{,usr/}{,s}bin/ifconfig ixr,
-audit deny /{,usr/}{,s}bin/if{up,down} r, # the system uses these, snaps shouldn't
 /{,usr/}{,s}bin/ip ixr,
 /{,usr/}{,s}bin/ipmaddr ixr,
 /{,usr/}{,s}bin/iptunnel ixr,
-audit deny /{,usr/}{,s}bin/mii-tool r,    # needs capability sys_module
 /{,usr/}{,s}bin/nameif ixr,
 /{,usr/}{,s}bin/netstat ixr,              # -p not supported
 /{,usr/}{,s}bin/nstat ixr,


### PR DESCRIPTION
Remove two more explicit denies. These were only there to safeguard against accidental inclusion elsewhere but aren't strictly needed.