### PR TITLE
release: use os-release instead of lsb-release for cross-distro use

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -51,18 +51,18 @@ func ReadLSB() (*LSB, error) {
 	for _, line := range strings.Split(string(content), "\n") {
 		if strings.HasPrefix(line, "NAME=") {
 			tmp := strings.SplitN(line, "=", 2)
-			lsb.ID = strings.Trim(tmp[1],"\"")
+			lsb.ID = strings.Trim(tmp[1], "\"")
 		}
 		if strings.HasPrefix(line, "VERSION_ID=") {
 			tmp := strings.SplitN(line, "=", 2)
-			lsb.Release = strings.Trim(tmp[1],"\"")
+			lsb.Release = strings.Trim(tmp[1], "\"")
 		}
 		if strings.HasPrefix(line, "UBUNTU_CODENAME=") {
 			tmp := strings.SplitN(line, "=", 2)
-			lsb.Codename = strings.Trim(tmp[1],"\"")
+			lsb.Codename = strings.Trim(tmp[1], "\"")
 		}
 	}
-	if (lsb.Codename == "") {
+	if lsb.Codename == "" {
 		lsb.Codename = "xenial"
 	}
 

--- a/release/release.go
+++ b/release/release.go
@@ -30,37 +30,40 @@ import (
 // Series holds the Ubuntu Core series for snapd to use.
 var Series = "16"
 
-// LSB contains the /etc/lsb-release information of the system.
+// LSB contains the /etc/os-release information of the system.
 type LSB struct {
 	ID       string
 	Release  string
 	Codename string
 }
 
-var lsbReleasePath = "/etc/lsb-release"
+var lsbReleasePath = "/etc/os-release"
 
-// ReadLSB returns the lsb-release information of the current system.
+// ReadLSB returns the os-release information of the current system.
 func ReadLSB() (*LSB, error) {
 	lsb := &LSB{}
 
 	content, err := ioutil.ReadFile(lsbReleasePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read lsb-release: %s", err)
+		return nil, fmt.Errorf("cannot read os-release: %s", err)
 	}
 
 	for _, line := range strings.Split(string(content), "\n") {
-		if strings.HasPrefix(line, "DISTRIB_ID=") {
+		if strings.HasPrefix(line, "NAME=") {
 			tmp := strings.SplitN(line, "=", 2)
-			lsb.ID = tmp[1]
+			lsb.ID = strings.Trim(tmp[1],"\"")
 		}
-		if strings.HasPrefix(line, "DISTRIB_RELEASE=") {
+		if strings.HasPrefix(line, "VERSION_ID=") {
 			tmp := strings.SplitN(line, "=", 2)
-			lsb.Release = tmp[1]
+			lsb.Release = strings.Trim(tmp[1],"\"")
 		}
-		if strings.HasPrefix(line, "DISTRIB_CODENAME=") {
+		if strings.HasPrefix(line, "UBUNTU_CODENAME=") {
 			tmp := strings.SplitN(line, "=", 2)
-			lsb.Codename = tmp[1]
+			lsb.Codename = strings.Trim(tmp[1],"\"")
 		}
+	}
+	if (lsb.Codename == "") {
+		lsb.Codename = "xenial"
 	}
 
 	return lsb, nil

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -46,10 +46,16 @@ func makeMockLSBRelease(c *C) string {
 	//        can do release.SetLSBReleasePath() here directly
 	mockLSBRelease := filepath.Join(c.MkDir(), "mock-lsb-release")
 	s := `
-DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=18.09
-DISTRIB_CODENAME=awsome
-DISTRIB_DESCRIPTION=I'm not real!
+NAME="Ubuntu"
+VERSION="18.09 (Awesome Artichoke)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="I'm not real!"
+VERSION_ID="18.09"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+UBUNTU_CODENAME=awesome
 `
 	err := ioutil.WriteFile(mockLSBRelease, []byte(s), 0644)
 	c.Assert(err, IsNil)
@@ -65,7 +71,7 @@ func (s *ReleaseTestSuite) TestReadLSB(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(lsb.ID, Equals, "Ubuntu")
 	c.Assert(lsb.Release, Equals, "18.09")
-	c.Assert(lsb.Codename, Equals, "awsome")
+	c.Assert(lsb.Codename, Equals, "awesome")
 }
 
 func (s *ReleaseTestSuite) TestReadLSBNotFound(c *C) {
@@ -73,7 +79,7 @@ func (s *ReleaseTestSuite) TestReadLSBNotFound(c *C) {
 	defer reset()
 
 	_, err := release.ReadLSB()
-	c.Assert(err, ErrorMatches, "cannot read lsb-release:.*")
+	c.Assert(err, ErrorMatches, "cannot read os-release:.*")
 }
 
 func (s *ReleaseTestSuite) TestOnClassic(c *C) {


### PR DESCRIPTION
Use /etc/os-release, which is guaranteed to be part of base-files on both
Ubuntu and Debian, instead of /etc/lsb-release which doesn't exist at all
on Debian.

If no UBUNTU_CODENAME field is found, default to 'xenial', the codename for
the most recent Ubuntu LTS.  This field is used for downloads of Ubuntu
rootfses from LXD, so must be an Ubuntu codename, not the codename for
another distribution.