### PR TITLE
tests: stop the update-pot check in run-checks

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -121,15 +121,6 @@ if [ ! -z "$STATIC" ]; then
         exit 1
     fi
 
-    # pot file
-    echo Checking translations
-    TMPF="$(mktemp)"
-    addtrap "rm -f \"$TMPF\""
-    ./update-pot "$TMPF"
-    if ! diff -u --ignore-matching-lines=.*POT-Creation-Date.* po/snappy.pot $TMPF; then
-        echo "You need to run ./update-pot"
-        exit 1
-    fi
 fi
 
 if [ ! -z "$UNIT" ]; then


### PR DESCRIPTION
We already do a `update-pot` on package build time and that is enough. Avoids unneeded conflicts during the development.