### PR TITLE
snappy: do nothing in SetNextBoot when running on classic

### DIFF
--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/partition"
 	"github.com/ubuntu-core/snappy/progress"
+	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/snap"
 )
 
@@ -122,6 +123,9 @@ func extractKernelAssets(s *snap.Info, snapf snap.File, flags InstallFlags, inte
 // SetNextBoot will schedule the given os or kernel snap to be used in
 // the next boot
 func SetNextBoot(s *snap.Info) error {
+	if release.OnClassic {
+		return nil
+	}
 	if s.Type != snap.TypeOS && s.Type != snap.TypeKernel {
 		return nil
 	}

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -210,6 +210,9 @@ func nameAndRevnoFromSnap(snap string) (string, int) {
 // misleading. This code will check what kernel/os booted and set
 // those versions active.
 func SyncBoot() error {
+	if release.OnClassic {
+		return nil
+	}
 	bootloader, err := findBootloader()
 	if err != nil {
 		return fmt.Errorf("cannot run SyncBoot: %s", err)

--- a/snappy/kernel_os_test.go
+++ b/snappy/kernel_os_test.go
@@ -22,6 +22,9 @@ package snappy
 import (
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/partition"
+	"github.com/ubuntu-core/snappy/release"
+	"github.com/ubuntu-core/snappy/snap"
+	"github.com/ubuntu-core/snappy/snap/snaptest"
 
 	. "gopkg.in/check.v1"
 )
@@ -59,6 +62,9 @@ type: os
 `
 
 func (s *kernelTestSuite) TestSyncBoot(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
 	// make an OS
 	_, err := makeInstalledMockSnap(osYaml+"version: v1", 10)
 	c.Assert(err, IsNil)
@@ -105,4 +111,15 @@ func (s *kernelTestSuite) TestSyncBoot(c *C) {
 	c.Assert(found[0].Revision(), Equals, 20)
 	c.Assert(found[0].Version(), Equals, "v1")
 	c.Assert(found[0].IsActive(), Equals, true)
+}
+
+// SetNextBoot should do nothing on classic LP: #1580403
+func (s *kernelTestSuite) TestSetNextBootOnClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// Create a fake OS snap that we try to update
+	snapInfo := snaptest.MockSnap(c, "type: os", &snap.SideInfo{Revision: 42})
+	err := SetNextBoot(snapInfo)
+	c.Assert(err, IsNil)
 }

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ubuntu-core/snappy/dirs"
 	"github.com/ubuntu-core/snappy/osutil"
 	"github.com/ubuntu-core/snappy/partition"
+	"github.com/ubuntu-core/snappy/release"
 	"github.com/ubuntu-core/snappy/snap"
 	"github.com/ubuntu-core/snappy/snap/squashfs"
 	"github.com/ubuntu-core/snappy/systemd"
@@ -230,6 +231,9 @@ vendor: Someone
 `
 
 func (s *SquashfsTestSuite) TestInstallOsSnapUpdatesBootloader(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
 	snapPkg := makeTestSnapPackage(c, packageOS)
 	si := &snap.SideInfo{
 		OfficialName: "ubuntu-core",
@@ -252,6 +256,9 @@ vendor: Someone
 `
 
 func (s *SquashfsTestSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
 	files := [][]string{
 		{"kernel.img", "I'm a kernel"},
 		{"initrd.img", "...and I'm an initrd"},


### PR DESCRIPTION
This patch ensures that SetNextBoot does nothing at all when running
on classic environment. This makes it possible to use snappy on classic
on uboot (e.g. the mate remix)

Fixes: https://bugs.launchpad.net/snappy/+bug/1580403
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>