### PR TITLE
debian: workaround for XDG_DATA_DIRS issues

### DIFF
--- a/debian/snapd.dirs
+++ b/debian/snapd.dirs
@@ -1,6 +1,6 @@
 snap
 var/lib/snapd/snaps
 var/lib/snapd/lib/gl
-usr/lib/snapd/desktop
+var/lib/snapd/desktop
 usr/lib/snapd
 var/snap

--- a/debian/snapd.dirs
+++ b/debian/snapd.dirs
@@ -1,5 +1,6 @@
 snap
 var/lib/snapd/snaps
 var/lib/snapd/lib/gl
+usr/lib/snapd/desktop
 usr/lib/snapd
 var/snap

--- a/etc/X11/Xsession.d/65snappy
+++ b/etc/X11/Xsession.d/65snappy
@@ -1,7 +1,12 @@
 # This file is sourced by Xsession(5), not executed.
 # Add additionnal the additonal snappy desktop path
 
-XDG_DATA_DIRS=$XDG_DATA_DIRS:/var/lib/snapd/desktop
+if [ -z "$XDG_DATA_DIRS" ]; then
+    # 60x11-common_xdg_path does not always set XDG_DATA_DIRS
+    # so we ensure we have sensible defaults here (LP: #1575014)
+    # as a workaround
+    XDG_DATA_DIRS=/usr/local/share/:/usr/share/:/var/lib/snapd/desktop
+else
+    XDG_DATA_DIRS="$XDG_DATA_DIRS":/var/lib/snapd/desktop
+fi
 export XDG_DATA_DIRS
-
-


### PR DESCRIPTION
Applies minor fix to #1175 to get it in.