### PR TITLE
snap: validate snap type.

### DIFF
--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -192,3 +192,16 @@ type: app`
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
 	c.Assert(err, ErrorMatches, "invalid snap name.*")
 }
+
+func (s *infoSuite) TestReadInfoFromSnapFileCatchesInvalidType(c *C) {
+	yaml := `name: foo
+version: 1.0
+type: foo`
+	snapPath := makeTestSnap(c, yaml)
+
+	snapf, err := snap.Open(snapPath)
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
+	c.Assert(err, ErrorMatches, ".*invalid snap type.*")
+}

--- a/snap/types_test.go
+++ b/snap/types_test.go
@@ -21,6 +21,8 @@ package snap
 
 import (
 	"encoding/json"
+	"fmt"
+	"gopkg.in/yaml.v2"
 
 	. "gopkg.in/check.v1"
 )
@@ -35,7 +37,7 @@ func (s *typeSuite) TestJSONerr(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *typeSuite) TestMarshalTypes(c *C) {
+func (s *typeSuite) TestJsonMarshalTypes(c *C) {
 	out, err := json.Marshal(TypeApp)
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "\"app\"")
@@ -43,9 +45,17 @@ func (s *typeSuite) TestMarshalTypes(c *C) {
 	out, err = json.Marshal(TypeGadget)
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "\"gadget\"")
+
+	out, err = json.Marshal(TypeOS)
+	c.Assert(err, IsNil)
+	c.Check(string(out), Equals, "\"os\"")
+
+	out, err = json.Marshal(TypeKernel)
+	c.Assert(err, IsNil)
+	c.Check(string(out), Equals, "\"kernel\"")
 }
 
-func (s *typeSuite) TestUnmarshalTypes(c *C) {
+func (s *typeSuite) TestJsonUnmarshalTypes(c *C) {
 	var st Type
 
 	err := json.Unmarshal([]byte("\"application\""), &st)
@@ -59,4 +69,72 @@ func (s *typeSuite) TestUnmarshalTypes(c *C) {
 	err = json.Unmarshal([]byte("\"gadget\""), &st)
 	c.Assert(err, IsNil)
 	c.Check(st, Equals, TypeGadget)
+
+	err = json.Unmarshal([]byte("\"os\""), &st)
+	c.Assert(err, IsNil)
+	c.Check(st, Equals, TypeOS)
+
+	err = json.Unmarshal([]byte("\"kernel\""), &st)
+	c.Assert(err, IsNil)
+	c.Check(st, Equals, TypeKernel)
+}
+
+func (s *typeSuite) TestJsonUnmarshalInvalidTypes(c *C) {
+	invalidTypes := []string{"foo", "-app", "gadget_"}
+	var st Type
+	for _, invalidType := range invalidTypes {
+		err := json.Unmarshal([]byte(fmt.Sprintf("%q", invalidType)), &st)
+		c.Assert(err, NotNil, Commentf("Expected '%s' to be an invalid type", invalidType))
+	}
+}
+
+func (s *typeSuite) TestYamlMarshalTypes(c *C) {
+	out, err := yaml.Marshal(TypeApp)
+	c.Assert(err, IsNil)
+	c.Check(string(out), Equals, "app\n")
+
+	out, err = yaml.Marshal(TypeGadget)
+	c.Assert(err, IsNil)
+	c.Check(string(out), Equals, "gadget\n")
+
+	out, err = yaml.Marshal(TypeOS)
+	c.Assert(err, IsNil)
+	c.Check(string(out), Equals, "os\n")
+
+	out, err = yaml.Marshal(TypeKernel)
+	c.Assert(err, IsNil)
+	c.Check(string(out), Equals, "kernel\n")
+}
+
+func (s *typeSuite) TestYamlUnmarshalTypes(c *C) {
+	var st Type
+
+	err := yaml.Unmarshal([]byte("application"), &st)
+	c.Assert(err, IsNil)
+	c.Check(st, Equals, TypeApp)
+
+	err = yaml.Unmarshal([]byte("app"), &st)
+	c.Assert(err, IsNil)
+	c.Check(st, Equals, TypeApp)
+
+	err = yaml.Unmarshal([]byte("gadget"), &st)
+	c.Assert(err, IsNil)
+	c.Check(st, Equals, TypeGadget)
+
+	err = yaml.Unmarshal([]byte("os"), &st)
+	c.Assert(err, IsNil)
+	c.Check(st, Equals, TypeOS)
+
+	err = yaml.Unmarshal([]byte("kernel"), &st)
+	c.Assert(err, IsNil)
+	c.Check(st, Equals, TypeKernel)
+}
+
+func (s *typeSuite) TestYamlUnmarshalInvalidTypes(c *C) {
+	invalidTypes := []string{"foo", "-app", "gadget_"}
+	var st Type
+	for _, invalidType := range invalidTypes {
+		err := yaml.Unmarshal([]byte(invalidType), &st)
+		c.Assert(err, NotNil, Commentf("Expected '%s' to be an invalid type", invalidType))
+	}
 }


### PR DESCRIPTION
snapd currently doesn't locally validate the snap type, which means it will happily install a snap of `type: foo`. The review tools will catch this upon upload, but this PR fixes LP: [#1583687](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1583687) by adding local validation to make sure such snaps can't be sideloaded.