### PR TITLE
integration-tests: log-observe interface test

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -33,7 +33,7 @@ if [ -z "$ADT_REBOOT_MARK" ]; then
     go test -tags classiconly -c ./integration-tests/tests
 fi
 
-./tests.test  -check.vv -check.f 'snapHelloWorldExampleSuite|snapOpSuite|searchSuite|installAppSuite|authSuite|networkInterfaceSuite|networkBindInterfaceSuite|homeInterfaceSuite|unity7|snapPersistsSuite'
+./tests.test  -check.vv -check.f 'snapHelloWorldExampleSuite|snapOpSuite|searchSuite|installAppSuite|authSuite|networkInterfaceSuite|networkBindInterfaceSuite|homeInterfaceSuite|logObserveInterfaceSuite|unity7|snapPersistsSuite'
 
 if [ -e ${NEEDS_REBOOT} ]; then
     mark=`cat ${NEEDS_REBOOT}`

--- a/integration-tests/data/snaps/log-observe-consumer/bin/consumer
+++ b/integration-tests/data/snaps/log-observe-consumer/bin/consumer
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+ERROR_MSG = "error controlling firewall"
+
+def get_message():
+  try:
+    subprocess.check_output("tail -n 10 /var/log/syslog", shell=True)
+    message = "ok\n"
+  except Exception as e:
+    message = "error accessing log\n"
+
+  return message
+
+class testRequestHandler(BaseHTTPRequestHandler):
+  def do_GET(self):
+    self.send_response(200)
+
+    self.send_header('Content-type','text/html')
+    self.end_headers()
+
+    message = get_message()
+
+    self.wfile.write(bytes('<!doctype html>'+message, "utf8"))
+    return
+
+def run():
+  server_address = ('', 8081)
+  httpd = HTTPServer(server_address, testRequestHandler)
+  httpd.serve_forever()
+
+if __name__ == '__main__':
+  sys.exit(run())

--- a/integration-tests/data/snaps/log-observe-consumer/meta/snap.yaml
+++ b/integration-tests/data/snaps/log-observe-consumer/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: log-observe-consumer
+version: 1.0
+summary: Basic log-observe consumer snap
+description: A basic snap declaring a plug on log-observe
+
+apps:
+  log-observe-consumer:
+    command: bin/consumer
+    daemon: simple
+    plugs: [network-bind, log-observe]

--- a/integration-tests/data/snaps/network-consumer/bin/consumer
+++ b/integration-tests/data/snaps/network-consumer/bin/consumer
@@ -4,7 +4,6 @@ import sys
 from socket import timeout
 import urllib.request
 
-
 if len(sys.argv) > 1:
   url = sys.argv[1]
 else:
@@ -12,8 +11,9 @@ else:
 
 try:
   response = urllib.request.urlopen(url, timeout=3)
-  if '<!doctype html>' in response.read().decode('utf-8'):
-    print('ok')
+  decoded_response = response.read().decode('utf-8')
+  if '<!doctype html>' in decoded_response:
+    print(decoded_response.replace('<!doctype html>', ''), end="")
 except urllib.error.URLError as e:
   print("Error, reason: ", e.reason)
 except timeout:

--- a/integration-tests/tests/log_observe_interface_test.go
+++ b/integration-tests/tests/log_observe_interface_test.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !excludeintegration
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tests
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
+	"github.com/ubuntu-core/snappy/integration-tests/testutils/data"
+)
+
+var _ = check.Suite(&logObserveInterfaceSuite{
+	interfaceSuite: interfaceSuite{
+		sampleSnaps: []string{data.LogObserveConsumerSnapName, data.NetworkConsumerSnapName},
+		slot:        "log-observe",
+		plug:        "log-observe-consumer"}})
+
+type logObserveInterfaceSuite struct {
+	interfaceSuite
+}
+
+func (s *logObserveInterfaceSuite) TestConnectedPlugAllowsLogObserve(c *check.C) {
+	cli.ExecCommand(c, "sudo", "snap", "connect",
+		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+
+	output := cli.ExecCommand(c, "network-consumer", "http://127.0.0.1:8081")
+	c.Assert(output, check.Equals, "ok\n")
+}
+
+func (s *logObserveInterfaceSuite) TestDisconnectedPlugDisablesLogObserve(c *check.C) {
+	output := cli.ExecCommand(c, "network-consumer", "http://127.0.0.1:8081")
+	c.Assert(output, check.Equals, "error accessing log\n")
+}

--- a/integration-tests/testutils/data/data.go
+++ b/integration-tests/testutils/data/data.go
@@ -37,6 +37,8 @@ const (
 	NetworkConsumerSnapName = "network-consumer"
 	// NetworkBindConsumerSnapName is the name of the snap with network plug
 	NetworkBindConsumerSnapName = "network-bind-consumer"
+	// LogObserveConsumerSnapName is the name of the snap with log-observe plug
+	LogObserveConsumerSnapName = "log-observe-consumer"
 	// HomeConsumerSnapName is the name of the snap with home plug
 	HomeConsumerSnapName = "home-consumer"
 	// WrongYamlSnapName is the name of a snap with an invalid meta yaml


### PR DESCRIPTION
The `log-observe` snap binary access the log from a daemon in order to prevent permission errors.

The test has been added to the autopkgtest suite.