### PR TITLE
integration-tests: extend find command tests

### DIFF
--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -21,8 +21,6 @@
 package tests
 
 import (
-	"fmt"
-
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/common"
 
@@ -100,18 +98,4 @@ func (s *searchSuite) TestFindShowsHelp(c *check.C) {
 	actual := cli.ExecCommand(c, "snap", "find", "--help")
 
 	c.Assert(actual, check.Matches, expected)
-}
-
-// SNAP_FIND_007: find packages with search string containing special characters
-func (s *searchSuite) TestFindWithSpecialCharsInSearchString(c *check.C) {
-	c.Skip("Reenable when LP: 1583952 is fixed")
-	specialChars := "!@#$%^&*/=[]+_:;,.?{}"
-
-	for _, char := range specialChars {
-		s := string(char)
-		expected := fmt.Sprintf(`error: no snaps found for "%s"`, s)
-		searchOutput := cli.ExecCommand(c, "snap", "find", s)
-
-		c.Check(searchOutput, check.Matches, expected)
-	}
 }

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const fullListPattern = "(?ms)" +
-	"Name +Version +Summary *\n" +
+	"Name +Version +Price +Summary *\n" +
 	".*" +
 	"^canonical-pc +.* *\n" +
 	".*" +
@@ -75,7 +75,7 @@ func (s *searchSuite) TestFindMustPrintCompleteList(c *check.C) {
 func (s *searchSuite) TestFindWorksWithDifferentFormats(c *check.C) {
 	for _, snapName := range []string{"http", "ubuntu-clock-app", "go-example-webserver"} {
 		expected := "(?ms)" +
-			"Name +Version +Summary *\n" +
+			"Name +Version +Price +Summary *\n" +
 			".*" +
 			"^" + snapName + " +.* *\n" +
 			".*"

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const fullListPattern = "(?ms)" +
-	"Name +Version +Price +Summary *\n" +
+	"Name +Version +(Price +)?Summary *\n" +
 	".*" +
 	"^canonical-pc +.* *\n" +
 	".*" +
@@ -52,7 +52,7 @@ type searchSuite struct {
 func (s *searchSuite) TestSearchMustPrintMatch(c *check.C) {
 	// XXX: Summary is empty atm, waiting for store support
 	expected := "(?ms)" +
-		"Name +Version +Summary *\n" +
+		"Name +Version +(Price +)?Summary *\n" +
 		".*" +
 		"^hello-world +.* *\n" +
 		".*"
@@ -75,7 +75,7 @@ func (s *searchSuite) TestFindMustPrintCompleteList(c *check.C) {
 func (s *searchSuite) TestFindWorksWithDifferentFormats(c *check.C) {
 	for _, snapName := range []string{"http", "ubuntu-clock-app", "go-example-webserver"} {
 		expected := "(?ms)" +
-			"Name +Version +Price +Summary *\n" +
+			"Name +Version +(Price +)?Summary *\n" +
 			".*" +
 			"^" + snapName + " +.* *\n" +
 			".*"

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -21,27 +21,13 @@
 package tests
 
 import (
+	"fmt"
+
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/cli"
 	"github.com/ubuntu-core/snappy/integration-tests/testutils/common"
 
 	"gopkg.in/check.v1"
 )
-
-const fullListPattern = "(?ms)" +
-	"Name +Version +(Price +)?Summary *\n" +
-	".*" +
-	"^canonical-pc +.* *\n" +
-	".*" +
-	"^canonical-pc-linux +.* *\n" +
-	".*" +
-	"^go-example-webserver +.* *\n" +
-	".*" +
-	"^hello-world +.* *\n" +
-	".*" +
-	"^ubuntu-clock-app +.* *\n" +
-	".*" +
-	"^ubuntu-core +.* *\n" +
-	".*"
 
 var _ = check.Suite(&searchSuite{})
 
@@ -66,6 +52,22 @@ func (s *searchSuite) TestSearchMustPrintMatch(c *check.C) {
 
 // SNAP_FIND_001: list all packages available on the store
 func (s *searchSuite) TestFindMustPrintCompleteList(c *check.C) {
+	fullListPattern := "(?ms)" +
+		"Name +Version +(Price +)?Summary *\n" +
+		".*" +
+		"^canonical-pc +.* *\n" +
+		".*" +
+		"^canonical-pc-linux +.* *\n" +
+		".*" +
+		"^go-example-webserver +.* *\n" +
+		".*" +
+		"^hello-world +.* *\n" +
+		".*" +
+		"^ubuntu-clock-app +.* *\n" +
+		".*" +
+		"^ubuntu-core +.* *\n" +
+		".*"
+
 	searchOutput := cli.ExecCommand(c, "snap", "find")
 
 	c.Assert(searchOutput, check.Matches, fullListPattern)
@@ -102,11 +104,14 @@ func (s *searchSuite) TestFindShowsHelp(c *check.C) {
 
 // SNAP_FIND_007: find packages with search string containing special characters
 func (s *searchSuite) TestFindWithSpecialCharsInSearchString(c *check.C) {
+	c.Skip("Reenable when LP: 1583952 is fixed")
 	specialChars := "!@#$%^&*/=[]+_:;,.?{}"
 
 	for _, char := range specialChars {
-		searchOutput := cli.ExecCommand(c, "snap", "find", string(char))
+		s := string(char)
+		expected := fmt.Sprintf(`error: no snaps found for "%s"`, s)
+		searchOutput := cli.ExecCommand(c, "snap", "find", s)
 
-		c.Check(searchOutput, check.Matches, fullListPattern)
+		c.Check(searchOutput, check.Matches, expected)
 	}
 }


### PR DESCRIPTION
Added tests according to the recommendations from the Ubuntu Personal - Product Test team. A reference to the Test Case ID is included in each test comment.